### PR TITLE
feat(provider): add aimfox

### DIFF
--- a/src/providers/aimfox/actions.ts
+++ b/src/providers/aimfox/actions.ts
@@ -1,0 +1,258 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+import type { JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "aimfox";
+
+const statusSchema = s.nullableString("The status returned by Aimfox.");
+const rawObjectSchema = s.looseObject("A raw object returned by Aimfox.");
+const rawObjectArraySchema = s.array("Raw objects returned by Aimfox.", rawObjectSchema);
+const filterValuesSchema = s.array(
+  "Filter values for an Aimfox lead search facet.",
+  s.nonEmptyString("A filter value."),
+);
+
+const leadSearchBodyFields: Record<string, JsonSchema> = {
+  keywords: s.string("Keywords to search for in Aimfox leads."),
+  current_companies: filterValuesSchema,
+  past_companies: filterValuesSchema,
+  education: filterValuesSchema,
+  interests: filterValuesSchema,
+  labels: filterValuesSchema,
+  languages: filterValuesSchema,
+  locations: filterValuesSchema,
+  origins: filterValuesSchema,
+  skills: filterValuesSchema,
+  lead_of: filterValuesSchema,
+  optimize: s.boolean("Whether Aimfox should optimize the lead search."),
+};
+
+const leadSearchBodyOptionalFields = [
+  "keywords",
+  "current_companies",
+  "past_companies",
+  "education",
+  "interests",
+  "labels",
+  "languages",
+  "locations",
+  "origins",
+  "skills",
+  "lead_of",
+  "optimize",
+] as const;
+
+const leadSearchInputSchema = s.object(
+  "Input for searching Aimfox leads.",
+  {
+    ...leadSearchBodyFields,
+    start: s.nonNegativeInteger("The zero-based offset for the lead search results."),
+    count: s.positiveInteger("The number of lead search results to return."),
+  },
+  {
+    optional: [...leadSearchBodyOptionalFields, "start", "count"],
+  },
+);
+
+const leadCountInputSchema = s.object("Input for counting Aimfox leads.", leadSearchBodyFields, {
+  optional: leadSearchBodyOptionalFields,
+});
+
+const campaignIdInputSchema = s.actionInput(
+  {
+    campaign_id: s.nonEmptyString("The Aimfox campaign ID."),
+  },
+  ["campaign_id"],
+  "Input for referencing one Aimfox campaign.",
+);
+
+export type AimfoxActionName =
+  | "list_campaigns"
+  | "get_campaign"
+  | "get_campaign_metrics"
+  | "add_profile_to_campaign"
+  | "remove_profile_from_campaign"
+  | "get_lead"
+  | "search_leads"
+  | "get_total_leads_count"
+  | "list_recent_leads"
+  | "list_interactions"
+  | "list_workspace_labels";
+
+export const aimfoxActions: Array<ProviderActionDefinition<AimfoxActionName>> = [
+  defineProviderAction(service, {
+    name: "list_campaigns",
+    description: "List Aimfox campaigns, optionally filtering by outreach type or profile inserts.",
+    inputSchema: s.actionInput(
+      {
+        outreach_type: s.stringEnum("The outreach type to filter campaigns by.", ["inbound", "outbound"]),
+        accepts_profiles: s.boolean("Whether to return only campaigns that accept profile inserts."),
+      },
+      [],
+      "Input for listing Aimfox campaigns.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        campaigns: rawObjectArraySchema,
+      },
+      "The campaigns returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_campaign",
+    description: "Fetch one Aimfox campaign by campaign ID.",
+    inputSchema: campaignIdInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        campaign: rawObjectSchema,
+      },
+      "The campaign returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_campaign_metrics",
+    description: "Fetch interaction metrics for one Aimfox campaign.",
+    inputSchema: campaignIdInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        metrics: rawObjectSchema,
+      },
+      "The campaign metrics returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "add_profile_to_campaign",
+    description: "Add one LinkedIn profile URL to an Aimfox campaign audience.",
+    inputSchema: s.actionInput(
+      {
+        campaign_id: s.nonEmptyString("The Aimfox campaign ID."),
+        profile_url: s.url("The LinkedIn profile URL to add to the campaign audience."),
+      },
+      ["campaign_id", "profile_url"],
+      "Input for adding a profile to an Aimfox campaign.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+      },
+      "The status returned after adding a profile to an Aimfox campaign.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "remove_profile_from_campaign",
+    description: "Remove one LinkedIn profile from an Aimfox campaign audience by URN or public ID.",
+    inputSchema: s.actionInput(
+      {
+        campaign_id: s.nonEmptyString("The Aimfox campaign ID."),
+        urn: s.nonEmptyString("The LinkedIn profile URN or public identifier to remove."),
+      },
+      ["campaign_id", "urn"],
+      "Input for removing a profile from an Aimfox campaign.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+      },
+      "The status returned after removing a profile from an Aimfox campaign.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_lead",
+    description: "Fetch one Aimfox lead by lead ID.",
+    inputSchema: s.actionInput(
+      {
+        lead_id: s.nonEmptyString("The Aimfox lead ID."),
+      },
+      ["lead_id"],
+      "Input for fetching an Aimfox lead.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        lead: rawObjectSchema,
+      },
+      "The lead returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "search_leads",
+    description: "Search Aimfox leads with documented facet filters and offset pagination.",
+    inputSchema: leadSearchInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        leads: rawObjectArraySchema,
+      },
+      "The leads returned by Aimfox search.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_total_leads_count",
+    description: "Count Aimfox leads that match the documented lead search filters.",
+    inputSchema: leadCountInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        total_leads: s.nonNegativeInteger("The number of matching Aimfox leads."),
+        sync: s.boolean("Whether Aimfox reports the count as synchronized."),
+        accounts_sync: rawObjectSchema,
+      },
+      "The total lead count returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_recent_leads",
+    description: "List recent Aimfox lead transition events for the workspace.",
+    inputSchema: s.actionInput({}, [], "Input for listing recent Aimfox leads."),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        leads: rawObjectArraySchema,
+      },
+      "The recent lead events returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_interactions",
+    description: "List Aimfox interaction buckets for a timestamp range.",
+    inputSchema: s.actionInput(
+      {
+        bucket: s.stringEnum("The interval used to group interaction metrics.", ["1 hour", "1 day"]),
+        from: s.nonNegativeInteger("The range start timestamp in milliseconds."),
+        to: s.nonNegativeInteger("The range end timestamp in milliseconds."),
+        account_ids: s.array(
+          "Aimfox account IDs to filter interactions by.",
+          s.nonEmptyString("An Aimfox account ID."),
+        ),
+        campaign_id: s.nonEmptyString("The Aimfox campaign ID to filter interactions by."),
+      },
+      ["bucket", "from", "to"],
+      "Input for listing Aimfox interactions.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        count: s.nonNegativeInteger("The number of interaction buckets returned by Aimfox."),
+        buckets: rawObjectArraySchema,
+      },
+      "The interaction buckets returned by Aimfox.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_workspace_labels",
+    description: "List labels configured in the Aimfox workspace.",
+    inputSchema: s.actionInput({}, [], "Input for listing Aimfox workspace labels."),
+    outputSchema: s.actionOutput(
+      {
+        status: statusSchema,
+        labels: rawObjectArraySchema,
+      },
+      "The workspace labels returned by Aimfox.",
+    ),
+  }),
+];

