### PR TITLE
feat(railway): add provider

### DIFF
--- a/src/providers/railway/actions.ts
+++ b/src/providers/railway/actions.ts
@@ -70,7 +70,21 @@ const deploymentTargetFields = {
   environmentId: id("Railway environment ID."),
 };
 
-export const railwayActions: readonly ProviderActionDefinition[] = [
+type RailwayActionDefinitions = readonly [
+  ProviderActionDefinition<"list_projects">,
+  ProviderActionDefinition<"get_project">,
+  ProviderActionDefinition<"get_service_instance">,
+  ProviderActionDefinition<"list_deployments">,
+  ProviderActionDefinition<"get_deployment">,
+  ProviderActionDefinition<"get_deployment_logs">,
+  ProviderActionDefinition<"deploy_service">,
+  ProviderActionDefinition<"upsert_variable">,
+  ProviderActionDefinition<"rollback_deployment">,
+];
+
+export type RailwayActionName = RailwayActionDefinitions[number]["name"];
+
+export const railwayActions: RailwayActionDefinitions = [
   defineProviderAction(service, {
     name: "list_projects",
     description: "List Railway projects available to the configured account or workspace token.",
@@ -240,5 +254,3 @@ export const railwayActions: readonly ProviderActionDefinition[] = [
     }),
   }),
 ];
-
-export type RailwayActionName = (typeof railwayActions)[number]["name"];

