### PR TITLE
Describe OpenConnector as Composio alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
 [![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
 
+An open-source alternative to Composio for agent-ready SaaS auth, tools, and integrations.
+
 OpenConnector is an open-source auth gateway that currently provides 680+ providers and 7,000+
 prebuilt Actions in this repository. It supports Cloudflare-compatible deployment and lets AI
 agents call real SaaS products safely through the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,8 @@
 [![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
 [![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
 
+面向 Agent SaaS 鉴权、工具调用和集成的 Composio 开源替代品。
+
 OpenConnector 是一个开源鉴权网关，当前在本仓库提供 680+ 个 provider 和 7,000+ 个可直接调用的预置 Action。
 它兼容 Cloudflare 部署，并通过 [Connector SDK](https://github.com/oomol-lab/connector-sdk)、MCP 和 HTTP 让 AI Agent
 安全地调用真实 SaaS。


### PR DESCRIPTION
## Summary

OpenConnector already explains its open-source auth gateway, provider catalog, Action executors, and agent-facing SDK/MCP/HTTP surfaces, but the README did not state the direct product positioning for people comparing it with Composio. That made readers infer the comparison from the feature list instead of seeing the intended category up front.

This change adds a concise positioning sentence near the top of both the English and Simplified Chinese READMEs, directly under the badges and before the detailed product description. The wording frames OpenConnector as an open-source alternative to Composio for agent-ready SaaS auth, tools, and integrations, while the following paragraphs continue to describe the concrete provider/action coverage and runtime model.

## Validation

- npm run lint
- npm run fix-check
