### PR TITLE
chore: rename to @oomol-lab/open-connector, bump to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "oomol-connect",
-  "version": "0.1.0",
+  "name": "@oomol-lab/open-connector",
+  "version": "1.0.0",
   "private": true,
   "workspaces": [
     "web"


### PR DESCRIPTION
Renames the root package from `oomol-connect` to the scoped `@oomol-lab/open-connector` so it matches the repository, and bumps the version from `0.1.0` to `1.0.0` to mark the first stable release.