### PR TITLE
feat(luckin-coffee): add MCP provider

### DIFF
--- a/src/providers/luckin_coffee/actions.test.ts
+++ b/src/providers/luckin_coffee/actions.test.ts
@@ -1,5 +1,11 @@
+import type { JsonSchema } from "../../core/types.ts";
+
 import { describe, expect, it } from "vitest";
 import { luckinCoffeeActions, luckinMcpToolNames } from "./actions.ts";
+
+function schemaProperties(schema: JsonSchema | undefined): Record<string, JsonSchema> {
+  return (schema?.properties as Record<string, JsonSchema> | undefined) ?? {};
+}
 
 describe("Luckin Coffee actions", () => {
   it("exposes the complete public MCP tool catalog exactly once", () => {
@@ -21,5 +27,29 @@ describe("Luckin Coffee actions", () => {
     expect(createOrder?.description).toContain("real Luckin Coffee order");
     expect(createOrder?.description).toContain("confirmation");
     expect(cancelOrder?.description).toContain("irreversible");
+  });
+
+  it("keeps every createOrder result field, including the lossless orderIdStr handoff", () => {
+    // Regression guard: the created-order schema has a field literally named `description`.
+    // Built with s.looseObject it would be misread as options and drop all fields, erasing the
+    // orderIdStr that queryOrderDetailInfo and cancelOrder consume.
+    const createOrder = luckinCoffeeActions.find((action) => action.name === "createOrder");
+    const dataSchema = schemaProperties(createOrder?.outputSchema).data;
+    const fieldNames = Object.keys(schemaProperties(dataSchema));
+    expect(fieldNames).toEqual(
+      expect.arrayContaining([
+        "orderId",
+        "orderIdStr",
+        "payOrderUrl",
+        "payOrderQrCodeUrl",
+        "discountPrice",
+        "needPay",
+        "tradeNo",
+        "description",
+        "businessNotifyUrl",
+        "subMchid",
+      ]),
+    );
+    expect(fieldNames).toContain("orderIdStr");
   });
 });

--- a/src/providers/luckin_coffee/actions.test.ts
+++ b/src/providers/luckin_coffee/actions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { luckinCoffeeActions, luckinMcpToolNames } from "./actions.ts";
+
+describe("Luckin Coffee actions", () => {
+  it("exposes the complete public MCP tool catalog exactly once", () => {
+    const actionNames = luckinCoffeeActions.map((action) => action.name);
+    expect(actionNames).toEqual([...luckinMcpToolNames]);
+    expect(new Set(actionNames).size).toBe(8);
+  });
+
+  it("marks the required official inputs for store lookup and order creation", () => {
+    const queryShop = luckinCoffeeActions.find((action) => action.name === "queryShopList");
+    const createOrder = luckinCoffeeActions.find((action) => action.name === "createOrder");
+    expect(queryShop?.inputSchema.required).toEqual(["longitude", "latitude"]);
+    expect(createOrder?.inputSchema.required).toEqual(["deptId", "productList", "longitude", "latitude"]);
+  });
+
+  it("warns about real-order side effects", () => {
+    const createOrder = luckinCoffeeActions.find((action) => action.name === "createOrder");
+    const cancelOrder = luckinCoffeeActions.find((action) => action.name === "cancelOrder");
+    expect(createOrder?.description).toContain("real Luckin Coffee order");
+    expect(createOrder?.description).toContain("confirmation");
+    expect(cancelOrder?.description).toContain("irreversible");
+  });
+});

--- a/src/providers/luckin_coffee/actions.ts
+++ b/src/providers/luckin_coffee/actions.ts
@@ -101,18 +101,25 @@ const previewOrderSchema = s.looseObject("A Luckin Coffee order preview.", {
   totalInitialPrice: s.number("The total list price."),
 });
 
-const createOrderResultSchema = s.looseObject("The created Luckin Coffee order and payment details.", {
-  orderId: s.number("The numeric order ID. Prefer `orderIdStr` when passing it to another action."),
-  payOrderUrl: s.string("The WeChat payment URL."),
-  payOrderQrCodeUrl: s.string("The payment QR-code URL."),
-  discountPrice: s.number("The amount to pay."),
-  needPay: s.boolean("Whether payment is required."),
-  tradeNo: s.nullableString("The payment transaction number."),
-  description: s.nullableString("Additional order information."),
-  businessNotifyUrl: s.nullableString("The business notification URL."),
-  subMchid: s.nullableString("The WeChat Pay sub-merchant ID."),
-  orderIdStr: s.string("The order ID as a lossless string."),
-});
+// Use s.object(..., { additionalProperties: true }) rather than s.looseObject here: this
+// schema has a field literally named `description`, which s.looseObject's string-first form
+// would misread as its options argument and silently drop every declared field.
+const createOrderResultSchema = s.object(
+  "The created Luckin Coffee order and payment details.",
+  {
+    orderId: s.number("The numeric order ID. Prefer `orderIdStr` when passing it to another action."),
+    payOrderUrl: s.string("The WeChat payment URL."),
+    payOrderQrCodeUrl: s.string("The payment QR-code URL."),
+    discountPrice: s.number("The amount to pay."),
+    needPay: s.boolean("Whether payment is required."),
+    tradeNo: s.nullableString("The payment transaction number."),
+    description: s.nullableString("Additional order information."),
+    businessNotifyUrl: s.nullableString("The business notification URL."),
+    subMchid: s.nullableString("The WeChat Pay sub-merchant ID."),
+    orderIdStr: s.string("The order ID as a lossless string."),
+  },
+  { additionalProperties: true },
+);
 
 const takeMealCodeSchema = s.looseObject("Pickup-code information.", {
   code: s.string("The pickup code or its generation status."),

--- a/src/providers/luckin_coffee/actions.ts
+++ b/src/providers/luckin_coffee/actions.ts
@@ -1,0 +1,266 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "luckin_coffee";
+
+export const luckinMcpToolNames = [
+  "queryShopList",
+  "searchProductForMcp",
+  "switchProduct",
+  "queryProductDetailInfo",
+  "previewOrder",
+  "createOrder",
+  "queryOrderDetailInfo",
+  "cancelOrder",
+] as const;
+
+export type LuckinCoffeeActionName = (typeof luckinMcpToolNames)[number];
+
+const longitudeSchema = s.number("Longitude in decimal degrees.", { minimum: -180, maximum: 180 });
+const latitudeSchema = s.number("Latitude in decimal degrees.", { minimum: -90, maximum: 90 });
+const departmentIdSchema = s.positiveInteger("The Luckin Coffee store ID returned by `queryShopList`.");
+const productIdSchema = s.positiveInteger("The Luckin Coffee product ID.");
+const skuCodeSchema = s.nonEmptyString("The exact product SKU code.");
+
+const shopSchema = s.looseObject("A Luckin Coffee store.", {
+  deptId: s.integer("The store ID."),
+  deptName: s.string("The store name."),
+  address: s.string("The store address."),
+  deptTags: s.stringArray("Store tags."),
+  longitude: s.number("The store longitude."),
+  latitude: s.number("The store latitude."),
+  workTimeStart: s.string("The opening time."),
+  workTimeEnd: s.string("The closing time."),
+  distance: s.number("The distance from the requested coordinates in kilometers."),
+  number: s.string("The store number."),
+});
+
+const productSubAttributeSchema = s.looseObject("One selectable product attribute value.", {
+  attributeId: s.integer("The attribute value ID."),
+  attributeName: s.string("The attribute value name."),
+  selected: s.nullableBoolean("Whether this value is selected."),
+  price: s.number("The price adjustment for this value."),
+  canSelected: s.nullableNumber("Whether this value can be selected."),
+});
+
+const productAttributeSchema = s.looseObject("One product attribute group.", {
+  attributeId: s.integer("The attribute group ID."),
+  attributeName: s.string("The attribute group name."),
+  productSubAttrs: s.array("Selectable values in this group.", productSubAttributeSchema),
+});
+
+const productSchema = s.looseObject("A Luckin Coffee product and its current configuration.", {
+  productId: s.integer("The product ID."),
+  productName: s.string("The product name."),
+  skuCode: s.string("The configured product SKU code."),
+  pictureUrl: s.string("The product image URL."),
+  productAttrs: s.array("The product attribute groups.", productAttributeSchema),
+  tags: s.nullable(s.stringArray("Product tags.")),
+  initialPrice: s.number("The list price."),
+  estimatePrice: s.number("The estimated final price."),
+});
+
+const orderProductInputSchema = s.requiredObject("One configured product in an order.", {
+  amount: s.positiveInteger("The quantity to order."),
+  productId: productIdSchema,
+  skuCode: skuCodeSchema,
+});
+
+const orderProductOutputSchema = s.looseObject("One product in an order response.", {
+  productId: s.integer("The product ID."),
+  skuCode: s.string("The product SKU code."),
+  name: s.string("The product name."),
+  amount: s.integer("The ordered quantity."),
+  additionDesc: s.string("The selected attribute summary."),
+  bigPicUrl: s.nullableString("The large product image URL."),
+  breviaryPicUrl: s.nullableString("The product thumbnail URL."),
+  initPrice: s.number("The product list price."),
+  estimatePrice: s.number("The estimated unit price."),
+  estimateTotalPrice: s.number("The estimated line total."),
+});
+
+const granularCommoditySchema = s.looseObject("One order commodity price breakdown.", {
+  commodityId: s.integer("The commodity ID."),
+  commodityCode: s.string("The commodity code."),
+  commodityName: s.string("The commodity name."),
+  payableMoney: s.number("The payable amount."),
+  payMoney: s.number("The paid amount."),
+});
+
+const previewOrderSchema = s.looseObject("A Luckin Coffee order preview.", {
+  aboutTime: s.number("The estimated pickup or delivery timestamp."),
+  discountPrice: s.number("The estimated amount to pay."),
+  shopInfo: shopSchema,
+  productInfoList: s.array("The configured products in the preview.", orderProductOutputSchema),
+  couponCodeList: s.stringArray("Coupon codes selected by the preview."),
+  orderGranularCommodityList: s.array("Per-commodity price details.", granularCommoditySchema),
+  expressExpectTime: s.nullableNumber("The estimated delivery time."),
+  privilegeMoney: s.number("The discount amount."),
+  totalInitialPrice: s.number("The total list price."),
+});
+
+const createOrderResultSchema = s.looseObject("The created Luckin Coffee order and payment details.", {
+  orderId: s.number("The numeric order ID. Prefer `orderIdStr` when passing it to another action."),
+  payOrderUrl: s.string("The WeChat payment URL."),
+  payOrderQrCodeUrl: s.string("The payment QR-code URL."),
+  discountPrice: s.number("The amount to pay."),
+  needPay: s.boolean("Whether payment is required."),
+  tradeNo: s.nullableString("The payment transaction number."),
+  description: s.nullableString("Additional order information."),
+  businessNotifyUrl: s.nullableString("The business notification URL."),
+  subMchid: s.nullableString("The WeChat Pay sub-merchant ID."),
+  orderIdStr: s.string("The order ID as a lossless string."),
+});
+
+const takeMealCodeSchema = s.looseObject("Pickup-code information.", {
+  code: s.string("The pickup code or its generation status."),
+  takeOrderId: s.string("The pickup order ID."),
+});
+
+const dispatchInfoSchema = s.looseObject("Delivery information.", {
+  dispatcherName: s.string("The courier name."),
+  dispatcherMobile: s.string("The courier phone number."),
+  dispatchAboutTime: s.string("The estimated delivery time."),
+  destinationDistance: s.number("The remaining delivery distance."),
+});
+
+const orderDetailSchema = s.looseObject("Luckin Coffee order details.", {
+  orderId: s.string("The order ID."),
+  orderStatus: s.integer(
+    "Order status: 10 pending payment, 20 placed, 30 preparing, 60 ready, 80 completed, 100 canceled.",
+  ),
+  orderStatusName: s.string("The localized order status name."),
+  aboutTime: s.number("The estimated pickup or delivery timestamp."),
+  takeMealTime: s.string("The actual pickup time."),
+  takeMealCodeInfo: takeMealCodeSchema,
+  shopInfo: shopSchema,
+  productInfoList: s.nullable(s.array("Products in the order.", orderProductOutputSchema)),
+  orderPayAmount: s.number("The paid order amount."),
+  dispatchInfo: dispatchInfoSchema,
+  orderCommodityList: s.array("Commodity price details.", granularCommoditySchema),
+  orderType: s.string("The order type."),
+  customerParams: s.nullable(s.unknownObject("Additional customer parameters.")),
+});
+
+function luckinResponse(description: string, data: JsonSchema): JsonSchema {
+  return s.looseObject(description, {
+    code: s.integer("The upstream result code. Zero indicates success."),
+    msg: s.string("The upstream result message."),
+    data,
+    success: s.boolean("Whether the operation succeeded."),
+  });
+}
+
+export const luckinCoffeeActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "queryShopList",
+    description: "Find nearby Luckin Coffee stores using a location and optional store name.",
+    requiredScopes: [],
+    inputSchema: s.object(
+      "Input for finding Luckin Coffee stores.",
+      {
+        deptName: s.string("An optional store-name filter."),
+        longitude: longitudeSchema,
+        latitude: latitudeSchema,
+      },
+      { optional: ["deptName"] },
+    ),
+    outputSchema: luckinResponse("Nearby Luckin Coffee stores.", s.array("Matching stores.", shopSchema)),
+    followUpActions: ["luckin_coffee.searchProductForMcp"],
+  }),
+  defineProviderAction(service, {
+    name: "searchProductForMcp",
+    description: "Search and recommend Luckin Coffee products at a specific store from the user's original request.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for searching Luckin Coffee products.", {
+      deptId: departmentIdSchema,
+      query: s.nonEmptyString("The user's original product request in natural language."),
+    }),
+    outputSchema: luckinResponse("Matching Luckin Coffee products.", s.array("Matching products.", productSchema)),
+    followUpActions: ["luckin_coffee.queryProductDetailInfo", "luckin_coffee.switchProduct"],
+  }),
+  defineProviderAction(service, {
+    name: "switchProduct",
+    description: "Change a selectable attribute on a Luckin Coffee product and return the updated SKU and price.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for changing one product attribute.", {
+      deptId: departmentIdSchema,
+      productId: productIdSchema,
+      skuCode: skuCodeSchema,
+      attrOperationParam: s.requiredObject("The attribute operation to apply.", {
+        attributeId: s.positiveInteger("The attribute group ID."),
+        subAttr: s.requiredObject("The attribute value operation.", {
+          attributeId: s.positiveInteger("The attribute value ID."),
+          operation: s.integer("The operation code. Use 3 to select the value."),
+        }),
+      }),
+      amount: s.positiveInteger("The product quantity."),
+    }),
+    outputSchema: luckinResponse("The updated product configuration.", productSchema),
+    followUpActions: ["luckin_coffee.previewOrder"],
+  }),
+  defineProviderAction(service, {
+    name: "queryProductDetailInfo",
+    description: "Get the current details, attributes, SKU, and price for one Luckin Coffee product at a store.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for reading product details.", {
+      deptId: departmentIdSchema,
+      productId: productIdSchema,
+    }),
+    outputSchema: luckinResponse("Luckin Coffee product details.", productSchema),
+    followUpActions: ["luckin_coffee.switchProduct", "luckin_coffee.previewOrder"],
+  }),
+  defineProviderAction(service, {
+    name: "previewOrder",
+    description: "Preview a Luckin Coffee order, including prices and available coupons, without creating it.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for previewing an order.", {
+      deptId: departmentIdSchema,
+      productList: s.array("The configured products to preview.", orderProductInputSchema, { minItems: 1 }),
+    }),
+    outputSchema: luckinResponse("The Luckin Coffee order preview.", previewOrderSchema),
+    followUpActions: ["luckin_coffee.createOrder"],
+  }),
+  defineProviderAction(service, {
+    name: "createOrder",
+    description:
+      "Create a real Luckin Coffee order that may require payment. Preview the order first and obtain the user's confirmation before calling this action.",
+    requiredScopes: [],
+    inputSchema: s.object(
+      "Input for creating a confirmed Luckin Coffee order.",
+      {
+        deptId: departmentIdSchema,
+        productList: s.array("The configured products to order.", orderProductInputSchema, { minItems: 1 }),
+        longitude: longitudeSchema,
+        latitude: latitudeSchema,
+        couponCodeList: s.stringArray("Coupon codes returned by `previewOrder`."),
+        remark: s.string("An optional order note."),
+      },
+      { optional: ["couponCodeList", "remark"] },
+    ),
+    outputSchema: luckinResponse("The created Luckin Coffee order.", createOrderResultSchema),
+    followUpActions: ["luckin_coffee.queryOrderDetailInfo", "luckin_coffee.cancelOrder"],
+  }),
+  defineProviderAction(service, {
+    name: "queryOrderDetailInfo",
+    description: "Get the current status, pickup details, products, payment, and delivery information for an order.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for reading Luckin Coffee order details.", {
+      orderId: s.nonEmptyString("The lossless order ID string returned by `createOrder`."),
+    }),
+    outputSchema: luckinResponse("Luckin Coffee order details.", orderDetailSchema),
+    followUpActions: ["luckin_coffee.cancelOrder"],
+  }),
+  defineProviderAction(service, {
+    name: "cancelOrder",
+    description:
+      "Cancel a Luckin Coffee order. This changes a real order and may be irreversible; confirm the exact order with the user first.",
+    requiredScopes: [],
+    inputSchema: s.requiredObject("Input for canceling a Luckin Coffee order.", {
+      orderId: s.nonEmptyString("The exact order ID to cancel."),
+    }),
+    outputSchema: luckinResponse("The Luckin Coffee order cancellation result.", s.boolean("Whether it was canceled.")),
+  }),
+];

