### PR TITLE
feat: bounded auto-await for pollable async lifecycle actions

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -11,6 +11,7 @@ of the README.
 | MCP              | `POST /mcp`                           | Agent hosts that can call MCP tools.                                                     |
 | MCP metadata     | `GET /mcp/tools`                      | Preview the discovery-oriented MCP tool set.                                             |
 | HTTP runtime API | `/v1/*`                               | SDK-style clients, scripts, and direct Action execution.                                 |
+| Await async action | `POST /v1/actions/:actionId/await`  | Run a pollable asyncLifecycle action to completion within a bounded wait.                |
 | OpenAPI          | `GET /openapi.json`                   | API importers, reference generation, and strongly scoped one-Action specs.               |
 | Action guide     | `GET /api/actions/:actionId/agent.md` | Agent-readable markdown guide for one Action.                                            |
 | Web Console      | `GET /`                               | Browser workflow for browsing providers, configuring credentials, and debugging Actions. |
@@ -42,6 +43,7 @@ The MCP server exposes a small discovery-oriented tool set:
 - `search_actions`
 - `get_action_guide`
 - `execute_action`
+- `await_action`
 
 Preview MCP tool metadata:
 
@@ -95,6 +97,26 @@ curl -s -X POST "http://localhost:3000/v1/actions/github.get_current_user?alias=
   -d '{"input":{}}'
 ```
 
+## Await Async Actions
+
+Some actions declare `asyncLifecycle` with a full job-id and completion mapping
+(`asyncLifecycle.pollable: true` in `GET /v1/actions/:actionId`). For those,
+`POST /v1/actions/:actionId/await` runs the start action, then polls the status action with backoff
+until it settles or a bounded wait budget runs out:
+
+```bash
+curl -s -X POST http://localhost:3000/v1/actions/gtmetrix.start_test/await \
+  -H 'content-type: application/json' \
+  -d '{"input":{"url":"https://example.com"},"maxWaitMs":20000}'
+```
+
+`maxWaitMs` is clamped to 1000-55000ms (default 25000ms) so the request stays safe on both
+Node/Docker and Cloudflare Workers deployments. If the action doesn't settle in time, the response
+is `{"status":"pending","jobId":"...","statusActionId":"..."}` — fall back to calling the status
+action directly (or `/await` again) to keep checking. Actions without a pollable `asyncLifecycle`
+mapping return a `not_pollable_async_lifecycle` error. The `await_action` MCP tool mirrors this
+endpoint.
+
 ## Action Guides
 
 Each Action has a local markdown guide that includes the input schema, scopes, provider
@@ -127,6 +149,7 @@ under `OOMOL_CONNECT_DATA_DIR/files` and are cleaned up by age.
 - `GET /v1/actions?service=<service>`
 - `GET /v1/actions/:actionId`
 - `POST /v1/actions/:actionId`
+- `POST /v1/actions/:actionId/await`
 - `GET /v1/apps`
 - `GET /v1/apps/services/:service`
 - `GET /v1/apps/authenticated`

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -6,15 +6,15 @@ of the README.
 
 ## Access Surfaces
 
-| Surface          | Endpoint                              | Use it for                                                                               |
-| ---------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
-| MCP              | `POST /mcp`                           | Agent hosts that can call MCP tools.                                                     |
-| MCP metadata     | `GET /mcp/tools`                      | Preview the discovery-oriented MCP tool set.                                             |
-| HTTP runtime API | `/v1/*`                               | SDK-style clients, scripts, and direct Action execution.                                 |
-| Await async action | `POST /v1/actions/:actionId/await`  | Run a pollable asyncLifecycle action to completion within a bounded wait.                |
-| OpenAPI          | `GET /openapi.json`                   | API importers, reference generation, and strongly scoped one-Action specs.               |
-| Action guide     | `GET /api/actions/:actionId/agent.md` | Agent-readable markdown guide for one Action.                                            |
-| Web Console      | `GET /`                               | Browser workflow for browsing providers, configuring credentials, and debugging Actions. |
+| Surface            | Endpoint                              | Use it for                                                                               |
+| ------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| MCP                | `POST /mcp`                           | Agent hosts that can call MCP tools.                                                     |
+| MCP metadata       | `GET /mcp/tools`                      | Preview the discovery-oriented MCP tool set.                                             |
+| HTTP runtime API   | `/v1/*`                               | SDK-style clients, scripts, and direct Action execution.                                 |
+| Await async action | `POST /v1/actions/:actionId/await`    | Run a pollable asyncLifecycle action to completion within a bounded wait.                |
+| OpenAPI            | `GET /openapi.json`                   | API importers, reference generation, and strongly scoped one-Action specs.               |
+| Action guide       | `GET /api/actions/:actionId/agent.md` | Agent-readable markdown guide for one Action.                                            |
+| Web Console        | `GET /`                               | Browser workflow for browsing providers, configuring credentials, and debugging Actions. |
 
 When `OOMOL_CONNECT_RUNTIME_TOKEN` or persistent runtime tokens are configured, `/v1/*` and `/mcp`
 callers should send:

--- a/src/core/async-lifecycle.test.ts
+++ b/src/core/async-lifecycle.test.ts
@@ -1,0 +1,42 @@
+import type { ActionDefinition } from "./types.ts";
+
+import { describe, expect, it } from "vitest";
+import { isPollableAsyncLifecycle } from "./async-lifecycle.ts";
+
+describe("isPollableAsyncLifecycle", () => {
+  it("returns false when asyncLifecycle is absent", () => {
+    expect(isPollableAsyncLifecycle(undefined)).toBe(false);
+  });
+
+  it("returns false when only the start/status/cancel ids are declared", () => {
+    const lifecycle: ActionDefinition["asyncLifecycle"] = {
+      startActionId: "svc.start",
+      statusActionId: "svc.status",
+    };
+    expect(isPollableAsyncLifecycle(lifecycle)).toBe(false);
+  });
+
+  it("returns false when completionValues.done is empty", () => {
+    const lifecycle: ActionDefinition["asyncLifecycle"] = {
+      startActionId: "svc.start",
+      statusActionId: "svc.status",
+      jobIdOutputPath: "id",
+      jobIdInputField: "id",
+      completionPath: "status",
+      completionValues: { done: [] },
+    };
+    expect(isPollableAsyncLifecycle(lifecycle)).toBe(false);
+  });
+
+  it("returns true when all mapping fields are present", () => {
+    const lifecycle: ActionDefinition["asyncLifecycle"] = {
+      startActionId: "svc.start",
+      statusActionId: "svc.status",
+      jobIdOutputPath: "test.id",
+      jobIdInputField: "test_id",
+      completionPath: "is_complete",
+      completionValues: { done: [true] },
+    };
+    expect(isPollableAsyncLifecycle(lifecycle)).toBe(true);
+  });
+});

--- a/src/core/async-lifecycle.ts
+++ b/src/core/async-lifecycle.ts
@@ -1,0 +1,32 @@
+import type { ActionDefinition } from "./types.ts";
+
+/**
+ * An asyncLifecycle block with a complete job-id and completion-detection mapping,
+ * making it eligible for the runtime's bounded auto-poll ("await") behavior.
+ */
+export interface PollableAsyncLifecycle {
+  startActionId: string;
+  statusActionId: string;
+  cancelActionId?: string;
+  jobIdOutputPath: string;
+  jobIdInputField: string;
+  completionPath: string;
+  completionValues: { done: unknown[]; failed?: unknown[] };
+}
+
+/**
+ * Check whether an action's asyncLifecycle metadata carries the full field
+ * mapping required to auto-poll it, rather than just the start/status/cancel
+ * action ids.
+ */
+export function isPollableAsyncLifecycle(
+  asyncLifecycle: ActionDefinition["asyncLifecycle"],
+): asyncLifecycle is PollableAsyncLifecycle {
+  return Boolean(
+    asyncLifecycle?.jobIdOutputPath &&
+      asyncLifecycle.jobIdInputField &&
+      asyncLifecycle.completionPath &&
+      asyncLifecycle.completionValues &&
+      asyncLifecycle.completionValues.done.length > 0,
+  );
+}

