### PR TITLE
feat(provider): add PubMed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@scalar/hono-api-reference": "^0.11.7",
         "ali-oss": "^6.23.0",
+        "fast-xml-parser": "^5.9.3",
         "hono": "^4.12.27",
         "imapflow": "^1.4.6",
         "mailparser": "^3.9.14",
@@ -1414,6 +1415,18 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oomol/connect-web": {
       "resolved": "web",
@@ -4142,6 +4155,18 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT"
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -5161,6 +5186,45 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5607,6 +5671,18 @@
         "is-class-hotfix": "~0.0.6",
         "isstream": "~0.1.2"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -7235,6 +7311,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8288,6 +8379,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -9177,6 +9283,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@scalar/hono-api-reference": "^0.11.7",
     "ali-oss": "^6.23.0",
+    "fast-xml-parser": "^5.9.3",
     "hono": "^4.12.27",
     "imapflow": "^1.4.6",
     "mailparser": "^3.9.14",

--- a/src/core/cast.test.ts
+++ b/src/core/cast.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { base64Bytes, positiveInteger } from "./cast.ts";
+import { base64Bytes, positiveInteger, requiredStringArray } from "./cast.ts";
 
 describe("cast helpers", () => {
   it("decodes strict base64 bytes", () => {
@@ -17,5 +17,13 @@ describe("cast helpers", () => {
 
   it("accepts positive integer strings", () => {
     expect(positiveInteger("2", "page")).toBe(2);
+  });
+
+  it("reads an array containing only strings", () => {
+    expect(requiredStringArray(["one", "two"], "values")).toEqual(["one", "two"]);
+  });
+
+  it("rejects non-string array items", () => {
+    expect(() => requiredStringArray(["one", 2], "values")).toThrow("values must be an array of strings");
   });
 });

--- a/src/core/cast.ts
+++ b/src/core/cast.ts
@@ -147,6 +147,22 @@ export function stringArray(
 }
 
 /**
+ * Return an array only when every item is already a string, or throw.
+ * Unlike `stringArray`, this helper does not coerce scalar values.
+ */
+export function requiredStringArray(
+  value: unknown,
+  fieldName: string,
+  createError: CastErrorFactory = (message) => new CastError(message),
+): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw createError(`${fieldName} must be an array of strings`);
+  }
+
+  return value;
+}
+
+/**
  * Return every array item as a plain object record, or throw. Examples:
  * `objectArray([{ a: 1 }], "items") => [{ a: 1 }]`, `objectArray([1], "items")` throws.
  */

--- a/src/providers/pubmed/actions.ts
+++ b/src/providers/pubmed/actions.ts
@@ -1,0 +1,222 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "pubmed";
+
+export type PubmedActionName =
+  | "search_articles"
+  | "match_citation"
+  | "get_article"
+  | "get_articles"
+  | "find_related_articles"
+  | "get_citing_articles"
+  | "get_article_references"
+  | "convert_article_ids";
+
+const pmidSchema = s.string("The numeric PubMed identifier (PMID).", {
+  minLength: 1,
+  pattern: "^[0-9]+$",
+});
+const offsetSchema = s.integer("The zero-based search result offset.", {
+  minimum: 0,
+  maximum: 9_999,
+  default: 0,
+});
+const limitSchema = s.integer("The maximum number of articles to return.", {
+  minimum: 1,
+  maximum: 50,
+  default: 10,
+});
+const sortSchema = s.stringEnum("The PubMed result sort order.", [
+  "relevance",
+  "publication_date",
+  "first_author",
+  "journal",
+]);
+const publicationDateRangeSchema = s.object("An inclusive PubMed publication date range.", {
+  from: s.date("The earliest publication date to include."),
+  to: s.date("The latest publication date to include."),
+});
+const articleIdTypeSchema = s.stringEnum("The type shared by every input article identifier.", [
+  "pmid",
+  "pmcid",
+  "doi",
+  "mid",
+]);
+
+const abstractSectionSchema = s.object("One section of a PubMed abstract.", {
+  label: s.nullableString("The structured abstract section label when present."),
+  text: s.string("The normalized abstract section text."),
+});
+const authorSchema = s.object("A normalized PubMed author or author group.", {
+  name: s.string("The author or collective author name."),
+  orcid: s.nullableString("The author's ORCID when present."),
+  affiliations: s.array("The author's affiliations.", s.string("One affiliation.")),
+});
+const journalSchema = s.object("The journal information attached to a PubMed record.", {
+  title: s.nullableString("The full journal title."),
+  abbreviation: s.nullableString("The NLM journal abbreviation."),
+  issn: s.nullableString("The journal ISSN returned by PubMed."),
+  volume: s.nullableString("The journal volume."),
+  issue: s.nullableString("The journal issue."),
+});
+const articleSchema = s.object("A normalized PubMed article record.", {
+  pmid: pmidSchema,
+  title: s.string("The article title."),
+  abstract: s.array("The structured or unstructured abstract sections.", abstractSectionSchema),
+  authors: s.array("The article authors.", authorSchema),
+  journal: journalSchema,
+  publicationDate: s.nullableString("The publication date or source Medline date."),
+  publicationTypes: s.array("The PubMed publication types.", s.string("One publication type.")),
+  meshTerms: s.array("The assigned Medical Subject Headings.", s.string("One MeSH descriptor.")),
+  keywords: s.array("The keywords attached to the PubMed record.", s.string("One keyword.")),
+  languages: s.array("The article language codes returned by PubMed.", s.string("One language code.")),
+  doi: s.nullableString("The article DOI when present."),
+  pmcid: s.nullableString("The PubMed Central identifier when present."),
+  pubmedUrl: s.url("The canonical PubMed record URL."),
+  pmcUrl: s.nullable(s.url("The PubMed Central article URL when available.")),
+});
+const convertedArticleIdSchema = s.object("The available identifiers for one requested article.", {
+  requestedId: s.string("The original identifier from the request."),
+  pmid: s.nullableString("The PubMed identifier when the article has one."),
+  pmcid: s.nullableString("The PubMed Central identifier when the article is represented in PMC."),
+  doi: s.nullableString("The DOI when PMC reports one."),
+  mid: s.nullableString("The author manuscript identifier when PMC reports one."),
+  error: s.nullableString("The PMC ID Converter error when the requested identifier could not be resolved."),
+});
+
+export const pubmedActions: readonly ProviderActionDefinition<PubmedActionName>[] = [
+  defineProviderAction(service, {
+    name: "search_articles",
+    description: "Search PubMed with the official query syntax and return normalized article records.",
+    inputSchema: s.object(
+      "Input parameters for searching PubMed articles.",
+      {
+        query: s.nonEmptyString(
+          "The PubMed query, including optional official field tags and Boolean operators such as cancer[Title] AND 2025[pdat].",
+        ),
+        offset: offsetSchema,
+        limit: limitSchema,
+        sort: sortSchema,
+        publicationDateRange: publicationDateRangeSchema,
+      },
+      { optional: ["offset", "limit", "sort", "publicationDateRange"] },
+    ),
+    outputSchema: s.object("A page of normalized PubMed search results.", {
+      total: s.nonNegativeInteger("The total number of matching PubMed records."),
+      offset: s.nonNegativeInteger("The zero-based result offset."),
+      limit: s.positiveInteger("The requested page size."),
+      queryTranslation: s.nullableString("The query translation reported by PubMed."),
+      articles: s.array("The normalized articles in this page.", articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "match_citation",
+    description: "Match one raw biomedical citation to PubMed and return normalized candidate articles.",
+    inputSchema: s.object("Input parameters for matching one citation.", {
+      citation: s.nonEmptyString(
+        "The citation text to match, such as an article title followed by its journal, year, volume, and pages.",
+      ),
+    }),
+    outputSchema: s.object("The PubMed articles matched from the citation text.", {
+      matched: s.boolean("Whether PubMed returned at least one candidate article."),
+      articles: s.array("The normalized candidate articles returned by PubMed.", articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_article",
+    description: "Get one normalized PubMed article by PMID.",
+    inputSchema: s.object("Input parameters for getting one PubMed article.", {
+      pmid: pmidSchema,
+    }),
+    outputSchema: s.object("The result of retrieving one PubMed article.", {
+      found: s.boolean("Whether PubMed returned the requested record."),
+      article: s.nullable(articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_articles",
+    description: "Get multiple normalized PubMed articles by PMID in one request.",
+    inputSchema: s.object("Input parameters for getting multiple PubMed articles.", {
+      pmids: s.array("The PubMed identifiers to retrieve.", pmidSchema, {
+        minItems: 1,
+        maxItems: 50,
+      }),
+    }),
+    outputSchema: s.object("The result of retrieving multiple PubMed articles.", {
+      articles: s.array("The PubMed records that were found.", articleSchema),
+      notFoundPmids: s.array("The requested PMIDs that PubMed did not return.", pmidSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "find_related_articles",
+    description: "Find normalized PubMed articles related to one source PMID.",
+    inputSchema: s.object(
+      "Input parameters for finding related PubMed articles.",
+      {
+        pmid: pmidSchema,
+        limit: limitSchema,
+      },
+      { optional: ["limit"] },
+    ),
+    outputSchema: s.object("The related PubMed articles returned for one source record.", {
+      sourcePmid: pmidSchema,
+      articles: s.array("The normalized related PubMed articles.", articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_citing_articles",
+    description:
+      "Get normalized PubMed articles known to cite one source PMID. PubMed citation coverage depends on data supplied by publishers and NCBI sources and may be incomplete.",
+    inputSchema: s.object(
+      "Input parameters for getting articles that cite a source PubMed record.",
+      {
+        pmid: pmidSchema,
+        limit: limitSchema,
+      },
+      { optional: ["limit"] },
+    ),
+    outputSchema: s.object("The citing PubMed articles returned for one source record.", {
+      sourcePmid: pmidSchema,
+      articles: s.array("The normalized articles known to cite the source record.", articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_article_references",
+    description:
+      "Get normalized PubMed references for one source PMID. References are available only when supplied by publishers or recoverable from PMC data.",
+    inputSchema: s.object(
+      "Input parameters for getting references from a source PubMed record.",
+      {
+        pmid: pmidSchema,
+        limit: limitSchema,
+      },
+      { optional: ["limit"] },
+    ),
+    outputSchema: s.object("The PubMed references returned for one source record.", {
+      sourcePmid: pmidSchema,
+      articles: s.array("The normalized PubMed articles referenced by the source record.", articleSchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "convert_article_ids",
+    description:
+      "Convert PMID, PMCID, DOI, or author manuscript identifiers with the PMC ID Converter. Complete mappings are available only for articles represented in PubMed Central.",
+    inputSchema: s.object("Input parameters for converting article identifiers.", {
+      ids: s.array(
+        "The article identifiers to convert. Every identifier must have the same idType.",
+        s.nonEmptyString("One PMID, PMCID, DOI, or author manuscript identifier."),
+        {
+          minItems: 1,
+          maxItems: 200,
+        },
+      ),
+      idType: articleIdTypeSchema,
+    }),
+    outputSchema: s.object("The available identifier mappings returned by PMC.", {
+      records: s.array("One conversion result for each identifier returned by PMC.", convertedArticleIdSchema),
+    }),
+  }),
+];

--- a/src/providers/pubmed/definition.ts
+++ b/src/providers/pubmed/definition.ts
@@ -1,0 +1,29 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { pubmedActions } from "./actions.ts";
+
+const service = "pubmed";
+
+/**
+ * PubMed provider backed by public NCBI literature APIs.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "PubMed",
+  description:
+    "Search, retrieve, match, and trace biomedical literature through official NCBI APIs. NCBI disclaimer and copyright information: https://www.ncbi.nlm.nih.gov/home/about/policies/",
+  categories: ["Data"],
+  authTypes: ["no_auth", "api_key"],
+  auth: [
+    { type: "no_auth" },
+    {
+      type: "api_key",
+      label: "NCBI API Key",
+      placeholder: "NCBI_API_KEY",
+      description:
+        "Optional NCBI API key passed as the api_key query parameter. Create one from your NCBI account settings to raise the default E-utilities rate limit from 3 to 10 requests per second.",
+    },
+  ],
+  homepageUrl: "https://pubmed.ncbi.nlm.nih.gov/",
+  actions: pubmedActions,
+};

--- a/src/providers/pubmed/executors.test.ts
+++ b/src/providers/pubmed/executors.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pubmedActions } from "./actions.ts";
+import { executors } from "./executors.ts";
+import { pubmedActionHandlers } from "./runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("PubMed executors", () => {
+  it("defines one handler for every catalog action", () => {
+    expect(Object.keys(pubmedActionHandlers).sort()).toEqual(pubmedActions.map((action) => action.name).sort());
+  });
+
+  it("executes article retrieval with a no-auth connection", async () => {
+    const fetcher = vi.fn(
+      async (): Promise<Response> =>
+        new Response(`
+          <PubmedArticleSet>
+            <PubmedArticle>
+              <MedlineCitation>
+                <PMID>12345678</PMID>
+                <Article>
+                  <Journal><Title>Test Journal</Title></Journal>
+                  <ArticleTitle>Test article</ArticleTitle>
+                </Article>
+              </MedlineCitation>
+              <PubmedData><ArticleIdList /></PubmedData>
+            </PubmedArticle>
+          </PubmedArticleSet>
+        `),
+    );
+    vi.stubGlobal("fetch", fetcher);
+
+    const result = await executors["pubmed.get_article"]?.(
+      { pmid: "12345678" },
+      { getCredential: async () => ({ authType: "no_auth" }) },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        found: true,
+        article: { pmid: "12345678", title: "Test article" },
+      },
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+});

--- a/src/providers/pubmed/executors.ts
+++ b/src/providers/pubmed/executors.ts
@@ -1,0 +1,27 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { defineProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
+import { createPubmedActionContext, pubmedActionHandlers, validatePubmedCredential } from "./runtime.ts";
+
+const service = "pubmed";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: pubmedActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch) {
+    const credential = await context.getCredential(service);
+    if (!credential || credential.authType === "no_auth") {
+      return createPubmedActionContext({ fetcher, signal: context.signal });
+    }
+    if (credential.authType === "api_key") {
+      return createPubmedActionContext({ apiKey: credential.apiKey, fetcher, signal: context.signal });
+    }
+    throw new ProviderRequestError(401, "Connect PubMed without authentication or configure an NCBI API key.");
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validatePubmedCredential(input, fetcher, signal);
+  },
+};

--- a/src/providers/pubmed/runtime-xml.ts
+++ b/src/providers/pubmed/runtime-xml.ts
@@ -1,0 +1,387 @@
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import { optionalRecord, optionalString } from "../../core/cast.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+interface XmlElement {
+  attributes: Record<string, unknown>;
+  content: XmlNode[];
+}
+
+type XmlNode = Record<string, unknown>;
+
+export interface PubmedAbstractSection {
+  label: string | null;
+  text: string;
+}
+
+export interface PubmedAuthor {
+  name: string;
+  orcid: string | null;
+  affiliations: string[];
+}
+
+export interface PubmedJournal {
+  title: string | null;
+  abbreviation: string | null;
+  issn: string | null;
+  volume: string | null;
+  issue: string | null;
+}
+
+export interface PubmedArticle {
+  pmid: string;
+  title: string;
+  abstract: PubmedAbstractSection[];
+  authors: PubmedAuthor[];
+  journal: PubmedJournal;
+  publicationDate: string | null;
+  publicationTypes: string[];
+  meshTerms: string[];
+  keywords: string[];
+  languages: string[];
+  doi: string | null;
+  pmcid: string | null;
+  pubmedUrl: string;
+  pmcUrl: string | null;
+}
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  parseAttributeValue: false,
+  parseTagValue: false,
+  preserveOrder: true,
+  processEntities: true,
+  trimValues: false,
+});
+
+const monthNumbers: Record<string, string> = {
+  jan: "01",
+  feb: "02",
+  mar: "03",
+  apr: "04",
+  may: "05",
+  jun: "06",
+  jul: "07",
+  aug: "08",
+  sep: "09",
+  oct: "10",
+  nov: "11",
+  dec: "12",
+};
+
+/** Parse PubMed EFetch XML into normalized article records. */
+export function parsePubmedArticleSet(xml: string): PubmedArticle[] {
+  const validation = XMLValidator.validate(xml);
+  if (validation !== true) {
+    throw new ProviderRequestError(502, "PubMed returned malformed article XML", validation.err);
+  }
+
+  const document = xmlParser.parse(xml) as XmlNode[];
+  const articleSet = firstChild(document, "PubmedArticleSet");
+  if (!articleSet) {
+    throw new ProviderRequestError(502, "PubMed returned an article response without PubmedArticleSet");
+  }
+
+  return articleSet.content.flatMap((node) => {
+    const article = elementFromNode(node, "PubmedArticle");
+    if (article) {
+      return [parsePubmedArticle(article)];
+    }
+    const bookArticle = elementFromNode(node, "PubmedBookArticle");
+    return bookArticle ? [parsePubmedBookArticle(bookArticle)] : [];
+  });
+}
+
+function parsePubmedArticle(pubmedArticle: XmlElement): PubmedArticle {
+  const citation = requireChild(pubmedArticle.content, "MedlineCitation", "PubMed article");
+  const article = requireChild(citation.content, "Article", "PubMed citation");
+  const pmid = requireText(citation.content, "PMID", "PubMed citation");
+  const journal = firstChild(article.content, "Journal");
+  const identifiers = readArticleIdentifiers(pubmedArticle);
+  const pmcid = identifiers.get("pmc") ?? null;
+
+  return {
+    pmid,
+    title: childText(article.content, "ArticleTitle") ?? "",
+    abstract: readAbstract(article),
+    authors: readAuthors(article),
+    journal: readJournal(journal),
+    publicationDate: readPublicationDate(journal),
+    publicationTypes: childTexts(firstChild(article.content, "PublicationTypeList"), "PublicationType"),
+    meshTerms: readMeshTerms(citation),
+    keywords: children(citation.content, "KeywordList").flatMap((keywordList) => childTexts(keywordList, "Keyword")),
+    languages: childTexts(article, "Language"),
+    doi: identifiers.get("doi") ?? readElectronicDoi(article),
+    pmcid,
+    pubmedUrl: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+    pmcUrl: pmcid ? `https://pmc.ncbi.nlm.nih.gov/articles/${pmcid}/` : null,
+  };
+}
+
+function parsePubmedBookArticle(pubmedBookArticle: XmlElement): PubmedArticle {
+  const document = requireChild(pubmedBookArticle.content, "BookDocument", "PubMed book article");
+  const book = requireChild(document.content, "Book", "PubMed book document");
+  const pmid = requireText(document.content, "PMID", "PubMed book document");
+  const identifiers = readBookArticleIdentifiers(pubmedBookArticle, document);
+  const pmcid = identifiers.get("pmc") ?? null;
+  const volume = childText(book.content, "Volume") ?? null;
+
+  return {
+    pmid,
+    title: childText(document.content, "ArticleTitle") ?? childText(book.content, "BookTitle") ?? "",
+    abstract: readAbstract(document),
+    authors: readAuthors(document),
+    journal: {
+      title: childText(book.content, "BookTitle") ?? null,
+      abbreviation: null,
+      issn: null,
+      volume,
+      issue: null,
+    },
+    publicationDate: readDate(firstChild(book.content, "PubDate")),
+    publicationTypes: childTexts(document, "PublicationType"),
+    meshTerms: [],
+    keywords: children(document.content, "KeywordList").flatMap((keywordList) => childTexts(keywordList, "Keyword")),
+    languages: childTexts(document, "Language"),
+    doi: identifiers.get("doi") ?? readElectronicDoi(book),
+    pmcid,
+    pubmedUrl: `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`,
+    pmcUrl: pmcid ? `https://pmc.ncbi.nlm.nih.gov/articles/${pmcid}/` : null,
+  };
+}
+
+function readAbstract(article: XmlElement): PubmedAbstractSection[] {
+  const abstract = firstChild(article.content, "Abstract");
+  if (!abstract) {
+    return [];
+  }
+
+  return children(abstract.content, "AbstractText")
+    .map((section) => ({
+      label: readAttribute(section, "Label") ?? readAttribute(section, "NlmCategory") ?? null,
+      text: textContent(section.content),
+    }))
+    .filter((section) => section.text.length > 0);
+}
+
+function readAuthors(article: XmlElement): PubmedAuthor[] {
+  const authorList = firstChild(article.content, "AuthorList");
+  if (!authorList) {
+    return [];
+  }
+
+  return children(authorList.content, "Author").flatMap((author) => {
+    const collectiveName = childText(author.content, "CollectiveName");
+    const familyName = childText(author.content, "LastName");
+    const givenName = childText(author.content, "ForeName") ?? childText(author.content, "Initials");
+    const name = collectiveName ?? [givenName, familyName].filter(Boolean).join(" ");
+    if (!name) {
+      return [];
+    }
+
+    const orcid = children(author.content, "Identifier").find(
+      (identifier) => readAttribute(identifier, "Source")?.toLowerCase() === "orcid",
+    );
+
+    return [
+      {
+        name,
+        orcid: orcid ? textContent(orcid.content) || null : null,
+        affiliations: children(author.content, "AffiliationInfo")
+          .map((info) => childText(info.content, "Affiliation"))
+          .filter((value): value is string => value !== undefined),
+      },
+    ];
+  });
+}
+
+function readJournal(journal: XmlElement | undefined): PubmedJournal {
+  const issue = journal ? firstChild(journal.content, "JournalIssue") : undefined;
+  return {
+    title: journal ? (childText(journal.content, "Title") ?? null) : null,
+    abbreviation: journal ? (childText(journal.content, "ISOAbbreviation") ?? null) : null,
+    issn: journal ? (childText(journal.content, "ISSN") ?? null) : null,
+    volume: issue ? (childText(issue.content, "Volume") ?? null) : null,
+    issue: issue ? (childText(issue.content, "Issue") ?? null) : null,
+  };
+}
+
+function readPublicationDate(journal: XmlElement | undefined): string | null {
+  const issue = journal ? firstChild(journal.content, "JournalIssue") : undefined;
+  return readDate(issue ? firstChild(issue.content, "PubDate") : undefined);
+}
+
+function readDate(publicationDate: XmlElement | undefined): string | null {
+  if (!publicationDate) {
+    return null;
+  }
+
+  const medlineDate = childText(publicationDate.content, "MedlineDate");
+  if (medlineDate) {
+    return medlineDate;
+  }
+
+  const year = childText(publicationDate.content, "Year");
+  if (!year) {
+    return null;
+  }
+  const season = childText(publicationDate.content, "Season");
+  if (season) {
+    return `${year} ${season}`;
+  }
+  const month = normalizeMonth(childText(publicationDate.content, "Month"));
+  const day = normalizeDay(childText(publicationDate.content, "Day"));
+  return [year, month, day].filter(Boolean).join("-");
+}
+
+function readMeshTerms(citation: XmlElement): string[] {
+  const headings = firstChild(citation.content, "MeshHeadingList");
+  if (!headings) {
+    return [];
+  }
+
+  return children(headings.content, "MeshHeading")
+    .map((heading) => childText(heading.content, "DescriptorName"))
+    .filter((value): value is string => value !== undefined);
+}
+
+function readArticleIdentifiers(pubmedArticle: XmlElement): Map<string, string> {
+  const identifiers = new Map<string, string>();
+  const pubmedData = firstChild(pubmedArticle.content, "PubmedData");
+  const identifierList = pubmedData ? firstChild(pubmedData.content, "ArticleIdList") : undefined;
+  addIdentifiers(identifiers, identifierList);
+  return identifiers;
+}
+
+function readBookArticleIdentifiers(pubmedBookArticle: XmlElement, document: XmlElement): Map<string, string> {
+  const identifiers = new Map<string, string>();
+  addIdentifiers(identifiers, firstChild(document.content, "ArticleIdList"));
+  const pubmedBookData = firstChild(pubmedBookArticle.content, "PubmedBookData");
+  addIdentifiers(identifiers, pubmedBookData ? firstChild(pubmedBookData.content, "ArticleIdList") : undefined);
+  return identifiers;
+}
+
+function addIdentifiers(identifiers: Map<string, string>, identifierList: XmlElement | undefined): void {
+  if (!identifierList) {
+    return;
+  }
+  for (const identifier of children(identifierList.content, "ArticleId")) {
+    const type = readAttribute(identifier, "IdType")?.toLowerCase();
+    const value = textContent(identifier.content);
+    if (type && value) {
+      identifiers.set(type, value);
+    }
+  }
+}
+
+function readElectronicDoi(article: XmlElement): string | null {
+  const location = children(article.content, "ELocationID").find(
+    (identifier) => readAttribute(identifier, "EIdType")?.toLowerCase() === "doi",
+  );
+  return location ? textContent(location.content) || null : null;
+}
+
+function normalizeMonth(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (/^\d{1,2}$/u.test(value)) {
+    return value.padStart(2, "0");
+  }
+  return monthNumbers[value.slice(0, 3).toLowerCase()];
+}
+
+function normalizeDay(value: string | undefined): string | undefined {
+  return value && /^\d{1,2}$/u.test(value) ? value.padStart(2, "0") : undefined;
+}
+
+function childTexts(parent: XmlElement | undefined, name: string): string[];
+function childTexts(parent: XmlNode[], name: string): string[];
+function childTexts(parent: XmlElement | XmlNode[] | undefined, name: string): string[] {
+  const content = Array.isArray(parent) ? parent : parent?.content;
+  return content
+    ? children(content, name)
+        .map((element) => textContent(element.content))
+        .filter((value) => value.length > 0)
+    : [];
+}
+
+function childText(content: XmlNode[], name: string): string | undefined {
+  const child = firstChild(content, name);
+  if (!child) {
+    return undefined;
+  }
+  return textContent(child.content) || undefined;
+}
+
+function requireText(content: XmlNode[], name: string, source: string): string {
+  const value = childText(content, name);
+  if (!value) {
+    throw new ProviderRequestError(502, `${source} is missing ${name}`);
+  }
+  return value;
+}
+
+function requireChild(content: XmlNode[], name: string, source: string): XmlElement {
+  const child = firstChild(content, name);
+  if (!child) {
+    throw new ProviderRequestError(502, `${source} is missing ${name}`);
+  }
+  return child;
+}
+
+function firstChild(content: XmlNode[], name: string): XmlElement | undefined {
+  return children(content, name)[0];
+}
+
+function elementFromNode(node: XmlNode, name: string): XmlElement | undefined {
+  const childContent = node[name];
+  return Array.isArray(childContent)
+    ? {
+        content: childContent as XmlNode[],
+        attributes: optionalRecord(node[":@"]) ?? {},
+      }
+    : undefined;
+}
+
+function children(content: XmlNode[], name: string): XmlElement[] {
+  return content.map((node) => elementFromNode(node, name)).filter((child): child is XmlElement => child !== undefined);
+}
+
+function readAttribute(element: XmlElement, name: string): string | undefined {
+  return optionalString(element.attributes[`@_${name}`]);
+}
+
+function textContent(value: unknown): string {
+  const text = decodeNumericCharacterReferences(collectText(value));
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+function decodeNumericCharacterReferences(value: string): string {
+  return value.replace(
+    /&#(?:x([\da-f]+)|(\d+));/giu,
+    (reference, hex: string | undefined, decimal: string | undefined) => {
+      const codePoint = Number.parseInt(hex ?? decimal ?? "", hex ? 16 : 10);
+      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+        ? String.fromCodePoint(codePoint)
+        : reference;
+    },
+  );
+}
+
+function collectText(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(collectText).join("");
+  }
+  const record = optionalRecord(value);
+  if (!record) {
+    return "";
+  }
+  return Object.entries(record)
+    .filter(([key]) => key !== ":@")
+    .map(([, child]) => collectText(child))
+    .join("");
+}

--- a/src/providers/pubmed/runtime.test.ts
+++ b/src/providers/pubmed/runtime.test.ts
@@ -1,0 +1,805 @@
+import { describe, expect, it, vi } from "vitest";
+import { parsePubmedArticleSet } from "./runtime-xml.ts";
+import { PubmedRequestGate, PubmedRequestGatePool, pubmedActionHandlers, validatePubmedCredential } from "./runtime.ts";
+
+const articleXml = `<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation Status="MEDLINE">
+      <PMID Version="1">12345678</PMID>
+      <Article PubModel="Electronic">
+        <Journal>
+          <ISSN IssnType="Electronic">1234-5678</ISSN>
+          <JournalIssue>
+            <Volume>12</Volume>
+            <Issue>3</Issue>
+            <PubDate><Year>2025</Year><Month>Dec</Month><Day>24</Day></PubDate>
+          </JournalIssue>
+          <Title>Journal of Useful Results</Title>
+          <ISOAbbreviation>J Useful Results</ISOAbbreviation>
+        </Journal>
+        <ArticleTitle>Testing <i>structured</i> biomedical records.</ArticleTitle>
+        <Abstract>
+          <AbstractText Label="BACKGROUND">Why the test matters.</AbstractText>
+          <AbstractText Label="METHODS">Parsed with <b>mixed content</b>.</AbstractText>
+        </Abstract>
+        <AuthorList>
+          <Author>
+            <LastName>Lovelace</LastName><ForeName>Ada</ForeName><Initials>A</Initials>
+            <Identifier Source="ORCID">0000-0001-2345-6789</Identifier>
+            <AffiliationInfo><Affiliation>Analytical Engine Institute</Affiliation></AffiliationInfo>
+          </Author>
+          <Author><CollectiveName>PubMed Study Group</CollectiveName></Author>
+        </AuthorList>
+        <Language>eng</Language>
+        <PublicationTypeList><PublicationType>Journal Article</PublicationType></PublicationTypeList>
+      </Article>
+      <MeshHeadingList>
+        <MeshHeading><DescriptorName UI="D012345">Information Storage and Retrieval</DescriptorName></MeshHeading>
+      </MeshHeadingList>
+      <KeywordList><Keyword>literature search</Keyword></KeywordList>
+    </MedlineCitation>
+    <PubmedData>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">12345678</ArticleId>
+        <ArticleId IdType="doi">10.1000/example</ArticleId>
+        <ArticleId IdType="pmc">PMC1234567</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>`;
+
+const bookArticleXml = `<?xml version="1.0" ?>
+<PubmedArticleSet>
+  <PubmedBookArticle>
+    <BookDocument>
+      <PMID>87654321</PMID>
+      <ArticleIdList>
+        <ArticleId IdType="pubmed">87654321</ArticleId>
+        <ArticleId IdType="doi">10.1000/book-chapter</ArticleId>
+      </ArticleIdList>
+      <Book>
+        <Publisher><PublisherName>National Library of Medicine</PublisherName></Publisher>
+        <BookTitle>Biomedical Reference</BookTitle>
+        <PubDate><Year>2024</Year><Month>Jan</Month><Day>2</Day></PubDate>
+        <Volume>2</Volume>
+      </Book>
+      <ArticleTitle>Genomics in clinical practice</ArticleTitle>
+      <Language>eng</Language>
+      <AuthorList>
+        <Author><LastName>Hopper</LastName><ForeName>Grace</ForeName></Author>
+      </AuthorList>
+      <PublicationType UI="D002363">Book Chapter</PublicationType>
+      <Abstract><AbstractText>A chapter abstract.</AbstractText></Abstract>
+      <KeywordList><Keyword>genomics</Keyword></KeywordList>
+    </BookDocument>
+    <PubmedBookData>
+      <PublicationStatus>ppublish</PublicationStatus>
+      <ArticleIdList>
+        <ArticleId IdType="pmc">PMC7654321</ArticleId>
+      </ArticleIdList>
+    </PubmedBookData>
+  </PubmedBookArticle>
+</PubmedArticleSet>`;
+
+describe("PubMed runtime", () => {
+  it("normalizes a PubMed XML article without losing mixed text content", () => {
+    expect(parsePubmedArticleSet(articleXml)).toEqual([
+      {
+        pmid: "12345678",
+        title: "Testing structured biomedical records.",
+        abstract: [
+          { label: "BACKGROUND", text: "Why the test matters." },
+          { label: "METHODS", text: "Parsed with mixed content." },
+        ],
+        authors: [
+          {
+            name: "Ada Lovelace",
+            orcid: "0000-0001-2345-6789",
+            affiliations: ["Analytical Engine Institute"],
+          },
+          {
+            name: "PubMed Study Group",
+            orcid: null,
+            affiliations: [],
+          },
+        ],
+        journal: {
+          title: "Journal of Useful Results",
+          abbreviation: "J Useful Results",
+          issn: "1234-5678",
+          volume: "12",
+          issue: "3",
+        },
+        publicationDate: "2025-12-24",
+        publicationTypes: ["Journal Article"],
+        meshTerms: ["Information Storage and Retrieval"],
+        keywords: ["literature search"],
+        languages: ["eng"],
+        doi: "10.1000/example",
+        pmcid: "PMC1234567",
+        pubmedUrl: "https://pubmed.ncbi.nlm.nih.gov/12345678/",
+        pmcUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC1234567/",
+      },
+    ]);
+  });
+
+  it("decodes numeric character references in PubMed text", () => {
+    const encodedXml = articleXml.replace("Why the test matters.", "Why &#x3b2; matters.");
+
+    expect(parsePubmedArticleSet(encodedXml)[0]?.abstract[0]?.text).toBe("Why \u03b2 matters.");
+  });
+
+  it("preserves a PubMed publication season", () => {
+    const seasonalXml = articleXml.replace(
+      "<Year>2025</Year><Month>Dec</Month><Day>24</Day>",
+      "<Year>2025</Year><Season>Winter</Season>",
+    );
+
+    expect(parsePubmedArticleSet(seasonalXml)[0]?.publicationDate).toBe("2025 Winter");
+  });
+
+  it("normalizes PubMed book articles instead of dropping them", () => {
+    expect(parsePubmedArticleSet(bookArticleXml)).toEqual([
+      {
+        pmid: "87654321",
+        title: "Genomics in clinical practice",
+        abstract: [{ label: null, text: "A chapter abstract." }],
+        authors: [{ name: "Grace Hopper", orcid: null, affiliations: [] }],
+        journal: {
+          title: "Biomedical Reference",
+          abbreviation: null,
+          issn: null,
+          volume: "2",
+          issue: null,
+        },
+        publicationDate: "2024-01-02",
+        publicationTypes: ["Book Chapter"],
+        meshTerms: [],
+        keywords: ["genomics"],
+        languages: ["eng"],
+        doi: "10.1000/book-chapter",
+        pmcid: "PMC7654321",
+        pubmedUrl: "https://pubmed.ncbi.nlm.nih.gov/87654321/",
+        pmcUrl: "https://pmc.ncbi.nlm.nih.gov/articles/PMC7654321/",
+      },
+    ]);
+  });
+
+  it("searches PubMed and batch-fetches normalized articles", async () => {
+    const requestedUrls: URL[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(input.toString());
+      requestedUrls.push(url);
+      if (url.pathname.endsWith("/esearch.fcgi")) {
+        return Response.json({
+          esearchresult: {
+            count: "42",
+            retmax: "1",
+            retstart: "10",
+            idlist: ["12345678"],
+            querytranslation: "cancer[All Fields]",
+          },
+        });
+      }
+      return new Response(articleXml, { headers: { "content-type": "application/xml" } });
+    });
+
+    const result = await pubmedActionHandlers.search_articles(
+      {
+        query: "cancer",
+        offset: 10,
+        limit: 5,
+        sort: "publication_date",
+        publicationDateRange: { from: "2024-01-01", to: "2025-12-31" },
+      },
+      createContext(fetcher),
+    );
+
+    expect(result).toMatchObject({
+      total: 42,
+      offset: 10,
+      limit: 5,
+      queryTranslation: "cancer[All Fields]",
+      articles: [{ pmid: "12345678", doi: "10.1000/example" }],
+    });
+    expect(requestedUrls).toHaveLength(2);
+    expect(Object.fromEntries(requestedUrls[0]!.searchParams)).toMatchObject({
+      db: "pubmed",
+      term: "cancer",
+      retmode: "json",
+      retstart: "10",
+      retmax: "5",
+      sort: "pub date",
+      datetype: "pdat",
+      mindate: "2024/01/01",
+      maxdate: "2025/12/31",
+      tool: "openconnector",
+    });
+    expect(requestedUrls[0]!.searchParams.has("api_key")).toBe(false);
+    expect(Object.fromEntries(requestedUrls[1]!.searchParams)).toMatchObject({
+      db: "pubmed",
+      id: "12345678",
+      retmode: "xml",
+      tool: "openconnector",
+    });
+  });
+
+  it("uses POST for long PubMed search queries", async () => {
+    let requestedUrl: URL | undefined;
+    let requestedInit: RequestInit | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requestedUrl = new URL(input.toString());
+      requestedInit = init;
+      return Response.json({
+        esearchresult: {
+          count: "0",
+          retmax: "0",
+          retstart: "0",
+          idlist: [],
+          querytranslation: "",
+        },
+      });
+    });
+    const query = "cancer OR ".repeat(60);
+
+    await pubmedActionHandlers.search_articles({ query }, createContext(fetcher));
+
+    expect(requestedInit?.method).toBe("POST");
+    expect(new Headers(requestedInit?.headers).get("content-type")).toBe("application/x-www-form-urlencoded");
+    expect(requestedUrl!.search).toBe("");
+    const body = new URLSearchParams(String(requestedInit?.body));
+    expect(body.get("term")).toBe(query.trim());
+    expect(body.get("db")).toBe("pubmed");
+    expect(body.get("tool")).toBe("openconnector");
+  });
+
+  it("rejects search pages beyond PubMed's first 10,000 results", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      pubmedActionHandlers.search_articles({ query: "cancer", offset: 9_999, limit: 2 }, createContext(fetcher)),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "offset plus limit must not exceed 10000 for PubMed searches",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects an inverted publication date range", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      pubmedActionHandlers.search_articles(
+        {
+          query: "cancer",
+          publicationDateRange: { from: "2025-01-01", to: "2024-01-01" },
+        },
+        createContext(fetcher),
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "publicationDateRange.from must not be after publicationDateRange.to",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("gets one article with an optional NCBI API key", async () => {
+    let requestedUrl: URL | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      requestedUrl = new URL(input.toString());
+      return new Response(articleXml, { headers: { "content-type": "application/xml" } });
+    });
+
+    const result = await pubmedActionHandlers.get_article(
+      { pmid: "12345678" },
+      createContext(fetcher, "ncbi-test-key"),
+    );
+
+    expect(result).toMatchObject({
+      found: true,
+      article: { pmid: "12345678", title: "Testing structured biomedical records." },
+    });
+    expect(Object.fromEntries(requestedUrl!.searchParams)).toMatchObject({
+      db: "pubmed",
+      id: "12345678",
+      retmode: "xml",
+      api_key: "ncbi-test-key",
+      tool: "openconnector",
+    });
+  });
+
+  it("reports missing PMIDs from a batch fetch", async () => {
+    const fetcher = vi.fn(async (): Promise<Response> => new Response(articleXml));
+
+    const result = await pubmedActionHandlers.get_articles({ pmids: ["12345678", "99999999"] }, createContext(fetcher));
+
+    expect(result).toMatchObject({
+      articles: [{ pmid: "12345678" }],
+      notFoundPmids: ["99999999"],
+    });
+  });
+
+  it("finds related articles without returning the source PMID", async () => {
+    const requestedUrls: URL[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(input.toString());
+      requestedUrls.push(url);
+      if (url.pathname.endsWith("/elink.fcgi")) {
+        return Response.json({
+          linksets: [
+            {
+              ids: ["11111111"],
+              linksetdbs: [{ linkname: "pubmed_pubmed", links: ["11111111", "12345678"] }],
+            },
+          ],
+        });
+      }
+      return new Response(articleXml);
+    });
+
+    const result = await pubmedActionHandlers.find_related_articles(
+      { pmid: "11111111", limit: 5 },
+      createContext(fetcher),
+    );
+
+    expect(result).toMatchObject({
+      sourcePmid: "11111111",
+      articles: [{ pmid: "12345678" }],
+    });
+    expect(Object.fromEntries(requestedUrls[0]!.searchParams)).toMatchObject({
+      dbfrom: "pubmed",
+      db: "pubmed",
+      id: "11111111",
+      linkname: "pubmed_pubmed",
+      cmd: "neighbor",
+      retmode: "json",
+    });
+    expect(requestedUrls[1]!.searchParams.get("id")).toBe("12345678");
+  });
+
+  it("matches a raw citation and returns normalized articles", async () => {
+    const requestedUrls: URL[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(input.toString());
+      requestedUrls.push(url);
+      if (url.pathname === "/api/citmatch/") {
+        return Response.json({
+          version: "1.0",
+          operation: "citmatch",
+          success: true,
+          result: {
+            count: 1,
+            type: "uids",
+            uids: [{ pubmed: "12345678" }],
+          },
+        });
+      }
+      return new Response(articleXml);
+    });
+
+    const result = await pubmedActionHandlers.match_citation(
+      { citation: "Testing structured biomedical records. J Useful Results. 2025;12(3)." },
+      createContext(fetcher),
+    );
+
+    expect(result).toMatchObject({
+      matched: true,
+      articles: [{ pmid: "12345678", title: "Testing structured biomedical records." }],
+    });
+    expect(requestedUrls[0]!.origin).toBe("https://pubmed.ncbi.nlm.nih.gov");
+    expect(requestedUrls[0]!.pathname).toBe("/api/citmatch/");
+    expect(Object.fromEntries(requestedUrls[0]!.searchParams)).toEqual({
+      method: "heuristic",
+      "raw-text": "Testing structured biomedical records. J Useful Results. 2025;12(3).",
+    });
+    expect(requestedUrls[1]!.searchParams.get("id")).toBe("12345678");
+  });
+
+  it("gets articles that cite a source PMID", async () => {
+    const requestedUrls: URL[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(input.toString());
+      requestedUrls.push(url);
+      if (url.pathname.endsWith("/elink.fcgi")) {
+        return Response.json({
+          linksets: [
+            {
+              ids: ["11111111"],
+              linksetdbs: [{ linkname: "pubmed_pubmed_citedin", links: ["12345678"] }],
+            },
+          ],
+        });
+      }
+      return new Response(articleXml);
+    });
+
+    const result = await pubmedActionHandlers.get_citing_articles(
+      { pmid: "11111111", limit: 5 },
+      createContext(fetcher),
+    );
+
+    expect(result).toMatchObject({
+      sourcePmid: "11111111",
+      articles: [{ pmid: "12345678" }],
+    });
+    expect(requestedUrls[0]!.searchParams.get("linkname")).toBe("pubmed_pubmed_citedin");
+    expect(requestedUrls[1]!.searchParams.get("id")).toBe("12345678");
+  });
+
+  it("gets PubMed references for a source PMID", async () => {
+    const requestedUrls: URL[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url = new URL(input.toString());
+      requestedUrls.push(url);
+      if (url.pathname.endsWith("/elink.fcgi")) {
+        return Response.json({
+          linksets: [
+            {
+              ids: ["11111111"],
+              linksetdbs: [{ linkname: "pubmed_pubmed_refs", links: ["12345678"] }],
+            },
+          ],
+        });
+      }
+      return new Response(articleXml);
+    });
+
+    const result = await pubmedActionHandlers.get_article_references(
+      { pmid: "11111111", limit: 5 },
+      createContext(fetcher),
+    );
+
+    expect(result).toMatchObject({
+      sourcePmid: "11111111",
+      articles: [{ pmid: "12345678" }],
+    });
+    expect(requestedUrls[0]!.searchParams.get("linkname")).toBe("pubmed_pubmed_refs");
+    expect(requestedUrls[1]!.searchParams.get("id")).toBe("12345678");
+  });
+
+  it("converts article identifiers and preserves not-found results", async () => {
+    let requestedUrl: URL | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      requestedUrl = new URL(input.toString());
+      return Response.json({
+        status: "ok",
+        records: [
+          {
+            doi: "10.1000/example",
+            pmcid: "PMC1234567",
+            pmid: 12345678,
+            "requested-id": "12345678",
+          },
+          {
+            pmid: 99999999,
+            "requested-id": "99999999",
+            status: "error",
+            errmsg: "Identifier not found in PMC",
+          },
+        ],
+      });
+    });
+
+    const result = await pubmedActionHandlers.convert_article_ids(
+      { ids: ["12345678", "99999999"], idType: "pmid" },
+      createContext(fetcher),
+    );
+
+    expect(result).toEqual({
+      records: [
+        {
+          requestedId: "12345678",
+          pmid: "12345678",
+          pmcid: "PMC1234567",
+          doi: "10.1000/example",
+          mid: null,
+          error: null,
+        },
+        {
+          requestedId: "99999999",
+          pmid: "99999999",
+          pmcid: null,
+          doi: null,
+          mid: null,
+          error: "Identifier not found in PMC",
+        },
+      ],
+    });
+    expect(requestedUrl!.origin).toBe("https://pmc.ncbi.nlm.nih.gov");
+    expect(requestedUrl!.pathname).toBe("/tools/idconv/api/v1/articles/");
+    expect(Object.fromEntries(requestedUrl!.searchParams)).toEqual({
+      ids: "12345678,99999999",
+      idtype: "pmid",
+      format: "json",
+      tool: "openconnector",
+    });
+    expect(requestedUrl!.searchParams.has("email")).toBe(false);
+  });
+
+  it("serializes concurrent requests through a shared rate-limit gate", async () => {
+    let now = 1_000;
+    const delays: number[] = [];
+    const gate = new PubmedRequestGate(
+      () => now,
+      async (delayMs) => {
+        delays.push(delayMs);
+        now += delayMs;
+      },
+    );
+
+    await Promise.all([gate.wait(334), gate.wait(334), gate.wait(334)]);
+
+    expect(delays).toEqual([334, 334]);
+  });
+
+  it("cancels a queued rate-limit wait before reserving a request slot", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const gate = new PubmedRequestGate();
+
+    await expect(gate.wait(334, controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("immediately removes a cancelled wait from the rate-limit queue", async () => {
+    let releaseDelay: (() => void) | undefined;
+    const delay = new Promise<void>((resolve) => {
+      releaseDelay = resolve;
+    });
+    const gate = new PubmedRequestGate(
+      () => 0,
+      async () => delay,
+    );
+    await gate.wait(334);
+    const activeWait = gate.wait(334);
+    const controller = new AbortController();
+    const cancelledWait = gate.wait(334, controller.signal);
+
+    controller.abort();
+
+    await expect(cancelledWait).rejects.toMatchObject({ name: "AbortError" });
+    releaseDelay?.();
+    await activeWait;
+  });
+
+  it("shares rate limits by NCBI quota identity", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T04:00:00.000Z"));
+    try {
+      const pool = new PubmedRequestGatePool(2);
+      await pool.forKey("key-one").wait(100);
+      const sameKey = pool.forKey("key-one").wait(100);
+      const secondKey = pool.forKey("key-two").wait(100);
+      let sameKeySettled = false;
+      void sameKey.then(() => {
+        sameKeySettled = true;
+      });
+
+      await secondKey;
+      expect(sameKeySettled).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      await sameKey;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("binds cached quota gates when each wait begins", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T04:00:00.000Z"));
+    try {
+      const pool = new PubmedRequestGatePool(1);
+      const firstContext = pool.forKey("secret-one");
+      await pool.forKey("secret-two").wait(100);
+      await firstContext.wait(100);
+      const sameKeyWait = pool.forKey("secret-one").wait(100);
+      let sameKeySettled = false;
+      void sameKeyWait.then(() => {
+        sameKeySettled = true;
+      });
+
+      expect(sameKeySettled).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      await sameKeyWait;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries a rate-limited request using Retry-After", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({ error: "API rate limit exceeded" }, { status: 429, headers: { "retry-after": "1" } }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          esearchresult: {
+            count: "1",
+            retmax: "1",
+            retstart: "0",
+            idlist: ["12345678"],
+            querytranslation: "test",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(articleXml));
+    const context = createContext(fetcher);
+    context.sleep = sleep;
+
+    const result = await pubmedActionHandlers.search_articles({ query: "test", limit: 1 }, context);
+
+    expect(result).toMatchObject({ articles: [{ pmid: "12345678" }] });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(1_000, undefined);
+  });
+
+  it("honors an HTTP-date Retry-After value", async () => {
+    const now = Date.parse("2026-07-11T04:00:00.000Z");
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const sleep = vi.fn(async () => undefined);
+      const fetcher = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          Response.json(
+            { error: "API rate limit exceeded" },
+            { status: 429, headers: { "retry-after": "Sat, 11 Jul 2026 04:00:05 GMT" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          Response.json({
+            esearchresult: {
+              count: "0",
+              retmax: "0",
+              retstart: "0",
+              idlist: [],
+              querytranslation: "test",
+            },
+          }),
+        );
+      const context = createContext(fetcher);
+      context.sleep = sleep;
+
+      await pubmedActionHandlers.search_articles({ query: "test" }, context);
+
+      expect(sleep).toHaveBeenCalledWith(5_000, undefined);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("stops retrying when the request is aborted during backoff", async () => {
+    const controller = new AbortController();
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        Response.json({ error: "API rate limit exceeded" }, { status: 429, headers: { "retry-after": "1" } }),
+      );
+    const context = {
+      ...createContext(fetcher),
+      signal: controller.signal,
+      sleep: async (_delayMs: number, signal?: AbortSignal) => {
+        controller.abort();
+        if (!signal?.aborted) {
+          throw new Error("backoff did not receive the request signal");
+        }
+        const error = new Error("aborted");
+        error.name = "AbortError";
+        throw error;
+      },
+    };
+
+    await expect(pubmedActionHandlers.search_articles({ query: "test" }, context)).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("times out an NCBI request that does not complete", async () => {
+    vi.useFakeTimers();
+    try {
+      let requestedSignal: AbortSignal | undefined;
+      const fetcher = vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+          new Promise((_resolve, reject) => {
+            requestedSignal = init?.signal ?? undefined;
+            requestedSignal?.addEventListener(
+              "abort",
+              () => {
+                const error = new Error("aborted");
+                error.name = "AbortError";
+                reject(error);
+              },
+              { once: true },
+            );
+          }),
+      );
+
+      const request = pubmedActionHandlers.search_articles({ query: "test" }, createContext(fetcher));
+      const outcome = request.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestedSignal).toBeInstanceOf(AbortSignal);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(outcome).resolves.toMatchObject({
+        status: 504,
+        message: "PubMed request timed out",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves caller cancellation when it races with the request timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const fetcher = vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                setTimeout(() => {
+                  const error = new Error("caller aborted");
+                  error.name = "AbortError";
+                  reject(error);
+                }, 2);
+              },
+              { once: true },
+            );
+          }),
+      );
+      const context = { ...createContext(fetcher), signal: controller.signal };
+
+      const request = pubmedActionHandlers.search_articles({ query: "test" }, context);
+      const outcome = request.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      setTimeout(() => controller.abort(), 29_999);
+
+      await vi.advanceTimersByTimeAsync(30_001);
+      await expect(outcome).resolves.toMatchObject({
+        name: "AbortError",
+        message: "caller aborted",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("validates an NCBI API key with the PubMed EInfo endpoint", async () => {
+    let requestedUrl: URL | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      requestedUrl = new URL(input.toString());
+      return Response.json({
+        einforesult: {
+          dbinfo: [{ dbname: "pubmed", menuname: "PubMed" }],
+        },
+      });
+    });
+
+    const result = await validatePubmedCredential({ apiKey: "ncbi-test-key" }, fetcher);
+
+    expect(result).toEqual({});
+    expect(requestedUrl!.pathname).toMatch(/\/einfo\.fcgi$/u);
+    expect(requestedUrl!.searchParams.get("api_key")).toBe("ncbi-test-key");
+  });
+});
+
+function createContext(fetcher: typeof fetch, apiKey?: string) {
+  return {
+    apiKey,
+    fetcher,
+    requestGate: { wait: async () => undefined },
+    sleep: async () => undefined,
+  };
+}

--- a/src/providers/pubmed/runtime.ts
+++ b/src/providers/pubmed/runtime.ts
@@ -29,6 +29,11 @@ interface PubmedActionContext {
   sleep(delayMs: number, signal?: AbortSignal): Promise<void>;
 }
 
+interface PubmedLinkedArticlesResult {
+  sourcePmid: string;
+  articles: PubmedArticle[];
+}
+
 interface NcbiTextRequestOptions {
   source: string;
   maxBytes: number;
@@ -520,7 +525,7 @@ async function fetchLinkedArticles(
   linkName: "pubmed_pubmed_citedin" | "pubmed_pubmed_refs",
   limit: number,
   context: PubmedActionContext,
-): Promise<unknown> {
+): Promise<PubmedLinkedArticlesResult> {
   const payload = requiredRecord(
     await requestPubmedJson(
       "elink.fcgi",

--- a/src/providers/pubmed/runtime.ts
+++ b/src/providers/pubmed/runtime.ts
@@ -1,0 +1,778 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { PubmedActionName } from "./actions.ts";
+import type { PubmedArticle } from "./runtime-xml.ts";
+
+import { createHash } from "node:crypto";
+import {
+  objectArray,
+  optionalInteger,
+  optionalObjectArray,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+  requiredStringArray,
+} from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { parsePubmedArticleSet } from "./runtime-xml.ts";
+
+type PubmedSort = "first_author" | "journal" | "publication_date" | "relevance";
+type PubmedIdType = "doi" | "mid" | "pmcid" | "pmid";
+
+interface PubmedActionContext {
+  apiKey?: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+  requestGate: Pick<PubmedRequestGate, "wait">;
+  sleep(delayMs: number, signal?: AbortSignal): Promise<void>;
+}
+
+interface NcbiTextRequestOptions {
+  source: string;
+  maxBytes: number;
+  intervalMs: number;
+  init: RequestInit;
+}
+
+interface PendingPubmedRequest {
+  intervalMs: number;
+  signal?: AbortSignal;
+  resolve(): void;
+  reject(error: unknown): void;
+  abort(): void;
+}
+
+interface CachedPubmedRequestGate {
+  leases: number;
+  requestGate: PubmedRequestGate;
+}
+
+/** Serializes E-utility calls and reserves the next provider request slot. */
+export class PubmedRequestGate {
+  private readonly now: () => number;
+  private readonly sleep: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+  private nextRequestAt = 0;
+  private readonly queue: PendingPubmedRequest[] = [];
+  private processing = false;
+
+  constructor(now: () => number = Date.now, sleep: (delayMs: number, signal?: AbortSignal) => Promise<void> = delay) {
+    this.now = now;
+    this.sleep = sleep;
+  }
+
+  wait(intervalMs: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      return Promise.reject(createAbortError());
+    }
+
+    return new Promise((resolve, reject) => {
+      const request: PendingPubmedRequest = {
+        intervalMs,
+        signal,
+        resolve,
+        reject,
+        abort: () => {
+          const index = this.queue.indexOf(request);
+          if (index < 0) {
+            return;
+          }
+          this.queue.splice(index, 1);
+          signal?.removeEventListener("abort", request.abort);
+          reject(createAbortError());
+        },
+      };
+      signal?.addEventListener("abort", request.abort, { once: true });
+      this.queue.push(request);
+      void this.processQueue();
+    });
+  }
+
+  isIdle(): boolean {
+    return !this.processing && this.queue.length === 0 && this.nextRequestAt <= this.now();
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
+    try {
+      let request: PendingPubmedRequest | undefined;
+      while ((request = this.queue.shift())) {
+        request.signal?.removeEventListener("abort", request.abort);
+        try {
+          throwIfAborted(request.signal);
+          const waitMs = Math.max(0, this.nextRequestAt - this.now());
+          if (waitMs > 0) {
+            await this.sleep(waitMs, request.signal);
+          }
+          throwIfAborted(request.signal);
+          this.nextRequestAt = this.now() + request.intervalMs;
+          request.resolve();
+        } catch (error) {
+          request.reject(error);
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+}
+
+/** Keep per-key NCBI quota gates without retaining raw credentials or growing without bound. */
+export class PubmedRequestGatePool {
+  private readonly maximumEntries: number;
+  private readonly requestGates = new Map<string, CachedPubmedRequestGate>();
+  private readonly overflowEntry: CachedPubmedRequestGate = {
+    leases: 0,
+    requestGate: new PubmedRequestGate(),
+  };
+
+  constructor(maximumEntries: number) {
+    if (!Number.isInteger(maximumEntries) || maximumEntries < 1) {
+      throw new RangeError("maximumEntries must be a positive integer");
+    }
+    this.maximumEntries = maximumEntries;
+  }
+
+  forKey(apiKey: string): Pick<PubmedRequestGate, "wait"> {
+    return {
+      wait: (intervalMs, signal) => this.wait(apiKey, intervalMs, signal),
+    };
+  }
+
+  private async wait(apiKey: string, intervalMs: number, signal?: AbortSignal): Promise<void> {
+    const identity = createHash("sha256").update(apiKey).digest("hex");
+    const existing = this.requestGates.get(identity);
+    let entry: CachedPubmedRequestGate;
+    if (existing) {
+      this.requestGates.delete(identity);
+      this.requestGates.set(identity, existing);
+      entry = existing;
+    } else {
+      if (this.requestGates.size >= this.maximumEntries && !this.isEvictable(this.overflowEntry)) {
+        entry = this.overflowEntry;
+      } else {
+        if (this.requestGates.size >= this.maximumEntries) {
+          for (const [cachedIdentity, cachedEntry] of this.requestGates) {
+            if (this.isEvictable(cachedEntry)) {
+              this.requestGates.delete(cachedIdentity);
+              break;
+            }
+          }
+        }
+        entry =
+          this.requestGates.size >= this.maximumEntries
+            ? this.overflowEntry
+            : { leases: 0, requestGate: new PubmedRequestGate() };
+        if (entry !== this.overflowEntry) {
+          this.requestGates.set(identity, entry);
+        }
+      }
+    }
+
+    entry.leases += 1;
+    try {
+      await entry.requestGate.wait(intervalMs, signal);
+    } finally {
+      entry.leases -= 1;
+    }
+  }
+
+  private isEvictable(entry: CachedPubmedRequestGate): boolean {
+    return entry.leases === 0 && entry.requestGate.isIdle();
+  }
+}
+
+const pubmedApiBaseUrl = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
+const citationMatcherUrl = "https://pubmed.ncbi.nlm.nih.gov/api/citmatch/";
+const idConverterUrl = "https://pmc.ncbi.nlm.nih.gov/tools/idconv/api/v1/articles/";
+const pubmedToolName = "openconnector";
+const pubmedSortValues: Record<PubmedSort, string> = {
+  first_author: "Author",
+  journal: "JournalName",
+  publication_date: "pub date",
+  relevance: "relevance",
+};
+const anonymousRequestIntervalMs = 334;
+const apiKeyRequestIntervalMs = 100;
+const pubmedRequestTimeoutMs = 30_000;
+const maximumJsonResponseBytes = 1024 * 1024;
+const maximumXmlResponseBytes = 10 * 1024 * 1024;
+const maximumCachedApiKeyRequestGates = 100;
+const anonymousRequestGate = new PubmedRequestGate();
+const apiKeyRequestGates = new PubmedRequestGatePool(maximumCachedApiKeyRequestGates);
+
+function delay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(createAbortError());
+  }
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, delayMs);
+    const abort = (): void => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", abort);
+      reject(createAbortError());
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function immediateDelay(_delayMs: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  return Promise.resolve();
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+function createAbortError(): Error {
+  const error = new Error("The PubMed request was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export const pubmedActionHandlers: Record<PubmedActionName, ProviderRuntimeHandler<PubmedActionContext>> = {
+  async search_articles(input, context) {
+    const query = requiredString(input.query, "query", invalidInput);
+    const offset = optionalInteger(input.offset) ?? 0;
+    const limit = optionalInteger(input.limit) ?? 10;
+    if (offset + limit > 10_000) {
+      throw invalidInput("offset plus limit must not exceed 10000 for PubMed searches");
+    }
+    const sort = readSort(input.sort);
+    const publicationDateRange = readPublicationDateRange(input.publicationDateRange);
+    const searchPayload = requiredRecord(
+      await requestPubmedJson(
+        "esearch.fcgi",
+        {
+          term: query,
+          retstart: String(offset),
+          retmax: String(limit),
+          sort: sort ? pubmedSortValues[sort] : undefined,
+          datetype: publicationDateRange ? "pdat" : undefined,
+          mindate: formatNcbiDate(publicationDateRange?.from),
+          maxdate: formatNcbiDate(publicationDateRange?.to),
+        },
+        context,
+      ),
+      "PubMed search response",
+      invalidResponse,
+    );
+    const result = requiredRecord(searchPayload.esearchresult, "PubMed esearchresult", invalidResponse);
+    const pmids = requiredStringArray(result.idlist, "PubMed search idlist", invalidResponse);
+
+    return {
+      total: readIntegerString(result.count, "PubMed search count"),
+      offset,
+      limit,
+      queryTranslation: optionalString(result.querytranslation) ?? null,
+      articles: pmids.length > 0 ? await fetchArticles(pmids, context) : [],
+    };
+  },
+  async get_article(input, context) {
+    const pmid = readPmid(input.pmid, "pmid");
+    const articles = await fetchArticles([pmid], context);
+    return {
+      found: articles.length > 0,
+      article: articles[0] ?? null,
+    };
+  },
+  async get_articles(input, context) {
+    const pmids = readPmidArray(input.pmids);
+    const articles = await fetchArticles(pmids, context);
+    const returnedPmids = new Set(articles.map((article) => article.pmid));
+    return {
+      articles,
+      notFoundPmids: pmids.filter((pmid) => !returnedPmids.has(pmid)),
+    };
+  },
+  async find_related_articles(input, context) {
+    const sourcePmid = readPmid(input.pmid, "pmid");
+    const limit = readLimit(input.limit);
+
+    const payload = requiredRecord(
+      await requestPubmedJson(
+        "elink.fcgi",
+        {
+          dbfrom: "pubmed",
+          id: sourcePmid,
+          linkname: "pubmed_pubmed",
+          cmd: "neighbor",
+        },
+        context,
+      ),
+      "PubMed related articles response",
+      invalidResponse,
+    );
+    const relatedPmids = readLinkedPmids(payload, "pubmed_pubmed", "PubMed related article links")
+      .filter((pmid) => pmid !== sourcePmid)
+      .slice(0, limit);
+    return {
+      sourcePmid,
+      articles: relatedPmids.length > 0 ? await fetchArticles(relatedPmids, context) : [],
+    };
+  },
+  async match_citation(input, context) {
+    const citation = requiredString(input.citation, "citation", invalidInput);
+    const url = new URL(citationMatcherUrl);
+    url.searchParams.set("method", "heuristic");
+    url.searchParams.set("raw-text", citation);
+    const payload = requiredRecord(
+      await requestNcbiJson(url, "PubMed Citation Matcher", context),
+      "PubMed Citation Matcher response",
+      invalidResponse,
+    );
+    if (payload.success !== true) {
+      throw new ProviderRequestError(502, "PubMed Citation Matcher reported an unsuccessful response");
+    }
+    const result = requiredRecord(payload.result, "PubMed Citation Matcher result", invalidResponse);
+    const pmids = readCitationPmids(result.uids);
+    return {
+      matched: pmids.length > 0,
+      articles: pmids.length > 0 ? await fetchArticles(pmids, context) : [],
+    };
+  },
+  async get_citing_articles(input, context) {
+    return fetchLinkedArticles(readPmid(input.pmid, "pmid"), "pubmed_pubmed_citedin", readLimit(input.limit), context);
+  },
+  async get_article_references(input, context) {
+    return fetchLinkedArticles(readPmid(input.pmid, "pmid"), "pubmed_pubmed_refs", readLimit(input.limit), context);
+  },
+  async convert_article_ids(input, context) {
+    const ids = readArticleIds(input.ids);
+    const idType = readIdType(input.idType);
+    const url = new URL(idConverterUrl);
+    url.searchParams.set("ids", ids.join(","));
+    url.searchParams.set("idtype", idType);
+    url.searchParams.set("format", "json");
+    url.searchParams.set("tool", pubmedToolName);
+    const payload = requiredRecord(
+      await requestNcbiJson(url, "PMC ID Converter", context),
+      "PMC ID Converter response",
+      invalidResponse,
+    );
+    const records = objectArray(payload.records, "PMC ID Converter records", invalidResponse);
+    return {
+      records: records.map((record, index) => ({
+        requestedId: readIdentifier(record["requested-id"], `PMC ID Converter records[${index}].requested-id`),
+        pmid: optionalIdentifier(record.pmid),
+        pmcid: optionalString(record.pmcid) ?? null,
+        doi: optionalString(record.doi) ?? null,
+        mid: optionalString(record.mid) ?? null,
+        error: optionalString(record.errmsg) ?? null,
+      })),
+    };
+  },
+};
+
+export async function validatePubmedCredential(
+  input: { apiKey: string },
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createPubmedActionContext({
+    apiKey: input.apiKey,
+    fetcher,
+    signal,
+  });
+  const payload = requiredRecord(
+    await requestPubmedJson("einfo.fcgi", {}, context),
+    "PubMed credential validation response",
+    invalidResponse,
+  );
+  const result = requiredRecord(payload.einforesult, "PubMed einforesult", invalidResponse);
+  const database = optionalObjectArray(result.dbinfo, "PubMed EInfo database", invalidResponse).find(
+    (entry) => optionalString(entry.dbname) === "pubmed",
+  );
+  if (!database) {
+    throw new ProviderRequestError(400, "NCBI API key could not access PubMed");
+  }
+
+  return {};
+}
+
+interface CreatePubmedActionContextOptions {
+  apiKey?: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export function createPubmedActionContext(options: CreatePubmedActionContextOptions): PubmedActionContext {
+  return {
+    ...options,
+    requestGate: options.fetcher === fetch ? requestGateFor(options.apiKey) : { wait: immediateDelay },
+    sleep: options.fetcher === fetch ? delay : immediateDelay,
+  };
+}
+
+function requestGateFor(apiKey: string | undefined): Pick<PubmedRequestGate, "wait"> {
+  if (!apiKey) {
+    return anonymousRequestGate;
+  }
+
+  return apiKeyRequestGates.forKey(apiKey);
+}
+
+function invalidInput(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function invalidResponse(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}
+
+function readSort(value: unknown): PubmedSort | undefined {
+  const sort = optionalString(value);
+  if (!sort) {
+    return undefined;
+  }
+  if (sort in pubmedSortValues) {
+    return sort as PubmedSort;
+  }
+  throw invalidInput("sort is not supported by PubMed");
+}
+
+function readPmid(value: unknown, fieldName: string): string {
+  const pmid = requiredString(value, fieldName, invalidInput);
+  if (!/^\d+$/u.test(pmid)) {
+    throw invalidInput(`${fieldName} must contain only digits`);
+  }
+  return pmid;
+}
+
+function readPmidArray(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 50) {
+    throw invalidInput("pmids must contain between 1 and 50 PubMed IDs");
+  }
+  return value.map((pmid, index) => readPmid(pmid, `pmids[${index}]`));
+}
+
+function readLimit(value: unknown): number {
+  const limit = optionalInteger(value) ?? 10;
+  if (limit < 1 || limit > 50) {
+    throw invalidInput("limit must be between 1 and 50");
+  }
+  return limit;
+}
+
+function readArticleIds(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 200) {
+    throw invalidInput("ids must contain between 1 and 200 article identifiers");
+  }
+  return value.map((id, index) => requiredString(id, `ids[${index}]`, invalidInput));
+}
+
+function readIdType(value: unknown): PubmedIdType {
+  const idType = requiredString(value, "idType", invalidInput);
+  if (idType === "doi" || idType === "mid" || idType === "pmcid" || idType === "pmid") {
+    return idType;
+  }
+  throw invalidInput("idType must be doi, mid, pmcid, or pmid");
+}
+
+interface PublicationDateRange {
+  from: string;
+  to: string;
+}
+
+function readPublicationDateRange(value: unknown): PublicationDateRange | undefined {
+  const range = optionalRecord(value);
+  if (!range) {
+    return undefined;
+  }
+  const from = requiredString(range.from, "publicationDateRange.from", invalidInput);
+  const to = requiredString(range.to, "publicationDateRange.to", invalidInput);
+  if (from > to) {
+    throw invalidInput("publicationDateRange.from must not be after publicationDateRange.to");
+  }
+  return { from, to };
+}
+
+function formatNcbiDate(value: string | undefined): string | undefined {
+  return value?.replaceAll("-", "/");
+}
+
+async function fetchArticles(pmids: string[], context: PubmedActionContext): Promise<PubmedArticle[]> {
+  const xml = await requestPubmedText(
+    "efetch.fcgi",
+    {
+      id: pmids.join(","),
+      retmode: "xml",
+    },
+    context,
+    maximumXmlResponseBytes,
+    "application/xml, text/xml",
+  );
+  return parsePubmedArticleSet(xml);
+}
+
+async function fetchLinkedArticles(
+  sourcePmid: string,
+  linkName: "pubmed_pubmed_citedin" | "pubmed_pubmed_refs",
+  limit: number,
+  context: PubmedActionContext,
+): Promise<unknown> {
+  const payload = requiredRecord(
+    await requestPubmedJson(
+      "elink.fcgi",
+      {
+        dbfrom: "pubmed",
+        id: sourcePmid,
+        linkname: linkName,
+        cmd: "neighbor",
+      },
+      context,
+    ),
+    `PubMed ${linkName} response`,
+    invalidResponse,
+  );
+  const pmids = readLinkedPmids(payload, linkName, `PubMed ${linkName} links`).slice(0, limit);
+  return {
+    sourcePmid,
+    articles: pmids.length > 0 ? await fetchArticles(pmids, context) : [],
+  };
+}
+
+async function requestNcbiJson(url: URL, source: string, context: PubmedActionContext): Promise<unknown> {
+  const headers = new Headers({
+    accept: "application/json",
+    "user-agent": providerUserAgent,
+  });
+  const text = await requestNcbiText(
+    url,
+    {
+      source,
+      maxBytes: maximumJsonResponseBytes,
+      intervalMs: anonymousRequestIntervalMs,
+      init: { headers },
+    },
+    context,
+  );
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new ProviderRequestError(502, `${source} returned malformed JSON`);
+  }
+}
+
+async function requestPubmedJson(
+  utility: string,
+  query: Record<string, string | undefined>,
+  context: PubmedActionContext,
+): Promise<unknown> {
+  const text = await requestPubmedText(
+    utility,
+    { ...query, retmode: "json" },
+    context,
+    maximumJsonResponseBytes,
+    "application/json",
+  );
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new ProviderRequestError(502, `PubMed returned malformed JSON from ${utility}`);
+  }
+}
+
+async function requestPubmedText(
+  utility: string,
+  query: Record<string, string | undefined>,
+  context: PubmedActionContext,
+  maxBytes: number,
+  accept: string,
+): Promise<string> {
+  const url = new URL(utility, pubmedApiBaseUrl);
+  url.searchParams.set("db", "pubmed");
+  url.searchParams.set("tool", pubmedToolName);
+  for (const [name, value] of Object.entries(query)) {
+    if (value !== undefined) {
+      url.searchParams.set(name, value);
+    }
+  }
+  if (context.apiKey) {
+    url.searchParams.set("api_key", context.apiKey);
+  }
+  const usePost = utility === "esearch.fcgi" && (query.term?.length ?? 0) > 500;
+  const body = usePost ? new URLSearchParams(url.searchParams) : undefined;
+  if (usePost) {
+    url.search = "";
+  }
+  const headers = new Headers({
+    accept,
+    "user-agent": providerUserAgent,
+  });
+  if (usePost) {
+    headers.set("content-type", "application/x-www-form-urlencoded");
+  }
+
+  return requestNcbiText(
+    url,
+    {
+      source: "PubMed",
+      maxBytes,
+      intervalMs: context.apiKey ? apiKeyRequestIntervalMs : anonymousRequestIntervalMs,
+      init: {
+        headers,
+        method: usePost ? "POST" : "GET",
+        body,
+      },
+    },
+    context,
+  );
+}
+
+async function requestNcbiText(
+  url: URL,
+  options: NcbiTextRequestOptions,
+  context: PubmedActionContext,
+): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await context.requestGate.wait(options.intervalMs, context.signal);
+    const { response, text } = await requestNcbiTextOnce(url, options, context);
+    if (response.ok) {
+      return text;
+    }
+    if (attempt < 2 && isRetryableStatus(response.status)) {
+      await context.sleep(readRetryDelay(response, attempt), context.signal);
+      continue;
+    }
+    throw new ProviderRequestError(
+      response.status,
+      extractPubmedError(text) ?? `${options.source} request failed with HTTP ${response.status}`,
+    );
+  }
+
+  throw new ProviderRequestError(502, `${options.source} request failed after retries`);
+}
+
+async function requestNcbiTextOnce(
+  url: URL,
+  options: NcbiTextRequestOptions,
+  context: PubmedActionContext,
+): Promise<{ response: Response; text: string }> {
+  const timeout = createProviderTimeout(context.signal, pubmedRequestTimeoutMs);
+  try {
+    const response = await context.fetcher(url, {
+      ...options.init,
+      signal: timeout.signal,
+    });
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: options.maxBytes,
+      fieldName: `${options.source} response`,
+      createError: (message) => new ProviderRequestError(502, message),
+    });
+    return {
+      response,
+      text: new TextDecoder().decode(bytes),
+    };
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (context.signal?.aborted) {
+      throw error;
+    }
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, `${options.source} request timed out`);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error
+        ? `${options.source} request failed: ${error.message}`
+        : `${options.source} request failed`,
+    );
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function readRetryDelay(response: Response, attempt: number): number {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter) {
+    if (/^\d+$/u.test(retryAfter)) {
+      return Math.min(Number(retryAfter) * 1_000, 30_000);
+    }
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt)) {
+      return Math.min(Math.max(0, retryAt - Date.now()), 30_000);
+    }
+  }
+  return 250 * 2 ** attempt;
+}
+
+function extractPubmedError(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const payload = optionalRecord(JSON.parse(trimmed));
+    const direct = optionalString(payload?.error);
+    if (direct) {
+      return direct;
+    }
+    const errors = payload?.errors;
+    if (Array.isArray(errors)) {
+      return errors.filter((item): item is string => typeof item === "string").join("; ") || undefined;
+    }
+  } catch {
+    return trimmed.slice(0, 500);
+  }
+  return trimmed.slice(0, 500);
+}
+
+function readLinkedPmids(payload: Record<string, unknown>, linkName: string, fieldName: string): string[] {
+  const linksets = optionalObjectArray(payload.linksets, `${fieldName} linkset`, invalidResponse);
+  for (const linkset of linksets) {
+    const related = optionalObjectArray(linkset.linksetdbs, `${fieldName} database`, invalidResponse).find(
+      (linksetDatabase) => optionalString(linksetDatabase.linkname) === linkName,
+    );
+    if (related) {
+      return requiredStringArray(related.links, fieldName, invalidResponse);
+    }
+  }
+  return [];
+}
+
+function readCitationPmids(value: unknown): string[] {
+  return objectArray(value, "PubMed Citation Matcher UIDs", invalidResponse).map((record, index) =>
+    readPmid(record.pubmed, `PubMed Citation Matcher UIDs[${index}].pubmed`),
+  );
+}
+
+function readIdentifier(value: unknown, fieldName: string): string {
+  const identifier = optionalIdentifier(value);
+  if (!identifier) {
+    throw new ProviderRequestError(502, `${fieldName} is malformed`);
+  }
+  return identifier;
+}
+
+function optionalIdentifier(value: unknown): string | null {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return String(value);
+  }
+  return optionalString(value) ?? null;
+}
+
+function readIntegerString(value: unknown, fieldName: string): number {
+  const text = optionalString(value);
+  const parsed = text ? Number(text) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new ProviderRequestError(502, `${fieldName} is malformed`);
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

Add a PubMed provider backed by official NCBI APIs, with normalized biomedical article records and optional API key authentication.

## Changes

- Add 8 PubMed actions for search, article retrieval, citation matching, related/citing/reference traversal, and PMC identifier conversion.
- Support both no-auth access and optional NCBI API keys, with per-quota rate limiting, bounded gate caching, retries, cancellation, request timeouts, and response size limits.
- Parse PubMed article and book XML into stable output schemas using `fast-xml-parser`.
- Add a strict `requiredStringArray` cast helper for validating upstream response arrays without coercion.
- Add runtime, XML normalization, executor parity, rate-limit, retry, timeout, and credential validation tests.

## Validation

- [x] `npm run generate:catalog`
- [x] `npm run fix-check`
- [x] `npm test` (53 files, 588 tests)
- [x] `npm audit --omit=dev`
- [x] Generated PubMed catalog and registry match all 8 executable actions