### PR TITLE
feat: add okta provider

### DIFF
--- a/src/providers/okta/actions.ts
+++ b/src/providers/okta/actions.ts
@@ -1,0 +1,343 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "okta";
+
+const trimmedString = (description: string) => s.string({ description, minLength: 1, pattern: "\\S" });
+
+const listLimit = s.integer({
+  description: "The maximum number of records to return. Okta supports values from 1 through 200.",
+  minimum: 1,
+  maximum: 200,
+  default: 100,
+});
+
+const afterCursor = trimmedString("The Okta pagination cursor from a previous response.");
+
+const oktaRawObject = (description: string) => s.looseObject(description);
+
+const oktaUserSchema = s.object("One normalized Okta user.", {
+  id: s.string("The Okta user ID."),
+  status: s.nullableString("The Okta user status, such as ACTIVE or SUSPENDED."),
+  created: s.nullableString("When Okta created the user."),
+  activated: s.nullableString("When Okta activated the user, if returned."),
+  statusChanged: s.nullableString("When the user's status last changed, if returned."),
+  lastLogin: s.nullableString("When the user last signed in, if returned."),
+  lastUpdated: s.nullableString("When the user was last updated, if returned."),
+  passwordChanged: s.nullableString("When the user's password last changed, if returned."),
+  profile: oktaRawObject("The Okta user profile object."),
+  raw: oktaRawObject("The raw Okta user object."),
+});
+
+const oktaGroupSchema = s.object("One normalized Okta group.", {
+  id: s.string("The Okta group ID."),
+  type: s.nullableString("The Okta group type, such as OKTA_GROUP."),
+  created: s.nullableString("When Okta created the group."),
+  lastUpdated: s.nullableString("When the group was last updated, if returned."),
+  lastMembershipUpdated: s.nullableString("When group membership last changed, if returned."),
+  objectClass: s.array("The Okta group object classes.", s.string("One object class value.")),
+  profile: oktaRawObject("The Okta group profile object."),
+  raw: oktaRawObject("The raw Okta group object."),
+});
+
+const usersPageSchema = s.object("A page of Okta users.", {
+  users: s.array("The returned Okta users.", oktaUserSchema),
+  nextAfter: s.nullableString("The next Okta `after` cursor, or null when there is no next page."),
+  raw: s.array("The raw Okta user objects.", oktaRawObject("One raw Okta user object.")),
+});
+
+const groupsPageSchema = s.object("A page of Okta groups.", {
+  groups: s.array("The returned Okta groups.", oktaGroupSchema),
+  nextAfter: s.nullableString("The next Okta `after` cursor, or null when there is no next page."),
+  raw: s.array("The raw Okta group objects.", oktaRawObject("One raw Okta group object.")),
+});
+
+const userIdInput = {
+  userId: trimmedString("The Okta user ID, login, or login shortname accepted by the Users API."),
+};
+
+const groupIdInput = {
+  groupId: trimmedString("The Okta group ID."),
+};
+
+const userWriteBody = {
+  profile: oktaRawObject(
+    "Okta user profile fields. Include required profile attributes such as login, email, firstName, and lastName when creating a user.",
+  ),
+  credentials: oktaRawObject("Optional Okta user credentials object, such as password or recovery question fields."),
+};
+
+const userOutputSchema = s.object("The normalized Okta user response.", {
+  user: oktaUserSchema,
+  raw: oktaRawObject("The raw Okta user object."),
+});
+
+const groupOutputSchema = s.object("The normalized Okta group response.", {
+  group: oktaGroupSchema,
+  raw: oktaRawObject("The raw Okta group object."),
+});
+
+const listUsersAction = defineProviderAction(service, {
+  name: "list_users",
+  description: "List Okta users with optional search, filter, and pagination controls.",
+  inputSchema: s.object(
+    "The input payload for listing Okta users.",
+    {
+      limit: listLimit,
+      after: afterCursor,
+      search: trimmedString('An Okta Users API search expression, such as `profile.email eq "a@example.com"`.'),
+      filter: trimmedString("An Okta Users API filter expression."),
+      q: trimmedString("A query string for matching user login, first name, last name, or email."),
+    },
+    { optional: ["limit", "after", "search", "filter", "q"] },
+  ),
+  outputSchema: usersPageSchema,
+});
+
+const getUserAction = defineProviderAction(service, {
+  name: "get_user",
+  description: "Get one Okta user by ID, login, or login shortname.",
+  inputSchema: s.object("The input payload for getting an Okta user.", userIdInput, { required: ["userId"] }),
+  outputSchema: userOutputSchema,
+});
+
+const createUserAction = defineProviderAction(service, {
+  name: "create_user",
+  description: "Create an Okta user with profile fields, optional credentials, and optional initial groups.",
+  inputSchema: s.object(
+    "The input payload for creating an Okta user.",
+    {
+      ...userWriteBody,
+      groupIds: s.stringArray("Okta group IDs to assign during user creation."),
+      activate: s.boolean({
+        description: "Whether Okta should activate the user after creation.",
+        default: true,
+      }),
+    },
+    { required: ["profile"], optional: ["credentials", "groupIds", "activate"] },
+  ),
+  outputSchema: userOutputSchema,
+});
+
+const updateUserAction = defineProviderAction(service, {
+  name: "update_user",
+  description: "Update an Okta user's profile and optional credential fields.",
+  inputSchema: s.object(
+    "The input payload for updating an Okta user.",
+    {
+      ...userIdInput,
+      ...userWriteBody,
+    },
+    { required: ["userId"], optional: ["profile", "credentials"] },
+  ),
+  outputSchema: userOutputSchema,
+});
+
+const deleteUserAction = defineProviderAction(service, {
+  name: "delete_user",
+  description: "Delete an Okta user. Okta may require the user to be deactivated before permanent deletion.",
+  inputSchema: s.object(
+    "The input payload for deleting an Okta user.",
+    {
+      ...userIdInput,
+      sendEmail: s.boolean("Whether Okta should send a deactivation email when applicable."),
+    },
+    { optional: ["sendEmail"] },
+  ),
+  outputSchema: s.object("The normalized Okta delete user response.", {
+    userId: s.string("The Okta user ID or login passed to the action."),
+    deleted: s.boolean("Whether the delete request completed successfully."),
+  }),
+});
+
+const lifecycleOperationSchema = s.stringEnum("The Okta user lifecycle operation to perform.", [
+  "activate",
+  "reactivate",
+  "deactivate",
+  "suspend",
+  "unsuspend",
+  "unlock",
+  "expire_password",
+]);
+
+const lifecycleUserAction = defineProviderAction(service, {
+  name: "lifecycle_user",
+  description:
+    "Run a supported Okta user lifecycle operation: activate, reactivate, deactivate, suspend, unsuspend, unlock, or expire password.",
+  inputSchema: s.object(
+    "The input payload for an Okta user lifecycle operation.",
+    {
+      ...userIdInput,
+      operation: lifecycleOperationSchema,
+      sendEmail: s.boolean(
+        "Whether Okta should send email for lifecycle operations that support it, such as activate or deactivate.",
+      ),
+      tempPassword: s.boolean(
+        "For expire_password, whether Okta should return a temporary password when the org policy allows it.",
+      ),
+    },
+    { required: ["userId", "operation"], optional: ["sendEmail", "tempPassword"] },
+  ),
+  outputSchema: s.object("The normalized Okta lifecycle response.", {
+    userId: s.string("The Okta user ID or login passed to the action."),
+    operation: lifecycleOperationSchema,
+    result: s.nullable(oktaRawObject("The Okta lifecycle response body, or null for empty responses.")),
+    raw: s.nullable(oktaRawObject("The raw Okta lifecycle response body, or null for empty responses.")),
+  }),
+});
+
+const listGroupsAction = defineProviderAction(service, {
+  name: "list_groups",
+  description: "List Okta groups with optional query, search, filter, and pagination controls.",
+  inputSchema: s.object(
+    "The input payload for listing Okta groups.",
+    {
+      limit: listLimit,
+      after: afterCursor,
+      search: trimmedString("An Okta Groups API search expression."),
+      filter: trimmedString("An Okta Groups API filter expression."),
+      q: trimmedString("A query string for matching group names."),
+    },
+    { optional: ["limit", "after", "search", "filter", "q"] },
+  ),
+  outputSchema: groupsPageSchema,
+});
+
+const getGroupAction = defineProviderAction(service, {
+  name: "get_group",
+  description: "Get one Okta group by ID.",
+  inputSchema: s.object("The input payload for getting an Okta group.", groupIdInput, { required: ["groupId"] }),
+  outputSchema: groupOutputSchema,
+});
+
+const groupProfileSchema = s.object(
+  "The Okta group profile fields.",
+  {
+    name: trimmedString("The Okta group name."),
+    description: s.string("The Okta group description."),
+  },
+  { optional: ["description"] },
+);
+
+const createGroupAction = defineProviderAction(service, {
+  name: "create_group",
+  description: "Create an Okta group with a profile name and optional description.",
+  inputSchema: s.object(
+    "The input payload for creating an Okta group.",
+    {
+      profile: groupProfileSchema,
+    },
+    { required: ["profile"] },
+  ),
+  outputSchema: groupOutputSchema,
+});
+
+const updateGroupAction = defineProviderAction(service, {
+  name: "update_group",
+  description: "Replace an Okta group's profile name and optional description.",
+  inputSchema: s.object(
+    "The input payload for updating an Okta group.",
+    {
+      ...groupIdInput,
+      profile: groupProfileSchema,
+    },
+    { required: ["groupId", "profile"] },
+  ),
+  outputSchema: groupOutputSchema,
+});
+
+const deleteGroupAction = defineProviderAction(service, {
+  name: "delete_group",
+  description: "Delete an Okta group by ID.",
+  inputSchema: s.object("The input payload for deleting an Okta group.", groupIdInput, { required: ["groupId"] }),
+  outputSchema: s.object("The normalized Okta delete group response.", {
+    groupId: s.string("The Okta group ID passed to the action."),
+    deleted: s.boolean("Whether the delete request completed successfully."),
+  }),
+});
+
+const listGroupUsersAction = defineProviderAction(service, {
+  name: "list_group_users",
+  description: "List users that are members of an Okta group.",
+  inputSchema: s.object(
+    "The input payload for listing Okta group members.",
+    {
+      ...groupIdInput,
+      limit: listLimit,
+      after: afterCursor,
+    },
+    { required: ["groupId"], optional: ["limit", "after"] },
+  ),
+  outputSchema: usersPageSchema,
+});
+
+const addUserToGroupAction = defineProviderAction(service, {
+  name: "add_user_to_group",
+  description: "Add an Okta user to an Okta group.",
+  inputSchema: s.object(
+    "The input payload for adding an Okta user to a group.",
+    {
+      ...groupIdInput,
+      ...userIdInput,
+    },
+    { required: ["groupId", "userId"] },
+  ),
+  outputSchema: s.object("The normalized Okta add group member response.", {
+    groupId: s.string("The Okta group ID passed to the action."),
+    userId: s.string("The Okta user ID passed to the action."),
+    added: s.boolean("Whether the membership request completed successfully."),
+  }),
+});
+
+const removeUserFromGroupAction = defineProviderAction(service, {
+  name: "remove_user_from_group",
+  description: "Remove an Okta user from an Okta group.",
+  inputSchema: s.object(
+    "The input payload for removing an Okta user from a group.",
+    {
+      ...groupIdInput,
+      ...userIdInput,
+    },
+    { required: ["groupId", "userId"] },
+  ),
+  outputSchema: s.object("The normalized Okta remove group member response.", {
+    groupId: s.string("The Okta group ID passed to the action."),
+    userId: s.string("The Okta user ID passed to the action."),
+    removed: s.boolean("Whether the membership removal request completed successfully."),
+  }),
+});
+
+export type OktaActionName =
+  | "list_users"
+  | "get_user"
+  | "create_user"
+  | "update_user"
+  | "delete_user"
+  | "lifecycle_user"
+  | "list_groups"
+  | "get_group"
+  | "create_group"
+  | "update_group"
+  | "delete_group"
+  | "list_group_users"
+  | "add_user_to_group"
+  | "remove_user_from_group";
+
+export const oktaActions: ProviderActionDefinition<OktaActionName>[] = [
+  listUsersAction,
+  getUserAction,
+  createUserAction,
+  updateUserAction,
+  deleteUserAction,
+  lifecycleUserAction,
+  listGroupsAction,
+  getGroupAction,
+  createGroupAction,
+  updateGroupAction,
+  deleteGroupAction,
+  listGroupUsersAction,
+  addUserToGroupAction,
+  removeUserFromGroupAction,
+];