--- a/src/providers/aimfox/definition.ts
+++ b/src/providers/aimfox/definition.ts
@@ -1,0 +1,24 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { aimfoxActions } from "./actions.ts";
+
+const service = "aimfox";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Aimfox",
+  categories: ["Communication", "Marketing"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "aimfox_api_key",
+      description:
+        "Aimfox API key sent with the Authorization Bearer header. Create it from Workspace Settings > Integrations in your Aimfox dashboard: https://docs.aimfox.com/.",
+      extraFields: [],
+    },
+  ],
+  homepageUrl: "https://aimfox.com",
+  actions: aimfoxActions,
+};

--- a/src/providers/aimfox/executors.ts
+++ b/src/providers/aimfox/executors.ts
@@ -1,0 +1,382 @@
+import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type { AimfoxActionName } from "./actions.ts";
+
+import {
+  compactObject,
+  objectArray,
+  optionalBoolean,
+  optionalNumber,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import { queryParams } from "../../core/request.ts";
+import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+const service = "aimfox";
+const apiBaseUrl = "https://api.aimfox.com/api/v2";
+const campaignValidationPath = "/campaigns";
+
+const leadSearchBodyKeys = [
+  "keywords",
+  "current_companies",
+  "past_companies",
+  "education",
+  "interests",
+  "labels",
+  "languages",
+  "locations",
+  "origins",
+  "skills",
+  "lead_of",
+  "optimize",
+] as const;
+
+type AimfoxActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+
+export const aimfoxActionHandlers: Record<AimfoxActionName, AimfoxActionHandler> = {
+  async list_campaigns(input, context) {
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/campaigns",
+      phase: "execute",
+      query: compactObject({
+        outreach_type: optionalString(input.outreach_type),
+        accepts_profiles: optionalBoolean(input.accepts_profiles),
+      }),
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      campaigns: readObjectArray(payload.campaigns, "campaigns"),
+    };
+  },
+
+  async get_campaign(input, context) {
+    const campaignId = requiredProviderString(input.campaign_id, "campaign_id");
+    const payload = await requestAimfoxJson({
+      context,
+      path: `/campaigns/${encodeURIComponent(campaignId)}`,
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      campaign: readRequiredObject(payload.campaign, "campaign"),
+    };
+  },
+
+  async get_campaign_metrics(input, context) {
+    const campaignId = requiredProviderString(input.campaign_id, "campaign_id");
+    const payload = await requestAimfoxJson({
+      context,
+      path: `/campaigns/${encodeURIComponent(campaignId)}/metrics`,
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      metrics: readRequiredObject(payload.metrics, "metrics"),
+    };
+  },
+
+  async add_profile_to_campaign(input, context) {
+    const campaignId = requiredProviderString(input.campaign_id, "campaign_id");
+    const payload = await requestAimfoxJson({
+      context,
+      path: `/campaigns/${encodeURIComponent(campaignId)}/audience`,
+      method: "POST",
+      body: {
+        profile_url: requiredProviderString(input.profile_url, "profile_url"),
+      },
+      phase: "execute",
+      query: {},
+    });
+
+    return { status: readNullableStatus(payload) };
+  },
+
+  async remove_profile_from_campaign(input, context) {
+    const campaignId = requiredProviderString(input.campaign_id, "campaign_id");
+    const urn = requiredProviderString(input.urn, "urn");
+    const payload = await requestAimfoxJson({
+      context,
+      path: `/campaigns/${encodeURIComponent(campaignId)}/audience/${encodeURIComponent(urn)}`,
+      method: "DELETE",
+      phase: "execute",
+      query: {},
+    });
+
+    return { status: readNullableStatus(payload) };
+  },
+
+  async get_lead(input, context) {
+    const leadId = requiredProviderString(input.lead_id, "lead_id");
+    const payload = await requestAimfoxJson({
+      context,
+      path: `/leads/${encodeURIComponent(leadId)}`,
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      lead: readRequiredObject(payload.lead, "lead"),
+    };
+  },
+
+  async search_leads(input, context) {
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/leads:search",
+      method: "POST",
+      body: pickLeadSearchBody(input),
+      phase: "execute",
+      query: compactObject({
+        start: optionalNumber(input.start),
+        count: optionalNumber(input.count),
+      }),
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      leads: readObjectArray(payload.leads, "leads"),
+    };
+  },
+
+  async get_total_leads_count(input, context) {
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/leads:search/total",
+      method: "POST",
+      body: pickLeadSearchBody(input),
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      total_leads: readRequiredNumber(payload.total_leads, "total_leads"),
+      sync: readRequiredBoolean(payload.sync, "sync"),
+      accounts_sync: optionalRecord(payload.accounts_sync) ?? {},
+    };
+  },
+
+  async list_recent_leads(_input, context) {
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/analytics/recent-leads",
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      leads: readObjectArray(payload.leads, "leads"),
+    };
+  },
+
+  async list_interactions(input, context) {
+    const from = requiredProviderNumber(input.from, "from");
+    const to = requiredProviderNumber(input.to, "to");
+    if (from > to) {
+      throw new ProviderRequestError(400, "from must be earlier than or equal to to");
+    }
+
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/analytics/interactions",
+      phase: "execute",
+      query: compactObject({
+        bucket: requiredProviderString(input.bucket, "bucket"),
+        from,
+        to,
+        account_ids: optionalJsonArray(input.account_ids),
+        campaign_id: optionalString(input.campaign_id),
+      }),
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      count: readRequiredNumber(payload.count, "count"),
+      buckets: readObjectArray(payload.buckets, "buckets"),
+    };
+  },
+
+  async list_workspace_labels(_input, context) {
+    const payload = await requestAimfoxJson({
+      context,
+      path: "/labels",
+      phase: "execute",
+      query: {},
+    });
+
+    return {
+      status: readNullableStatus(payload),
+      labels: readObjectArray(payload.labels, "labels"),
+    };
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, aimfoxActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    await requestAimfoxJson({
+      context: { apiKey: input.apiKey, fetcher, signal },
+      path: campaignValidationPath,
+      phase: "validate",
+      query: {},
+    });
+
+    return {
+      profile: {
+        accountId: "api_key",
+        displayName: "Aimfox API Key",
+      },
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl,
+        validationEndpoint: campaignValidationPath,
+      },
+    };
+  },
+};
+
+async function requestAimfoxJson(input: {
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
+  path: string;
+  phase: "validate" | "execute";
+  query: Record<string, string | number | boolean | undefined>;
+  method?: "GET" | "POST" | "DELETE";
+  body?: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
+  const url = new URL(`${apiBaseUrl}${input.path}`);
+  for (const [key, value] of Object.entries(queryParams(input.query))) {
+    url.searchParams.set(key, value);
+  }
+
+  let response: Response;
+  let payload: unknown;
+  try {
+    response = await input.context.fetcher(url, {
+      method: input.method ?? "GET",
+      headers: buildHeaders(input.context.apiKey, input.body !== undefined),
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal: input.context.signal,
+    });
+    payload = await readPayload(response);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Aimfox API request failed: ${error.message}` : "Aimfox API request failed",
+    );
+  }
+
+  if (!response.ok) {
+    throw createAimfoxError(response, payload, input.phase);
+  }
+
+  return readRequiredObject(payload, "Aimfox response");
+}
+
+function buildHeaders(apiKey: string, hasBody: boolean): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    authorization: `Bearer ${apiKey}`,
+    "user-agent": providerUserAgent,
+  };
+  if (hasBody) {
+    headers["content-type"] = "application/json";
+  }
+  return headers;
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new ProviderRequestError(502, "Aimfox API returned a non-JSON response");
+  }
+}
+
+function createAimfoxError(response: Response, payload: unknown, phase: "validate" | "execute"): ProviderRequestError {
+  const record = optionalRecord(payload);
+  const error = optionalRecord(record?.error);
+  const message =
+    optionalString(error?.message) ??
+    optionalString(record?.message) ??
+    `Aimfox API request failed with status ${response.status}`;
+  if (phase === "validate" && (response.status === 401 || response.status === 403)) {
+    return new ProviderRequestError(400, message, payload);
+  }
+  return new ProviderRequestError(response.status >= 500 ? 502 : response.status, message, payload);
+}
+
+function pickLeadSearchBody(input: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const key of leadSearchBodyKeys) {
+    const value = input[key];
+    if (value !== undefined) {
+      body[key] = value;
+    }
+  }
+  return body;
+}
+
+function optionalJsonArray(value: unknown): string | undefined {
+  return Array.isArray(value) ? JSON.stringify(value) : undefined;
+}
+
+function readNullableStatus(payload: Record<string, unknown>): string | null {
+  return optionalString(payload.status) ?? null;
+}
+
+function requiredProviderString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function requiredProviderNumber(value: unknown, fieldName: string): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  throw new ProviderRequestError(400, `${fieldName} is required`);
+}
+
+function readRequiredNumber(value: unknown, fieldName: string): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  throw new ProviderRequestError(502, `Aimfox response missing ${fieldName}`);
+}
+
+function readRequiredBoolean(value: unknown, fieldName: string): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  throw new ProviderRequestError(502, `Aimfox response missing ${fieldName}`);
+}
+
+function readRequiredObject(value: unknown, fieldName: string): Record<string, unknown> {
+  return requiredRecord(value, fieldName, (message) => new ProviderRequestError(502, message));
+}
+
+function readObjectArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
+  return objectArray(value, fieldName, (message) => new ProviderRequestError(502, message));
+}


### PR DESCRIPTION
## Summary
- Add the Aimfox API key provider definition and action catalog.
- Implement local executors for campaign, lead, analytics, and workspace label actions.
- Add Aimfox credential validation against the campaigns endpoint.

## Test Plan
- npm test
- npm run fix-check
- npm run generate:catalog
- git diff --check