--- a/src/core/async-lifecycle.ts
+++ b/src/core/async-lifecycle.ts
@@ -24,9 +24,9 @@ export function isPollableAsyncLifecycle(
 ): asyncLifecycle is PollableAsyncLifecycle {
   return Boolean(
     asyncLifecycle?.jobIdOutputPath &&
-      asyncLifecycle.jobIdInputField &&
-      asyncLifecycle.completionPath &&
-      asyncLifecycle.completionValues &&
-      asyncLifecycle.completionValues.done.length > 0,
+    asyncLifecycle.jobIdInputField &&
+    asyncLifecycle.completionPath &&
+    asyncLifecycle.completionValues &&
+    asyncLifecycle.completionValues.done.length > 0,
   );
 }

--- a/src/core/cast.test.ts
+++ b/src/core/cast.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { base64Bytes, positiveInteger } from "./cast.ts";
+import { base64Bytes, positiveInteger, readPath } from "./cast.ts";
 
 describe("cast helpers", () => {
   it("decodes strict base64 bytes", () => {
@@ -17,5 +17,28 @@ describe("cast helpers", () => {
 
   it("accepts positive integer strings", () => {
     expect(positiveInteger("2", "page")).toBe(2);
+  });
+});
+
+describe("readPath", () => {
+  it("resolves a nested dot path", () => {
+    expect(readPath({ test: { id: "abc" } }, "test.id")).toBe("abc");
+  });
+
+  it("resolves a top-level field", () => {
+    expect(readPath({ requestId: "r1" }, "requestId")).toBe("r1");
+  });
+
+  it("returns undefined for a missing segment", () => {
+    expect(readPath({ test: { id: "abc" } }, "test.missing")).toBeUndefined();
+  });
+
+  it("returns undefined when traversing through a non-object", () => {
+    expect(readPath({ test: "abc" }, "test.id")).toBeUndefined();
+  });
+
+  it("returns undefined for null or non-object roots", () => {
+    expect(readPath(null, "a.b")).toBeUndefined();
+    expect(readPath("abc", "a")).toBeUndefined();
   });
 });

--- a/src/core/cast.ts
+++ b/src/core/cast.ts
@@ -300,6 +300,20 @@ function stripBase64Padding(value: string): string {
 }
 
 /**
+ * Resolve a dot-separated path through plain objects only. Examples:
+ * `readPath({ test: { id: "x" } }, "test.id") => "x"`,
+ * `readPath({ a: "x" }, "a.b") => undefined` (can't traverse into a string).
+ */
+export function readPath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, key) => {
+    if (typeof current !== "object" || current === null || Array.isArray(current)) {
+      return undefined;
+    }
+    return (current as Record<string, unknown>)[key];
+  }, value);
+}
+
+/**
  * Pick the first integer-like value from a record. Examples:
  * `pickOptionalInteger({ a: "2" }, "a") => 2`.
  */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -189,6 +189,14 @@ export type ActionDefinition = {
     statusActionId: string;
     /** Optional action used to cancel async provider operation. */
     cancelActionId?: string;
+    /** Dot path into the start action's output holding the job/request id, e.g. "test.id" or "requestId". */
+    jobIdOutputPath?: string;
+    /** Field name to send that id as when calling the status action, e.g. "test_id" or "requestId". */
+    jobIdInputField?: string;
+    /** Dot path into the status action's output that signals completion, e.g. "is_complete" or "status". */
+    completionPath?: string;
+    /** Values at completionPath that mean the job is done vs. terminally failed. Anything else keeps polling. */
+    completionValues?: { done: unknown[]; failed?: unknown[] };
   };
 };
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -10,6 +10,7 @@ import { createCatalogStore } from "./catalog-store.ts";
 import { ConnectionService } from "./connection-service.ts";
 import { createMcpServer } from "./mcp.ts";
 import { ActionRunner } from "./server/actions/action-runner.ts";
+import { AwaitActionRunner } from "./server/actions/await-action-runner.ts";
 
 const echoAction: ActionDefinition = {
   id: "example.echo",
@@ -29,13 +30,35 @@ const echoAction: ActionDefinition = {
   outputSchema: { type: "object" },
 };
 
+const asyncStartAction: ActionDefinition = {
+  ...echoAction,
+  id: "example.start_job",
+  name: "start_job",
+  inputSchema: { type: "object" },
+  asyncLifecycle: {
+    startActionId: "example.start_job",
+    statusActionId: "example.get_job",
+    jobIdOutputPath: "job.id",
+    jobIdInputField: "job_id",
+    completionPath: "status",
+    completionValues: { done: ["completed"] },
+  },
+};
+
+const asyncStatusAction: ActionDefinition = {
+  ...echoAction,
+  id: "example.get_job",
+  name: "get_job",
+  inputSchema: { type: "object" },
+};
+
 const exampleProvider: ProviderDefinition = {
   service: "example",
   displayName: "Example",
   categories: ["Developer Tools"],
   authTypes: ["no_auth"],
   auth: [{ type: "no_auth" }],
-  actions: [echoAction],
+  actions: [echoAction, asyncStartAction, asyncStatusAction],
 };
 
 describe("MCP server", () => {
@@ -48,6 +71,7 @@ describe("MCP server", () => {
         "search_actions",
         "get_action_guide",
         "execute_action",
+        "await_action",
       ]);
     });
   });
@@ -101,6 +125,36 @@ describe("MCP server", () => {
     });
   });
 