--- a/src/providers/railway/actions.ts
+++ b/src/providers/railway/actions.ts
@@ -1,0 +1,244 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "railway" as const;
+
+const id = (description: string) => s.nonEmptyString(description);
+
+const serviceSummary = s.object(
+  "A Railway service.",
+  {
+    id: id("Railway service ID."),
+    name: s.nonEmptyString("Service name."),
+    icon: s.nullableString("Service icon URL or identifier."),
+  },
+  { required: ["id", "name"], optional: ["icon"] },
+);
+
+const environmentSummary = s.object("A Railway environment.", {
+  id: id("Railway environment ID."),
+  name: s.nonEmptyString("Environment name."),
+});
+
+const projectSummary = s.object(
+  "A Railway project.",
+  {
+    id: id("Railway project ID."),
+    name: s.nonEmptyString("Project name."),
+    description: s.nullableString("Project description."),
+    createdAt: s.dateTime("When the project was created."),
+    updatedAt: s.dateTime("When the project was last updated."),
+  },
+  { required: ["id", "name"], optional: ["description", "createdAt", "updatedAt"] },
+);
+
+const deploymentSummary = s.object(
+  "A Railway deployment.",
+  {
+    id: id("Railway deployment ID."),
+    status: s.nonEmptyString("Current Railway deployment status."),
+    createdAt: s.dateTime("When the deployment was created."),
+    url: s.nullableString("Deployment URL."),
+    staticUrl: s.nullableString("Static deployment URL."),
+  },
+  { required: ["id", "status"], optional: ["createdAt", "url", "staticUrl"] },
+);
+
+const deploymentDetail = s.object(
+  "Detailed Railway deployment information.",
+  {
+    id: id("Railway deployment ID."),
+    status: s.nonEmptyString("Current Railway deployment status."),
+    createdAt: s.dateTime("When the deployment was created."),
+    url: s.nullableString("Deployment URL."),
+    staticUrl: s.nullableString("Static deployment URL."),
+    canRedeploy: s.boolean("Whether Railway allows this deployment to be redeployed."),
+    canRollback: s.boolean("Whether Railway allows a rollback to this deployment."),
+    meta: s.nullable(s.unknownObject("Provider-defined deployment metadata.")),
+  },
+  {
+    required: ["id", "status"],
+    optional: ["createdAt", "url", "staticUrl", "canRedeploy", "canRollback", "meta"],
+  },
+);
+
+const deploymentTargetFields = {
+  projectId: id("Railway project ID."),
+  serviceId: id("Railway service ID."),
+  environmentId: id("Railway environment ID."),
+};
+
+export const railwayActions: readonly ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_projects",
+    description: "List Railway projects available to the configured account or workspace token.",
+    inputSchema: s.object("Input for listing Railway projects.", {}),
+    outputSchema: s.object("Railway projects available to the token.", {
+      projects: s.array(projectSummary, { description: "Railway projects." }),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_project",
+    description: "Get a Railway project together with its services and environments.",
+    inputSchema: s.object("Input for retrieving a Railway project.", {
+      projectId: id("Railway project ID."),
+    }),
+    outputSchema: s.object("A Railway project with related resources.", {
+      project: s.object(
+        "Railway project details.",
+        {
+          id: id("Railway project ID."),
+          name: s.nonEmptyString("Project name."),
+          description: s.nullableString("Project description."),
+          createdAt: s.dateTime("When the project was created."),
+          services: s.array(serviceSummary, { description: "Services in the project." }),
+          environments: s.array(environmentSummary, { description: "Environments in the project." }),
+        },
+        { required: ["id", "name", "services", "environments"], optional: ["description", "createdAt"] },
+      ),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_service_instance",
+    description: "Get Railway service configuration and its latest deployment in one environment.",
+    inputSchema: s.object("Input for retrieving a Railway service instance.", {
+      serviceId: id("Railway service ID."),
+      environmentId: id("Railway environment ID."),
+    }),
+    outputSchema: s.object("Railway service instance configuration.", {
+      serviceInstance: s.looseRequiredObject(
+        "A Railway service instance.",
+        {
+          id: id("Railway service instance ID."),
+          serviceName: s.nonEmptyString("Service name."),
+          startCommand: s.nullableString("Configured start command."),
+          buildCommand: s.nullableString("Configured build command."),
+          rootDirectory: s.nullableString("Configured repository root directory."),
+          healthcheckPath: s.nullableString("Configured health check path."),
+          region: s.nullableString("Deployment region."),
+          numReplicas: s.nullableInteger("Configured replica count."),
+          restartPolicyType: s.nullableString("Restart policy type."),
+          restartPolicyMaxRetries: s.nullableInteger("Maximum restart attempts."),
+          latestDeployment: s.nullable(deploymentSummary),
+        },
+        {
+          optional: [
+            "startCommand",
+            "buildCommand",
+            "rootDirectory",
+            "healthcheckPath",
+            "region",
+            "numReplicas",
+            "restartPolicyType",
+            "restartPolicyMaxRetries",
+            "latestDeployment",
+          ],
+        },
+      ),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_deployments",
+    description: "List recent Railway deployments for a service and environment.",
+    inputSchema: s.object(
+      "Filters for Railway deployments.",
+      {
+        ...deploymentTargetFields,
+        limit: s.integer("Maximum number of deployments to return.", { minimum: 1, maximum: 100, default: 20 }),
+      },
+      { required: ["projectId", "serviceId", "environmentId"], optional: ["limit"] },
+    ),
+    outputSchema: s.object("Recent Railway deployments.", {
+      deployments: s.array(deploymentSummary, { description: "Railway deployments ordered by the provider." }),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_deployment",
+    description: "Get one Railway deployment and its redeploy and rollback capabilities.",
+    inputSchema: s.object("Input for retrieving a Railway deployment.", {
+      deploymentId: id("Railway deployment ID."),
+    }),
+    outputSchema: s.object("A Railway deployment.", { deployment: deploymentDetail }),
+  }),
+  defineProviderAction(service, {
+    name: "get_deployment_logs",
+    description: "Read runtime logs for a Railway deployment with optional text and time filters.",
+    inputSchema: s.object(
+      "Filters for Railway deployment logs.",
+      {
+        deploymentId: id("Railway deployment ID."),
+        limit: s.integer("Maximum number of log entries to return.", { minimum: 1, maximum: 5000, default: 500 }),
+        filter: s.nonEmptyString("Railway log filter expression."),
+        startDate: s.dateTime("Start of the log time range."),
+        endDate: s.dateTime("End of the log time range."),
+      },
+      { required: ["deploymentId"], optional: ["limit", "filter", "startDate", "endDate"] },
+    ),
+    outputSchema: s.object("Runtime log entries for a Railway deployment.", {
+      logs: s.array(
+        s.object(
+          "A Railway runtime log entry.",
+          {
+            timestamp: s.nonEmptyString("Provider timestamp for the log entry."),
+            message: s.string("Log message."),
+            severity: s.nullableString("Log severity."),
+          },
+          { required: ["timestamp", "message"], optional: ["severity"] },
+        ),
+        { description: "Railway runtime log entries." },
+      ),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "deploy_service",
+    description: "Trigger a Railway deployment for a service, optionally at a specific connected-repository commit.",
+    inputSchema: s.object(
+      "Input for deploying a Railway service.",
+      {
+        serviceId: id("Railway service ID."),
+        environmentId: id("Railway environment ID."),
+        commitSha: s.nonEmptyString("Commit SHA from the repository connected to the Railway service."),
+      },
+      { required: ["serviceId", "environmentId"], optional: ["commitSha"] },
+    ),
+    outputSchema: s.object("The triggered Railway deployment.", {
+      deploymentId: id("Railway deployment ID."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "upsert_variable",
+    description: "Create or update one Railway variable for an environment or service.",
+    inputSchema: s.object(
+      "Input for creating or updating a Railway variable.",
+      {
+        ...deploymentTargetFields,
+        name: s.string({
+          minLength: 1,
+          maxLength: 255,
+          pattern: "^[A-Za-z_][A-Za-z0-9_]*$",
+          description: "Variable name.",
+        }),
+        value: s.string("Variable value. This may contain a Railway variable reference."),
+        skipDeploys: s.boolean("Do not automatically redeploy after updating the variable."),
+      },
+      { required: ["projectId", "environmentId", "name", "value"], optional: ["serviceId", "skipDeploys"] },
+    ),
+    outputSchema: s.object("Result of updating a Railway variable.", {
+      updated: s.boolean("Whether Railway accepted the variable update."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "rollback_deployment",
+    description: "Roll a Railway service back to a deployment that Railway marks as rollback-capable.",
+    inputSchema: s.object("Input for rolling back a Railway deployment.", {
+      deploymentId: id("Rollback-capable Railway deployment ID."),
+    }),
+    outputSchema: s.object("The Railway deployment created by the rollback.", {
+      deployment: deploymentSummary,
+    }),
+  }),
+];
+
+export type RailwayActionName = (typeof railwayActions)[number]["name"];

--- a/src/providers/railway/definition.ts
+++ b/src/providers/railway/definition.ts
@@ -1,0 +1,35 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { railwayActions } from "./actions.ts";
+
+const service = "railway";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Railway",
+  description: "Inspect Railway projects and services, manage deployments, read logs, and update variables.",
+  categories: ["Developer Tools", "Infrastructure"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "Account or Workspace Token",
+      placeholder: "Enter your Railway token",
+      description:
+        "A Railway account or workspace token sent as a Bearer token. Create one at https://railway.com/account/tokens. Project tokens use a different authentication header and are not supported by this credential type.",
+      extraFields: [
+        {
+          key: "workspaceId",
+          label: "Workspace ID",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "Optional Railway workspace ID",
+          description: "Required when using a workspace-scoped token. Leave blank for an account token.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://railway.com",
+  actions: railwayActions,
+};

--- a/src/providers/railway/executors.ts
+++ b/src/providers/railway/executors.ts
@@ -1,0 +1,28 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { RailwayActionContext } from "./runtime.ts";
+
+import { defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
+import { createRailwayContext, railwayActionHandlers, validateRailwayCredential } from "./runtime.ts";
+
+const service = "railway";
+
+export const executors: ProviderExecutors = defineProviderExecutors<RailwayActionContext>({
+  service,
+  handlers: railwayActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<RailwayActionContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return createRailwayContext(credential.values, credential.apiKey, fetcher, context.signal);
+  },
+  fallbackMessage: "Railway request failed",
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateRailwayCredential(input.apiKey, input.values, fetcher, signal);
+  },
+};

--- a/src/providers/railway/runtime.test.ts
+++ b/src/providers/railway/runtime.test.ts
@@ -100,6 +100,25 @@ describe("Railway runtime", () => {
     });
   });
 
+  it("rejects a missing variable update result", async () => {
+    const context = createContext(async () => jsonResponse({ data: {} }));
+
+    await expect(
+      railwayActionHandlers.upsert_variable(
+        {
+          projectId: "project_1",
+          environmentId: "environment_1",
+          name: "OPTIONAL_VALUE",
+          value: "value",
+        },
+        context,
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Railway variable update result was not returned",
+    });
+  });
+
   it("maps GraphQL errors returned with HTTP 200 to provider errors", async () => {
     const context = createContext(async () =>
       jsonResponse({ data: null, errors: [{ message: "Not Authorized", path: ["projects"] }] }),

--- a/src/providers/railway/runtime.test.ts
+++ b/src/providers/railway/runtime.test.ts
@@ -1,0 +1,126 @@
+import type { RailwayActionContext } from "./runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { railwayActionHandlers, validateRailwayCredential } from "./runtime.ts";
+
+describe("Railway runtime", () => {
+  it("validates a workspace token with its workspace identity", async () => {
+    let requestHeaders: Headers | undefined;
+    let requestBody: Record<string, unknown> | undefined;
+    const result = await validateRailwayCredential(
+      "workspace-token",
+      { workspaceId: "workspace_1" },
+      async (_input, init) => {
+        requestHeaders = new Headers(init?.headers);
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return jsonResponse({ data: { workspace: { id: "workspace_1", name: "Platform" } } });
+      },
+    );
+
+    expect(requestHeaders?.get("authorization")).toBe("Bearer workspace-token");
+    expect(requestBody?.variables).toEqual({ workspaceId: "workspace_1" });
+    expect(result).toEqual({
+      profile: { accountId: "workspace_1", displayName: "Platform" },
+      grantedScopes: [],
+      metadata: { tokenType: "workspace", workspaceId: "workspace_1" },
+    });
+  });
+
+  it("lists projects and normalizes GraphQL connection edges", async () => {
+    const context = createContext(async () =>
+      jsonResponse({
+        data: {
+          projects: {
+            edges: [
+              { node: { id: "project_1", name: "API" } },
+              { node: null },
+              { node: { id: "project_2", name: "Worker" } },
+            ],
+          },
+        },
+      }),
+    );
+
+    await expect(railwayActionHandlers.list_projects({}, context)).resolves.toEqual({
+      projects: [
+        { id: "project_1", name: "API" },
+        { id: "project_2", name: "Worker" },
+      ],
+    });
+  });
+
+  it("sends an optional commit SHA when deploying a service", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const context = createContext(async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return jsonResponse({ data: { serviceInstanceDeployV2: "deployment_1" } });
+    });
+
+    await expect(
+      railwayActionHandlers.deploy_service(
+        { serviceId: "service_1", environmentId: "environment_1", commitSha: "abc123" },
+        context,
+      ),
+    ).resolves.toEqual({ deploymentId: "deployment_1" });
+    expect(requestBody?.variables).toEqual({
+      serviceId: "service_1",
+      environmentId: "environment_1",
+      commitSha: "abc123",
+    });
+  });
+
+  it("preserves empty variable values", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const context = createContext(async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return jsonResponse({ data: { variableUpsert: true } });
+    });
+
+    await expect(
+      railwayActionHandlers.upsert_variable(
+        {
+          projectId: "project_1",
+          environmentId: "environment_1",
+          name: "OPTIONAL_VALUE",
+          value: "",
+          skipDeploys: true,
+        },
+        context,
+      ),
+    ).resolves.toEqual({ updated: true });
+    expect(requestBody?.variables).toEqual({
+      input: {
+        projectId: "project_1",
+        environmentId: "environment_1",
+        name: "OPTIONAL_VALUE",
+        value: "",
+        skipDeploys: true,
+      },
+    });
+  });
+
+  it("maps GraphQL errors returned with HTTP 200 to provider errors", async () => {
+    const context = createContext(async () =>
+      jsonResponse({ data: null, errors: [{ message: "Not Authorized", path: ["projects"] }] }),
+    );
+
+    const promise = railwayActionHandlers.list_projects({}, context);
+    await expect(promise).rejects.toBeInstanceOf(ProviderRequestError);
+    await expect(promise).rejects.toMatchObject({ status: 400, message: "Not Authorized" });
+  });
+});
+
+function createContext(fetcher: typeof fetch): RailwayActionContext {
+  return {
+    apiKey: "account-token",
+    fetcher,
+  };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/providers/railway/runtime.ts
+++ b/src/providers/railway/runtime.ts
@@ -246,7 +246,9 @@ export const railwayActionHandlers: Record<RailwayActionName, RailwayActionHandl
         }),
       },
     );
-    return { updated: data.variableUpsert === true };
+    return {
+      updated: requireGraphqlValue(data.variableUpsert, "Railway variable update result was not returned"),
+    };
   },
 
   async rollback_deployment(input, context) {

--- a/src/providers/railway/runtime.ts
+++ b/src/providers/railway/runtime.ts
@@ -1,0 +1,382 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { RailwayActionName } from "./actions.ts";
+
+import {
+  compactObject,
+  objectArray,
+  optionalBoolean,
+  optionalInteger,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
+import { objectPayload, requestJson } from "../http-json-runtime.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+const railwayApiBaseUrl = "https://backboard.railway.com";
+const railwayGraphqlPath = "/graphql/v2";
+
+export interface RailwayActionContext extends ApiKeyProviderContext {
+  workspaceId?: string;
+}
+
+interface RailwayGraphqlError {
+  message?: string;
+  path?: Array<string | number>;
+}
+
+interface RailwayConnection<T> {
+  edges?: Array<{ node?: T | null }>;
+}
+
+interface RailwayProject {
+  id: string;
+  name: string;
+  description?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  services?: RailwayConnection<Record<string, unknown>>;
+  environments?: RailwayConnection<Record<string, unknown>>;
+}
+
+interface RailwayDeployment {
+  id: string;
+  status: string;
+  createdAt?: string;
+  url?: string | null;
+  staticUrl?: string | null;
+  canRedeploy?: boolean;
+  canRollback?: boolean;
+  meta?: Record<string, unknown>;
+}
+
+type RailwayActionHandler = ProviderRuntimeHandler<RailwayActionContext>;
+
+export function createRailwayContext(
+  values: Record<string, string>,
+  apiKey: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): RailwayActionContext {
+  return {
+    apiKey,
+    workspaceId: optionalString(values.workspaceId),
+    fetcher,
+    signal,
+  };
+}
+
+export const railwayActionHandlers: Record<RailwayActionName, RailwayActionHandler> = {
+  async list_projects(_input, context) {
+    const data = context.workspaceId
+      ? await railwayGraphql<{ projects?: RailwayConnection<RailwayProject> }>(
+          context,
+          `query workspaceProjects($workspaceId: String!) {
+            projects(workspaceId: $workspaceId) {
+              edges { node { id name description createdAt updatedAt } }
+            }
+          }`,
+          { workspaceId: context.workspaceId },
+        )
+      : await railwayGraphql<{ projects?: RailwayConnection<RailwayProject> }>(
+          context,
+          `query projects {
+            projects {
+              edges { node { id name description createdAt updatedAt } }
+            }
+          }`,
+        );
+
+    return { projects: connectionNodes(data.projects) };
+  },
+
+  async get_project(input, context) {
+    const data = await railwayGraphql<{ project?: RailwayProject }>(
+      context,
+      `query project($id: String!) {
+        project(id: $id) {
+          id
+          name
+          description
+          createdAt
+          services { edges { node { id name icon } } }
+          environments { edges { node { id name } } }
+        }
+      }`,
+      { id: inputString(input, "projectId") },
+    );
+    const project = requireGraphqlValue(data.project, "Railway project was not returned");
+    return {
+      project: {
+        id: project.id,
+        name: project.name,
+        description: project.description ?? null,
+        createdAt: project.createdAt,
+        services: connectionNodes(project.services),
+        environments: connectionNodes(project.environments),
+      },
+    };
+  },
+
+  async get_service_instance(input, context) {
+    const data = await railwayGraphql<{ serviceInstance?: Record<string, unknown> }>(
+      context,
+      `query serviceInstance($serviceId: String!, $environmentId: String!) {
+        serviceInstance(serviceId: $serviceId, environmentId: $environmentId) {
+          id
+          serviceName
+          startCommand
+          buildCommand
+          rootDirectory
+          healthcheckPath
+          region
+          numReplicas
+          restartPolicyType
+          restartPolicyMaxRetries
+          latestDeployment { id status createdAt url staticUrl }
+        }
+      }`,
+      {
+        serviceId: inputString(input, "serviceId"),
+        environmentId: inputString(input, "environmentId"),
+      },
+    );
+    return {
+      serviceInstance: requireGraphqlValue(data.serviceInstance, "Railway service instance was not returned"),
+    };
+  },
+
+  async list_deployments(input, context) {
+    const data = await railwayGraphql<{ deployments?: RailwayConnection<RailwayDeployment> }>(
+      context,
+      `query deployments($input: DeploymentListInput!, $first: Int) {
+        deployments(input: $input, first: $first) {
+          edges { node { id status createdAt url staticUrl } }
+        }
+      }`,
+      {
+        input: {
+          projectId: inputString(input, "projectId"),
+          serviceId: inputString(input, "serviceId"),
+          environmentId: inputString(input, "environmentId"),
+        },
+        first: optionalInteger(input.limit) ?? 20,
+      },
+    );
+    return { deployments: connectionNodes(data.deployments) };
+  },
+
+  async get_deployment(input, context) {
+    const data = await railwayGraphql<{ deployment?: RailwayDeployment }>(
+      context,
+      `query deployment($id: String!) {
+        deployment(id: $id) {
+          id status createdAt url staticUrl meta canRedeploy canRollback
+        }
+      }`,
+      { id: inputString(input, "deploymentId") },
+    );
+    return { deployment: requireGraphqlValue(data.deployment, "Railway deployment was not returned") };
+  },
+
+  async get_deployment_logs(input, context) {
+    const data = await railwayGraphql<{ deploymentLogs?: Array<Record<string, unknown>> }>(
+      context,
+      `query deploymentLogs(
+        $deploymentId: String!
+        $limit: Int
+        $filter: String
+        $startDate: DateTime
+        $endDate: DateTime
+      ) {
+        deploymentLogs(
+          deploymentId: $deploymentId
+          limit: $limit
+          filter: $filter
+          startDate: $startDate
+          endDate: $endDate
+        ) {
+          timestamp message severity
+        }
+      }`,
+      compactObject({
+        deploymentId: inputString(input, "deploymentId"),
+        limit: optionalInteger(input.limit) ?? 500,
+        filter: optionalString(input.filter),
+        startDate: optionalString(input.startDate),
+        endDate: optionalString(input.endDate),
+      }),
+    );
+    return { logs: data.deploymentLogs ?? [] };
+  },
+
+  async deploy_service(input, context) {
+    const data = await railwayGraphql<{ serviceInstanceDeployV2?: string }>(
+      context,
+      `mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!, $commitSha: String) {
+        serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId, commitSha: $commitSha)
+      }`,
+      compactObject({
+        serviceId: inputString(input, "serviceId"),
+        environmentId: inputString(input, "environmentId"),
+        commitSha: optionalString(input.commitSha),
+      }),
+    );
+    return {
+      deploymentId: requireGraphqlValue(data.serviceInstanceDeployV2, "Railway deployment ID was not returned"),
+    };
+  },
+
+  async upsert_variable(input, context) {
+    const data = await railwayGraphql<{ variableUpsert?: boolean }>(
+      context,
+      `mutation variableUpsert($input: VariableUpsertInput!) {
+        variableUpsert(input: $input)
+      }`,
+      {
+        input: compactObject({
+          projectId: inputString(input, "projectId"),
+          environmentId: inputString(input, "environmentId"),
+          serviceId: optionalString(input.serviceId),
+          name: inputString(input, "name"),
+          value: inputRawString(input, "value"),
+          skipDeploys: optionalBoolean(input.skipDeploys),
+        }),
+      },
+    );
+    return { updated: data.variableUpsert === true };
+  },
+
+  async rollback_deployment(input, context) {
+    const data = await railwayGraphql<{ deploymentRollback?: RailwayDeployment }>(
+      context,
+      `mutation deploymentRollback($id: String!) {
+        deploymentRollback(id: $id) { id status createdAt url staticUrl }
+      }`,
+      { id: inputString(input, "deploymentId") },
+    );
+    return {
+      deployment: requireGraphqlValue(data.deploymentRollback, "Railway rollback deployment was not returned"),
+    };
+  },
+};
+
+export async function validateRailwayCredential(
+  apiKey: string,
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createRailwayContext(values, apiKey, fetcher, signal);
+  if (context.workspaceId) {
+    const data = await railwayGraphql<{ workspace?: { id?: string; name?: string } }>(
+      context,
+      `query workspace($workspaceId: String!) {
+        workspace(workspaceId: $workspaceId) { id name }
+      }`,
+      { workspaceId: context.workspaceId },
+      "validate",
+    );
+    const workspace = requireGraphqlValue(data.workspace, "Railway workspace was not returned");
+    return {
+      profile: {
+        accountId: workspace.id ?? context.workspaceId,
+        displayName: workspace.name ?? context.workspaceId,
+      },
+      grantedScopes: [],
+      metadata: { tokenType: "workspace", workspaceId: context.workspaceId },
+    };
+  }
+
+  const data = await railwayGraphql<{ me?: { id?: string; name?: string; email?: string } }>(
+    context,
+    `query currentUser { me { id name email } }`,
+    undefined,
+    "validate",
+  );
+  const user = requireGraphqlValue(data.me, "Railway account was not returned");
+  const accountId = user.id ?? user.email;
+  if (!accountId) {
+    throw new ProviderRequestError(502, "Railway account identity was not returned");
+  }
+  return {
+    profile: {
+      accountId,
+      displayName: user.name ?? user.email ?? accountId,
+    },
+    grantedScopes: [],
+    metadata: { tokenType: "account" },
+  };
+}
+
+async function railwayGraphql<T extends Record<string, unknown>>(
+  context: RailwayActionContext,
+  query: string,
+  variables?: Record<string, unknown>,
+  phase: "validate" | "execute" = "execute",
+): Promise<T> {
+  const payload = await requestJson({
+    providerName: "Railway",
+    baseUrl: railwayApiBaseUrl,
+    path: railwayGraphqlPath,
+    fetcher: context.fetcher,
+    signal: context.signal,
+    headers: { authorization: `Bearer ${context.apiKey}` },
+    body: variables ? { query, variables } : { query },
+    phase,
+  });
+  const envelope = objectPayload(payload, "Railway GraphQL API");
+  const errors = (Array.isArray(envelope.errors) ? objectArray(envelope.errors, "errors") : [])
+    .map((error) => toRailwayGraphqlError(error))
+    .filter((error): error is RailwayGraphqlError => error !== undefined);
+  if (errors.length > 0) {
+    const message =
+      errors
+        .map((error) => error.message)
+        .filter(Boolean)
+        .join("; ") || "Railway GraphQL request failed";
+    throw new ProviderRequestError(400, message, errors);
+  }
+  const data = optionalRecord(envelope.data);
+  if (!data) {
+    throw new ProviderRequestError(502, "Railway GraphQL response did not include data", payload);
+  }
+  return data as T;
+}
+
+function toRailwayGraphqlError(value: Record<string, unknown>): RailwayGraphqlError | undefined {
+  const message = optionalString(value.message);
+  if (!message) {
+    return undefined;
+  }
+  const path = Array.isArray(value.path)
+    ? value.path.filter((part): part is string | number => typeof part === "string" || typeof part === "number")
+    : undefined;
+  return { message, path };
+}
+
+function connectionNodes<T>(connection: RailwayConnection<T> | undefined): T[] {
+  return (connection?.edges ?? []).flatMap((edge) => (edge.node ? [edge.node] : []));
+}
+
+function inputString(input: Record<string, unknown>, key: string): string {
+  const value = requiredString(input[key], key, (message) => new ProviderRequestError(400, message));
+  return value.trim();
+}
+
+function inputRawString(input: Record<string, unknown>, key: string): string {
+  const value = optionalRawString(input[key]);
+  if (value === undefined) {
+    throw new ProviderRequestError(400, `${key} is required.`);
+  }
+  return value;
+}
+
+function requireGraphqlValue<T>(value: T | null | undefined, message: string): T {
+  if (value === undefined || value === null) {
+    throw new ProviderRequestError(502, message);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- add a Railway provider for account and workspace bearer tokens
- expose nine locally executable actions covering projects, service configuration, deployments, runtime logs, variable updates, and rollbacks
- normalize GraphQL connections and surface HTTP 200 GraphQL errors as provider errors
- add focused tests for workspace credential validation, Bearer authentication, deployment inputs, empty variable values, and GraphQL errors

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (40 files, 275 tests)

Live Railway API calls were not run because no Railway test credential was available.