### PR TITLE
docs(readme): center header block on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # OpenConnector
 
 [English](README.md) | [简体中文](README.zh-CN.md)
@@ -8,8 +10,10 @@
 ![MCP](https://img.shields.io/badge/MCP-ready-111827)
 ![OpenAPI](https://img.shields.io/badge/OpenAPI-3.1-6BA539)
 
-[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
-[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
+[![Providers](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
+[![Actions](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
+
+</div>
 
 OpenConnector is an open-source alternative to Composio for agent-ready SaaS auth, tools, and
 integrations. It is a connector layer for agents that need reliable access to user accounts in

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 # OpenConnector
 
 [English](README.md) | [简体中文](README.zh-CN.md)
@@ -8,8 +10,10 @@
 ![MCP](https://img.shields.io/badge/MCP-ready-111827)
 ![OpenAPI](https://img.shields.io/badge/OpenAPI-3.1-6BA539)
 
-[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
-[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
+[![Providers](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
+[![Actions](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
+
+</div>
 
 OpenConnector 是 Composio 的开源替代方案，用于面向 Agent 的 SaaS 鉴权、工具和集成。它是一层开源
 connector，用于让 Agent 可靠访问用户在外部应用中的账号。它负责鉴权、工具执行和面向 Agent 的集成。当前开源


### PR DESCRIPTION
The README header (title, language links, and badges) was left-aligned. Wrapping it in a `<div align="center">` centers it on GitHub while preserving the H1 underline and heading anchor, and body paragraphs stay left-aligned so the prose remains readable.

Also swaps the placeholder `Dynamic JSON Badge` alt text on the Providers and Actions badges for `Providers` and `Actions`, which helps screen readers and the broken-image fallback without changing the rendered badge.

Applied identically to `README.md` and `README.zh-CN.md`.