### PR TITLE
feat(server): add KV-backed transit file service as R2 alternative

### DIFF
--- a/src/server/cloudflare.test.ts
+++ b/src/server/cloudflare.test.ts
@@ -2,6 +2,7 @@ import type {
   AssetsBinding,
   D1DatabaseBinding,
   D1PreparedStatementBinding,
+  KVNamespaceBinding,
   R2BucketBinding,
   R2ObjectBinding,
 } from "./cloudflare/cloudflare-bindings.ts";
@@ -61,6 +62,76 @@ describe("cloudflare worker", () => {
     );
     expect(JSON.stringify(info.mock.calls)).not.toContain("unused-secret");
   });
+
+  it("selects the KV backend and round-trips a file when TRANSIT_FILES_BACKEND is kv", async () => {
+    const namespace = new MemoryKVNamespace();
+    // A distinct host keeps this out of the R2 test's cached app instance.
+    const origin = "https://kv.example.com";
+    const env: CloudflareEnv = {
+      DB: new UnusedD1Database(),
+      TRANSIT_FILES: namespace,
+      TRANSIT_FILES_BACKEND: "kv",
+      ASSETS: memoryAssets({ "/catalog/apps.json": [provider] }),
+    };
+
+    const form = new FormData();
+    form.set("file", new File(["kv-payload"], "note.txt", { type: "text/plain" }));
+    const uploadResponse = await worker.fetch(
+      new Request(`${origin}/api/files`, { method: "POST", body: form }),
+      env,
+      createExecutionContext(),
+    );
+    expect(uploadResponse.status).toBe(200);
+    const upload = (await uploadResponse.json()) as { fileId: string };
+    expect(upload.fileId).toMatch(/^[a-f0-9]{32}\.txt$/);
+
+    // Only KVTransitFileService writes an expirationTtl; its presence proves the KV
+    // backend (not R2) was selected end-to-end from the TRANSIT_FILES_BACKEND flag.
+    expect(namespace.entry(`transit/${upload.fileId}`)?.expirationTtl).toBe(86_400);
+
+    const getResponse = await worker.fetch(
+      new Request(`${origin}/api/files/${upload.fileId}`),
+      env,
+      createExecutionContext(),
+    );
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.text()).resolves.toBe("kv-payload");
+  });
+
+  it("defaults to the R2 backend when TRANSIT_FILES_BACKEND is unset and round-trips a file", async () => {
+    const bucket = new MemoryR2Bucket();
+    // A distinct host keeps this out of the other tests' cached app instances.
+    const origin = "https://r2.example.com";
+    const env: CloudflareEnv = {
+      DB: new UnusedD1Database(),
+      TRANSIT_FILES: bucket,
+      // TRANSIT_FILES_BACKEND intentionally omitted -> must fall back to R2.
+      ASSETS: memoryAssets({ "/catalog/apps.json": [provider] }),
+    };
+
+    const form = new FormData();
+    form.set("file", new File(["r2-payload"], "note.txt", { type: "text/plain" }));
+    const uploadResponse = await worker.fetch(
+      new Request(`${origin}/api/files`, { method: "POST", body: form }),
+      env,
+      createExecutionContext(),
+    );
+    expect(uploadResponse.status).toBe(200);
+    const upload = (await uploadResponse.json()) as { fileId: string };
+    expect(upload.fileId).toMatch(/^[a-f0-9]{32}\.txt$/);
+
+    // Only R2TransitFileService writes httpMetadata.contentType (KV never does); its
+    // presence proves the R2 backend was selected by default from an absent flag.
+    expect(bucket.stored(`transit/${upload.fileId}`)?.httpMetadata?.contentType).toBe("text/plain");
+
+    const getResponse = await worker.fetch(
+      new Request(`${origin}/api/files/${upload.fileId}`),
+      env,
+      createExecutionContext(),
+    );
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.text()).resolves.toBe("r2-payload");
+  });
 });
 
 function createEnv(): CloudflareEnv {
@@ -111,4 +182,96 @@ class UnusedR2Bucket implements R2BucketBinding {
   async delete(): Promise<void> {
     throw new Error("Unexpected R2 delete");
   }
+}
+
+class MemoryKVNamespace implements KVNamespaceBinding {
+  private readonly store = new Map<string, { bytes: ArrayBuffer; expirationTtl?: number }>();
+
+  async put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options?: { expirationTtl?: number; expiration?: number },
+  ): Promise<void> {
+    this.store.set(key, { bytes: await toArrayBuffer(value), expirationTtl: options?.expirationTtl });
+  }
+
+  get(key: string, type: "text"): Promise<string | null>;
+  get(key: string, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+  async get(key: string, type: "text" | "arrayBuffer"): Promise<string | ArrayBuffer | null> {
+    const stored = this.store.get(key);
+    if (!stored) {
+      return null;
+    }
+    return type === "text" ? new TextDecoder().decode(stored.bytes) : stored.bytes.slice(0);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  entry(key: string): { bytes: ArrayBuffer; expirationTtl?: number } | undefined {
+    return this.store.get(key);
+  }
+}
+
+class MemoryR2Bucket implements R2BucketBinding {
+  private readonly objects = new Map<string, MemoryR2Object>();
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown> {
+    this.objects.set(key, new MemoryR2Object(await toArrayBuffer(value), options?.httpMetadata));
+    return {};
+  }
+
+  async get(key: string): Promise<R2ObjectBinding | null> {
+    return this.objects.get(key) ?? null;
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+
+  stored(key: string): MemoryR2Object | undefined {
+    return this.objects.get(key);
+  }
+}
+
+class MemoryR2Object implements R2ObjectBinding {
+  readonly body: ReadableStream;
+  readonly httpMetadata?: { contentType?: string };
+
+  private readonly bytes: ArrayBuffer;
+
+  constructor(bytes: ArrayBuffer, httpMetadata?: { contentType?: string }) {
+    this.bytes = bytes;
+    this.body = new Blob([bytes]).stream();
+    this.httpMetadata = httpMetadata;
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    return this.bytes.slice(0);
+  }
+}
+
+async function toArrayBuffer(
+  value: string | ArrayBuffer | ArrayBufferView | ReadableStream | Blob,
+): Promise<ArrayBuffer> {
+  if (typeof value === "string") {
+    return new TextEncoder().encode(value).buffer;
+  }
+  if (value instanceof Blob) {
+    return await value.arrayBuffer();
+  }
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0);
+  }
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return new Uint8Array(bytes).buffer;
+  }
+
+  return await new Response(value).arrayBuffer();
 }

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -1,5 +1,5 @@
 import type { CatalogStore } from "../catalog-store.ts";