--- a/src/providers/luckin_coffee/definition.ts
+++ b/src/providers/luckin_coffee/definition.ts
@@ -1,0 +1,28 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { luckinCoffeeActions } from "./actions.ts";
+
+const service = "luckin_coffee";
+
+/**
+ * Luckin Coffee provider backed by the official Streamable HTTP MCP service.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Luckin Coffee",
+  description:
+    "Find Luckin Coffee stores and products, preview orders, and manage orders through the official MCP service.",
+  categories: ["Location", "Productivity"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "MCP Token",
+      placeholder: "Paste your Luckin Coffee MCP token",
+      description:
+        "The Bearer token shared by Luckin Coffee MCP and CLI. Sign in and create or copy it at https://open.lkcoffee.com/mcp. Keep this token private because it is linked to your Luckin Coffee account session.",
+    },
+  ],
+  homepageUrl: "https://open.lkcoffee.com/mcp",
+  actions: luckinCoffeeActions,
+};

--- a/src/providers/luckin_coffee/executors.ts
+++ b/src/providers/luckin_coffee/executors.ts
@@ -1,0 +1,179 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type { LuckinCoffeeActionName } from "./actions.ts";
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { createHash } from "node:crypto";
+import {
+  defineApiKeyProviderExecutors,
+  defineProviderProxy,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
+import { luckinMcpToolNames } from "./actions.ts";
+
+const service = "luckin_coffee";
+const luckinMcpOrigin = "https://gwmcp.lkcoffee.com";
+const luckinMcpEndpoint = "https://gwmcp.lkcoffee.com/order/user/mcp";
+const luckinRequestTimeoutMs = 60_000;
+
+type LuckinActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
+type LuckinActionHandler = (input: Record<string, unknown>, context: LuckinActionContext) => Promise<unknown>;
+type LuckinMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+interface LuckinMcpToolSummary {
+  name: string;
+  description?: string;
+}
+
+export const luckinActionHandlers: Record<LuckinCoffeeActionName, LuckinActionHandler> = Object.fromEntries(
+  luckinMcpToolNames.map((toolName) => [
+    toolName,
+    (input: Record<string, unknown>, context: LuckinActionContext) => callLuckinMcpTool(context, toolName, input),
+  ]),
+) as Record<LuckinCoffeeActionName, LuckinActionHandler>;
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, luckinActionHandlers);
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: luckinMcpOrigin,
+  auth: {
+    type: "api_key_authorization",
+    prefix: "Bearer ",
+  },
+  allowedEndpoint: (endpoint) => endpoint === "/order/user/mcp",
+});
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    const tools = await listLuckinMcpTools({ apiKey: input.apiKey, fetcher, signal });
+    const tokenHash = hashLuckinToken(input.apiKey);
+    return {
+      profile: {
+        accountId: `luckin-coffee:mcp:${tokenHash}`,
+        displayName: `Luckin Coffee MCP - ${tokenHash.slice(-6)}`,
+      },
+      grantedScopes: [],
+      metadata: {
+        mcpEndpoint: luckinMcpEndpoint,
+        mcpTools: tools.map((tool) => tool.name).sort(),
+      },
+    };
+  },
+};
+
+async function listLuckinMcpTools(input: {
+  apiKey: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<LuckinMcpToolSummary[]> {
+  return withLuckinMcpClient(input, async (client) => {
+    const result = await client.listTools({}, { timeout: luckinRequestTimeoutMs });
+    return result.tools.map((tool) => ({
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+    }));
+  });
+}
+
+async function callLuckinMcpTool(
+  context: LuckinActionContext,
+  toolName: LuckinCoffeeActionName,
+  argumentsInput: Record<string, unknown>,
+): Promise<unknown> {
+  return withLuckinMcpClient(context, async (client) => {
+    const result = await client.callTool({ name: toolName, arguments: argumentsInput }, undefined, {
+      timeout: luckinRequestTimeoutMs,
+    });
+    return normalizeLuckinMcpToolResult(toolName, result);
+  });
+}
+
+async function withLuckinMcpClient<T>(
+  input: { apiKey: string; fetcher: typeof fetch; signal?: AbortSignal },
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${input.apiKey}`);
+  headers.set("user-agent", providerUserAgent);
+  const transport = new StreamableHTTPClientTransport(new URL(luckinMcpEndpoint), {
+    fetch: input.fetcher,
+    requestInit: { headers, signal: input.signal },
+  });
+  const client = new Client({ name: "oomol-connect-luckin-coffee", version: "1.0.0" });
+
+  try {
+    await client.connect(transport, { timeout: luckinRequestTimeoutMs });
+    return await run(client);
+  } catch (error) {
+    throw mapLuckinMcpError(error);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function normalizeLuckinMcpToolResult(toolName: string, result: LuckinMcpToolResult): unknown {
+  if ("toolResult" in result) return result;
+  if (result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `Luckin Coffee MCP tool ${toolName} returned an error: ${formatLuckinMcpToolContent(result)}`,
+      result,
+    );
+  }
+  if (result.structuredContent) return result.structuredContent;
+
+  const textItems = result.content.filter((content) => content.type === "text");
+  if (textItems.length === 1) {
+    try {
+      return JSON.parse(textItems[0]!.text) as unknown;
+    } catch {
+      // Preserve the MCP content envelope when the tool intentionally returns plain text.
+    }
+  }
+  return result;
+}
+
+function formatLuckinMcpToolContent(result: Extract<LuckinMcpToolResult, { content: unknown }>): string {
+  const text = result.content
+    .map((content) => {
+      if (content.type === "text") return content.text;
+      if (content.type === "resource") return "text" in content.resource ? content.resource.text : content.resource.uri;
+      if (content.type === "resource_link") return content.uri;
+      return content.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+  return text.slice(0, 300) || "empty error content";
+}
+
+function mapLuckinMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "Luckin Coffee MCP token is invalid or expired", error);
+  }
+  if (error instanceof StreamableHTTPError) {
+    const status = error.code;
+    return new ProviderRequestError(
+      status === 401 || status === 403 ? 401 : status && status >= 400 && status < 500 ? 400 : 502,
+      `Luckin Coffee MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof McpError) {
+    return new ProviderRequestError(502, `Luckin Coffee MCP request failed: ${error.message}`, error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `Luckin Coffee MCP request failed: ${error.message}` : "Luckin Coffee MCP request failed",
+    error,
+  );
+}
+
+function hashLuckinToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}

--- a/src/providers/luckin_coffee/executors.ts
+++ b/src/providers/luckin_coffee/executors.ts
@@ -24,11 +24,6 @@ type LuckinActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "s
 type LuckinActionHandler = (input: Record<string, unknown>, context: LuckinActionContext) => Promise<unknown>;
 type LuckinMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
-interface LuckinMcpToolSummary {
-  name: string;
-  description?: string;
-}
-
 export const luckinActionHandlers: Record<LuckinCoffeeActionName, LuckinActionHandler> = Object.fromEntries(
   luckinMcpToolNames.map((toolName) => [
     toolName,
@@ -60,7 +55,7 @@ export const credentialValidators: CredentialValidators = {
       grantedScopes: [],
       metadata: {
         mcpEndpoint: luckinMcpEndpoint,
-        mcpTools: tools.map((tool) => tool.name).sort(),
+        mcpTools: tools.sort(),
       },
     };
   },
@@ -70,13 +65,10 @@ async function listLuckinMcpTools(input: {
   apiKey: string;
   fetcher: typeof fetch;
   signal?: AbortSignal;
-}): Promise<LuckinMcpToolSummary[]> {
+}): Promise<string[]> {
   return withLuckinMcpClient(input, async (client) => {
     const result = await client.listTools({}, { timeout: luckinRequestTimeoutMs });
-    return result.tools.map((tool) => ({
-      name: tool.name,
-      ...(tool.description ? { description: tool.description } : {}),
-    }));
+    return result.tools.map((tool) => tool.name);
   });
 }
 
@@ -159,7 +151,13 @@ function mapLuckinMcpError(error: unknown): ProviderRequestError {
   if (error instanceof StreamableHTTPError) {
     const status = error.code;
     return new ProviderRequestError(
-      status === 401 || status === 403 ? 401 : status && status >= 400 && status < 500 ? 400 : 502,
+      status === 401 || status === 403
+        ? 401
+        : status === 429
+          ? 429
+          : status && status >= 400 && status < 500
+            ? 400
+            : 502,
       `Luckin Coffee MCP request failed: ${error.message}`,
       error,
     );


### PR DESCRIPTION
## Summary

Add an OpenConnector provider for the official [Luckin Coffee MCP](https://open.lkcoffee.com/mcp).

- connects to the official Streamable HTTP endpoint with a Bearer MCP token
- exposes the complete public catalog of 8 Luckin Coffee tools as statically typed actions
- models the store → product → preview → create → status/cancel workflow with follow-up actions
- validates credentials through MCP `tools/list`
- restricts proxy access to the official MCP path
- preserves lossless string order IDs and adds explicit confirmation warnings for creating or canceling real orders

## Actions

- `queryShopList`
- `searchProductForMcp`
- `switchProduct`
- `queryProductDetailInfo`
- `previewOrder`
- `createOrder`
- `queryOrderDetailInfo`
- `cancelOrder`

## Verification

- `oxlint . --fix`
- `oxfmt .`
- provider registry and catalog generation
- typecheck: `src`, `scripts-all`, and `examples`
- full test suite: 38 files, 260 tests passed
- live unauthenticated endpoint probe confirmed the expected HTTP 401 behavior