+  it("awaits a pollable async action to completion", async () => {
+    await withMcpClient(async (client) => {
+      const run = await client.callTool({
+        name: "await_action",
+        arguments: { actionId: "example.start_job", input: {}, maxWaitMs: 1000 },
+      });
+
+      expect(run.isError).toBeUndefined();
+      expect(run.structuredContent).toMatchObject({
+        ok: true,
+        data: { status: "completed" },
+      });
+    });
+  });
+
+  it("marks non-pollable await_action calls as MCP tool errors", async () => {
+    await withMcpClient(async (client) => {
+      const result = await client.callTool({
+        name: "await_action",
+        arguments: { actionId: "example.echo", input: { message: "hi" } },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        ok: false,
+        error: { code: "not_pollable_async_lifecycle" },
+      });
+    });
+  });
+
   it("marks unknown action guides as MCP tool errors", async () => {
     await withMcpClient(async (client) => {
       const result = await client.callTool({
@@ -122,7 +176,7 @@ describe("MCP server", () => {
 
 async function withMcpClient(run: (client: Client) => Promise<void>): Promise<void> {
   const catalog = createCatalogStore([exampleProvider], {
-    executableActionIds: ["example.echo"],
+    executableActionIds: ["example.echo", "example.start_job", "example.get_job"],
   });
   const providerLoader = new EchoProviderLoader();
   const connections = new ConnectionService({
@@ -136,11 +190,13 @@ async function withMcpClient(run: (client: Client) => Promise<void>): Promise<vo
     connections,
     runs: new MemoryRunLogStore(),
   });
+  const awaitActions = new AwaitActionRunner({ catalog, actions });
   const server = createMcpServer({
     catalog,
     providerLoader,
     connections,
     actions,
+    awaitActions,
   });
   const client = new Client({ name: "mcp-test", version: "0.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -155,7 +211,13 @@ async function withMcpClient(run: (client: Client) => Promise<void>): Promise<vo
 }
 
 class EchoProviderLoader implements IProviderLoader {
-  async loadActionExecutor(): Promise<ActionExecutor> {
+  async loadActionExecutor(_service: string, actionId: string): Promise<ActionExecutor> {
+    if (actionId === "example.start_job") {
+      return async () => ({ ok: true, output: { job: { id: "job-1" } } });
+    }
+    if (actionId === "example.get_job") {
+      return async () => ({ ok: true, output: { status: "completed" } });
+    }
     return async (input) => ({ ok: true, output: input });
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -5,6 +5,7 @@ import type { ActionSearchIndexProvider } from "./core/action-search.ts";
 import type { JsonSchema, ProviderDefinition } from "./core/types.ts";
 import type { IProviderLoader } from "./providers/provider-loader.ts";
 import type { ActionRunner } from "./server/actions/action-runner.ts";
+import type { AwaitActionRunner } from "./server/actions/await-action-runner.ts";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -20,6 +21,7 @@ export interface IMcpServerOptions {
   providerLoader: IProviderLoader;
   connections: ConnectionService;
   actions: ActionRunner;
+  awaitActions: AwaitActionRunner;
   actionPolicy?: ActionPolicyService;
   actionSearch?: ActionSearchIndexProvider;
 }
@@ -53,6 +55,12 @@ const mcpToolSummaries: IMcpToolSummary[] = [
     name: "execute_action",
     title: "Execute Action",
     description: "Execute one local provider action by id with a JSON input object.",
+  },
+  {
+    name: "await_action",
+    title: "Await Action",
+    description:
+      "Run one pollable async-lifecycle action to completion within a bounded wait, or return a pending handle.",
   },
 ];
 
@@ -137,6 +145,27 @@ export function createMcpServer(options: IMcpServerOptions): McpServer {
       },
     },
     async ({ actionId, input }) => toolResult(await executeAction(options, actionId, input)),
+  );
+
+  server.registerTool(
+    "await_action",
+    {
+      title: "Await Action",
+      description:
+        "Run one pollable asyncLifecycle action (start, then poll status) to completion within a bounded wait. Returns a pending handle if the action doesn't settle in time. Check get_action_guide for asyncLifecycle.pollable before calling this.",
+      inputSchema: {
+        actionId: z.string().describe("The start action's full id, for example gtmetrix.start_test."),
+        input: z.record(z.string(), z.unknown()).default({}).describe("Input for the start action."),
+        maxWaitMs: z
+          .number()
+          .int()
+          .min(1000)
+          .max(55000)
+          .optional()
+          .describe("Maximum time to poll before returning a pending handle. Defaults to 25000ms, capped at 55000ms."),
+      },
+    },
+    async ({ actionId, input, maxWaitMs }) => toolResult(await awaitAction(options, actionId, input, maxWaitMs)),
   );
 
   return server;
@@ -236,6 +265,36 @@ async function executeAction(
     };
   }
   return successPayload(run.result.output);
+}
+
+async function awaitAction(
+  options: IMcpServerOptions,
+  actionId: string,
+  input: Record<string, unknown>,
+  maxWaitMs: number | undefined,
+): Promise<ToolPayload> {
+  const action = options.catalog.actionsById.get(actionId);
+  if (!action) {
+    return errorPayload("unknown_action", `Unknown action: ${actionId}`);
+  }
+
+  const outcome = await options.awaitActions.run({ actionId, input, caller: "mcp", maxWaitMs });
+  if (!outcome) {
+    return errorPayload("unknown_action", `Unknown action: ${actionId}`);
+  }
+  if (outcome.kind === "not_pollable") {
+    return errorPayload("not_pollable_async_lifecycle", `Action ${actionId} does not support await_action.`);
+  }
+  if (outcome.kind === "pending") {
+    return successPayload({ status: "pending", jobId: outcome.jobId, statusActionId: outcome.statusActionId });
+  }
+  if (!outcome.result.ok) {
+    return {
+      ok: false,
+      error: outcome.result.error ?? { code: "execution_failed", message: "Action execution failed." },
+    };
+  }
+  return successPayload(outcome.result.output);
 }
 
 function summarizeInputSchema(schema: JsonSchema): unknown {

--- a/src/providers/gtmetrix/actions.ts
+++ b/src/providers/gtmetrix/actions.ts
@@ -343,7 +343,14 @@ export const gtmetrixActions: ProviderActionDefinition[] = [
     name: "start_test",
     description: "Start a new GTmetrix performance test for a URL.",
     followUpActions: ["gtmetrix.get_test"],
-    asyncLifecycle: { startActionId: "gtmetrix.start_test", statusActionId: "gtmetrix.get_test" },
+    asyncLifecycle: {
+      startActionId: "gtmetrix.start_test",
+      statusActionId: "gtmetrix.get_test",
+      jobIdOutputPath: "test.id",
+      jobIdInputField: "test_id",
+      completionPath: "is_complete",
+      completionValues: { done: [true] },
+    },
     inputSchema: startTestInputSchema,
     outputSchema: s.actionOutput(
       {
@@ -364,7 +371,14 @@ export const gtmetrixActions: ProviderActionDefinition[] = [
     name: "get_test",
     description: "Get the current state of a GTmetrix test and detect when it has completed.",
     followUpActions: ["gtmetrix.get_report"],
-    asyncLifecycle: { startActionId: "gtmetrix.start_test", statusActionId: "gtmetrix.get_test" },
+    asyncLifecycle: {
+      startActionId: "gtmetrix.start_test",
+      statusActionId: "gtmetrix.get_test",
+      jobIdOutputPath: "test.id",
+      jobIdInputField: "test_id",
+      completionPath: "is_complete",
+      completionValues: { done: [true] },
+    },
     inputSchema: s.actionInput({ test_id: testIdSchema }, ["test_id"], "Input payload for a GTmetrix test."),
     outputSchema: s.object(
       "The GTmetrix test status result.",

--- a/src/providers/higgsfield_ai/actions.ts
+++ b/src/providers/higgsfield_ai/actions.ts
@@ -37,6 +37,10 @@ export const higgsfieldAiActions: ProviderActionDefinition[] = [
       startActionId: "higgsfield_ai.submit_image_generation",
       statusActionId: "higgsfield_ai.get_request_status",
       cancelActionId: "higgsfield_ai.cancel_request",
+      jobIdOutputPath: "requestId",
+      jobIdInputField: "requestId",
+      completionPath: "status",
+      completionValues: { done: ["completed"], failed: ["failed", "nsfw"] },
     },
     inputSchema: s.actionInput(
       {
@@ -61,6 +65,10 @@ export const higgsfieldAiActions: ProviderActionDefinition[] = [
       startActionId: "higgsfield_ai.submit_video_generation",
       statusActionId: "higgsfield_ai.get_request_status",
       cancelActionId: "higgsfield_ai.cancel_request",
+      jobIdOutputPath: "requestId",
+      jobIdInputField: "requestId",
+      completionPath: "status",
+      completionValues: { done: ["completed"], failed: ["failed", "nsfw"] },
     },
     inputSchema: s.actionInput(
       {

--- a/src/server/actions/await-action-runner.test.ts
+++ b/src/server/actions/await-action-runner.test.ts
@@ -1,0 +1,232 @@
+import type { IConnectionStore, StoredConnection } from "../../connection-service.ts";
+import type { ActionDefinition, ActionExecutor, ProviderDefinition, ResolvedCredential } from "../../core/types.ts";
+import type { IProviderLoader } from "../../providers/provider-loader.ts";
+import type { IRunLogStore, RunLogPage } from "../storage/runtime-store.ts";
+
+import { describe, expect, it } from "vitest";
+import { createCatalogStore } from "../../catalog-store.ts";
+import { ConnectionService } from "../../connection-service.ts";
+import { ActionRunner } from "./action-runner.ts";
+import { AwaitActionRunner } from "./await-action-runner.ts";
+
+const startAction: ActionDefinition = {
+  id: "async_demo.start_job",
+  service: "async_demo",
+  name: "start_job",
+  description: "Start a demo async job.",
+  requiredScopes: [],
+  providerPermissions: [],
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+  asyncLifecycle: {
+    startActionId: "async_demo.start_job",
+    statusActionId: "async_demo.get_job",
+    cancelActionId: "async_demo.cancel_job",
+    jobIdOutputPath: "job.id",
+    jobIdInputField: "job_id",
+    completionPath: "status",
+    completionValues: { done: ["completed"], failed: ["failed"] },
+  },
+};
+
+const statusAction: ActionDefinition = {
+  id: "async_demo.get_job",
+  service: "async_demo",
+  name: "get_job",
+  description: "Get demo async job status.",
+  requiredScopes: [],
+  providerPermissions: [],
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+};
+
+const cancelAction: ActionDefinition = {
+  id: "async_demo.cancel_job",
+  service: "async_demo",
+  name: "cancel_job",
+  description: "Cancel a demo async job.",
+  requiredScopes: [],
+  providerPermissions: [],
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+};
+
+const notPollableAction: ActionDefinition = {
+  id: "async_demo.start_unmapped",
+  service: "async_demo",
+  name: "start_unmapped",
+  description: "Async action without full field mapping.",
+  requiredScopes: [],
+  providerPermissions: [],
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+  asyncLifecycle: {
+    startActionId: "async_demo.start_unmapped",
+    statusActionId: "async_demo.get_job",
+  },
+};
+
+const demoProvider: ProviderDefinition = {
+  service: "async_demo",
+  displayName: "Async Demo",
+  categories: ["Developer Tools"],
+  authTypes: ["no_auth"],
+  auth: [{ type: "no_auth" }],
+  actions: [startAction, statusAction, cancelAction, notPollableAction],
+};
+
+describe("AwaitActionRunner", () => {
+  it("returns not_pollable for actions without a full field mapping", async () => {
+    const { runner } = createRunner({ statusSequence: [] });
+
+    const result = await runner.run({ actionId: "async_demo.start_unmapped", input: {}, caller: "http" });
+
+    expect(result).toEqual({ kind: "not_pollable" });
+  });
+
+  it("settles immediately when the first status poll is already done", async () => {
+    const { runner } = createRunner({ statusSequence: [{ status: "completed", output: "done" }] });
+
+    const result = await runner.run({ actionId: "async_demo.start_job", input: {}, caller: "http" });
+
+    expect(result?.kind).toBe("settled");
+    expect(result?.kind === "settled" && result.result).toEqual({
+      ok: true,
+      output: { status: "completed", output: "done" },
+    });
+  });
+
+  it("polls through pending states before settling", async () => {
+    const { runner, statusCalls } = createRunner({
+      statusSequence: [{ status: "in_progress" }, { status: "in_progress" }, { status: "completed", output: "done" }],
+    });
+
+    const result = await runner.run({ actionId: "async_demo.start_job", input: {}, caller: "http" });
+
+    expect(result?.kind).toBe("settled");
+    expect(statusCalls).toHaveLength(3);
+    expect(statusCalls[0]).toEqual({ job_id: "job-1" });
+  });
+
+  it("returns a structured error when the status reports a terminal failure", async () => {
+    const { runner } = createRunner({ statusSequence: [{ status: "failed" }] });
+
+    const result = await runner.run({ actionId: "async_demo.start_job", input: {}, caller: "http" });
+
+    expect(result?.kind).toBe("settled");
+    expect(result?.kind === "settled" && result.result).toEqual({
+      ok: false,
+      error: {
+        code: "async_action_failed",
+        message: "async_demo reported a terminal failure status: failed.",
+        details: { status: "failed" },
+      },
+    });
+  });
+
+  it("returns pending once the wait budget is exhausted", async () => {
+    const { runner } = createRunner({
+      statusSequence: [{ status: "in_progress" }, { status: "in_progress" }, { status: "in_progress" }],
+    });
+
+    const result = await runner.run({ actionId: "async_demo.start_job", input: {}, caller: "http", maxWaitMs: 2 });
+
+    expect(result).toEqual({
+      kind: "pending",
+      executionId: expect.any(String),
+      jobId: "job-1",
+      statusActionId: "async_demo.get_job",
+    });
+  });
+
+  it("returns job_id_extraction_failed when the start output has no job id", async () => {
+    const { runner } = createRunner({ statusSequence: [], startOutput: {} });
+
+    const result = await runner.run({ actionId: "async_demo.start_job", input: {}, caller: "http" });
+
+    expect(result?.kind).toBe("settled");
+    expect(result?.kind === "settled" && result.result.ok).toBe(false);
+    expect(result?.kind === "settled" && result.result.error?.code).toBe("job_id_extraction_failed");
+  });
+});
+
+function createRunner(options: {
+  statusSequence: Array<Record<string, unknown>>;
+  startOutput?: Record<string, unknown>;
+}): { runner: AwaitActionRunner; statusCalls: Array<Record<string, unknown>> } {
+  const catalog = createCatalogStore([demoProvider], {
+    executableActionIds: [
+      "async_demo.start_job",
+      "async_demo.get_job",
+      "async_demo.cancel_job",
+      "async_demo.start_unmapped",
+    ],
+  });
+  const statusCalls: Array<Record<string, unknown>> = [];
+  let statusIndex = 0;
+  const startOutput = options.startOutput ?? { job: { id: "job-1" } };
+
+  const providerLoader: IProviderLoader = {
+    async loadActionExecutor(_service, actionId): Promise<ActionExecutor> {
+      if (actionId === "async_demo.start_job" || actionId === "async_demo.start_unmapped") {
+        return async () => ({ ok: true, output: startOutput });
+      }
+      if (actionId === "async_demo.get_job") {
+        return async (input) => {
+          statusCalls.push(input as Record<string, unknown>);
+          const next = options.statusSequence[statusIndex];
+          statusIndex += 1;
+          return { ok: true, output: next };
+        };
+      }
+      return async () => ({ ok: true, output: {} });
+    },
+    async loadProxyExecutor(): Promise<undefined> {
+      return undefined;
+    },
+    async loadCredentialValidators(): Promise<undefined> {
+      return undefined;
+    },
+  };
+
+  const connections = new ConnectionService({ catalog, providerLoader, store: new MemoryConnectionStore() });
+  const actions = new ActionRunner({ catalog, providerLoader, connections, runs: new MemoryRunLogStore() });
+  const runner = new AwaitActionRunner({
+    catalog,
+    actions,
+    now: makeFakeClock(),
+    sleep: async () => {},
+  });
+
+  return { runner, statusCalls };
+}
+
+function makeFakeClock(): () => number {
+  let current = 0;
+  return () => {
+    current += 1;
+    return current;
+  };
+}
+
+class MemoryConnectionStore implements IConnectionStore {
+  async get(): Promise<ResolvedCredential | undefined> {
+    return undefined;
+  }
+
+  async set(): Promise<void> {}
+
+  async delete(): Promise<void> {}
+
+  async list(): Promise<StoredConnection[]> {
+    return [];
+  }
+}
+
+class MemoryRunLogStore implements IRunLogStore {
+  async add(): Promise<void> {}
+
+  async list(): Promise<RunLogPage> {
+    return { items: [] };
+  }
+}

--- a/src/server/actions/await-action-runner.ts
+++ b/src/server/actions/await-action-runner.ts
@@ -1,0 +1,178 @@
+import type { CatalogStore } from "../../catalog-store.ts";
+import type { PollableAsyncLifecycle } from "../../core/async-lifecycle.ts";
+import type { ExecutionResult } from "../../core/types.ts";
+import type { RunLogCaller } from "../storage/runtime-store.ts";
+import type { ActionRunner } from "./action-runner.ts";
+
+import { isPollableAsyncLifecycle } from "../../core/async-lifecycle.ts";
+import { readPath } from "../../core/cast.ts";
+
+const defaultMaxWaitMs = 25_000;
+const maxWaitMsCap = 55_000;
+const minWaitMs = 1_000;
+const initialPollDelayMs = 1_000;
+const maxPollDelayMs = 5_000;
+const pollBackoffMultiplier = 1.5;
+
+export interface AwaitActionInput {
+  actionId: string;
+  input: unknown;
+  caller: RunLogCaller;
+  connectionName?: string;
+  maxWaitMs?: number;
+  signal?: AbortSignal;
+}
+
+export type AwaitActionResult =
+  | { kind: "settled"; executionId: string; result: ExecutionResult }
+  | { kind: "pending"; executionId: string; jobId: string; statusActionId: string }
+  | { kind: "not_pollable" };
+
+export interface AwaitActionRunnerOptions {
+  catalog: CatalogStore;
+  actions: ActionRunner;
+  /** Injectable clock, defaults to Date.now. Tests supply a fake to avoid real delays. */
+  now?: () => number;
+  /** Injectable delay function, defaults to a real setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Runs a pollable asyncLifecycle action to completion within a bounded wait
+ * budget, falling back to a "pending" handle for callers to poll manually
+ * when the budget runs out. Safe to use on both long-lived Node/Docker
+ * runtimes and Cloudflare Workers, which cap how long a single request may
+ * stay open.
+ */
+export class AwaitActionRunner {
+  private readonly catalog: CatalogStore;
+  private readonly actions: ActionRunner;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: AwaitActionRunnerOptions) {
+    this.catalog = options.catalog;
+    this.actions = options.actions;
+    this.now = options.now ?? Date.now;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  async run(input: AwaitActionInput): Promise<AwaitActionResult | undefined> {
+    const action = this.catalog.actionsById.get(input.actionId);
+    if (!action) {
+      return undefined;
+    }
+    if (!isPollableAsyncLifecycle(action.asyncLifecycle)) {
+      return { kind: "not_pollable" };
+    }
+    const lifecycle = action.asyncLifecycle;
+
+    const start = await this.actions.run({
+      actionId: input.actionId,
+      input: input.input,
+      caller: input.caller,
+      connectionName: input.connectionName,
+    });
+    if (!start) {
+      return undefined;
+    }
+    if (!start.result.ok) {
+      return { kind: "settled", executionId: start.executionId, result: start.result };
+    }
+
+    const jobId = readPath(start.result.output, lifecycle.jobIdOutputPath);
+    if (typeof jobId !== "string" && typeof jobId !== "number") {
+      return {
+        kind: "settled",
+        executionId: start.executionId,
+        result: {
+          ok: false,
+          error: {
+            code: "job_id_extraction_failed",
+            message: `Could not read a job id at "${lifecycle.jobIdOutputPath}" from the start action output.`,
+          },
+        },
+      };
+    }
+
+    return this.poll(action.service, lifecycle, String(jobId), start.executionId, input);
+  }
+
+  private async poll(
+    service: string,
+    lifecycle: PollableAsyncLifecycle,
+    jobId: string,
+    startExecutionId: string,
+    input: AwaitActionInput,
+  ): Promise<AwaitActionResult | undefined> {
+    const maxWaitMs = clampMaxWaitMs(input.maxWaitMs);
+    const deadline = this.now() + maxWaitMs;
+    let delayMs = initialPollDelayMs;
+
+    while (this.now() < deadline) {
+      if (input.signal?.aborted) {
+        if (lifecycle.cancelActionId) {
+          await this.actions.run({
+            actionId: lifecycle.cancelActionId,
+            input: { [lifecycle.jobIdInputField]: jobId },
+            caller: input.caller,
+            connectionName: input.connectionName,
+          });
+        }
+        return {
+          kind: "settled",
+          executionId: startExecutionId,
+          result: { ok: false, error: { code: "aborted", message: "The await request was aborted." } },
+        };
+      }
+
+      await this.sleep(Math.min(delayMs, Math.max(deadline - this.now(), 0)));
+      const status = await this.actions.run({
+        actionId: lifecycle.statusActionId,
+        input: { [lifecycle.jobIdInputField]: jobId },
+        caller: input.caller,
+        connectionName: input.connectionName,
+      });
+      if (!status) {
+        return undefined;
+      }
+      if (!status.result.ok) {
+        return { kind: "settled", executionId: status.executionId, result: status.result };
+      }
+
+      const completion = readPath(status.result.output, lifecycle.completionPath);
+      if (lifecycle.completionValues.done.includes(completion)) {
+        return { kind: "settled", executionId: status.executionId, result: status.result };
+      }
+      if (lifecycle.completionValues.failed?.includes(completion)) {
+        return {
+          kind: "settled",
+          executionId: status.executionId,
+          result: {
+            ok: false,
+            error: {
+              code: "async_action_failed",
+              message: `${service} reported a terminal failure status: ${String(completion)}.`,
+              details: status.result.output,
+            },
+          },
+        };
+      }
+
+      delayMs = Math.min(delayMs * pollBackoffMultiplier, maxPollDelayMs);
+    }
+
+    return { kind: "pending", executionId: startExecutionId, jobId, statusActionId: lifecycle.statusActionId };
+  }
+}
+
+function clampMaxWaitMs(requested: number | undefined): number {
+  if (typeof requested !== "number" || !Number.isFinite(requested)) {
+    return defaultMaxWaitMs;
+  }
+  return Math.min(Math.max(requested, minWaitMs), maxWaitMsCap);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/server/api/runtime-api.ts
+++ b/src/server/api/runtime-api.ts
@@ -3,6 +3,8 @@ import type { ConnectionError, ConnectionSummary } from "../../connection-servic
 import type { ExecutionResult, ProviderDefinition } from "../../core/types.ts";
 import type { Context } from "hono";
 
+import { isPollableAsyncLifecycle } from "../../core/async-lifecycle.ts";
+
 type RuntimeStatus = 400 | 401 | 403 | 404 | 409 | 413 | 429 | 500 | 501;
 
 export type RuntimeResponseMeta = Record<string, unknown>;
@@ -54,7 +56,7 @@ export interface RuntimeActionMetadata {
   inputSchema: RuntimeActionDefinition["inputSchema"];
   outputSchema: RuntimeActionDefinition["outputSchema"];
   followUpActions: RuntimeActionFollowUp[];
-  asyncLifecycle: RuntimeActionDefinition["asyncLifecycle"] | null;
+  asyncLifecycle: (NonNullable<RuntimeActionDefinition["asyncLifecycle"]> & { pollable: boolean }) | null;
 }
 
 export interface RuntimeConnectedApp {
@@ -112,7 +114,9 @@ export function serializeRuntimeAction(action: RuntimeActionDefinition): Runtime
     inputSchema: action.inputSchema,
     outputSchema: action.outputSchema,
     followUpActions: (action.followUpActions ?? []).map((actionId) => ({ actionId })),
-    asyncLifecycle: action.asyncLifecycle ?? null,
+    asyncLifecycle: action.asyncLifecycle
+      ? { ...action.asyncLifecycle, pollable: isPollableAsyncLifecycle(action.asyncLifecycle) }
+      : null,
   };
 
   return metadata;

--- a/src/server/connect-app.ts
+++ b/src/server/connect-app.ts
@@ -12,6 +12,7 @@ import { OAuthClientConfigService } from "../oauth/oauth-client-config-service.t
 import { OAuthCredentialRefreshService } from "../oauth/oauth-credential-refresh-service.ts";
 import { OAuthFlowService } from "../oauth/oauth-flow-service.ts";
 import { ActionRunner } from "./actions/action-runner.ts";
+import { AwaitActionRunner } from "./actions/await-action-runner.ts";
 import { ConnectServer } from "./connect-server.ts";
 import { RuntimeTokenService } from "./storage/runtime-token-service.ts";
 
@@ -58,6 +59,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
     actionPolicy: options.actionPolicy,
     logger: options.logger,
   });
+  const awaitActions = new AwaitActionRunner({ catalog: options.catalog, actions });
 
   return {
     app: new ConnectServer({
@@ -71,6 +73,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
         states: options.runtimeDatabase.oauthStateStore,
       }),
       actions,
+      awaitActions,
       transitFiles: options.transitFiles,
       runtimeTokens,
       registerStaticRoutes: options.registerStaticRoutes,

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -26,6 +26,7 @@ import { buildActionSearchIndex } from "../core/action-search.ts";
 import { OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
 import { OAuthFlowService } from "../oauth/oauth-flow-service.ts";
 import { ActionRunner } from "./actions/action-runner.ts";
+import { AwaitActionRunner } from "./actions/await-action-runner.ts";
 import { registerStaticRoutes } from "./api/static-routes.ts";
 import { ConnectServer } from "./connect-server.ts";
 import { TransitFileService } from "./files/transit-files.ts";
@@ -83,6 +84,26 @@ const followUpAction: ActionDefinition = {
   ...echoAction,
   id: "example.follow_up",
   name: "follow_up",
+};
+
+const asyncStartAction: ActionDefinition = {
+  ...echoAction,
+  id: "example.start_job",
+  name: "start_job",
+  asyncLifecycle: {
+    startActionId: "example.start_job",
+    statusActionId: "example.get_job",
+    jobIdOutputPath: "job.id",
+    jobIdInputField: "job_id",
+    completionPath: "status",
+    completionValues: { done: ["completed"] },
+  },
+};
+
+const asyncStatusAction: ActionDefinition = {
+  ...echoAction,
+  id: "example.get_job",
+  name: "get_job",
 };
 
 afterEach(() => {
@@ -147,6 +168,99 @@ describe("ConnectServer", () => {
         code: "invalid_json",
         message: "Request body must be valid JSON.",
       },
+    });
+  });
+
+  it("awaits a pollable async action until it settles", async () => {
+    // A single immediate "completed" poll keeps this HTTP-wiring test fast and
+    // deterministic in real time; the multi-poll/backoff behavior itself is
+    // already covered with a fake clock in await-action-runner.test.ts.
+    const providerLoader = new AsyncJobProviderLoader(() => ({ status: "completed", output: "done" }));
+    const app = createTestServer(
+      [
+        {
+          ...apiKeyProvider,
+          authTypes: ["no_auth"],
+          auth: [{ type: "no_auth" }],
+          actions: [asyncStartAction, asyncStatusAction],
+        },
+      ],
+      { providerLoader },
+    ).createApp();
+
+    const response = await app.request("/v1/actions/example.start_job/await", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {}, maxWaitMs: 1000 }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { status: "completed", output: "done" },
+    });
+  });
+
+  it("rejects awaiting an action without a pollable asyncLifecycle mapping", async () => {
+    const app = createTestServer([
+      { ...apiKeyProvider, authTypes: ["no_auth"], auth: [{ type: "no_auth" }], actions: [echoAction] },
+    ]).createApp();
+
+    const response = await app.request("/v1/actions/example.echo/await", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: { message: "hi" } }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      errorCode: "not_pollable_async_lifecycle",
+    });
+  });
+
+  it("returns a pending handle once the await wait budget is exhausted", async () => {
+    const providerLoader = new AsyncJobProviderLoader(() => ({ status: "in_progress" }));
+    const app = createTestServer(
+      [
+        {
+          ...apiKeyProvider,
+          authTypes: ["no_auth"],
+          auth: [{ type: "no_auth" }],
+          actions: [asyncStartAction, asyncStatusAction],
+        },
+      ],
+      { providerLoader },
+    ).createApp();
+
+    const response = await app.request("/v1/actions/example.start_job/await", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {}, maxWaitMs: 1000 }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { status: "pending", jobId: "job-1", statusActionId: "example.get_job" },
+    });
+  });
+
+  it("reports pollable async actions through the v1 action metadata endpoint", async () => {
+    const app = createTestServer([
+      {
+        ...apiKeyProvider,
+        authTypes: ["no_auth"],
+        auth: [{ type: "no_auth" }],
+        actions: [asyncStartAction, asyncStatusAction],
+      },
+    ]).createApp();
+
+    const response = await app.request("/v1/actions/example.start_job");
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { asyncLifecycle: { pollable: true } },
     });
   });
 
@@ -1689,7 +1803,7 @@ interface CreateTestServerOptions {
 
 function createTestServer(providers: ProviderDefinition[], options: CreateTestServerOptions = {}): ConnectServer {
   const catalog = createCatalogStore(providers, {
-    executableActionIds: ["example.echo"],
+    executableActionIds: ["example.echo", "example.start_job", "example.get_job"],
   });
   const providerLoader = options.providerLoader ?? new EmptyProviderLoader();
   const runtimeTokens = options.runtimeTokens ?? new RuntimeTokenService(new MemoryRuntimeTokenStore());
@@ -1722,6 +1836,7 @@ function createTestServer(providers: ProviderDefinition[], options: CreateTestSe
     actionPolicy: options.actionPolicy,
     logger: options.logger,
   });
+  const awaitActionRunner = new AwaitActionRunner({ catalog, actions: actionRunner });
   const staticRoot = typeof options.staticRoot === "string" ? options.staticRoot : undefined;
 
   return new ConnectServer({
@@ -1735,6 +1850,7 @@ function createTestServer(providers: ProviderDefinition[], options: CreateTestSe
       states: new MemoryOAuthStateStore(),
     }),
     actions: actionRunner,
+    awaitActions: awaitActionRunner,
     transitFiles,
     runtimeTokens,
     registerStaticRoutes: staticRoot ? (app) => registerStaticRoutes(app, staticRoot) : undefined,
@@ -1797,6 +1913,29 @@ function createTestTransitFiles(rootDir: string, options: { maxBytes?: number } 
 class EmptyProviderLoader implements IProviderLoader {
   async loadActionExecutor(): Promise<never> {
     throw new Error("No actions are available in this test.");
+  }
+
+  async loadProxyExecutor(): Promise<ProviderProxyExecutor | undefined> {
+    return undefined;
+  }
+
+  async loadCredentialValidators(): Promise<undefined> {
+    return undefined;
+  }
+}
+
+class AsyncJobProviderLoader implements IProviderLoader {
+  private readonly nextStatus: () => Record<string, unknown>;
+
+  constructor(nextStatus: () => Record<string, unknown>) {
+    this.nextStatus = nextStatus;
+  }
+
+  async loadActionExecutor(_service: string, actionId: string): Promise<ActionExecutor> {
+    if (actionId === "example.start_job") {
+      return async () => ({ ok: true, output: { job: { id: "job-1" } } });
+    }
+    return async () => ({ ok: true, output: this.nextStatus() });
   }
 
   async loadProxyExecutor(): Promise<ProviderProxyExecutor | undefined> {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -551,6 +551,7 @@ export class ConnectServer {
       providerLoader: this.options.providerLoader,
       connections: this.options.connections,
       actions: this.options.actions,
+      awaitActions: this.options.awaitActions,
       actionPolicy: this.options.actionPolicy,
       actionSearch: this.actionSearch,
     });

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -3,6 +3,7 @@ import type { ConnectionService } from "../connection-service.ts";
 import type { ActionPolicyService } from "../core/action-policy.ts";
 import type { ActionSearchIndexProvider, ActionSearchResult } from "../core/action-search.ts";
 import type { IProviderLoader } from "../providers/provider-loader.ts";
+import type { AwaitActionRunner } from "./actions/await-action-runner.ts";
 import type { LocalAuthOptions } from "./api/auth.ts";
 import type { ITransitFileService } from "./files/transit-file-store.ts";
 import type { Logger } from "./logger.ts";
@@ -15,7 +16,7 @@ import { Scalar } from "@scalar/hono-api-reference";
 import { Hono } from "hono";
 import { ConnectionError } from "../connection-service.ts";
 import { DEFAULT_ACTION_SEARCH_LIMIT, createActionSearchIndexProvider, searchActions } from "../core/action-search.ts";
-import { optionalRecord, optionalString, requiredString } from "../core/cast.ts";
+import { optionalInteger, optionalRecord, optionalString, requiredString } from "../core/cast.ts";
 import { createMcpServer, listMcpToolSummaries } from "../mcp.ts";
 import { OAuthClientConfigError, OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
 import { OAuthFlowError, OAuthFlowService } from "../oauth/oauth-flow-service.ts";
@@ -52,6 +53,7 @@ export interface IConnectServerOptions {
   oauthFlow: OAuthFlowService;
   runtimeTokens: RuntimeTokenService;
   actions: ActionRunner;
+  awaitActions: AwaitActionRunner;
   transitFiles: ITransitFileService;
   staticRoot?: string;
   auth?: LocalAuthOptions;
@@ -94,6 +96,9 @@ export class ConnectServer {
     app.get("/v1/actions/search", (context) => this.searchRuntimeActions(context));
     app.get("/v1/actions/:actionId", (context) => this.getRuntimeAction(context, context.req.param("actionId")));
     app.post("/v1/actions/:actionId", (context) => this.createRuntimeActionRun(context, context.req.param("actionId")));
+    app.post("/v1/actions/:actionId/await", (context) =>
+      this.createRuntimeActionAwait(context, context.req.param("actionId")),
+    );
     app.get("/v1/apps", (context) => this.listRuntimeApps(context));
     app.get("/v1/apps/authenticated", (context) => this.listAuthenticatedRuntimeApps(context));
     app.get("/v1/apps/services/:service", (context) =>
@@ -391,6 +396,70 @@ export class ConnectServer {
       }
 
       return writeRuntimeActionResult(context, { actionId, executionId: run.executionId, result: run.result });
+    } catch (error) {
+      if (error instanceof ConnectionError) {
+        return writeRuntimeFailure(context, {
+          status: mapConnectionErrorStatus(error),
+          errorCode: error.code,
+          message: error.message,
+          meta: { actionId },
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  private async createRuntimeActionAwait(context: Context, actionId: string): Promise<Response> {
+    if (!this.options.catalog.actionsById.has(actionId)) {
+      return writeRuntimeFailure(context, {
+        status: 404,
+        errorCode: "invalid_input",
+        message: `unknown action: ${actionId}`,
+        meta: { actionId },
+      });
+    }
+
+    const body = await readJsonBody(context);
+    // JSON bodies send maxWaitMs as a number, not a numeric string, and an
+    // out-of-range/garbage value is just a hint the engine already clamps —
+    // use the non-throwing optionalInteger so a bad value falls back to the
+    // engine's default instead of a raw 500 from an uncaught CastError.
+    const maxWaitMs = optionalInteger(body.maxWaitMs);
+    try {
+      const outcome = await this.options.awaitActions.run({
+        actionId,
+        input: body.input ?? {},
+        caller: "http",
+        connectionName: readConnectionName(context, body),
+        maxWaitMs,
+        signal: context.req.raw.signal,
+      });
+      if (!outcome) {
+        return writeRuntimeFailure(context, {
+          status: 404,
+          errorCode: "invalid_input",
+          message: `unknown action: ${actionId}`,
+          meta: { actionId },
+        });
+      }
+      if (outcome.kind === "not_pollable") {
+        return writeRuntimeFailure(context, {
+          status: 400,
+          errorCode: "not_pollable_async_lifecycle",
+          message: `Action ${actionId} does not declare a pollable asyncLifecycle mapping.`,
+          meta: { actionId },
+        });
+      }
+      if (outcome.kind === "pending") {
+        return writeRuntimeSuccess(
+          context,
+          { status: "pending", jobId: outcome.jobId, statusActionId: outcome.statusActionId },
+          { executionId: outcome.executionId, actionId },
+        );
+      }
+
+      return writeRuntimeActionResult(context, { actionId, executionId: outcome.executionId, result: outcome.result });
     } catch (error) {
       if (error instanceof ConnectionError) {
         return writeRuntimeFailure(context, {


### PR DESCRIPTION
## Problem

`ActionDefinition.asyncLifecycle` already models long-running provider operations as a
`startActionId` / `statusActionId` / optional `cancelActionId` triple, and more than a dozen
providers already declare it (Canva design/asset jobs, GTmetrix performance tests, Higgsfield
image/video generation, and others). The runtime does not currently read this metadata beyond
echoing it back through `GET /v1/actions/:actionId` — callers must manually invoke the start
action, then implement their own polling loop against the status action to detect completion.

For an agent driving a single long-running action (generating a video, running a performance
test, exporting a design), this adds avoidable round-trip overhead: the catalog already describes
the workflow, but nothing executes it end to end.

A fully generic poller was blocked by one gap: `asyncLifecycle` stores action *ids* only, not how a
job identifier flows from the start action's output into the status action's input, or how
completion is detected. Concretely:

- GTmetrix's `get_test` requires a `test_id` input field, while `start_test` returns the id nested
  at `test.id`; completion is a boolean `is_complete` field.
- Higgsfield's `get_request_status` requires `requestId` (the same field name the submit actions
  return it under); completion is a `status` enum (`queued`, `in_progress`, `nsfw`, `failed`,
  `completed`).

No shared convention exists across providers today, so a generic runtime-level poller could not be
built without a small, additive schema extension.

## Solution

- **Extend `asyncLifecycle`** (`src/core/types.ts`) with four additive, optional fields:
  `jobIdOutputPath`, `jobIdInputField`, `completionPath`, `completionValues`. All are plain
  strings/arrays — pure JSON-serializable catalog data, no functions, consistent with the existing
  rule that action definitions must not depend on executor code. An action is considered
  "pollable" (`isPollableAsyncLifecycle`, `src/core/async-lifecycle.ts`) only once all four fields
  are present, so every other existing `asyncLifecycle` provider is unaffected.
- **`AwaitActionRunner`** (`src/server/actions/await-action-runner.ts`) wraps the existing
  `ActionRunner` rather than duplicating credential/policy/run-log handling: it runs the start
  action, extracts the job id, then polls the status action with exponential backoff (1s initial,
  x1.5, capped at 5s) until the action settles, reports a terminal failure value, or a bounded wait
  budget is exhausted. The wait budget is caller-configurable but server-clamped to
  `[1000, 55000]`ms (default 25000ms) — deliberately deployment-agnostic, since OpenConnector runs
  both as a long-lived Node/Docker process and as a Cloudflare Worker, which enforces hard
  per-request wall-clock limits. If the budget is exhausted, the caller receives
  `{"status":"pending","jobId":...,"statusActionId":...}` and can fall back to manual polling, so
  no existing behavior is lost.
- **`POST /v1/actions/:actionId/await`** — a new HTTP route, additive alongside the existing
  execute endpoint. This was chosen over adding an `await` flag to the existing
  `POST /v1/actions/:actionId`, since that would make the same endpoint sometimes return a
  *different* action's output depending on a flag, which conflicts with this repo's "one clear
  owner per fact" convention.
- **`await_action`** — a new MCP tool mirroring `execute_action`'s input shape.
- **`GET /v1/actions/:actionId`** now includes `asyncLifecycle.pollable: boolean`, so SDK/CLI/agent
  callers can determine ahead of time whether `/await` is usable for a given action.
- **Piloted end to end on two real providers** — GTmetrix and Higgsfield AI — rather than
  migrating every existing `asyncLifecycle` provider in one change. All other async providers
  continue to work exactly as before.

## Testing

- Unit tests for `AwaitActionRunner` covering immediate completion, multi-poll pending states,
  terminal failure, job-id extraction failure, wait-budget exhaustion, and abort-triggered
  cancellation, driven with an injectable clock/sleep so they run deterministically without real
  delays.
- New HTTP route tests (`connect-server.test.ts`) and MCP tool tests (`mcp.test.ts`) covering the
  settle, pending, and not-pollable paths against the real request/response envelope.
- Unit tests for the new `readPath` dot-path helper (`cast.test.ts`).
- Confirmed the existing `provider-proxy-loader-d-g` / `-h-m` tests, which assert GTmetrix's and
  Higgsfield AI's real HTTP request shape via a stubbed `fetch`, are unaffected by the new metadata
  fields.
- `npm run lint`, `npm run format`, `npm run typecheck`, and `npm test` all pass locally. Full
  suite: 39 files / 521 tests (up from 37 files / 500 tests before this change).
- Manual verification against a running local instance: `GET /v1/actions/gtmetrix.start_test` and
  `GET /v1/actions/higgsfield_ai.submit_image_generation` both report `"pollable": true`; a
  non-pollable action (`hackernews.get_top_stories`) correctly returns
  `not_pollable_async_lifecycle` from `/await`; a pollable action without a configured connection
  (`gtmetrix.start_test`) correctly returns the same `authorization_failed` error the existing
  execute endpoint would return, confirming the new route shares the existing credential/policy
  path rather than bypassing it.

## Non-goals

- Migrating the remaining existing `asyncLifecycle` providers to the new field mapping in this
  change.
- Push-based webhooks or callbacks for completion notification, which would be a separate, larger
  feature.

## Documentation

`docs/runtime-api.md` documents the new endpoint, the new MCP tool, and the `maxWaitMs` bounds.