-import type { AssetsBinding } from "./cloudflare/cloudflare-bindings.ts";
+import type { AssetsBinding, KVNamespaceBinding, R2BucketBinding } from "./cloudflare/cloudflare-bindings.ts";
 import type { CloudflareEnv } from "./cloudflare/cloudflare-env.ts";
 import type { ConnectApp } from "./connect-app.ts";
 import type { Logger } from "./logger.ts";
@@ -12,6 +12,7 @@ import { isConsoleShellPath } from "./api/console-paths.ts";
 import { loadCatalogFromAssets } from "./cloudflare/catalog-assets.ts";
 import { readPositiveInteger, resolvePublicOrigin } from "./cloudflare/cloudflare-env.ts";
 import { createConnectApp } from "./connect-app.ts";
+import { KVTransitFileService } from "./files/kv-transit-files.ts";
 import { R2TransitFileService } from "./files/r2-transit-files.ts";
 import { createWorkerSecretCodec } from "./secrets/worker-secret-codec.ts";
 import { D1RuntimeDatabase } from "./storage/d1-runtime-store.ts";
@@ -44,35 +45,44 @@ export default {
 };
 
 async function createCloudflareApp(env: CloudflareEnv, publicOrigin: string): Promise<ConnectApp> {
-  const assets = env.ASSETS;
-  if (!assets) {
-    throw new Error("Cloudflare ASSETS binding is required to load the catalog");
-  }
-
-  const secretCodec = await createSecretCodec(env.OOMOL_CONNECT_ENCRYPTION_KEY);
-  return await createConnectApp({
-    catalog: await loadCatalogOnce(assets),
-    providerLoader: new ProviderLoader(),
-    runtimeDatabase: new D1RuntimeDatabase(env.DB, { secretCodec }),
-    transitFiles: new R2TransitFileService({
-      bucket: env.TRANSIT_FILES,
-      publicOrigin,
-      ttlSeconds: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_TTL_SECONDS, 86_400),
-      maxBytes: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_MAX_BYTES, 100 * 1024 * 1024),
-    }),
-    publicOrigin,
-    secretCodec,
-    adminToken: env.OOMOL_CONNECT_ADMIN_TOKEN,
-    runtimeToken: env.OOMOL_CONNECT_RUNTIME_TOKEN,
-    actionPolicy: new ActionPolicyService({
-      allowedActions: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_ACTIONS),
-      blockedActions: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_ACTIONS),
-      allowedProxies: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_PROXIES),
-      blockedProxies: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_PROXIES),
-    }),
-    logger: workerLogger,
-    computeRuntimeAuthConfigured: false,
-  });
+    const assets = env.ASSETS;
+    if (!assets) {
+        throw new Error("Cloudflare ASSETS binding is required to load the catalog");
+    }
+    const secretCodec = await createSecretCodec(env.OOMOL_CONNECT_ENCRYPTION_KEY);
+    return await createConnectApp({
+        catalog: await loadCatalogOnce(assets),
+        providerLoader: new ProviderLoader(),
+        runtimeDatabase: new D1RuntimeDatabase(env.DB, { secretCodec }),
+        transitFiles: (() => {
+            const transitFileOptions = {
+                publicOrigin,
+                ttlSeconds: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_TTL_SECONDS, 86_400),
+                maxBytes: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_MAX_BYTES, 25 * 1024 * 1024),
+            };
+            return env.TRANSIT_FILES_BACKEND === "kv"
+                ? new KVTransitFileService({
+                      namespace: env.TRANSIT_FILES as KVNamespaceBinding,
+                      ...transitFileOptions,
+                  })
+                : new R2TransitFileService({
+                      bucket: env.TRANSIT_FILES as R2BucketBinding,
+                      ...transitFileOptions,
+                  });
+        })(),
+        publicOrigin,
+        secretCodec,
+        adminToken: env.OOMOL_CONNECT_ADMIN_TOKEN,
+        runtimeToken: env.OOMOL_CONNECT_RUNTIME_TOKEN,
+        actionPolicy: new ActionPolicyService({
+            allowedActions: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_ACTIONS),
+            blockedActions: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_ACTIONS),
+            allowedProxies: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_PROXIES),
+            blockedProxies: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_PROXIES),
+        }),
+        logger: workerLogger,
+        computeRuntimeAuthConfigured: false,
+    });
 }
 
 const workerLogger = {

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -45,44 +45,44 @@ export default {
 };
 
 async function createCloudflareApp(env: CloudflareEnv, publicOrigin: string): Promise<ConnectApp> {
-    const assets = env.ASSETS;
-    if (!assets) {
-        throw new Error("Cloudflare ASSETS binding is required to load the catalog");
-    }
-    const secretCodec = await createSecretCodec(env.OOMOL_CONNECT_ENCRYPTION_KEY);
-    return await createConnectApp({
-        catalog: await loadCatalogOnce(assets),
-        providerLoader: new ProviderLoader(),
-        runtimeDatabase: new D1RuntimeDatabase(env.DB, { secretCodec }),
-        transitFiles: (() => {
-            const transitFileOptions = {
-                publicOrigin,
-                ttlSeconds: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_TTL_SECONDS, 86_400),
-                maxBytes: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_MAX_BYTES, 25 * 1024 * 1024),
-            };
-            return env.TRANSIT_FILES_BACKEND === "kv"
-                ? new KVTransitFileService({
-                      namespace: env.TRANSIT_FILES as KVNamespaceBinding,
-                      ...transitFileOptions,
-                  })
-                : new R2TransitFileService({
-                      bucket: env.TRANSIT_FILES as R2BucketBinding,
-                      ...transitFileOptions,
-                  });
-        })(),
+  const assets = env.ASSETS;
+  if (!assets) {
+    throw new Error("Cloudflare ASSETS binding is required to load the catalog");
+  }
+  const secretCodec = await createSecretCodec(env.OOMOL_CONNECT_ENCRYPTION_KEY);
+  return await createConnectApp({
+    catalog: await loadCatalogOnce(assets),
+    providerLoader: new ProviderLoader(),
+    runtimeDatabase: new D1RuntimeDatabase(env.DB, { secretCodec }),
+    transitFiles: (() => {
+      const transitFileOptions = {
         publicOrigin,
-        secretCodec,
-        adminToken: env.OOMOL_CONNECT_ADMIN_TOKEN,
-        runtimeToken: env.OOMOL_CONNECT_RUNTIME_TOKEN,
-        actionPolicy: new ActionPolicyService({
-            allowedActions: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_ACTIONS),
-            blockedActions: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_ACTIONS),
-            allowedProxies: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_PROXIES),
-            blockedProxies: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_PROXIES),
-        }),
-        logger: workerLogger,
-        computeRuntimeAuthConfigured: false,
-    });
+        ttlSeconds: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_TTL_SECONDS, 86_400),
+        maxBytes: readPositiveInteger(env.OOMOL_CONNECT_TRANSIT_FILE_MAX_BYTES, 100 * 1024 * 1024),
+      };
+      return env.TRANSIT_FILES_BACKEND === "kv"
+        ? new KVTransitFileService({
+            namespace: env.TRANSIT_FILES as KVNamespaceBinding,
+            ...transitFileOptions,
+          })
+        : new R2TransitFileService({
+            bucket: env.TRANSIT_FILES as R2BucketBinding,
+            ...transitFileOptions,
+          });
+    })(),
+    publicOrigin,
+    secretCodec,
+    adminToken: env.OOMOL_CONNECT_ADMIN_TOKEN,
+    runtimeToken: env.OOMOL_CONNECT_RUNTIME_TOKEN,
+    actionPolicy: new ActionPolicyService({
+      allowedActions: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_ACTIONS),
+      blockedActions: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_ACTIONS),
+      allowedProxies: parseActionPolicyList(env.OOMOL_CONNECT_ALLOWED_PROXIES),
+      blockedProxies: parseActionPolicyList(env.OOMOL_CONNECT_BLOCKED_PROXIES),
+    }),
+    logger: workerLogger,
+    computeRuntimeAuthConfigured: false,
+  });
 }
 
 const workerLogger = {

--- a/src/server/cloudflare/cloudflare-bindings.ts
+++ b/src/server/cloudflare/cloudflare-bindings.ts
@@ -29,3 +29,15 @@ export interface R2ObjectBinding {
 export interface AssetsBinding {
   fetch(request: Request): Promise<Response>;
 }
+
+// src/server/cloudflare/cloudflare-bindings.ts （追加）
+export interface KVNamespaceBinding {
+  put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options?: { expirationTtl?: number; expiration?: number },
+  ): Promise<void>;
+  get(key: string, type: "text"): Promise<string | null>;
+  get(key: string, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+  delete(key: string): Promise<void>;
+}

--- a/src/server/cloudflare/cloudflare-bindings.ts
+++ b/src/server/cloudflare/cloudflare-bindings.ts
@@ -30,7 +30,6 @@ export interface AssetsBinding {
   fetch(request: Request): Promise<Response>;
 }
 
-// src/server/cloudflare/cloudflare-bindings.ts （追加）
 export interface KVNamespaceBinding {
   put(
     key: string,

--- a/src/server/cloudflare/cloudflare-env.ts
+++ b/src/server/cloudflare/cloudflare-env.ts
@@ -1,8 +1,9 @@
-import type { AssetsBinding, D1DatabaseBinding, R2BucketBinding } from "./cloudflare-bindings.ts";
+import type { AssetsBinding, D1DatabaseBinding, KVNamespaceBinding, R2BucketBinding } from "./cloudflare-bindings.ts";
 
 export interface CloudflareEnv {
   DB: D1DatabaseBinding;
-  TRANSIT_FILES: R2BucketBinding;
+  TRANSIT_FILES: R2BucketBinding | KVNamespaceBinding;
+  TRANSIT_FILES_BACKEND?: "r2" | "kv"; // New: used to distinguish backend type at runtime
   ASSETS?: AssetsBinding;
   OOMOL_CONNECT_ORIGIN?: string;
   OOMOL_CONNECT_ADMIN_TOKEN?: string;

--- a/src/server/files/kv-transit-files.test.ts
+++ b/src/server/files/kv-transit-files.test.ts
@@ -137,6 +137,16 @@ describe("KVTransitFileService", () => {
     // A regex bug here previously replaced the letter "n" and let control bytes through.
     expect(response.headers.get("content-disposition")).toBe('attachment; filename="a_b_c_d_e.txt"');
   });
+
+  it("rejects non-integer, non-positive, or non-finite ttl/maxBytes at construction", () => {
+    // NaN maxBytes would otherwise slip past Math.min and disable the size check entirely.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 0, -1, 1.5]) {
+      expect(() => createService(new MemoryKVNamespace(), { maxBytes: bad })).toThrow(TypeError);
+      expect(() => createService(new MemoryKVNamespace(), { ttlSeconds: bad })).toThrow(TypeError);
+    }
+    // A valid-but-out-of-range value is still accepted and clamped, not rejected.
+    expect(() => createService(new MemoryKVNamespace(), { ttlSeconds: 10, maxBytes: 500 * 1024 * 1024 })).not.toThrow();
+  });
 });
 
 function createService(

--- a/src/server/files/kv-transit-files.test.ts
+++ b/src/server/files/kv-transit-files.test.ts
@@ -1,0 +1,206 @@
+import type { KVNamespaceBinding } from "../cloudflare/cloudflare-bindings.ts";
+
+import { describe, expect, it } from "vitest";
+import { KVTransitFileService } from "./kv-transit-files.ts";
+import { TransitFileError } from "./transit-file-store.ts";
+
+describe("KVTransitFileService", () => {
+  it("uploads, reads, and deletes transit files", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+
+    const upload = await service.create(new File(["hello transit"], "report.TXT", { type: "text/plain" }));
+    expect(upload.fileId).toMatch(/^[a-f0-9]{32}\.txt$/);
+    expect(upload.downloadUrl).toBe(`http://localhost:3000/api/files/${upload.fileId}`);
+    expect(upload).toMatchObject({
+      sizeBytes: 13,
+      name: "report.TXT",
+      mimeType: "text/plain",
+    });
+
+    const read = await service.read(upload.fileId);
+    expect(read).toMatchObject({
+      sizeBytes: 13,
+      name: "report.TXT",
+      mimeType: "text/plain",
+    });
+    await expect(read.file.text()).resolves.toBe("hello transit");
+
+    const response = await service.response(upload.fileId);
+    expect(response.headers.get("content-type")).toBe("text/plain");
+    expect(response.headers.get("content-length")).toBe("13");
+    await expect(response.text()).resolves.toBe("hello transit");
+
+    await expect(service.delete(upload.fileId)).resolves.toBe(true);
+    await expect(service.delete(upload.fileId)).resolves.toBe(false);
+    await expect(service.read(upload.fileId)).rejects.toMatchObject({ status: 404, code: "file_not_found" });
+  });
+
+  it("rejects files over the configured limit", async () => {
+    const service = createService(new MemoryKVNamespace(), { maxBytes: 4 });
+
+    await expect(service.create(new File(["12345"], "large.bin"))).rejects.toMatchObject({
+      status: 413,
+      code: "file_too_large",
+    });
+  });
+
+  it("writes both keys with KV native expirationTtl", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace, { ttlSeconds: 120 });
+
+    const upload = await service.create(new File(["ttl"], "ttl.txt"));
+
+    expect(namespace.entry(`transit/${upload.fileId}`)?.expirationTtl).toBe(120);
+    expect(namespace.entry(`transit/${upload.fileId}.meta.json`)?.expirationTtl).toBe(120);
+  });
+
+  it("clamps a sub-minimum ttl up to KV's 60 second floor", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace, { ttlSeconds: 10 });
+
+    const upload = await service.create(new File(["short"], "short.txt"));
+
+    expect(namespace.entry(`transit/${upload.fileId}`)?.expirationTtl).toBe(60);
+  });
+
+  it("clamps maxBytes down to KV's 25 MiB per-value limit", () => {
+    const service = createService(new MemoryKVNamespace(), { maxBytes: 100 * 1024 * 1024 });
+
+    expect(service.maxBytes).toBe(25 * 1024 * 1024);
+  });
+
+  it("does not delete the surviving key on a partial (eventually consistent) miss", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+    const upload = await service.create(new File(["payload"], "payload.txt"));
+
+    // Simulate the metadata write not having propagated yet.
+    await namespace.delete(`transit/${upload.fileId}.meta.json`);
+
+    await expect(service.read(upload.fileId)).rejects.toMatchObject({ status: 404 });
+    // The object key must survive so a later, fully-propagated read can succeed.
+    expect(namespace.has(`transit/${upload.fileId}`)).toBe(true);
+  });
+
+  it("treats malformed metadata as not found", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+    const upload = await service.create(new File(["broken"], "broken.txt"));
+    await namespace.put(`transit/${upload.fileId}.meta.json`, "{");
+
+    await expect(service.read(upload.fileId)).rejects.toBeInstanceOf(TransitFileError);
+    await expect(service.read(upload.fileId)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("fills safe defaults for partial-but-valid metadata", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+    const upload = await service.create(new File(["body"], "orig.txt", { type: "text/plain" }));
+    // Valid JSON, but missing every descriptive field.
+    await namespace.put(
+      `transit/${upload.fileId}.meta.json`,
+      JSON.stringify({ createdAt: "2020-01-01T00:00:00.000Z" }),
+    );
+
+    const read = await service.read(upload.fileId);
+    expect(read).toMatchObject({ name: "file", mimeType: "application/octet-stream", sizeBytes: 0 });
+  });
+
+  it("infers the mime type from the extension when the file has no type", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+
+    const upload = await service.create(new File(["{}"], "data.json"));
+
+    expect(upload.mimeType).toBe("application/json");
+    await expect(service.read(upload.fileId).then((r) => r.mimeType)).resolves.toBe("application/json");
+  });
+
+  it("rejects malformed file ids without touching storage (path-traversal guard)", async () => {
+    const service = createService(new MemoryKVNamespace());
+
+    for (const badId of ["../secret", "transit/evil", "ABCDEF", "not-hex", `${"a".repeat(32)}.exe/../x`]) {
+      await expect(service.read(badId)).rejects.toMatchObject({ status: 404, code: "file_not_found" });
+      await expect(service.delete(badId)).rejects.toMatchObject({ status: 404, code: "file_not_found" });
+    }
+  });
+
+  it("keeps ordinary letters while escaping quotes, backslashes, and control bytes in the filename header", async () => {
+    const namespace = new MemoryKVNamespace();
+    const service = createService(namespace);
+
+    // Includes a quote, backslash, CR and LF around ordinary letters (notably "n").
+    const upload = await service.create(new File(["ok"], 'a"b\\c\rd\ne.txt'));
+    const response = await service.response(upload.fileId);
+
+    // A regex bug here previously replaced the letter "n" and let control bytes through.
+    expect(response.headers.get("content-disposition")).toBe('attachment; filename="a_b_c_d_e.txt"');
+  });
+});
+
+function createService(
+  namespace: MemoryKVNamespace,
+  options: { ttlSeconds?: number; maxBytes?: number } = {},
+): KVTransitFileService {
+  return new KVTransitFileService({
+    namespace,
+    publicOrigin: "http://localhost:3000",
+    ttlSeconds: options.ttlSeconds ?? 60,
+    maxBytes: options.maxBytes ?? 1024 * 1024,
+  });
+}
+
+interface StoredValue {
+  bytes: ArrayBuffer;
+  expirationTtl?: number;
+}
+
+class MemoryKVNamespace implements KVNamespaceBinding {
+  private readonly store = new Map<string, StoredValue>();
+
+  async put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+    options?: { expirationTtl?: number; expiration?: number },
+  ): Promise<void> {
+    this.store.set(key, { bytes: await toArrayBuffer(value), expirationTtl: options?.expirationTtl });
+  }
+
+  get(key: string, type: "text"): Promise<string | null>;
+  get(key: string, type: "arrayBuffer"): Promise<ArrayBuffer | null>;
+  async get(key: string, type: "text" | "arrayBuffer"): Promise<string | ArrayBuffer | null> {
+    const stored = this.store.get(key);
+    if (!stored) {
+      return null;
+    }
+    return type === "text" ? new TextDecoder().decode(stored.bytes) : stored.bytes.slice(0);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+
+  entry(key: string): StoredValue | undefined {
+    return this.store.get(key);
+  }
+}
+
+async function toArrayBuffer(value: string | ArrayBuffer | ArrayBufferView | ReadableStream): Promise<ArrayBuffer> {
+  if (typeof value === "string") {
+    return new TextEncoder().encode(value).buffer;
+  }
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0);
+  }
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return new Uint8Array(bytes).buffer;
+  }
+
+  return await new Response(value).arrayBuffer();
+}

