### PR TITLE
feat(mcdonalds_cn): add McDonald's China provider

### DIFF
--- a/src/providers/mcdonalds_cn/actions.ts
+++ b/src/providers/mcdonalds_cn/actions.ts
@@ -1,0 +1,381 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+import type { JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "mcdonalds_cn";
+
+const flagString = s.stringEnum(["0", "1"], {
+  description: "McDonald's China flag value: 0 for no, 1 for yes.",
+});
+const dateString = s.string({
+  pattern: "^\\d{8}$",
+  description: "Date in yyyyMMdd format. When omitted, McDonald's China defaults to the current day.",
+});
+const timeString = s.string({
+  pattern: "^\\d{2}:\\d{2}$",
+  description: "Time in HH:mm format. When omitted, McDonald's China defaults to the current time.",
+});
+const queryString = s.nonEmptyString("A McDonald's China query parameter value.");
+const citySchema = s.object(
+  {
+    code: s.string("City code."),
+    name: s.string("City name."),
+    latitude: s.number("City center latitude."),
+    longitude: s.number("City center longitude."),
+  },
+  {
+    required: ["code", "name"],
+    additionalProperties: true,
+    description: "A McDonald's China city.",
+  },
+);
+const daypartSchema = s.object(
+  {
+    daypartCode: s.integer("Daypart code."),
+    daypartFlag: s.boolean("Whether this is the default daypart."),
+    daypartName: s.string("Daypart name."),
+    startTime: s.string("Daypart start time."),
+    endTime: s.string("Daypart end time."),
+  },
+  {
+    additionalProperties: true,
+    description: "A store daypart.",
+  },
+);
+const storeSchema = s.object(
+  {
+    code: s.string("Store code."),
+    name: s.string("Store name."),
+    shortName: s.string("Store short name."),
+    beCode: s.string("Store business entity code."),
+    beType: s.integer("Store business entity type."),
+    cityCode: s.string("City code."),
+    cityName: s.string("City name."),
+    address: s.string("Store address."),
+    latitude: s.number("Store latitude."),
+    longitude: s.number("Store longitude."),
+    businessStatus: s.integer("Business status code."),
+    telephone: s.string("Store phone number."),
+    distance: s.integer("Distance in meters."),
+    distanceText: s.string("Human-readable distance."),
+    dayparts: s.array("Available dayparts.", daypartSchema),
+  },
+  {
+    additionalProperties: true,
+    description: "A McDonald's China store.",
+  },
+);
+const priceInfoSchema = s.object(
+  {
+    eatInPriceText: s.string("Eat-in price text in yuan."),
+    takeOutPriceText: s.string("Take-out price text in yuan."),
+    deliveryPriceText: s.string("Delivery price text in yuan."),
+    eatInPrice: s.integer("Eat-in price in cents."),
+    takeOutPrice: s.integer("Take-out price in cents."),
+    deliveryPrice: s.integer("Delivery price in cents."),
+    discountPrice: s.integer("Discount price in cents."),
+    discountPriceText: s.string("Discount price text in yuan."),
+    priceShowStyle: s.integer("Price display style."),
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China product price information.",
+  },
+);
+const productSchema = s.object(
+  {
+    productCode: s.string("Product code."),
+    productName: s.string("Product name."),
+    productLongName: s.string("Full product name."),
+    productImage: s.url("Product image URL."),
+    productType: s.integer("Product type code."),
+    saleStatus: s.integer("Sale status code."),
+    maxPurchaseQuantity: s.integer("Maximum purchase quantity."),
+    priceInfo: priceInfoSchema,
+    categoryCodeList: s.array("Category codes that include this product.", s.string()),
+    tags: s.array("Product tags.", s.unknownObject("One product tag.")),
+    groupList: s.array("Products in this group or combo.", s.unknownObject("One group item.")),
+  },
+  {
+    additionalProperties: true,
+    description: "A McDonald's China menu product.",
+  },
+);
+const menuCategorySchema = s.object(
+  {
+    categoryCode: s.string("Menu category code."),
+    categoryName: s.string("Menu category name."),
+    image: s.url("Menu category image URL."),
+    products: s.array("Products in this category.", productSchema),
+  },
+  {
+    additionalProperties: true,
+    description: "A McDonald's China menu category.",
+  },
+);
+const productDetailSchema = s.object(
+  {
+    image: s.url("Product image URL."),
+    code: s.string("Product code."),
+    name: s.string("Product name."),
+    longName: s.string("Full product name."),
+    desc: s.string("Product description."),
+    price: s.integer("Product price in cents."),
+    priceText: s.string("Product price text in yuan."),
+    type: s.integer("Product type code."),
+    customizationMode: s.integer("Customization mode."),
+    specTypes: s.array("Product spec groups.", s.unknownObject("One product spec group.")),
+    choices: s.array("Product choices.", s.unknownObject("One product choice group.")),
+  },
+  {
+    additionalProperties: true,
+    description: "A McDonald's China product detail object.",
+  },
+);
+
+const citiesDataSchema = s.object(
+  {
+    cities: s.array("Available cities.", citySchema),
+    currentCity: citySchema,
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China cities response data.",
+  },
+);
+const storesDataSchema = s.object(
+  {
+    stores: s.array("Nearby stores.", storeSchema),
+    storeList: s.array("Nearby stores.", storeSchema),
+    datetime: s.string("Server datetime."),
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China nearby store response data.",
+  },
+);
+const menuDataSchema = s.object(
+  {
+    menu: s.array("Menu categories.", menuCategorySchema),
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China menu response data.",
+  },
+);
+const productDetailDataSchema = s.object(
+  {
+    maxPurchaseQuantity: s.integer("Maximum purchase quantity."),
+    product: productDetailSchema,
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China product detail response data.",
+  },
+);
+const productSearchDataSchema = s.object(
+  {
+    maxPurchaseQuantity: s.integer("Maximum purchase quantity."),
+    productList: s.array("Products matching the search.", productSchema),
+  },
+  {
+    additionalProperties: true,
+    description: "McDonald's China product search response data.",
+  },
+);
+
+export type McdonaldsCnActionName =
+  | "get_cities"
+  | "search_stores"
+  | "get_store"
+  | "get_store_business"
+  | "get_menu"
+  | "get_product_detail"
+  | "search_products";
+
+export const mcdonaldsCnActions: Array<ProviderActionDefinition<McdonaldsCnActionName>> = [
+  defineProviderAction(service, {
+    name: "get_cities",
+    description: "Get McDonald's China cities that support restaurant and menu lookup.",
+    inputSchema: s.object(
+      {
+        getCurrent: flagString,
+      },
+      {
+        optional: ["getCurrent"],
+        description: "City lookup options.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(citiesDataSchema, "McDonald's China city lookup result."),
+  }),
+  defineProviderAction(service, {
+    name: "search_stores",
+    description: "Search McDonald's China stores by delivery address, city, location, keyword, or order filters.",
+    inputSchema: s.object(
+      {
+        addressId: queryString,
+        beType: queryString,
+        cityCode: queryString,
+        date: dateString,
+        distance: queryString,
+        hotTagCode: queryString,
+        isCityCenter: flagString,
+        keyword: queryString,
+        latitude: queryString,
+        longitude: queryString,
+        orderType: queryString,
+        showType: queryString,
+        time: timeString,
+      },
+      {
+        optional: [
+          "addressId",
+          "beType",
+          "cityCode",
+          "date",
+          "distance",
+          "hotTagCode",
+          "isCityCenter",
+          "keyword",
+          "latitude",
+          "longitude",
+          "orderType",
+          "showType",
+          "time",
+        ],
+        description: "Nearby store search filters.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(storesDataSchema, "McDonald's China nearby store lookup result."),
+    followUpActions: ["mcdonalds_cn.get_store", "mcdonalds_cn.get_store_business", "mcdonalds_cn.get_menu"],
+  }),
+  defineProviderAction(service, {
+    name: "get_store",
+    description: "Get one McDonald's China store by store code.",
+    inputSchema: s.object(
+      {
+        storeCode: s.nonEmptyString("Store code."),
+      },
+      {
+        required: ["storeCode"],
+        description: "Store lookup input.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(storeSchema, "McDonald's China store detail result."),
+    followUpActions: ["mcdonalds_cn.get_store_business", "mcdonalds_cn.get_menu"],
+  }),
+  defineProviderAction(service, {
+    name: "get_store_business",
+    description: "Get McDonald's China business details for a store business entity code.",
+    inputSchema: s.object(
+      {
+        beCode: s.nonEmptyString("Store business entity code."),
+        date: dateString,
+        isGroupMeal: flagString,
+        time: timeString,
+      },
+      {
+        required: ["beCode"],
+        optional: ["date", "isGroupMeal", "time"],
+        description: "Store business detail input.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(storeSchema, "McDonald's China store business detail result."),
+    followUpActions: ["mcdonalds_cn.get_menu"],
+  }),
+  defineProviderAction(service, {
+    name: "get_menu",
+    description: "Get a McDonald's China store menu for an order type, daypart, and sales channel.",
+    inputSchema: s.object(
+      {
+        storeCode: s.nonEmptyString("Store code."),
+        channelCode: s.nonEmptyString("Sales channel code."),
+        orderType: s.integer("Order type."),
+        dayPartCode: s.integer("Daypart code."),
+        beCode: queryString,
+        date: dateString,
+        time: timeString,
+        isGroupMeal: s.integer({
+          minimum: 0,
+          maximum: 1,
+          description: "Group meal flag: 0 for no, 1 for yes.",
+        }),
+      },
+      {
+        required: ["storeCode", "channelCode", "orderType", "dayPartCode"],
+        optional: ["beCode", "date", "time", "isGroupMeal"],
+        description: "Menu lookup input.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(menuDataSchema, "McDonald's China menu result."),
+    followUpActions: ["mcdonalds_cn.get_product_detail", "mcdonalds_cn.search_products"],
+  }),
+  defineProviderAction(service, {
+    name: "get_product_detail",
+    description: "Get detailed McDonald's China menu product information.",
+    inputSchema: s.object(
+      {
+        code: s.nonEmptyString("Product code."),
+        storeCode: s.nonEmptyString("Store code."),
+        channelCode: s.nonEmptyString("Sales channel code."),
+        daypartCode: queryString,
+        orderType: queryString,
+        beCode: queryString,
+        cardId: queryString,
+        date: dateString,
+        time: timeString,
+        isGroupMeal: flagString,
+      },
+      {
+        required: ["code", "storeCode", "channelCode", "daypartCode", "orderType"],
+        optional: ["beCode", "cardId", "date", "time", "isGroupMeal"],
+        description: "Product detail lookup input.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(productDetailDataSchema, "McDonald's China product detail result."),
+  }),
+  defineProviderAction(service, {
+    name: "search_products",
+    description: "Search McDonald's China menu products for one store, daypart, and order type.",
+    inputSchema: s.object(
+      {
+        keyword: s.nonEmptyString("Search keyword."),
+        storeCode: s.nonEmptyString("Store code."),
+        daypartCode: queryString,
+        orderType: queryString,
+        beCode: queryString,
+        date: dateString,
+        time: timeString,
+        isGroupMeal: flagString,
+      },
+      {
+        required: ["keyword", "storeCode", "daypartCode", "orderType"],
+        optional: ["beCode", "date", "time", "isGroupMeal"],
+        description: "Product search input.",
+      },
+    ),
+    outputSchema: mcdonaldsEnvelope(productSearchDataSchema, "McDonald's China product search result."),
+    followUpActions: ["mcdonalds_cn.get_product_detail"],
+  }),
+];
+
+function mcdonaldsEnvelope(dataSchema: JsonSchema, description: string): JsonSchema {
+  return s.object(
+    {
+      traceId: s.string("McDonald's China trace identifier."),
+      datetime: s.string("Server datetime."),
+      code: s.integer("Provider status code."),
+      data: dataSchema,
+      success: s.boolean("Whether the provider request succeeded."),
+      message: s.string("Provider status message."),
+    },
+    {
+      required: ["code", "data"],
+      optional: ["traceId", "datetime", "success", "message"],
+      additionalProperties: true,
+      description,
+    },
+  );
+}

--- a/src/providers/mcdonalds_cn/definition.ts
+++ b/src/providers/mcdonalds_cn/definition.ts
@@ -1,0 +1,62 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { mcdonaldsCnActions } from "./actions.ts";
+
+const service = "mcdonalds_cn";
+
+/**
+ * McDonald's China provider backed by the McDonald's China Open Platform APIs.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "McDonald's China",
+  categories: ["Location", "Data"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "appId",
+          label: "App ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "McDonald's China AppId",
+          description: "McDonald's China merchant application ID from the Open Platform.",
+        },
+        {
+          key: "merchantId",
+          label: "Merchant ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "McDonald's China MerchantId",
+          description: "McDonald's China merchant ID from the Open Platform.",
+        },
+        {
+          key: "signingKey",
+          label: "Signing Key",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "McDonald's China signing key",
+          description:
+            "Signing key paired with the AppId and MerchantId. It is used to generate the Sign header required by the Open Platform.",
+        },
+        {
+          key: "environment",
+          label: "Environment",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "prod or uat",
+          description:
+            "McDonald's China API environment. Use prod for https://api.open.mcd.cn or uat for https://api-uat.open.mcdchina.net. Defaults to prod.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://open.mcd.cn",
+  actions: mcdonaldsCnActions,
+};

--- a/src/providers/mcdonalds_cn/executors.ts
+++ b/src/providers/mcdonalds_cn/executors.ts
@@ -1,0 +1,27 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { McdonaldsCnContext } from "./runtime.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createMcdonaldsCnContext, mcdonaldsCnActionHandlers, validateMcdonaldsCnCredential } from "./runtime.ts";
+
+const service = "mcdonalds_cn";
+
+export const executors: ProviderExecutors = defineProviderExecutors<McdonaldsCnContext>({
+  service,
+  handlers: mcdonaldsCnActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<McdonaldsCnContext> {
+    const credential = await requireCustomCredential(context, service);
+    return createMcdonaldsCnContext(credential.values, fetcher, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateMcdonaldsCnCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/mcdonalds_cn/runtime.ts
+++ b/src/providers/mcdonalds_cn/runtime.ts
@@ -1,0 +1,288 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { McdonaldsCnActionName } from "./actions.ts";
+
+import { createHash } from "node:crypto";
+import { integer, optionalIntegerLike, optionalScalarString, optionalString, requiredString } from "../../core/cast.ts";
+import { compactJson, encodePathSegment } from "../../core/request.ts";
+import { providerUserAgent, ProviderRequestError, readProviderJson } from "../provider-runtime.ts";
+
+const prodBaseUrl = "https://api.open.mcd.cn";
+const uatBaseUrl = "https://api-uat.open.mcdchina.net";
+const apiVersion = "1.0";
+
+export interface McdonaldsCnContext {
+  appId: string;
+  merchantId: string;
+  signingKey: string;
+  environment: McdonaldsCnEnvironment;
+  baseUrl: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+type McdonaldsCnEnvironment = "prod" | "uat";
+type McdonaldsCnActionHandler = (input: Record<string, unknown>, context: McdonaldsCnContext) => Promise<unknown>;
+type QueryValue = string | number | boolean | null | undefined;
+type QueryEntry = readonly [string, QueryValue];
+
+interface McdonaldsCnRequestInput {
+  method: "GET" | "POST";
+  path: string;
+  query?: QueryEntry[];
+  body?: Record<string, unknown>;
+}
+
+interface McdonaldsCnEnvelope {
+  code?: unknown;
+  message?: unknown;
+  msg?: unknown;
+  success?: unknown;
+}
+
+export const mcdonaldsCnActionHandlers: Record<McdonaldsCnActionName, McdonaldsCnActionHandler> = {
+  get_cities(input, context) {
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: "/cities/all",
+      query: [["getCurrent", optionalScalarString(input.getCurrent)]],
+    });
+  },
+  search_stores(input, context) {
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: "/stores/vicinity",
+      query: [
+        ["addressId", optionalScalarString(input.addressId)],
+        ["beType", optionalScalarString(input.beType)],
+        ["cityCode", optionalScalarString(input.cityCode)],
+        ["date", optionalScalarString(input.date)],
+        ["distance", optionalScalarString(input.distance)],
+        ["hotTagCode", optionalScalarString(input.hotTagCode)],
+        ["isCityCenter", optionalScalarString(input.isCityCenter)],
+        ["keyword", optionalScalarString(input.keyword)],
+        ["latitude", optionalScalarString(input.latitude)],
+        ["longitude", optionalScalarString(input.longitude)],
+        ["orderType", optionalScalarString(input.orderType)],
+        ["showType", optionalScalarString(input.showType)],
+        ["time", optionalScalarString(input.time)],
+      ],
+    });
+  },
+  get_store(input, context) {
+    const storeCode = requiredProviderString(input.storeCode, "storeCode");
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: `/stores/${encodePathSegment(storeCode)}`,
+    });
+  },
+  get_store_business(input, context) {
+    const beCode = requiredProviderString(input.beCode, "beCode");
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: `/stores/be/${encodePathSegment(beCode)}`,
+      query: [
+        ["date", optionalScalarString(input.date)],
+        ["isGroupMeal", optionalScalarString(input.isGroupMeal)],
+        ["time", optionalScalarString(input.time)],
+      ],
+    });
+  },
+  get_menu(input, context) {
+    return requestMcdonaldsCnJson(context, {
+      method: "POST",
+      path: "/products/menu",
+      body: {
+        date: optionalScalarString(input.date),
+        orderType: integer(input.orderType, "orderType", providerInputError),
+        beCode: optionalScalarString(input.beCode),
+        dayPartCode: integer(input.dayPartCode, "dayPartCode", providerInputError),
+        time: optionalScalarString(input.time),
+        isGroupMeal: optionalIntegerLike(input.isGroupMeal, "isGroupMeal", providerInputError),
+        channelCode: requiredProviderString(input.channelCode, "channelCode"),
+        storeCode: requiredProviderString(input.storeCode, "storeCode"),
+      },
+    });
+  },
+  get_product_detail(input, context) {
+    const code = requiredProviderString(input.code, "code");
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: `/products/detail/${encodePathSegment(code)}`,
+      query: [
+        ["beCode", optionalScalarString(input.beCode)],
+        ["cardId", optionalScalarString(input.cardId)],
+        ["channelCode", requiredProviderString(input.channelCode, "channelCode")],
+        ["date", optionalScalarString(input.date)],
+        ["daypartCode", requiredProviderString(input.daypartCode, "daypartCode")],
+        ["isGroupMeal", optionalScalarString(input.isGroupMeal)],
+        ["orderType", requiredProviderString(input.orderType, "orderType")],
+        ["storeCode", requiredProviderString(input.storeCode, "storeCode")],
+        ["time", optionalScalarString(input.time)],
+      ],
+    });
+  },
+  search_products(input, context) {
+    return requestMcdonaldsCnJson(context, {
+      method: "GET",
+      path: "/products/search",
+      query: [
+        ["beCode", optionalScalarString(input.beCode)],
+        ["date", optionalScalarString(input.date)],
+        ["daypartCode", requiredProviderString(input.daypartCode, "daypartCode")],
+        ["isGroupMeal", optionalScalarString(input.isGroupMeal)],
+        ["keyword", requiredProviderString(input.keyword, "keyword")],
+        ["orderType", requiredProviderString(input.orderType, "orderType")],
+        ["storeCode", requiredProviderString(input.storeCode, "storeCode")],
+        ["time", optionalScalarString(input.time)],
+      ],
+    });
+  },
+};
+
+export function createMcdonaldsCnContext(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): McdonaldsCnContext {
+  const environment = readEnvironment(values.environment);
+  return {
+    appId: requiredCredentialString(values.appId, "appId"),
+    merchantId: requiredCredentialString(values.merchantId, "merchantId"),
+    signingKey: requiredCredentialString(values.signingKey, "signingKey"),
+    environment,
+    baseUrl: environment === "uat" ? uatBaseUrl : prodBaseUrl,
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateMcdonaldsCnCredential(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createMcdonaldsCnContext(values, fetcher, signal);
+  await requestMcdonaldsCnJson(context, {
+    method: "GET",
+    path: "/cities/all",
+    query: [["getCurrent", "0"]],
+  });
+  return {
+    profile: {
+      accountId: `${context.environment}:${context.merchantId}:${context.appId}`,
+      displayName: `McDonald's China ${context.environment.toUpperCase()} merchant ${context.merchantId}`,
+    },
+    metadata: {
+      environment: context.environment,
+    },
+  };
+}
+
+async function requestMcdonaldsCnJson<T = unknown>(
+  context: McdonaldsCnContext,
+  input: McdonaldsCnRequestInput,
+): Promise<T> {
+  const query = definedQueryEntries(input.query ?? []);
+  const url = new URL(input.path, context.baseUrl);
+  for (const [key, value] of query) {
+    url.searchParams.set(key, value);
+  }
+
+  const body = input.method === "POST" ? JSON.stringify(compactJson(input.body ?? {})) : undefined;
+  const signBody = input.method === "POST" ? (body ?? "{}") : buildGetSignBody(input.path, query);
+  const timestamp = String(Date.now());
+  const headers = new Headers({
+    accept: "application/json",
+    AppId: context.appId,
+    MerchantId: context.merchantId,
+    Timestamp: timestamp,
+    Sign: createMcdonaldsCnSign(context, signBody, timestamp),
+    Version: apiVersion,
+    "user-agent": providerUserAgent,
+  });
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+  }
+
+  let response: Response;
+  try {
+    response = await context.fetcher(url, {
+      method: input.method,
+      headers,
+      body,
+      signal: context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `McDonald's China request failed: ${error.message}` : "McDonald's China request failed",
+    );
+  }
+
+  const payload = await readProviderJson<T>(response, "McDonald's China");
+  throwIfMcdonaldsCnError(payload);
+  return payload;
+}
+
+function createMcdonaldsCnSign(context: McdonaldsCnContext, body: string, timestamp: string): string {
+  const signInput = `AppId=${context.appId}&Body=${body}&MerchantId=${context.merchantId}&Timestamp=${timestamp}&key=${context.signingKey}`;
+  return createHash("md5").update(signInput, "utf8").digest("hex").toUpperCase();
+}
+
+function buildGetSignBody(path: string, query: Array<readonly [string, string]>): string {
+  if (query.length === 0) {
+    return path;
+  }
+  return `${path}?${query.map(([key, value]) => `${key}=${value}`).join("&")}`;
+}
+
+function definedQueryEntries(query: QueryEntry[]): Array<readonly [string, string]> {
+  const entries: Array<readonly [string, string]> = [];
+  for (const [key, value] of query) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    entries.push([key, String(value)]);
+  }
+  return entries;
+}
+
+function throwIfMcdonaldsCnError(payload: unknown): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+  const envelope = payload as McdonaldsCnEnvelope;
+  if (envelope.success !== false) {
+    return;
+  }
+  throw new ProviderRequestError(400, readMcdonaldsCnErrorMessage(envelope), payload);
+}
+
+function readMcdonaldsCnErrorMessage(envelope: McdonaldsCnEnvelope): string {
+  return (
+    optionalString(envelope.message) ??
+    optionalString(envelope.msg) ??
+    (envelope.code === undefined ? undefined : `McDonald's China returned code ${String(envelope.code)}`) ??
+    "McDonald's China request failed"
+  );
+}
+
+function readEnvironment(value: unknown): McdonaldsCnEnvironment {
+  const environment = optionalString(value)?.toLowerCase() ?? "prod";
+  if (environment === "prod" || environment === "uat") {
+    return environment;
+  }
+  throw new ProviderRequestError(400, "environment must be prod or uat");
+}
+
+function requiredProviderString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, providerInputError);
+}
+
+function requiredCredentialString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(401, message));
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}


### PR DESCRIPTION
Summary:
- Add the McDonald's China provider definition, action schemas, and runtime helpers.
- Wire executor handlers for the new provider actions.

Tests:
- npm run fix-check