### PR TITLE
feat(revenuecat): add RevenueCat provider

### DIFF
--- a/src/providers/revenuecat/actions.ts
+++ b/src/providers/revenuecat/actions.ts
@@ -1,0 +1,200 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "revenuecat" as const;
+
+const identifier = (description: string) => s.string({ minLength: 1, maxLength: 1500, description });
+
+const paginationFields = {
+  startingAfter: s.string("Return records after this RevenueCat cursor."),
+  limit: s.integer("Maximum number of records to return.", { minimum: 1, maximum: 100 }),
+};
+
+const rawObject = (description: string) => s.looseObject(description);
+
+const listOutput = (description: string, itemDescription: string) =>
+  s.object(description, {
+    object: s.literal("list", { description: "RevenueCat list response marker." }),
+    items: s.array(rawObject(itemDescription), { description: "Records returned by RevenueCat." }),
+    nextPage: s.nullableString("URL for the next page, or null when there are no more records."),
+    url: s.string("URL of the current RevenueCat list response."),
+  });
+
+const singleOutput = (description: string, field: string, itemDescription: string) =>
+  s.object(description, {
+    [field]: rawObject(itemDescription),
+  });
+
+const expandCustomerFields = s.array(s.stringEnum(["attributes"], { description: "A customer field to expand." }), {
+  maxItems: 1,
+  description: "Optional customer fields to expand in the response.",
+});
+
+const expandOfferingFields = s.array(
+  s.stringEnum(["items.package", "items.package.product"], {
+    description: "An Offering field to expand.",
+  }),
+  {
+    maxItems: 2,
+    description: "Optional Offering fields to expand in the response.",
+  },
+);
+
+const currency = s.stringEnum(
+  ["USD", "EUR", "GBP", "AUD", "CAD", "JPY", "BRL", "KRW", "CNY", "MXN", "SEK", "PLN", "NZD", "CHF"],
+  { description: "Currency used for the returned RevenueCat metrics." },
+);
+
+const projectInput = (description: string, properties: Record<string, object>, required: string[] = ["projectId"]) =>
+  s.object(description, { projectId: identifier("RevenueCat project ID."), ...properties }, { required });
+
+export const revenueCatActions: readonly ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_projects",
+    description: "List RevenueCat projects accessible to the configured secret API key.",
+    requiredScopes: ["project_configuration:projects:read"],
+    inputSchema: s.object("Pagination for RevenueCat projects.", paginationFields),
+    outputSchema: listOutput("A paginated list of RevenueCat projects.", "A RevenueCat project."),
+  }),
+  defineProviderAction(service, {
+    name: "list_customers",
+    description: "List customers in a RevenueCat project, optionally searching by email or customer identifier.",
+    requiredScopes: ["customer_information:customers:read"],
+    inputSchema: projectInput("Filters for RevenueCat customers.", {
+      ...paginationFields,
+      search: s.string("Search by customer email, app user ID, store transaction identifier, or Apple order ID.", {
+        minLength: 1,
+        maxLength: 255,
+      }),
+    }),
+    outputSchema: listOutput("A paginated list of RevenueCat customers.", "A RevenueCat customer."),
+  }),
+  defineProviderAction(service, {
+    name: "get_customer",
+    description: "Retrieve a RevenueCat customer and optionally expand the customer's attributes.",
+    requiredScopes: ["customer_information:customers:read"],
+    inputSchema: projectInput(
+      "Input for retrieving a RevenueCat customer.",
+      {
+        customerId: identifier("RevenueCat customer or app user ID."),
+        expand: expandCustomerFields,
+      },
+      ["projectId", "customerId"],
+    ),
+    outputSchema: singleOutput("A RevenueCat customer response.", "customer", "A RevenueCat customer."),
+  }),
+  defineProviderAction(service, {
+    name: "list_customer_subscriptions",
+    description: "List subscriptions belonging to a RevenueCat customer.",
+    requiredScopes: ["customer_information:subscriptions:read"],
+    inputSchema: projectInput(
+      "Pagination for a customer's RevenueCat subscriptions.",
+      {
+        customerId: identifier("RevenueCat customer or app user ID."),
+        ...paginationFields,
+      },
+      ["projectId", "customerId"],
+    ),
+    outputSchema: listOutput("A paginated list of customer subscriptions.", "A RevenueCat subscription."),
+  }),
+  defineProviderAction(service, {
+    name: "get_subscription",
+    description: "Retrieve a RevenueCat subscription by its subscription ID.",
+    requiredScopes: ["customer_information:subscriptions:read"],
+    inputSchema: projectInput(
+      "Input for retrieving a RevenueCat subscription.",
+      {
+        subscriptionId: identifier("RevenueCat subscription ID."),
+      },
+      ["projectId", "subscriptionId"],
+    ),
+    outputSchema: singleOutput("A RevenueCat subscription response.", "subscription", "A RevenueCat subscription."),
+  }),
+  defineProviderAction(service, {
+    name: "search_subscriptions",
+    description:
+      "Find subscriptions by a store subscription identifier such as an Apple transaction ID or Google order ID.",
+    requiredScopes: ["customer_information:subscriptions:read"],
+    inputSchema: projectInput(
+      "Input for searching RevenueCat subscriptions.",
+      {
+        storeSubscriptionIdentifier: identifier("Store subscription identifier to search for."),
+        includeScheduled: s.boolean("Whether to include subscriptions scheduled to start in the future."),
+      },
+      ["projectId", "storeSubscriptionIdentifier"],
+    ),
+    outputSchema: listOutput("A list of subscriptions matching the store identifier.", "A RevenueCat subscription."),
+  }),
+  defineProviderAction(service, {
+    name: "list_customer_active_entitlements",
+    description: "List the entitlements currently active for a RevenueCat customer.",
+    requiredScopes: ["customer_information:customers:read"],
+    inputSchema: projectInput(
+      "Pagination for a customer's active RevenueCat entitlements.",
+      {
+        customerId: identifier("RevenueCat customer or app user ID."),
+        ...paginationFields,
+      },
+      ["projectId", "customerId"],
+    ),
+    outputSchema: listOutput(
+      "A paginated list of active customer entitlements.",
+      "An active RevenueCat customer entitlement.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_entitlements",
+    description: "List entitlement definitions configured in a RevenueCat project.",
+    requiredScopes: ["project_configuration:entitlements:read"],
+    inputSchema: projectInput("Pagination for RevenueCat entitlements.", paginationFields),
+    outputSchema: listOutput("A paginated list of RevenueCat entitlements.", "A RevenueCat entitlement definition."),
+  }),
+  defineProviderAction(service, {
+    name: "list_offerings",
+    description: "List offerings configured in a RevenueCat project, optionally expanding packages and products.",
+    requiredScopes: ["project_configuration:offerings:read"],
+    inputSchema: projectInput("Pagination and expansion options for RevenueCat offerings.", {
+      ...paginationFields,
+      expand: expandOfferingFields,
+    }),
+    outputSchema: listOutput("A paginated list of RevenueCat offerings.", "A RevenueCat offering."),
+  }),
+  defineProviderAction(service, {
+    name: "list_products",
+    description: "List products configured in a RevenueCat project.",
+    requiredScopes: ["project_configuration:products:read"],
+    inputSchema: projectInput("Pagination for RevenueCat products.", paginationFields),
+    outputSchema: listOutput("A paginated list of RevenueCat products.", "A RevenueCat product."),
+  }),
+  defineProviderAction(service, {
+    name: "get_overview_metrics",
+    description: "Retrieve overview metrics for a RevenueCat project.",
+    requiredScopes: ["charts_metrics:overview:read"],
+    inputSchema: projectInput("Input for retrieving RevenueCat overview metrics.", { currency }),
+    outputSchema: singleOutput(
+      "RevenueCat overview metrics response.",
+      "metrics",
+      "RevenueCat project overview metrics.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_revenue_metric",
+    description: "Retrieve total RevenueCat project revenue for an inclusive date range.",
+    requiredScopes: ["charts_metrics:overview:read"],
+    inputSchema: projectInput(
+      "Input for retrieving RevenueCat revenue metrics.",
+      {
+        startDate: s.date("Inclusive start date in ISO 8601 format."),
+        endDate: s.date("Inclusive end date in ISO 8601 format."),
+        currency,
+        revenueType: s.stringEnum(["revenue", "revenue_net_of_taxes", "proceeds"], {
+          description: "Revenue definition returned as the metric value.",
+        }),
+      },
+      ["projectId", "startDate", "endDate"],
+    ),
+    outputSchema: singleOutput("RevenueCat revenue metric response.", "metric", "RevenueCat revenue metric data."),
+  }),
+];

--- a/src/providers/revenuecat/definition.ts
+++ b/src/providers/revenuecat/definition.ts
@@ -1,0 +1,25 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { revenueCatActions } from "./actions.ts";
+
+const service = "revenuecat";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "RevenueCat",
+  description: "Manage RevenueCat projects, customers, subscriptions, entitlements, offerings, products, and metrics.",
+  categories: ["Finance", "Developer Tools", "Subscriptions"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "V2 Secret API Key",
+      placeholder: "sk_...",
+      description:
+        "RevenueCat REST API v2 secret API key sent as a Bearer token. Create a V2 secret key in the RevenueCat project settings API keys page: https://www.revenuecat.com/docs/welcome/authentication.",
+      extraFields: [],
+    },
+  ],
+  homepageUrl: "https://www.revenuecat.com",
+  actions: revenueCatActions,
+};