--- a/src/server/files/kv-transit-files.ts
+++ b/src/server/files/kv-transit-files.ts
@@ -34,8 +34,11 @@ export class KVTransitFileService implements ITransitFileService {
   constructor(options: KVTransitFileOptions) {
     this.namespace = options.namespace;
     this.publicOrigin = options.publicOrigin.replace(/\/+$/, "");
-    this.ttlSeconds = Math.max(options.ttlSeconds, KV_MIN_TTL_SECONDS);
-    this.maxBytes = Math.min(options.maxBytes, KV_MAX_VALUE_BYTES);
+    // This constructor is exported; a non-finite/fractional/non-positive value would slip
+    // through the clamps below (NaN maxBytes silently disables the size check, NaN ttl yields
+    // an invalid expirationTtl), so reject anything that is not a positive integer up front.
+    this.ttlSeconds = Math.max(positiveInteger(options.ttlSeconds, "ttlSeconds"), KV_MIN_TTL_SECONDS);
+    this.maxBytes = Math.min(positiveInteger(options.maxBytes, "maxBytes"), KV_MAX_VALUE_BYTES);
   }
 
   async create(file: File): Promise<TransitFileUpload> {
@@ -141,6 +144,12 @@ function assertSafeFileId(fileId: string): void {
   if (!/^[a-f0-9]{32}(?:\.[a-z0-9]{1,16})?$/.test(fileId)) {
     throw new TransitFileError(404, "file_not_found", "Transit file was not found.");
   }
+}
+function positiveInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`KVTransitFileService: "${field}" must be a positive integer (received ${value}).`);
+  }
+  return value;
 }
 function escapeHeaderValue(value: string): string {
   return value.replace(/["\\\r\n]/g, "_");

--- a/src/server/files/kv-transit-files.ts
+++ b/src/server/files/kv-transit-files.ts
@@ -1,13 +1,20 @@
-// src/server/files/kv-transit-files.ts
 import type { KVNamespaceBinding } from "../cloudflare/cloudflare-bindings.ts";
 import type { ITransitFileService, TransitFileRead, TransitFileUpload } from "./transit-file-store.ts";
+
 import { extname } from "node:path";
 import { contentTypeFromFileId, TransitFileError } from "./transit-file-store.ts";
+
+// Workers KV rejects an `expirationTtl` below 60 seconds.
+const KV_MIN_TTL_SECONDS = 60;
+// Workers KV rejects any single value larger than 25 MiB.
+const KV_MAX_VALUE_BYTES = 25 * 1024 * 1024;
 
 export interface KVTransitFileOptions {
   namespace: KVNamespaceBinding;
   publicOrigin: string;
+  // Requested TTL in seconds. Values below KV's 60s minimum are clamped up to 60.
   ttlSeconds: number;
+  // Requested max upload size in bytes. Clamped down to KV's 25 MiB per-value limit.
   maxBytes: number;
 }
 
@@ -27,8 +34,8 @@ export class KVTransitFileService implements ITransitFileService {
   constructor(options: KVTransitFileOptions) {
     this.namespace = options.namespace;
     this.publicOrigin = options.publicOrigin.replace(/\/+$/, "");
-    this.ttlSeconds = options.ttlSeconds;
-    this.maxBytes = options.maxBytes;
+    this.ttlSeconds = Math.max(options.ttlSeconds, KV_MIN_TTL_SECONDS);
+    this.maxBytes = Math.min(options.maxBytes, KV_MAX_VALUE_BYTES);
   }
 
   async create(file: File): Promise<TransitFileUpload> {
@@ -81,10 +88,7 @@ export class KVTransitFileService implements ITransitFileService {
   async delete(fileId: string): Promise<boolean> {
     assertSafeFileId(fileId);
     const existing = await this.namespace.get(objectKey(fileId), "arrayBuffer");
-    await Promise.all([
-      this.namespace.delete(objectKey(fileId)),
-      this.namespace.delete(metadataKey(fileId)),
-    ]);
+    await Promise.all([this.namespace.delete(objectKey(fileId)), this.namespace.delete(metadataKey(fileId))]);
     return existing != null;
   }
 
@@ -100,8 +104,10 @@ export class KVTransitFileService implements ITransitFileService {
       this.namespace.get(objectKey(fileId), "arrayBuffer"),
       this.readMetadata(fileId),
     ]);
+    // Workers KV is eventually consistent: a partial miss may be a not-yet-propagated
+    // write rather than a genuinely absent file. Never delete on miss (native TTL handles
+    // cleanup), otherwise a transient read turns into permanent data loss.
     if (!buffer || !metadata) {
-      await this.delete(fileId);
       throw new TransitFileError(404, "file_not_found", "Transit file was not found.");
     }
     return { buffer, metadata };
@@ -137,7 +143,7 @@ function assertSafeFileId(fileId: string): void {
   }
 }
 function escapeHeaderValue(value: string): string {
-  return value.replace(/["\\\\n]/g, "_");
+  return value.replace(/["\\\r\n]/g, "_");
 }
 function safeExtension(name: string): string {
   const extension = extname(name).toLowerCase();
@@ -150,7 +156,8 @@ function randomHex(byteLength: number): string {
 function normalizeMetadata(input: Partial<TransitFileMetadata>): TransitFileMetadata {
   return {
     name: typeof input.name === "string" && input.name.trim() ? input.name.trim() : "file",
-    mimeType: typeof input.mimeType === "string" && input.mimeType.trim() ? input.mimeType.trim() : "application/octet-stream",
+    mimeType:
+      typeof input.mimeType === "string" && input.mimeType.trim() ? input.mimeType.trim() : "application/octet-stream",
     createdAt: typeof input.createdAt === "string" && input.createdAt ? input.createdAt : new Date().toISOString(),
     sizeBytes: typeof input.sizeBytes === "number" && Number.isFinite(input.sizeBytes) ? input.sizeBytes : 0,
   };

--- a/src/server/files/kv-transit-files.ts
+++ b/src/server/files/kv-transit-files.ts
@@ -1,0 +1,157 @@
+// src/server/files/kv-transit-files.ts
+import type { KVNamespaceBinding } from "../cloudflare/cloudflare-bindings.ts";
+import type { ITransitFileService, TransitFileRead, TransitFileUpload } from "./transit-file-store.ts";
+import { extname } from "node:path";
+import { contentTypeFromFileId, TransitFileError } from "./transit-file-store.ts";
+
+export interface KVTransitFileOptions {
+  namespace: KVNamespaceBinding;
+  publicOrigin: string;
+  ttlSeconds: number;
+  maxBytes: number;
+}
+
+interface TransitFileMetadata {
+  name: string;
+  mimeType: string;
+  createdAt: string;
+  sizeBytes: number;
+}
+
+export class KVTransitFileService implements ITransitFileService {
+  private readonly namespace: KVNamespaceBinding;
+  private readonly publicOrigin: string;
+  private readonly ttlSeconds: number;
+  readonly maxBytes: number;
+
+  constructor(options: KVTransitFileOptions) {
+    this.namespace = options.namespace;
+    this.publicOrigin = options.publicOrigin.replace(/\/+$/, "");
+    this.ttlSeconds = options.ttlSeconds;
+    this.maxBytes = options.maxBytes;
+  }
+
+  async create(file: File): Promise<TransitFileUpload> {
+    this.assertFileSize(file.size);
+    const fileId = `${randomHex(16)}${safeExtension(file.name)}`;
+    const metadata: TransitFileMetadata = {
+      name: file.name || fileId,
+      mimeType: file.type || contentTypeFromFileId(fileId),
+      createdAt: new Date().toISOString(),
+      sizeBytes: file.size,
+    };
+    const buffer = await file.arrayBuffer();
+    // KV 原生 TTL：写入时直接指定过期时间，无需 cleanupExpired
+    await this.namespace.put(objectKey(fileId), buffer, {
+      expirationTtl: this.ttlSeconds,
+    });
+    await this.namespace.put(metadataKey(fileId), JSON.stringify(metadata), {
+      expirationTtl: this.ttlSeconds,
+    });
+    return {
+      fileId,
+      downloadUrl: `${this.publicOrigin}/api/files/${encodeURIComponent(fileId)}`,
+      sizeBytes: metadata.sizeBytes,
+      name: metadata.name,
+      mimeType: metadata.mimeType,
+    };
+  }
+
+  async read(fileId: string): Promise<TransitFileRead> {
+    const { buffer, metadata } = await this.readObject(fileId);
+    return {
+      file: new File([buffer], metadata.name, { type: metadata.mimeType }),
+      sizeBytes: metadata.sizeBytes,
+      name: metadata.name,
+      mimeType: metadata.mimeType,
+    };
+  }
+
+  async response(fileId: string): Promise<Response> {
+    const { buffer, metadata } = await this.readObject(fileId);
+    return new Response(buffer, {
+      headers: {
+        "content-length": String(metadata.sizeBytes),
+        "content-type": metadata.mimeType,
+        "content-disposition": `attachment; filename="${escapeHeaderValue(metadata.name)}"`,
+      },
+    });
+  }
+
+  async delete(fileId: string): Promise<boolean> {
+    assertSafeFileId(fileId);
+    const existing = await this.namespace.get(objectKey(fileId), "arrayBuffer");
+    await Promise.all([
+      this.namespace.delete(objectKey(fileId)),
+      this.namespace.delete(metadataKey(fileId)),
+    ]);
+    return existing != null;
+  }
+
+  // KV 依赖原生 TTL 自动过期，无需手动清理
+  async cleanupExpired(): Promise<void> {}
+
+  private async readObject(fileId: string): Promise<{
+    buffer: ArrayBuffer;
+    metadata: TransitFileMetadata;
+  }> {
+    assertSafeFileId(fileId);
+    const [buffer, metadata] = await Promise.all([
+      this.namespace.get(objectKey(fileId), "arrayBuffer"),
+      this.readMetadata(fileId),
+    ]);
+    if (!buffer || !metadata) {
+      await this.delete(fileId);
+      throw new TransitFileError(404, "file_not_found", "Transit file was not found.");
+    }
+    return { buffer, metadata };
+  }
+
+  private async readMetadata(fileId: string): Promise<TransitFileMetadata | undefined> {
+    const raw = await this.namespace.get(metadataKey(fileId), "text");
+    if (!raw) return undefined;
+    try {
+      return normalizeMetadata(JSON.parse(raw) as Partial<TransitFileMetadata>);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private assertFileSize(size: number): void {
+    if (size > this.maxBytes) {
+      throw new TransitFileError(413, "file_too_large", `Transit file must be ${this.maxBytes} bytes or smaller.`);
+    }
+  }
+}
+
+// 以下工具函数与 r2-transit-files.ts 保持一致
+function objectKey(fileId: string): string {
+  return `transit/${fileId}`;
+}
+function metadataKey(fileId: string): string {
+  return `transit/${fileId}.meta.json`;
+}
+function assertSafeFileId(fileId: string): void {
+  if (!/^[a-f0-9]{32}(?:\.[a-z0-9]{1,16})?$/.test(fileId)) {
+    throw new TransitFileError(404, "file_not_found", "Transit file was not found.");
+  }
+}
+function escapeHeaderValue(value: string): string {
+  return value.replace(/["\\\\n]/g, "_");
+}
+function safeExtension(name: string): string {
+  const extension = extname(name).toLowerCase();
+  return /^\.[a-z0-9]{1,16}$/.test(extension) ? extension : "";
+}
+function randomHex(byteLength: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+function normalizeMetadata(input: Partial<TransitFileMetadata>): TransitFileMetadata {
+  return {
+    name: typeof input.name === "string" && input.name.trim() ? input.name.trim() : "file",
+    mimeType: typeof input.mimeType === "string" && input.mimeType.trim() ? input.mimeType.trim() : "application/octet-stream",
+    createdAt: typeof input.createdAt === "string" && input.createdAt ? input.createdAt : new Date().toISOString(),
+    sizeBytes: typeof input.sizeBytes === "number" && Number.isFinite(input.sizeBytes) ? input.sizeBytes : 0,
+  };
+}

--- a/wrangler.example.jsonc
+++ b/wrangler.example.jsonc
@@ -29,15 +29,21 @@
       "migrations_dir": "migrations",
     },
   ],
-{
-  // ...
-  // Option A: R2 backend (default)
+  // Transit-file storage — enable EXACTLY ONE of Option A or Option B.
+  // Both use the binding name TRANSIT_FILES; Wrangler rejects two bindings with the
+  // same name, so switching to Option B means commenting out Option A's block below.
+  //
+  // Option A: R2 backend (default). Comment out this whole block to use Option B.
   "r2_buckets": [
-    { "binding": "TRANSIT_FILES", "bucket_name": "<your-bucket-name>" }
+    {
+      "binding": "TRANSIT_FILES",
+      "bucket_name": "<your-bucket-name>",
+    },
   ],
-  // Option B: KV backend (no credit card required; max file size 25 MB)
+  // Option B: KV backend (no credit card required; max file size 25 MB).
+  // To use it: comment out the r2_buckets block above, then uncomment all three lines below.
   // "kv_namespaces": [
-  //   { "binding": "TRANSIT_FILES", "id": "<your-kv-namespace-id>" }
+  //   { "binding": "TRANSIT_FILES", "id": "<your-kv-namespace-id>" },
   // ],
-  // "vars": { "TRANSIT_FILES_BACKEND": "kv" }
+  // "vars": { "TRANSIT_FILES_BACKEND": "kv" },
 }

--- a/wrangler.example.jsonc
+++ b/wrangler.example.jsonc
@@ -29,10 +29,15 @@
       "migrations_dir": "migrations",
     },
   ],
+{
+  // ...
+  // Option A: R2 backend (default)
   "r2_buckets": [
-    {
-      "binding": "TRANSIT_FILES",
-      "bucket_name": "open-connector-transit-files",
-    },
+    { "binding": "TRANSIT_FILES", "bucket_name": "<your-bucket-name>" }
   ],
+  // Option B: KV backend (no credit card required; max file size 25 MB)
+  // "kv_namespaces": [
+  //   { "binding": "TRANSIT_FILES", "id": "<your-kv-namespace-id>" }
+  // ],
+  // "vars": { "TRANSIT_FILES_BACKEND": "kv" }
 }


### PR DESCRIPTION
## Motivation

Deploying OpenConnector on Cloudflare Workers currently requires an R2 bucket,
which mandates a credit card on file even though R2 has a generous free tier.
For lightweight OAuth token exchange scenarios where transit files are well under
25 MB, Cloudflare KV is a fully capable alternative that works without billing
setup.

## Changes

- Added `KVTransitFileService` implementing the existing `ITransitFileService`
  interface, using KV's native `expirationTtl` for automatic cleanup.
- Added `KVNamespaceBinding` interface to `cloudflare-bindings.ts`.
- Extended `CloudflareEnv` with an optional `TRANSIT_FILES_BACKEND` field
  (`"r2" | "kv"`); defaults to `"r2"` when unset, preserving full backward
  compatibility.
- Updated `cloudflare.ts` to select the appropriate service at runtime based
  on `TRANSIT_FILES_BACKEND`.
- Updated `wrangler.example.jsonc` with commented KV configuration example.

## Limitations

- KV enforces a 25 MB per-value limit; `maxBytes` is adjusted accordingly
  when the KV backend is selected.
- For use cases involving large transit files, R2 remains the recommended
  backend.

## Backward Compatibility

No existing configuration is affected. Users who do not set
`TRANSIT_FILES_BACKEND` continue to use R2 exactly as before.
