### PR TITLE
fix(apollo): use X-Api-Key header instead of Authorization: Bearer

### DIFF
--- a/src/providers/apollo/definition.ts
+++ b/src/providers/apollo/definition.ts
@@ -15,7 +15,7 @@ export const provider: ProviderDefinition = {
       label: "API Key",
       placeholder: "APOLLO_API_KEY",
       description:
-        "Apollo API key sent with the Authorization Bearer header. Create it in Settings > Integrations > API Keys: https://docs.apollo.io/docs/create-api-key. The first-pass actions require a master API key.",
+        "Apollo API key sent with the x-api-key header. Create it in Settings > Integrations > API Keys: https://docs.apollo.io/docs/create-api-key. The first-pass actions require a master API key.",
       extraFields: [],
     },
   ],

--- a/src/providers/apollo/executors.ts
+++ b/src/providers/apollo/executors.ts
@@ -172,7 +172,7 @@ async function requestApolloJson(input: {
   try {
     const headers: Record<string, string> = {
       accept: "application/json",
-      authorization: `Bearer ${input.apiKey}`,
+      "x-api-key": input.apiKey,
       "user-agent": providerUserAgent,
     };
     if (input.body) {


### PR DESCRIPTION
Fixes #80.

Apollo's REST API requires the API key in the `X-Api-Key` header. `requestApolloJson` (`src/providers/apollo/executors.ts`) was sending `Authorization: Bearer`, so all five Apollo actions and the credential validator failed with `Invalid access credentials`.

One-line header swap. Verified against `/api/v1/usage_stats/api_usage_stats` with the same master key: `X-Api-Key` returns 200, `Authorization: Bearer` returns 401.