--- a/src/providers/revenuecat/executors.test.ts
+++ b/src/providers/revenuecat/executors.test.ts
@@ -1,0 +1,70 @@
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { revenueCatActionHandlers } from "./executors.ts";
+
+describe("RevenueCat executors", () => {
+  it("sends bearer authentication and normalizes paginated customer responses", async () => {
+    let requestUrl = "";
+    let requestHeaders: Headers | undefined;
+    const context = createContext(async (input, init) => {
+      requestUrl = String(input);
+      requestHeaders = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          items: [{ id: "customer_1" }],
+          next_page: "/v2/projects/proj_1/customers?starting_after=customer_1",
+          url: "/v2/projects/proj_1/customers",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const output = await revenueCatActionHandlers.list_customers(
+      {
+        projectId: "proj/1",
+        startingAfter: "cursor_1",
+        limit: 2,
+        search: "person@example.com",
+      },
+      context,
+    );
+
+    expect(requestUrl).toBe(
+      "https://api.revenuecat.com/v2/projects/proj%2F1/customers?starting_after=cursor_1&limit=2&search=person%40example.com",
+    );
+    expect(requestHeaders?.get("authorization")).toBe("Bearer secret-key");
+    expect(output).toEqual({
+      object: "list",
+      items: [{ id: "customer_1" }],
+      nextPage: "/v2/projects/proj_1/customers?starting_after=customer_1",
+      url: "/v2/projects/proj_1/customers",
+    });
+  });
+
+  it("serializes expandable customer fields as repeated query parameters", async () => {
+    let requestUrl = "";
+    const context = createContext(async (input) => {
+      requestUrl = String(input);
+      return new Response(JSON.stringify({ id: "customer_1", attributes: { items: [] } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    await revenueCatActionHandlers.get_customer(
+      { projectId: "proj_1", customerId: "customer/1", expand: ["attributes"] },
+      context,
+    );
+
+    expect(requestUrl).toBe("https://api.revenuecat.com/v2/projects/proj_1/customers/customer%2F1?expand=attributes");
+  });
+});
+
+function createContext(fetcher: typeof fetch): ApiKeyProviderContext {
+  return {
+    apiKey: "secret-key",
+    fetcher,
+  };
+}

--- a/src/providers/revenuecat/executors.ts
+++ b/src/providers/revenuecat/executors.ts
@@ -1,0 +1,284 @@
+import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+  requiredStringArray,
+} from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
+import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+const service = "revenuecat";
+const revenueCatApiBaseUrl = "https://api.revenuecat.com";
+
+type RevenueCatPhase = "validate" | "execute";
+type RevenueCatActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
+type RevenueCatQueryValue = string | number | boolean | string[] | undefined;
+
+interface RevenueCatList {
+  object: string;
+  items: unknown[];
+  nextPage: string | null;
+  url: string;
+}
+
+export const revenueCatActionHandlers: Record<string, RevenueCatActionHandler> = {
+  list_projects(input, context) {
+    return listRevenueCatResource("/v2/projects", input, context, "projects");
+  },
+  list_customers(input, context) {
+    return listRevenueCatResource(`/v2/projects/${projectId(input)}/customers`, input, context, "customers", {
+      search: optionalString(input.search),
+    });
+  },
+  get_customer(input, context) {
+    return getRevenueCatResource(
+      `/v2/projects/${projectId(input)}/customers/${customerId(input)}`,
+      context,
+      "customer",
+      { expand: optionalStringArray(input.expand) },
+    );
+  },
+  list_customer_subscriptions(input, context) {
+    return listRevenueCatResource(
+      `/v2/projects/${projectId(input)}/customers/${customerId(input)}/subscriptions`,
+      input,
+      context,
+      "customer subscriptions",
+    );
+  },
+  get_subscription(input, context) {
+    return getRevenueCatResource(
+      `/v2/projects/${projectId(input)}/subscriptions/${subscriptionId(input)}`,
+      context,
+      "subscription",
+    );
+  },
+  search_subscriptions(input, context) {
+    return listRevenueCatResource(
+      `/v2/projects/${projectId(input)}/subscriptions`,
+      input,
+      context,
+      "subscriptions",
+      {
+        store_subscription_identifier: requiredString(
+          input.storeSubscriptionIdentifier,
+          "storeSubscriptionIdentifier",
+          inputError,
+        ),
+        include_scheduled: optionalBoolean(input.includeScheduled),
+      },
+      false,
+    );
+  },
+  list_customer_active_entitlements(input, context) {
+    return listRevenueCatResource(
+      `/v2/projects/${projectId(input)}/customers/${customerId(input)}/active_entitlements`,
+      input,
+      context,
+      "active customer entitlements",
+    );
+  },
+  list_entitlements(input, context) {
+    return listRevenueCatResource(`/v2/projects/${projectId(input)}/entitlements`, input, context, "entitlements");
+  },
+  list_offerings(input, context) {
+    return listRevenueCatResource(`/v2/projects/${projectId(input)}/offerings`, input, context, "offerings", {
+      expand: optionalStringArray(input.expand),
+    });
+  },
+  list_products(input, context) {
+    return listRevenueCatResource(`/v2/projects/${projectId(input)}/products`, input, context, "products");
+  },
+  get_overview_metrics(input, context) {
+    return getRevenueCatResource(`/v2/projects/${projectId(input)}/metrics/overview`, context, "metrics", {
+      currency: optionalString(input.currency),
+    });
+  },
+  get_revenue_metric(input, context) {
+    return getRevenueCatResource(`/v2/projects/${projectId(input)}/metrics/revenue`, context, "metric", {
+      start_date: requiredString(input.startDate, "startDate", inputError),
+      end_date: requiredString(input.endDate, "endDate", inputError),
+      currency: optionalString(input.currency),
+      revenue_type: optionalString(input.revenueType),
+    });
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, revenueCatActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const response = await requestRevenueCat(
+      "/v2/projects",
+      { apiKey: input.apiKey, fetcher, signal },
+      { limit: 1 },
+      "validate",
+    );
+    const page = readRevenueCatList(response, "projects");
+    const firstProject = optionalRecord(page.items[0]);
+
+    return {
+      profile: {
+        accountId: "revenuecat-api-key",
+        displayName: "RevenueCat API Key",
+      },
+      grantedScopes: [],
+      metadata: compactObject({
+        apiBaseUrl: revenueCatApiBaseUrl,
+        apiVersion: "v2",
+        validationEndpoint: "/v2/projects",
+        firstProjectId: optionalString(firstProject?.id),
+      }),
+    };
+  },
+};
+
+async function listRevenueCatResource(
+  path: string,
+  input: Record<string, unknown>,
+  context: ApiKeyProviderContext,
+  resourceName: string,
+  extraQuery: Record<string, RevenueCatQueryValue> = {},
+  includePagination = true,
+): Promise<RevenueCatList> {
+  const response = await requestRevenueCat(
+    path,
+    context,
+    {
+      ...(includePagination
+        ? {
+            starting_after: optionalString(input.startingAfter),
+            limit: optionalInteger(input.limit),
+          }
+        : {}),
+      ...extraQuery,
+    },
+    "execute",
+  );
+  return readRevenueCatList(response, resourceName);
+}
+
+async function getRevenueCatResource(
+  path: string,
+  context: ApiKeyProviderContext,
+  resourceName: string,
+  query: Record<string, RevenueCatQueryValue> = {},
+): Promise<Record<string, unknown>> {
+  const response = await requestRevenueCat(path, context, query, "execute");
+  const record = requiredRecord(response, `RevenueCat ${resourceName} response`, providerResponseError);
+  return { [resourceName]: record };
+}
+
+async function requestRevenueCat(
+  path: string,
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
+  query: Record<string, RevenueCatQueryValue>,
+  phase: RevenueCatPhase,
+): Promise<unknown> {
+  const url = new URL(path, revenueCatApiBaseUrl);
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      for (const item of value) url.searchParams.append(key, item);
+    } else if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  let response: Response;
+  let payload: unknown;
+  try {
+    response = await context.fetcher(url, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${context.apiKey}`,
+        "user-agent": providerUserAgent,
+      },
+      signal: context.signal,
+    });
+    payload = await readRevenueCatPayload(response);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) throw error;
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `RevenueCat request failed: ${error.message}` : "RevenueCat request failed",
+    );
+  }
+
+  if (!response.ok) {
+    const status = phase === "validate" && (response.status === 401 || response.status === 403) ? 400 : response.status;
+    throw new ProviderRequestError(status || 502, extractRevenueCatError(payload, response.status), payload);
+  }
+
+  return payload;
+}
+
+async function readRevenueCatPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    if (response.ok) throw new ProviderRequestError(502, "RevenueCat returned invalid JSON");
+    return text;
+  }
+}
+
+function readRevenueCatList(payload: unknown, resourceName: string): RevenueCatList {
+  const record = requiredRecord(payload, `RevenueCat ${resourceName} response`, providerResponseError);
+  if (!Array.isArray(record.items)) {
+    throw new ProviderRequestError(502, `RevenueCat ${resourceName} response is missing items`);
+  }
+
+  return {
+    object: optionalString(record.object) ?? "list",
+    items: record.items,
+    nextPage: optionalString(record.next_page) ?? null,
+    url: requiredString(record.url, `RevenueCat ${resourceName} response url`, providerResponseError),
+  };
+}
+
+function extractRevenueCatError(payload: unknown, status: number): string {
+  if (typeof payload === "string" && payload.trim()) return payload;
+  const record = optionalRecord(payload);
+  if (!record) return `RevenueCat request failed with HTTP ${status || 500}`;
+  return (
+    optionalString(record.message) ??
+    optionalString(record.detail) ??
+    optionalString(record.type) ??
+    `RevenueCat request failed with HTTP ${status || 500}`
+  );
+}
+
+function projectId(input: Record<string, unknown>): string {
+  return encodePathSegment(requiredString(input.projectId, "projectId", inputError));
+}
+
+function customerId(input: Record<string, unknown>): string {
+  return encodePathSegment(requiredString(input.customerId, "customerId", inputError));
+}
+
+function subscriptionId(input: Record<string, unknown>): string {
+  return encodePathSegment(requiredString(input.subscriptionId, "subscriptionId", inputError));
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  return requiredStringArray(value, "expand", inputError);
+}
+
+function inputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}


### PR DESCRIPTION
## Summary

- Add RevenueCat REST API v2 provider with Bearer API key authentication.
- Add 12 locally executable actions for projects, customers, subscriptions, entitlements, offerings, products, and metrics.
- Add credential validation, pagination, path encoding, response normalization, and runtime tests.

## Verification

- npm run generate:catalog
- npm run fix-check
- npm test

All checks pass. Live RevenueCat credentials were not used; provider request behavior is covered with mocks.