--- a/src/providers/okta/definition.ts
+++ b/src/providers/okta/definition.ts
@@ -1,0 +1,48 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { oktaActions } from "./actions.ts";
+
+const service = "okta";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Okta",
+  description: "Manage Okta users, groups, user lifecycle operations, and group memberships.",
+  categories: ["Security"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "apiToken",
+          label: "API Token",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "OKTA_API_TOKEN",
+          description:
+            "Okta API token sent with the Authorization: SSWS header. Create tokens from Okta Admin Console security settings: https://developer.okta.com/docs/guides/create-an-api-token/main/.",
+        },
+        {
+          key: "orgUrl",
+          label: "Org URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://example.okta.com",
+          description:
+            "The HTTPS base URL for your Okta organization, such as https://example.okta.com or https://example.okta-emea.com.",
+        },
+      ],
+      testAction: {
+        actionName: "list_users",
+        input: {
+          limit: 1,
+        },
+      },
+    },
+  ],
+  homepageUrl: "https://www.okta.com",
+  actions: oktaActions,
+};

--- a/src/providers/okta/executors.ts
+++ b/src/providers/okta/executors.ts
@@ -1,0 +1,29 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { OktaActionContext, OktaActionName } from "./runtime.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createOktaContext, oktaActionHandlers, validateOktaCredential } from "./runtime.ts";
+
+const service = "okta";
+
+export const executors: ProviderExecutors = defineProviderExecutors<OktaActionContext>({
+  service,
+  handlers: oktaActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<OktaActionContext> {
+    const credential = await requireCustomCredential(context, service);
+    return createOktaContext(credential.values, fetcher, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateOktaCredential(input.values, fetcher, signal);
+  },
+};
+
+export type { OktaActionName };

--- a/src/providers/okta/runtime.test.ts
+++ b/src/providers/okta/runtime.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { oktaActionHandlers, normalizeOktaOrgUrl } from "./runtime.ts";
+
+describe("Okta runtime", () => {
+  it("normalizes Okta org URLs to a safe HTTPS origin", () => {
+    expect(normalizeOktaOrgUrl("https://example.okta.com/admin/dashboard")).toBe("https://example.okta.com");
+    expect(() => normalizeOktaOrgUrl("http://example.okta.com")).toThrow("orgUrl must use https");
+    expect(() => normalizeOktaOrgUrl("https://token@example.okta.com")).toThrow("orgUrl must not include credentials");
+    expect(() => normalizeOktaOrgUrl("https://localhost")).toThrow("orgUrl must not target local hosts");
+  });
+
+  it("lists users with SSWS authorization and normalized pagination", async () => {
+    const fetcher = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+        new Response(
+          JSON.stringify([
+            {
+              id: "00u123",
+              status: "ACTIVE",
+              created: "2026-01-01T00:00:00.000Z",
+              profile: {
+                login: "user@example.com",
+                email: "user@example.com",
+              },
+            },
+          ]),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              link: '<https://example.okta.com/api/v1/users?after=cursor-2>; rel="next"',
+            },
+          },
+        ),
+    );
+
+    const result = await oktaActionHandlers.list_users(
+      {
+        limit: 2,
+        search: 'profile.email eq "user@example.com"',
+      },
+      {
+        apiToken: "test-token",
+        orgUrl: "https://example.okta.com",
+        fetcher,
+      },
+    );
+
+    expect(result).toEqual({
+      users: [
+        {
+          id: "00u123",
+          status: "ACTIVE",
+          created: "2026-01-01T00:00:00.000Z",
+          activated: null,
+          statusChanged: null,
+          lastLogin: null,
+          lastUpdated: null,
+          passwordChanged: null,
+          profile: {
+            login: "user@example.com",
+            email: "user@example.com",
+          },
+          raw: {
+            id: "00u123",
+            status: "ACTIVE",
+            created: "2026-01-01T00:00:00.000Z",
+            profile: {
+              login: "user@example.com",
+              email: "user@example.com",
+            },
+          },
+        },
+      ],
+      nextAfter: "cursor-2",
+      raw: [
+        {
+          id: "00u123",
+          status: "ACTIVE",
+          created: "2026-01-01T00:00:00.000Z",
+          profile: {
+            login: "user@example.com",
+            email: "user@example.com",
+          },
+        },
+      ],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      new URL("https://example.okta.com/api/v1/users?limit=2&search=profile.email+eq+%22user%40example.com%22"),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          accept: "application/json",
+          authorization: "SSWS test-token",
+          "content-type": "application/json",
+          "user-agent": "oomol-connect/0.1",
+        }),
+      }),
+    );
+  });
+});

