### PR TITLE
docs: update action count to 10,000+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </div>
 
 OpenConnector is an open-source connector gateway for AI agents and an alternative to Composio.
-Connect user app accounts once, then expose a shared catalog of 1,000+ providers and 9,400+
+Connect user app accounts once, then expose a shared catalog of 1,000+ providers and 10,000+
 prebuilt Actions to agents and applications.
 
 Use the [Connector SDK](https://github.com/oomol-lab/connector-sdk) from app code,

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -17,7 +17,7 @@
 
 OpenConnector est un connector gateway open source pour AI agents, et une alternative à Composio.
 Connectez les comptes d'apps utilisateur une fois, puis exposez un catalog partagé de 1,000+
-providers et 9 400+ Actions prêtes à l'emploi aux agents et applications.
+providers et 10 000+ Actions prêtes à l'emploi aux agents et applications.
 
 Utilisez le [Connector SDK](https://github.com/oomol-lab/connector-sdk) dans le code applicatif,
 [oo CLI](https://github.com/oomol-lab/oo-cli) comme relais pour les agents locaux, MCP pour les

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -16,7 +16,7 @@
 </div>
 
 OpenConnector は AI Agent 向けのオープンソース connector gateway であり、Composio の代替です。
-ユーザーのアプリアカウントを一度接続すれば、1,000+ の provider と 9,400+ の事前定義済み Action を含む共有
+ユーザーのアプリアカウントを一度接続すれば、1,000+ の provider と 10,000+ の事前定義済み Action を含む共有
 catalog を Agent とアプリケーションに公開できます。
 
 アプリコードには [Connector SDK](https://github.com/oomol-lab/connector-sdk)、ローカル

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -17,7 +17,7 @@
 
 OpenConnector — open-source connector gateway для AI agents и альтернатива Composio. Подключите
 пользовательские аккаунты приложений один раз, а затем откройте общий catalog из 1,000+ providers и
-9 400+ готовых Actions для агентов и приложений.
+10 000+ готовых Actions для агентов и приложений.
 
 В application code используйте [Connector SDK](https://github.com/oomol-lab/connector-sdk), для
 local-agent relay — [oo CLI](https://github.com/oomol-lab/oo-cli), для agent hosts — MCP, для

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -16,7 +16,7 @@
 </div>
 
 OpenConnector 是面向 AI Agent 的开源 connector gateway，也是 Composio 的开源替代方案。
-连接一次用户应用账号，就可以把包含 1,000+ 个 provider 和 9,400+ 个预置 Action 的共享 catalog 暴露给
+连接一次用户应用账号，就可以把包含 1,000+ 个 provider 和 10,000+ 个预置 Action 的共享 catalog 暴露给
 Agent 和应用。
 
 应用代码使用 [Connector SDK](https://github.com/oomol-lab/connector-sdk)，本地 Agent 使用


### PR DESCRIPTION
## Summary

The project README stated that the shared catalog includes 9,400+ prebuilt Actions, although the catalog now exceeds 10,000 Actions. This underreported the current integration coverage to users reading the repository landing page and localized documentation.

This change updates the advertised count to 10,000+ in the English, Simplified Chinese, French, Japanese, and Russian README variants. The wording and surrounding localized content remain unchanged.

## Validation

- Confirmed the prior 9,400+ Action wording was removed from all README language variants.
- Ran `git diff --check`.
- Ran `npm ci && npm run fix-check` successfully.