--- a/src/providers/okta/runtime.ts
+++ b/src/providers/okta/runtime.ts
@@ -1,0 +1,658 @@
+import type { QueryValue } from "../../core/request.ts";
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { OktaActionName } from "./actions.ts";
+
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl, compactJson, queryParams } from "../../core/request.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+type OktaActionHandler = (input: Record<string, unknown>, context: OktaActionContext) => Promise<unknown>;
+type OktaLifecycleOperation =
+  | "activate"
+  | "reactivate"
+  | "deactivate"
+  | "suspend"
+  | "unsuspend"
+  | "unlock"
+  | "expire_password";
+type OktaPhase = "validate" | "execute";
+
+interface OktaRequestInput {
+  context: OktaActionContext;
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  phase: OktaPhase;
+  query?: Record<string, QueryValue>;
+  body?: unknown;
+}
+
+interface OktaResponse {
+  data: unknown;
+  headers: Headers;
+  status: number;
+}
+
+interface NormalizedOktaUser {
+  id: string;
+  status: string | null;
+  created: string | null;
+  activated: string | null;
+  statusChanged: string | null;
+  lastLogin: string | null;
+  lastUpdated: string | null;
+  passwordChanged: string | null;
+  profile: Record<string, unknown>;
+  raw: Record<string, unknown>;
+}
+
+interface NormalizedOktaGroup {
+  id: string;
+  type: string | null;
+  created: string | null;
+  lastUpdated: string | null;
+  lastMembershipUpdated: string | null;
+  objectClass: string[];
+  profile: Record<string, unknown>;
+  raw: Record<string, unknown>;
+}
+
+export interface OktaActionContext {
+  orgUrl: string;
+  apiToken: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+const defaultListLimit = 100;
+const lifecyclePaths: Record<OktaLifecycleOperation, string> = {
+  activate: "activate",
+  reactivate: "reactivate",
+  deactivate: "deactivate",
+  suspend: "suspend",
+  unsuspend: "unsuspend",
+  unlock: "unlock",
+  expire_password: "expire_password",
+};
+
+export const oktaActionHandlers: Record<OktaActionName, OktaActionHandler> = {
+  list_users(input, context) {
+    return listUsers(input, context);
+  },
+  get_user(input, context) {
+    return getUser(input, context);
+  },
+  create_user(input, context) {
+    return createUser(input, context);
+  },
+  update_user(input, context) {
+    return updateUser(input, context);
+  },
+  delete_user(input, context) {
+    return deleteUser(input, context);
+  },
+  lifecycle_user(input, context) {
+    return lifecycleUser(input, context);
+  },
+  list_groups(input, context) {
+    return listGroups(input, context);
+  },
+  get_group(input, context) {
+    return getGroup(input, context);
+  },
+  create_group(input, context) {
+    return createGroup(input, context);
+  },
+  update_group(input, context) {
+    return updateGroup(input, context);
+  },
+  delete_group(input, context) {
+    return deleteGroup(input, context);
+  },
+  list_group_users(input, context) {
+    return listGroupUsers(input, context);
+  },
+  add_user_to_group(input, context) {
+    return addUserToGroup(input, context);
+  },
+  remove_user_from_group(input, context) {
+    return removeUserFromGroup(input, context);
+  },
+};
+
+export function createOktaContext(
+  input: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): OktaActionContext {
+  return {
+    orgUrl: normalizeOktaOrgUrl(input.orgUrl),
+    apiToken: requireCredentialString(input.apiToken, "apiToken"),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateOktaCredential(
+  input: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createOktaContext(input, fetcher, signal);
+  await requestOkta({
+    context,
+    method: "GET",
+    path: "/api/v1/users",
+    phase: "validate",
+    query: { limit: 1 },
+  });
+
+  return {
+    profile: {
+      accountId: context.orgUrl,
+      displayName: new URL(context.orgUrl).host,
+    },
+    grantedScopes: [],
+    metadata: {
+      orgUrl: context.orgUrl,
+    },
+  };
+}
+
+export function normalizeOktaOrgUrl(value: unknown): string {
+  const raw = requireCredentialString(value, "orgUrl");
+  const withProtocol = raw.includes("://") ? raw : `https://${raw}`;
+  const url = assertPublicHttpUrl(withProtocol, {
+    fieldName: "orgUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+  });
+  if (url.protocol !== "https:") {
+    throw new ProviderRequestError(400, "orgUrl must use https");
+  }
+  if (url.username || url.password) {
+    throw new ProviderRequestError(400, "orgUrl must not include credentials");
+  }
+  return url.origin;
+}
+
+async function listUsers(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const response = await requestOkta({
+    context,
+    method: "GET",
+    path: "/api/v1/users",
+    phase: "execute",
+    query: readListQuery(input),
+  });
+  const users = readResponseObjectArray(response.data, "users").map(normalizeOktaUser);
+  return {
+    users,
+    nextAfter: readNextAfter(response.headers),
+    raw: response.data,
+  };
+}
+
+async function getUser(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const userId = requireInputString(input.userId, "userId");
+  const response = await requestOkta({
+    context,
+    method: "GET",
+    path: `/api/v1/users/${encodeURIComponent(userId)}`,
+    phase: "execute",
+  });
+  const raw = readResponseObject(response.data, "user");
+  return {
+    user: normalizeOktaUser(raw),
+    raw,
+  };
+}
+
+async function createUser(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const response = await requestOkta({
+    context,
+    method: "POST",
+    path: "/api/v1/users",
+    phase: "execute",
+    query: {
+      activate: optionalBoolean(input.activate),
+    },
+    body: compactBody({
+      profile: readInputRecord(input.profile, "profile"),
+      credentials: readOptionalInputRecord(input.credentials, "credentials"),
+      groupIds: readOptionalStringArray(input.groupIds, "groupIds"),
+    }),
+  });
+  const raw = readResponseObject(response.data, "user");
+  return {
+    user: normalizeOktaUser(raw),
+    raw,
+  };
+}
+
+async function updateUser(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const userId = requireInputString(input.userId, "userId");
+  const body = compactBody({
+    profile: readOptionalInputRecord(input.profile, "profile"),
+    credentials: readOptionalInputRecord(input.credentials, "credentials"),
+  });
+  if (Object.keys(body).length === 0) {
+    throw new ProviderRequestError(400, "profile or credentials is required");
+  }
+
+  const response = await requestOkta({
+    context,
+    method: "POST",
+    path: `/api/v1/users/${encodeURIComponent(userId)}`,
+    phase: "execute",
+    body,
+  });
+  const raw = readResponseObject(response.data, "user");
+  return {
+    user: normalizeOktaUser(raw),
+    raw,
+  };
+}
+
+async function deleteUser(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const userId = requireInputString(input.userId, "userId");
+  await requestOkta({
+    context,
+    method: "DELETE",
+    path: `/api/v1/users/${encodeURIComponent(userId)}`,
+    phase: "execute",
+    query: {
+      sendEmail: optionalBoolean(input.sendEmail),
+    },
+  });
+  return {
+    userId,
+    deleted: true,
+  };
+}
+
+async function lifecycleUser(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const userId = requireInputString(input.userId, "userId");
+  const operation = readLifecycleOperation(input.operation);
+  const response = await requestOkta({
+    context,
+    method: "POST",
+    path: `/api/v1/users/${encodeURIComponent(userId)}/lifecycle/${lifecyclePaths[operation]}`,
+    phase: "execute",
+    query: lifecycleQuery(operation, input),
+  });
+  const result = response.data == null ? null : readResponseObject(response.data, "lifecycle result");
+  return {
+    userId,
+    operation,
+    result,
+    raw: result,
+  };
+}
+
+async function listGroups(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const response = await requestOkta({
+    context,
+    method: "GET",
+    path: "/api/v1/groups",
+    phase: "execute",
+    query: readListQuery(input),
+  });
+  const groups = readResponseObjectArray(response.data, "groups").map(normalizeOktaGroup);
+  return {
+    groups,
+    nextAfter: readNextAfter(response.headers),
+    raw: response.data,
+  };
+}
+
+async function getGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  const response = await requestOkta({
+    context,
+    method: "GET",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}`,
+    phase: "execute",
+  });
+  const raw = readResponseObject(response.data, "group");
+  return {
+    group: normalizeOktaGroup(raw),
+    raw,
+  };
+}
+
+async function createGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const response = await requestOkta({
+    context,
+    method: "POST",
+    path: "/api/v1/groups",
+    phase: "execute",
+    body: {
+      profile: readGroupProfile(input.profile),
+    },
+  });
+  const raw = readResponseObject(response.data, "group");
+  return {
+    group: normalizeOktaGroup(raw),
+    raw,
+  };
+}
+
+async function updateGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  const response = await requestOkta({
+    context,
+    method: "PUT",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}`,
+    phase: "execute",
+    body: {
+      profile: readGroupProfile(input.profile),
+    },
+  });
+  const raw = readResponseObject(response.data, "group");
+  return {
+    group: normalizeOktaGroup(raw),
+    raw,
+  };
+}
+
+async function deleteGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  await requestOkta({
+    context,
+    method: "DELETE",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}`,
+    phase: "execute",
+  });
+  return {
+    groupId,
+    deleted: true,
+  };
+}
+
+async function listGroupUsers(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  const response = await requestOkta({
+    context,
+    method: "GET",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}/users`,
+    phase: "execute",
+    query: {
+      limit: readLimit(input.limit),
+      after: optionalString(input.after),
+    },
+  });
+  const users = readResponseObjectArray(response.data, "users").map(normalizeOktaUser);
+  return {
+    users,
+    nextAfter: readNextAfter(response.headers),
+    raw: response.data,
+  };
+}
+
+async function addUserToGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  const userId = requireInputString(input.userId, "userId");
+  await requestOkta({
+    context,
+    method: "PUT",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(userId)}`,
+    phase: "execute",
+  });
+  return {
+    groupId,
+    userId,
+    added: true,
+  };
+}
+
+async function removeUserFromGroup(input: Record<string, unknown>, context: OktaActionContext): Promise<unknown> {
+  const groupId = requireInputString(input.groupId, "groupId");
+  const userId = requireInputString(input.userId, "userId");
+  await requestOkta({
+    context,
+    method: "DELETE",
+    path: `/api/v1/groups/${encodeURIComponent(groupId)}/users/${encodeURIComponent(userId)}`,
+    phase: "execute",
+  });
+  return {
+    groupId,
+    userId,
+    removed: true,
+  };
+}
+
+async function requestOkta(input: OktaRequestInput): Promise<OktaResponse> {
+  const url = new URL(input.path, `${input.context.orgUrl}/`);
+  for (const [key, value] of Object.entries(queryParams(input.query ?? {}))) {
+    url.searchParams.set(key, value);
+  }
+
+  let response: Response;
+  try {
+    response = await input.context.fetcher(url, {
+      method: input.method,
+      headers: {
+        accept: "application/json",
+        authorization: `SSWS ${input.context.apiToken}`,
+        "content-type": "application/json",
+        "user-agent": providerUserAgent,
+      },
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal: input.context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error && error.message ? `Okta request failed: ${error.message}` : "Okta request failed",
+    );
+  }
+
+  const text = await response.text().catch(() => "");
+  if (!response.ok) {
+    throw createOktaError(response.status, text, input.phase);
+  }
+  if (response.status === 204 || text.trim() === "") {
+    return {
+      data: null,
+      headers: response.headers,
+      status: response.status,
+    };
+  }
+
+  try {
+    return {
+      data: JSON.parse(text) as unknown,
+      headers: response.headers,
+      status: response.status,
+    };
+  } catch {
+    throw new ProviderRequestError(502, "Okta returned invalid JSON");
+  }
+}
+
+function readListQuery(input: Record<string, unknown>): Record<string, QueryValue> {
+  return {
+    limit: readLimit(input.limit),
+    after: optionalString(input.after),
+    search: optionalString(input.search),
+    filter: optionalString(input.filter),
+    q: optionalString(input.q),
+  };
+}
+
+function readLimit(value: unknown): number {
+  const limit = optionalInteger(value) ?? defaultListLimit;
+  if (limit < 1 || limit > 200) {
+    throw new ProviderRequestError(400, "limit must be between 1 and 200");
+  }
+  return limit;
+}
+
+function lifecycleQuery(operation: OktaLifecycleOperation, input: Record<string, unknown>): Record<string, QueryValue> {
+  switch (operation) {
+    case "activate":
+    case "reactivate":
+    case "deactivate":
+      return {
+        sendEmail: optionalBoolean(input.sendEmail),
+      };
+    case "expire_password":
+      return {
+        tempPassword: optionalBoolean(input.tempPassword),
+      };
+    case "suspend":
+    case "unsuspend":
+    case "unlock":
+      return {};
+  }
+}
+
+function readLifecycleOperation(value: unknown): OktaLifecycleOperation {
+  const operation = requireInputString(value, "operation");
+  if (operation in lifecyclePaths) {
+    return operation as OktaLifecycleOperation;
+  }
+  throw new ProviderRequestError(400, "operation is not supported");
+}
+
+function normalizeOktaUser(raw: Record<string, unknown>): NormalizedOktaUser {
+  return {
+    id: requireResponseString(raw.id, "user.id"),
+    status: optionalString(raw.status) ?? null,
+    created: optionalString(raw.created) ?? null,
+    activated: optionalString(raw.activated) ?? null,
+    statusChanged: optionalString(raw.statusChanged) ?? null,
+    lastLogin: optionalString(raw.lastLogin) ?? null,
+    lastUpdated: optionalString(raw.lastUpdated) ?? null,
+    passwordChanged: optionalString(raw.passwordChanged) ?? null,
+    profile: optionalRecord(raw.profile) ?? {},
+    raw,
+  };
+}
+
+function normalizeOktaGroup(raw: Record<string, unknown>): NormalizedOktaGroup {
+  return {
+    id: requireResponseString(raw.id, "group.id"),
+    type: optionalString(raw.type) ?? null,
+    created: optionalString(raw.created) ?? null,
+    lastUpdated: optionalString(raw.lastUpdated) ?? null,
+    lastMembershipUpdated: optionalString(raw.lastMembershipUpdated) ?? null,
+    objectClass: readStringValues(raw.objectClass),
+    profile: optionalRecord(raw.profile) ?? {},
+    raw,
+  };
+}
+
+function readGroupProfile(value: unknown): Record<string, unknown> {
+  const profile = readInputRecord(value, "profile");
+  const name = requireInputString(profile.name, "profile.name");
+  return compactBody({
+    name,
+    description: optionalString(profile.description),
+  });
+}
+
+function compactBody(input: Record<string, unknown>): Record<string, unknown> {
+  return compactJson(input) as Record<string, unknown>;
+}
+
+function readOptionalStringArray(value: unknown, fieldName: string): string[] | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(400, `${fieldName} must be a string array`);
+  }
+  return value.map((item, index) => requireInputString(item, `${fieldName}[${index}]`));
+}
+
+function readStringValues(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => optionalString(item)).filter((item): item is string => Boolean(item));
+}
+
+function readInputRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  return requiredRecord(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function readOptionalInputRecord(value: unknown, fieldName: string): Record<string, unknown> | undefined {
+  return value == null ? undefined : readInputRecord(value, fieldName);
+}
+
+function readResponseObject(value: unknown, fieldName: string): Record<string, unknown> {
+  return requiredRecord(value, fieldName, () => new ProviderRequestError(502, `Okta returned invalid ${fieldName}`));
+}
+
+function readResponseObjectArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, `Okta returned invalid ${fieldName}`);
+  }
+  return value.map((item, index) => readResponseObject(item, `${fieldName}[${index}]`));
+}
+
+function readNextAfter(headers: Headers): string | null {
+  const link = headers.get("link");
+  if (!link) {
+    return null;
+  }
+  for (const part of link.split(",")) {
+    if (!/;\s*rel="?next"?/u.test(part)) {
+      continue;
+    }
+    const match = /<([^>]+)>/u.exec(part);
+    if (!match) {
+      continue;
+    }
+    try {
+      return new URL(match[1]!).searchParams.get("after");
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function createOktaError(status: number, responseText: string, phase: OktaPhase): ProviderRequestError {
+  const message = readOktaErrorMessage(responseText) ?? `Okta request failed with HTTP ${status}`;
+  if (phase === "validate" && (status === 400 || status === 401 || status === 403)) {
+    return new ProviderRequestError(400, message);
+  }
+  if (status === 429) {
+    return new ProviderRequestError(429, message);
+  }
+  return new ProviderRequestError(status || 500, message);
+}
+
+function readOktaErrorMessage(responseText: string): string | undefined {
+  const text = responseText.trim();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    const payload = optionalRecord(JSON.parse(text) as unknown);
+    return optionalString(payload?.errorSummary) ?? optionalString(payload?.message) ?? text;
+  } catch {
+    return text;
+  }
+}
+
+function requireCredentialString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function requireInputString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function requireResponseString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, () => new ProviderRequestError(502, `Okta field ${fieldName} is missing`));
+}
+
+export type { OktaActionName };


### PR DESCRIPTION
## Summary

Add an Okta provider with custom API token authentication and runtime support for user, group, lifecycle, and group membership operations.

## Changes

- Add Okta provider definition with `apiToken` and `orgUrl` custom credential fields.
- Add 14 Okta actions:
  - Users: `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`
  - Lifecycle: `lifecycle_user`
  - Groups: `list_groups`, `get_group`, `create_group`, `update_group`, `delete_group`
  - Memberships: `list_group_users`, `add_user_to_group`, `remove_user_from_group`
- Implement Okta runtime execution with SSWS authorization, HTTPS org URL normalization, pagination cursor parsing, and normalized user/group responses.
- Add credential validation using a lightweight `list_users` request.
- Add runtime tests for org URL validation, request headers, user listing, and pagination handling.

## Validation

- [x] `npm run generate:catalog`
- [x] `npm run fix-check`

## Notes

Provider definitions and actions changed, so catalog generation should be run before merging.