### PR TITLE
feat(jumpserver): add MCP provider

### DIFF
--- a/src/providers/jumpserver/actions.ts
+++ b/src/providers/jumpserver/actions.ts
@@ -16,6 +16,45 @@ export const jumpServerMcpToolNames = [
 
 export type JumpServerActionName = (typeof jumpServerMcpToolNames)[number];
 
+interface JumpServerActionMetadata {
+  description: string;
+  resource: string;
+  followUpActions?: string[];
+}
+
+const actionMetadata: Record<JumpServerActionName, JumpServerActionMetadata> = {
+  assets_assets_list: {
+    description: "List assets visible to the configured JumpServer token, with optional pagination and search.",
+    resource: "assets",
+    followUpActions: ["jumpserver.assets_nodes_list", "jumpserver.accounts_accounts_list"],
+  },
+  assets_nodes_list: {
+    description: "List asset nodes visible to the configured JumpServer token.",
+    resource: "asset nodes",
+    followUpActions: ["jumpserver.assets_assets_list"],
+  },
+  accounts_accounts_list: {
+    description: "List managed accounts visible to the configured JumpServer token.",
+    resource: "managed accounts",
+    followUpActions: ["jumpserver.assets_assets_list"],
+  },
+  users_users_list: {
+    description: "List JumpServer users visible to the configured token.",
+    resource: "users",
+    followUpActions: ["jumpserver.perms_asset_permissions_list"],
+  },
+  perms_asset_permissions_list: {
+    description: "List asset permission rules visible to the configured JumpServer token.",
+    resource: "asset permission rules",
+    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
+  },
+  terminal_sessions_list: {
+    description: "List historical and active terminal sessions visible to the configured JumpServer token.",
+    resource: "terminal sessions",
+    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
+  },
+};
+
 const listInputSchema = s.object(
   "Common JumpServer list filters. Availability of matching records depends on the Bearer token permissions.",
   {
@@ -39,47 +78,12 @@ function listOutputSchema(resource: string): JsonSchema {
   );
 }
 
-export const jumpServerActions: ActionDefinition[] = [
+export const jumpServerActions: ActionDefinition[] = jumpServerMcpToolNames.map((name) =>
   defineProviderAction(service, {
-    name: "assets_assets_list",
-    description: "List assets visible to the configured JumpServer token, with optional pagination and search.",
+    name,
+    description: actionMetadata[name].description,
     inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("assets"),
-    followUpActions: ["jumpserver.assets_nodes_list", "jumpserver.accounts_accounts_list"],
+    outputSchema: listOutputSchema(actionMetadata[name].resource),
+    followUpActions: actionMetadata[name].followUpActions,
   }),
-  defineProviderAction(service, {
-    name: "assets_nodes_list",
-    description: "List asset nodes visible to the configured JumpServer token.",
-    inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("asset nodes"),
-    followUpActions: ["jumpserver.assets_assets_list"],
-  }),
-  defineProviderAction(service, {
-    name: "accounts_accounts_list",
-    description: "List managed accounts visible to the configured JumpServer token.",
-    inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("managed accounts"),
-    followUpActions: ["jumpserver.assets_assets_list"],
-  }),
-  defineProviderAction(service, {
-    name: "users_users_list",
-    description: "List JumpServer users visible to the configured token.",
-    inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("users"),
-    followUpActions: ["jumpserver.perms_asset_permissions_list"],
-  }),
-  defineProviderAction(service, {
-    name: "perms_asset_permissions_list",
-    description: "List asset permission rules visible to the configured JumpServer token.",
-    inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("asset permission rules"),
-    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
-  }),
-  defineProviderAction(service, {
-    name: "terminal_sessions_list",
-    description: "List historical and active terminal sessions visible to the configured JumpServer token.",
-    inputSchema: listInputSchema,
-    outputSchema: listOutputSchema("terminal sessions"),
-    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
-  }),
-];
+);

--- a/src/providers/jumpserver/actions.ts
+++ b/src/providers/jumpserver/actions.ts
@@ -1,63 +1,85 @@
-import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
 
-const service = "jumpserver" as const;
+const service = "jumpserver";
 
-const toolSchema = s.object(
-  "A tool discovered from the configured JumpServer MCP server.",
+export const jumpServerMcpToolNames = [
+  "assets_assets_list",
+  "assets_nodes_list",
+  "accounts_accounts_list",
+  "users_users_list",
+  "perms_asset_permissions_list",
+  "terminal_sessions_list",
+] as const;
+
+export type JumpServerActionName = (typeof jumpServerMcpToolNames)[number];
+
+const listInputSchema = s.object(
+  "Common JumpServer list filters. Availability of matching records depends on the Bearer token permissions.",
   {
-    name: s.nonEmptyString("JumpServer MCP tool name."),
-    description: s.string("Tool description supplied by JumpServer MCP."),
-    inputSchema: s.unknownObject("JSON Schema accepted by the JumpServer MCP tool."),
-    outputSchema: s.unknownObject("JSON Schema returned by the JumpServer MCP tool when declared."),
+    limit: s.positiveInteger("Maximum number of records to return."),
+    offset: s.nonNegativeInteger("Number of records to skip before returning results."),
+    search: s.string("Search text applied to fields supported by this JumpServer resource."),
   },
-  { required: ["name", "inputSchema"], optional: ["description", "outputSchema"] },
+  { optional: ["limit", "offset", "search"] },
 );
 
-type JumpServerActionDefinitions = readonly [
-  ProviderActionDefinition<"list_tools">,
-  ProviderActionDefinition<"call_tool">,
-];
+function listOutputSchema(resource: string): JsonSchema {
+  return s.object(
+    `A paginated list of JumpServer ${resource}.`,
+    {
+      count: s.nonNegativeInteger("Total number of matching records."),
+      next: s.nullableString("URL for the next page when one exists."),
+      previous: s.nullableString("URL for the previous page when one exists."),
+      results: s.array(`Matching JumpServer ${resource}.`, s.unknownObject(`One JumpServer ${resource} record.`)),
+    },
+    { required: ["count", "results"], optional: ["next", "previous"], additionalProperties: true },
+  );
+}
 
-export type JumpServerActionName = JumpServerActionDefinitions[number]["name"];
-
-export const jumpServerActions: JumpServerActionDefinitions = [
+export const jumpServerActions: ActionDefinition[] = [
   defineProviderAction(service, {
-    name: "list_tools",
-    description:
-      "List tools exposed by the configured JumpServer MCP server. The available tools depend on the JumpServer version, installed components, and Bearer token permissions.",
-    inputSchema: s.object(
-      "Input for listing JumpServer MCP tools.",
-      {
-        cursor: s.string("Opaque pagination cursor returned by a previous list_tools call."),
-      },
-      { optional: ["cursor"] },
-    ),
-    outputSchema: s.object(
-      "Tools exposed by JumpServer MCP.",
-      {
-        tools: s.array("JumpServer MCP tools.", toolSchema),
-        nextCursor: s.string("Opaque cursor for the next page when more tools are available."),
-      },
-      { required: ["tools"], optional: ["nextCursor"] },
-    ),
+    name: "assets_assets_list",
+    description: "List assets visible to the configured JumpServer token, with optional pagination and search.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("assets"),
+    followUpActions: ["jumpserver.assets_nodes_list", "jumpserver.accounts_accounts_list"],
   }),
   defineProviderAction(service, {
-    name: "call_tool",
-    description:
-      "Call any tool exposed by the configured JumpServer MCP server. Use list_tools first to inspect the exact tool name, description, and input schema. Warning: the selected JumpServer tool may create, modify, delete, or otherwise disrupt managed assets and access configuration.",
-    inputSchema: s.object(
-      "Input for calling one JumpServer MCP tool.",
-      {
-        toolName: s.nonEmptyString("Exact JumpServer MCP tool name returned by list_tools."),
-        arguments: s.unknownObject("Arguments validated by the selected JumpServer MCP tool."),
-      },
-      { required: ["toolName"], optional: ["arguments"] },
-    ),
-    outputSchema: s.unknownObject(
-      "The MCP call result, including content and optional structuredContent returned by JumpServer.",
-    ),
+    name: "assets_nodes_list",
+    description: "List asset nodes visible to the configured JumpServer token.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("asset nodes"),
+    followUpActions: ["jumpserver.assets_assets_list"],
+  }),
+  defineProviderAction(service, {
+    name: "accounts_accounts_list",
+    description: "List managed accounts visible to the configured JumpServer token.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("managed accounts"),
+    followUpActions: ["jumpserver.assets_assets_list"],
+  }),
+  defineProviderAction(service, {
+    name: "users_users_list",
+    description: "List JumpServer users visible to the configured token.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("users"),
+    followUpActions: ["jumpserver.perms_asset_permissions_list"],
+  }),
+  defineProviderAction(service, {
+    name: "perms_asset_permissions_list",
+    description: "List asset permission rules visible to the configured JumpServer token.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("asset permission rules"),
+    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
+  }),
+  defineProviderAction(service, {
+    name: "terminal_sessions_list",
+    description: "List historical and active terminal sessions visible to the configured JumpServer token.",
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema("terminal sessions"),
+    followUpActions: ["jumpserver.assets_assets_list", "jumpserver.users_users_list"],
   }),
 ];

--- a/src/providers/jumpserver/actions.ts
+++ b/src/providers/jumpserver/actions.ts
@@ -1,0 +1,63 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "jumpserver" as const;
+
+const toolSchema = s.object(
+  "A tool discovered from the configured JumpServer MCP server.",
+  {
+    name: s.nonEmptyString("JumpServer MCP tool name."),
+    description: s.string("Tool description supplied by JumpServer MCP."),
+    inputSchema: s.unknownObject("JSON Schema accepted by the JumpServer MCP tool."),
+    outputSchema: s.unknownObject("JSON Schema returned by the JumpServer MCP tool when declared."),
+  },
+  { required: ["name", "inputSchema"], optional: ["description", "outputSchema"] },
+);
+
+type JumpServerActionDefinitions = readonly [
+  ProviderActionDefinition<"list_tools">,
+  ProviderActionDefinition<"call_tool">,
+];
+
+export type JumpServerActionName = JumpServerActionDefinitions[number]["name"];
+
+export const jumpServerActions: JumpServerActionDefinitions = [
+  defineProviderAction(service, {
+    name: "list_tools",
+    description:
+      "List tools exposed by the configured JumpServer MCP server. The available tools depend on the JumpServer version, installed components, and Bearer token permissions.",
+    inputSchema: s.object(
+      "Input for listing JumpServer MCP tools.",
+      {
+        cursor: s.string("Opaque pagination cursor returned by a previous list_tools call."),
+      },
+      { optional: ["cursor"] },
+    ),
+    outputSchema: s.object(
+      "Tools exposed by JumpServer MCP.",
+      {
+        tools: s.array("JumpServer MCP tools.", toolSchema),
+        nextCursor: s.string("Opaque cursor for the next page when more tools are available."),
+      },
+      { required: ["tools"], optional: ["nextCursor"] },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "call_tool",
+    description:
+      "Call any tool exposed by the configured JumpServer MCP server. Use list_tools first to inspect the exact tool name, description, and input schema. Warning: the selected JumpServer tool may create, modify, delete, or otherwise disrupt managed assets and access configuration.",
+    inputSchema: s.object(
+      "Input for calling one JumpServer MCP tool.",
+      {
+        toolName: s.nonEmptyString("Exact JumpServer MCP tool name returned by list_tools."),
+        arguments: s.unknownObject("Arguments validated by the selected JumpServer MCP tool."),
+      },
+      { required: ["toolName"], optional: ["arguments"] },
+    ),
+    outputSchema: s.unknownObject(
+      "The MCP call result, including content and optional structuredContent returned by JumpServer.",
+    ),
+  }),
+];

--- a/src/providers/jumpserver/definition.ts
+++ b/src/providers/jumpserver/definition.ts
@@ -9,7 +9,7 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "JumpServer",
   description:
-    "Discover and call asset, account, permission, session, audit, and other tools exposed by an official JumpServer MCP server.",
+    "Inspect assets, nodes, accounts, users, permissions, and sessions through an official JumpServer MCP server.",
   categories: ["Developer Tools", "Infrastructure", "Security"],
   authTypes: ["custom_credential"],
   auth: [
@@ -22,9 +22,9 @@ export const provider: ProviderDefinition = {
           inputType: "text",
           required: true,
           secret: false,
-          placeholder: "http://127.0.0.1:8099/sse",
+          placeholder: "https://jumpserver-mcp.example.com/sse",
           description:
-            "The SSE endpoint of the official jumpserver/mcp server. Localhost, private-network, Tailscale, NetBird, and public HTTPS endpoints are supported. See https://github.com/jumpserver/mcp.",
+            "The SSE endpoint of the official jumpserver/mcp server. Public HTTPS endpoints are supported by default. Private-network, Tailscale, and NetBird endpoints require OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK. Loopback endpoints remain blocked. See https://github.com/jumpserver/mcp.",
         },
         {
           key: "token",

--- a/src/providers/jumpserver/definition.ts
+++ b/src/providers/jumpserver/definition.ts
@@ -1,0 +1,44 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { jumpServerActions } from "./actions.ts";
+
+const service = "jumpserver";
+
+/** JumpServer provider backed by the official jumpserver/mcp SSE server. */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "JumpServer",
+  description:
+    "Discover and call asset, account, permission, session, audit, and other tools exposed by an official JumpServer MCP server.",
+  categories: ["Developer Tools", "Infrastructure", "Security"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "mcpEndpoint",
+          label: "MCP SSE Endpoint",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "http://127.0.0.1:8099/sse",
+          description:
+            "The SSE endpoint of the official jumpserver/mcp server. Localhost, private-network, Tailscale, NetBird, and public HTTPS endpoints are supported. See https://github.com/jumpserver/mcp.",
+        },
+        {
+          key: "token",
+          label: "JumpServer Bearer Token",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Enter the JumpServer API token",
+          description:
+            "A JumpServer API Bearer token forwarded by jumpserver/mcp to the JumpServer API. If the MCP server enables api_key, configure it to accept this same token.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.jumpserver.org",
+  actions: jumpServerActions,
+};

--- a/src/providers/jumpserver/executors.ts
+++ b/src/providers/jumpserver/executors.ts
@@ -6,23 +6,44 @@ import type {
 } from "../../core/types.ts";
 import type { JumpServerMcpContext } from "./runtime.ts";
 
-import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
-import { createJumpServerMcpContext, jumpServerActionHandlers, validateJumpServerCredential } from "./runtime.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { createProviderFetch, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { jumpServerMcpToolNames } from "./actions.ts";
 
 const service = "jumpserver";
 
+type JumpServerRuntime = typeof import("./runtime.ts");
+type JumpServerActionHandler = (input: Record<string, unknown>, context: JumpServerMcpContext) => Promise<unknown>;
+
+let runtimeModule: Promise<JumpServerRuntime> | undefined;
+
+function loadJumpServerRuntime(): Promise<JumpServerRuntime> {
+  runtimeModule ??= import("./runtime.ts");
+  return runtimeModule;
+}
+
+const handlers = Object.fromEntries(
+  jumpServerMcpToolNames.map((toolName) => [
+    toolName,
+    async (input: Record<string, unknown>, context: JumpServerMcpContext): Promise<unknown> =>
+      (await loadJumpServerRuntime()).jumpServerActionHandlers[toolName](input, context),
+  ]),
+) as Record<(typeof jumpServerMcpToolNames)[number], JumpServerActionHandler>;
+
 export const executors: ProviderExecutors = defineProviderExecutors<JumpServerMcpContext>({
   service,
-  handlers: jumpServerActionHandlers,
+  handlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<JumpServerMcpContext> {
     const credential = await requireCustomCredential(context, service);
-    return createJumpServerMcpContext(credential.values, fetcher, context.signal);
+    return (await loadJumpServerRuntime()).createJumpServerMcpContext(credential.values, fetcher, context.signal);
   },
   fallbackMessage: "JumpServer MCP request failed",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
-  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    return validateJumpServerCredential(input.values, fetcher, signal);
+  async customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return (await loadJumpServerRuntime()).validateJumpServerCredential(input.values, guardedFetcher, signal);
   },
 };

--- a/src/providers/jumpserver/executors.ts
+++ b/src/providers/jumpserver/executors.ts
@@ -1,0 +1,28 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { JumpServerMcpContext } from "./runtime.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createJumpServerMcpContext, jumpServerActionHandlers, validateJumpServerCredential } from "./runtime.ts";
+
+const service = "jumpserver";
+
+export const executors: ProviderExecutors = defineProviderExecutors<JumpServerMcpContext>({
+  service,
+  handlers: jumpServerActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<JumpServerMcpContext> {
+    const credential = await requireCustomCredential(context, service);
+    return createJumpServerMcpContext(credential.values, fetcher, context.signal);
+  },
+  fallbackMessage: "JumpServer MCP request failed",
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateJumpServerCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/jumpserver/runtime.test.ts
+++ b/src/providers/jumpserver/runtime.test.ts
@@ -6,7 +6,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
-import { jumpServerActions } from "./actions.ts";
+import { jumpServerActions, jumpServerMcpToolNames } from "./actions.ts";
 import {
   createJumpServerMcpContext,
   jumpServerActionHandlers,
@@ -32,30 +32,25 @@ describe("JumpServer MCP provider contract", () => {
     expect(Object.keys(jumpServerActionHandlers).sort()).toEqual(jumpServerActions.map((action) => action.name).sort());
   });
 
-  it("validates credentials, discovers tools, and calls a tool over SSE", async () => {
-    const endpoint = await startJumpServerMcpFixture();
-    const values = { mcpEndpoint: endpoint, token: "jumpserver-token" };
+  it("validates credentials and calls curated static actions over SSE", async () => {
+    const fixture = await startJumpServerMcpFixture();
+    const values = { mcpEndpoint: fixture.endpoint, token: "jumpserver-token" };
 
-    await expect(validateJumpServerCredential(values, fetch)).resolves.toMatchObject({
+    await expect(validateJumpServerCredential(values, fixture.fetcher)).resolves.toMatchObject({
       profile: { displayName: expect.stringContaining("JumpServer MCP") },
-      metadata: { discoveredToolCount: 1, hasMoreTools: false },
+      metadata: { discoveredToolCount: jumpServerMcpToolNames.length, availableActions: jumpServerMcpToolNames },
     });
 
-    const context = createJumpServerMcpContext(values, fetch);
-    await expect(jumpServerActionHandlers.list_tools({}, context)).resolves.toMatchObject({
-      tools: [{ name: "assets_assets_list" }],
-    });
-    await expect(
-      jumpServerActionHandlers.call_tool({ toolName: "assets_assets_list", arguments: { limit: 1 } }, context),
-    ).resolves.toMatchObject({
-      content: [{ type: "text", text: '{"count":1}' }],
+    const context = createJumpServerMcpContext(values, fixture.fetcher);
+    await expect(jumpServerActionHandlers.assets_assets_list({ limit: 1 }, context)).resolves.toEqual({
+      count: 1,
+      results: [{ source: "assets_assets_list", limit: 1 }],
     });
   });
 });
 
 describe("normalizeJumpServerMcpEndpoint", () => {
   it.each([
-    ["http://127.0.0.1:8099/sse", "http://127.0.0.1:8099/sse"],
     ["http://10.0.0.12:8099/sse/", "http://10.0.0.12:8099/sse"],
     ["http://100.64.0.4:8099/sse", "http://100.64.0.4:8099/sse"],
     ["http://172.16.0.12:8099/sse", "http://172.16.0.12:8099/sse"],
@@ -64,14 +59,17 @@ describe("normalizeJumpServerMcpEndpoint", () => {
     ["https://10.0.0.12:8099/sse", "https://10.0.0.12:8099/sse"],
     ["https://mcp.example.com/sse?token=leak#part", "https://mcp.example.com/sse"],
   ])("accepts supported self-hosted endpoint %s", (input, expected) => {
-    expect(normalizeJumpServerMcpEndpoint(input).toString()).toBe(expected);
+    expect(normalizeJumpServerMcpEndpoint(input, true).toString()).toBe(expected);
   });
 
-  it("defaults an empty path to the official /sse path", () => {
-    expect(normalizeJumpServerMcpEndpoint("http://localhost:8099").toString()).toBe("http://localhost:8099/sse");
+  it("defaults an empty public HTTPS path to /sse", () => {
+    expect(normalizeJumpServerMcpEndpoint("https://mcp.example.com").toString()).toBe("https://mcp.example.com/sse");
   });
 
   it.each([
+    "http://127.0.0.1:8099/sse",
+    "http://localhost:8099/sse",
+    "http://10.0.0.12:8099/sse",
     "http://mcp.example.com/sse",
     "ftp://localhost/mcp",
     "http://user:password@localhost:8099/sse",
@@ -90,7 +88,12 @@ describe("normalizeJumpServerMcpEndpoint", () => {
   });
 });
 
-async function startJumpServerMcpFixture(): Promise<string> {
+interface JumpServerMcpFixture {
+  endpoint: string;
+  fetcher: typeof fetch;
+}
+
+async function startJumpServerMcpFixture(): Promise<JumpServerMcpFixture> {
   const transports = new Map<string, SSEServerTransport>();
   const httpServer = createServer(async (request, response) => {
     if (request.headers.authorization !== "Bearer jumpserver-token") {
@@ -122,30 +125,47 @@ async function startJumpServerMcpFixture(): Promise<string> {
     httpServer.listen(0, "127.0.0.1", resolve);
   });
   const address = httpServer.address() as AddressInfo;
-  return `http://127.0.0.1:${address.port}/sse`;
+  const localOrigin = `http://127.0.0.1:${address.port}`;
+  const fetcher: typeof fetch = (input, init) => {
+    const source = input instanceof Request ? input.url : input.toString();
+    const url = new URL(source);
+    if (url.hostname === "mcp.example.com") {
+      const target = new URL(`${url.pathname}${url.search}`, localOrigin);
+      return fetch(target, init);
+    }
+    return fetch(input, init);
+  };
+  return { endpoint: "https://mcp.example.com/sse", fetcher };
 }
 
 function createFixtureMcpServer(): Server {
   const server = new Server({ name: "jumpserver-test", version: "1.0.0" }, { capabilities: { tools: {} } });
   server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: [
-      {
-        name: "assets_assets_list",
-        description: "List JumpServer assets.",
-        inputSchema: {
-          type: "object",
-          properties: { limit: { type: "integer" } },
-          additionalProperties: false,
+    tools: jumpServerMcpToolNames.map((name) => ({
+      name,
+      description: `List JumpServer resources with ${name}.`,
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          limit: { type: "integer" },
+          offset: { type: "integer" },
+          search: { type: "string" },
         },
+        additionalProperties: false,
       },
-    ],
+    })),
   }));
   server.setRequestHandler(CallToolRequestSchema, (request) => {
-    expect(request.params).toMatchObject({
-      name: "assets_assets_list",
-      arguments: { limit: 1 },
-    });
-    return { content: [{ type: "text", text: '{"count":1}' }] };
+    expect(jumpServerMcpToolNames).toContain(request.params.name);
+    const limit = request.params.arguments?.limit;
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ count: 1, results: [{ source: request.params.name, limit }] }),
+        },
+      ],
+    };
   });
   return server;
 }

--- a/src/providers/jumpserver/runtime.test.ts
+++ b/src/providers/jumpserver/runtime.test.ts
@@ -47,6 +47,15 @@ describe("JumpServer MCP provider contract", () => {
       results: [{ source: "assets_assets_list", limit: 1 }],
     });
   });
+
+  it("rejects an MCP endpoint that exposes no supported static actions", async () => {
+    const fixture = await startJumpServerMcpFixture(["unrelated_tool"]);
+    const values = { mcpEndpoint: fixture.endpoint, token: "jumpserver-token" };
+
+    await expect(validateJumpServerCredential(values, fixture.fetcher)).rejects.toThrow(
+      "JumpServer MCP endpoint did not expose any supported tools",
+    );
+  });
 });
 
 describe("normalizeJumpServerMcpEndpoint", () => {
@@ -93,7 +102,9 @@ interface JumpServerMcpFixture {
   fetcher: typeof fetch;
 }
 
-async function startJumpServerMcpFixture(): Promise<JumpServerMcpFixture> {
+async function startJumpServerMcpFixture(
+  toolNames: readonly string[] = jumpServerMcpToolNames,
+): Promise<JumpServerMcpFixture> {
   const transports = new Map<string, SSEServerTransport>();
   const httpServer = createServer(async (request, response) => {
     if (request.headers.authorization !== "Bearer jumpserver-token") {
@@ -104,7 +115,7 @@ async function startJumpServerMcpFixture(): Promise<JumpServerMcpFixture> {
       const transport = new SSEServerTransport("/messages", response);
       transports.set(transport.sessionId, transport);
       transport.onclose = () => transports.delete(transport.sessionId);
-      await createFixtureMcpServer().connect(transport);
+      await createFixtureMcpServer(toolNames).connect(transport);
       return;
     }
     if (request.method === "POST" && request.url?.startsWith("/messages")) {
@@ -138,10 +149,10 @@ async function startJumpServerMcpFixture(): Promise<JumpServerMcpFixture> {
   return { endpoint: "https://mcp.example.com/sse", fetcher };
 }
 
-function createFixtureMcpServer(): Server {
+function createFixtureMcpServer(toolNames: readonly string[]): Server {
   const server = new Server({ name: "jumpserver-test", version: "1.0.0" }, { capabilities: { tools: {} } });
   server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: jumpServerMcpToolNames.map((name) => ({
+    tools: toolNames.map((name) => ({
       name,
       description: `List JumpServer resources with ${name}.`,
       inputSchema: {
@@ -156,7 +167,7 @@ function createFixtureMcpServer(): Server {
     })),
   }));
   server.setRequestHandler(CallToolRequestSchema, (request) => {
-    expect(jumpServerMcpToolNames).toContain(request.params.name);
+    expect(toolNames).toContain(request.params.name);
     const limit = request.params.arguments?.limit;
     return {
       content: [

--- a/src/providers/jumpserver/runtime.test.ts
+++ b/src/providers/jumpserver/runtime.test.ts
@@ -1,0 +1,151 @@
+import type { AddressInfo } from "node:net";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { jumpServerActions } from "./actions.ts";
+import {
+  createJumpServerMcpContext,
+  jumpServerActionHandlers,
+  normalizeJumpServerMcpEndpoint,
+  validateJumpServerCredential,
+} from "./runtime.ts";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+describe("JumpServer MCP provider contract", () => {
+  it("defines one runtime handler for every catalog action", () => {
+    expect(Object.keys(jumpServerActionHandlers).sort()).toEqual(jumpServerActions.map((action) => action.name).sort());
+  });
+
+  it("validates credentials, discovers tools, and calls a tool over SSE", async () => {
+    const endpoint = await startJumpServerMcpFixture();
+    const values = { mcpEndpoint: endpoint, token: "jumpserver-token" };
+
+    await expect(validateJumpServerCredential(values, fetch)).resolves.toMatchObject({
+      profile: { displayName: expect.stringContaining("JumpServer MCP") },
+      metadata: { discoveredToolCount: 1, hasMoreTools: false },
+    });
+
+    const context = createJumpServerMcpContext(values, fetch);
+    await expect(jumpServerActionHandlers.list_tools({}, context)).resolves.toMatchObject({
+      tools: [{ name: "assets_assets_list" }],
+    });
+    await expect(
+      jumpServerActionHandlers.call_tool({ toolName: "assets_assets_list", arguments: { limit: 1 } }, context),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: '{"count":1}' }],
+    });
+  });
+});
+
+describe("normalizeJumpServerMcpEndpoint", () => {
+  it.each([
+    ["http://127.0.0.1:8099/sse", "http://127.0.0.1:8099/sse"],
+    ["http://10.0.0.12:8099/sse/", "http://10.0.0.12:8099/sse"],
+    ["http://100.64.0.4:8099/sse", "http://100.64.0.4:8099/sse"],
+    ["http://172.16.0.12:8099/sse", "http://172.16.0.12:8099/sse"],
+    ["http://192.168.1.12:8099/sse", "http://192.168.1.12:8099/sse"],
+    ["http://jumpserver.internal:8099/sse", "http://jumpserver.internal:8099/sse"],
+    ["https://10.0.0.12:8099/sse", "https://10.0.0.12:8099/sse"],
+    ["https://mcp.example.com/sse?token=leak#part", "https://mcp.example.com/sse"],
+  ])("accepts supported self-hosted endpoint %s", (input, expected) => {
+    expect(normalizeJumpServerMcpEndpoint(input).toString()).toBe(expected);
+  });
+
+  it("defaults an empty path to the official /sse path", () => {
+    expect(normalizeJumpServerMcpEndpoint("http://localhost:8099").toString()).toBe("http://localhost:8099/sse");
+  });
+
+  it.each([
+    "http://mcp.example.com/sse",
+    "ftp://localhost/mcp",
+    "http://user:password@localhost:8099/sse",
+    "http://169.254.169.254/latest/meta-data",
+    "http://100.100.100.200/latest/meta-data",
+    "http://metadata.google.internal/computeMetadata/v1",
+    "https://instance-data.ec2.internal/latest/meta-data",
+    "https://metadata.goog/computeMetadata/v1",
+    "https://169.254.1.1/sse",
+    "https://224.0.0.1/sse",
+    "https://203.0.113.1/sse",
+    "http://[::1]:8099/sse",
+    "http://[fd7a:115c:a1e0::1]:8099/sse",
+  ])("rejects unsafe endpoint %s", (input) => {
+    expect(() => normalizeJumpServerMcpEndpoint(input)).toThrow(ProviderRequestError);
+  });
+});
+
+async function startJumpServerMcpFixture(): Promise<string> {
+  const transports = new Map<string, SSEServerTransport>();
+  const httpServer = createServer(async (request, response) => {
+    if (request.headers.authorization !== "Bearer jumpserver-token") {
+      response.writeHead(401).end("Unauthorized");
+      return;
+    }
+    if (request.method === "GET" && request.url === "/sse") {
+      const transport = new SSEServerTransport("/messages", response);
+      transports.set(transport.sessionId, transport);
+      transport.onclose = () => transports.delete(transport.sessionId);
+      await createFixtureMcpServer().connect(transport);
+      return;
+    }
+    if (request.method === "POST" && request.url?.startsWith("/messages")) {
+      const sessionId = new URL(request.url, "http://localhost").searchParams.get("sessionId");
+      const transport = sessionId ? transports.get(sessionId) : undefined;
+      if (!transport) {
+        response.writeHead(404).end("Unknown session");
+        return;
+      }
+      await transport.handlePostMessage(request, response);
+      return;
+    }
+    response.writeHead(404).end("Not found");
+  });
+  servers.push(httpServer);
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = httpServer.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}/sse`;
+}
+
+function createFixtureMcpServer(): Server {
+  const server = new Server({ name: "jumpserver-test", version: "1.0.0" }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [
+      {
+        name: "assets_assets_list",
+        description: "List JumpServer assets.",
+        inputSchema: {
+          type: "object",
+          properties: { limit: { type: "integer" } },
+          additionalProperties: false,
+        },
+      },
+    ],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, (request) => {
+    expect(request.params).toMatchObject({
+      name: "assets_assets_list",
+      arguments: { limit: 1 },
+    });
+    return { content: [{ type: "text", text: '{"count":1}' }] };
+  });
+  return server;
+}

--- a/src/providers/jumpserver/runtime.ts
+++ b/src/providers/jumpserver/runtime.ts
@@ -51,6 +51,9 @@ export async function validateJumpServerCredential(
   const context = createJumpServerMcpContext(values, fetcher, signal);
   const discoveredTools = await listJumpServerMcpTools(context);
   const availableActions = jumpServerMcpToolNames.filter((toolName) => discoveredTools.includes(toolName));
+  if (availableActions.length === 0) {
+    throw credentialError("JumpServer MCP endpoint did not expose any supported tools");
+  }
   const endpointHash = createHash("sha256").update(context.endpoint.origin).digest("hex").slice(0, 16);
   return {
     profile: {

--- a/src/providers/jumpserver/runtime.ts
+++ b/src/providers/jumpserver/runtime.ts
@@ -1,0 +1,308 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { JumpServerActionName } from "./actions.ts";
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport, SseError } from "@modelcontextprotocol/sdk/client/sse.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { createHash } from "node:crypto";
+import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+type JumpServerActionHandler = (input: Record<string, unknown>, context: JumpServerMcpContext) => Promise<unknown>;
+type JumpServerMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+export interface JumpServerMcpContext {
+  endpoint: URL;
+  token: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+interface JumpServerMcpToolSummary {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+interface JumpServerMcpToolPage {
+  tools: JumpServerMcpToolSummary[];
+  nextCursor?: string;
+}
+
+const requestTimeoutMs = 60_000;
+const blockedMetadataHosts = new Set([
+  "100.100.100.200",
+  "169.254.169.254",
+  "fd00:ec2::254",
+  "instance-data.ec2.internal",
+  "metadata",
+  "metadata.azure.internal",
+  "metadata.google.internal",
+  "metadata.goog",
+]);
+
+export const jumpServerActionHandlers: Record<JumpServerActionName, JumpServerActionHandler> = {
+  list_tools(input, context) {
+    return listJumpServerMcpTools(context, optionalString(input.cursor));
+  },
+  call_tool(input, context) {
+    return callJumpServerMcpTool(
+      context,
+      requiredString(input.toolName, "toolName", inputError),
+      optionalRecord(input.arguments) ?? {},
+    );
+  },
+};
+
+export function createJumpServerMcpContext(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): JumpServerMcpContext {
+  return {
+    endpoint: normalizeJumpServerMcpEndpoint(values.mcpEndpoint),
+    token: requiredString(values.token, "token", credentialError),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateJumpServerCredential(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createJumpServerMcpContext(values, fetcher, signal);
+  const page = await listJumpServerMcpTools(context);
+  const endpointHash = createHash("sha256").update(context.endpoint.origin).digest("hex").slice(0, 16);
+  return {
+    profile: {
+      accountId: `jumpserver:mcp:${endpointHash}`,
+      displayName: `JumpServer MCP · ${context.endpoint.host}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpEndpoint: context.endpoint.toString(),
+      discoveredToolCount: page.tools.length,
+      hasMoreTools: Boolean(page.nextCursor),
+    },
+  };
+}
+
+/**
+ * Normalize a trusted self-hosted JumpServer MCP endpoint.
+ *
+ * Loopback and private-network HTTP endpoints are intentional for the official
+ * Docker deployment. Public endpoints must use HTTPS, and cloud metadata
+ * targets are always rejected.
+ */
+export function normalizeJumpServerMcpEndpoint(value: unknown): URL {
+  const raw = requiredString(value, "mcpEndpoint", credentialError);
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw credentialError("mcpEndpoint must be a valid URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw credentialError("mcpEndpoint must use http or https");
+  }
+  if (url.username || url.password) {
+    throw credentialError("mcpEndpoint must not include credentials");
+  }
+
+  const hostname = normalizeHostname(url.hostname);
+  if (isBlockedMetadataHost(hostname)) {
+    throw credentialError("mcpEndpoint must not target a cloud metadata service");
+  }
+  if (isUnsafeIpAddress(hostname)) {
+    throw credentialError("mcpEndpoint must not target a reserved, link-local, multicast, or IPv6 address");
+  }
+  if (url.protocol === "http:" && !isTrustedPrivateHostname(hostname)) {
+    throw credentialError("public mcpEndpoint URLs must use https");
+  }
+
+  url.hash = "";
+  url.search = "";
+  url.pathname = url.pathname.replace(/\/+$/u, "") || "/sse";
+  return url;
+}
+
+async function listJumpServerMcpTools(context: JumpServerMcpContext, cursor?: string): Promise<JumpServerMcpToolPage> {
+  return withJumpServerMcpClient(context, async (client) => {
+    const result = await client.listTools(cursor ? { cursor } : {}, { timeout: requestTimeoutMs });
+    return {
+      tools: result.tools.map((tool) => ({
+        name: tool.name,
+        ...(tool.description ? { description: tool.description } : {}),
+        inputSchema: tool.inputSchema,
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+      })),
+      ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+    };
+  });
+}
+
+async function callJumpServerMcpTool(
+  context: JumpServerMcpContext,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  return withJumpServerMcpClient(context, async (client) => {
+    const result = await client.callTool({ name: toolName, arguments: args }, undefined, { timeout: requestTimeoutMs });
+    return normalizeJumpServerMcpToolResult(toolName, result);
+  });
+}
+
+async function withJumpServerMcpClient<T>(
+  context: JumpServerMcpContext,
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const headers = new Headers({
+    Authorization: `Bearer ${context.token}`,
+    "user-agent": providerUserAgent,
+  });
+  const transport = new SSEClientTransport(context.endpoint, {
+    fetch: context.fetcher,
+    requestInit: { headers, signal: context.signal },
+  });
+  const client = new Client({ name: "oomol-connect-jumpserver", version: "1.0.0" });
+
+  try {
+    await client.connect(transport, { timeout: requestTimeoutMs });
+    return await run(client);
+  } catch (error) {
+    throw mapJumpServerMcpError(error);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function normalizeJumpServerMcpToolResult(toolName: string, result: JumpServerMcpToolResult): unknown {
+  if ("toolResult" in result) return result;
+  if (result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `JumpServer MCP tool ${toolName} returned an error: ${formatMcpToolContent(result)}`,
+      result,
+    );
+  }
+  return result;
+}
+
+function formatMcpToolContent(result: Extract<JumpServerMcpToolResult, { content: unknown }>): string {
+  const text = result.content
+    .map((content) => {
+      if (content.type === "text") return content.text;
+      if (content.type === "resource") {
+        return "text" in content.resource ? content.resource.text : content.resource.uri;
+      }
+      if (content.type === "resource_link") return content.uri;
+      return content.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+  return text.slice(0, 300) || "empty error content";
+}
+
+function mapJumpServerMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "JumpServer MCP token is invalid or expired", error);
+  }
+  if (error instanceof SseError) {
+    const status = error.code;
+    return new ProviderRequestError(
+      status === 401 || status === 403 ? 401 : status && status >= 400 && status < 500 ? 400 : 502,
+      `JumpServer MCP connection failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof McpError) {
+    return new ProviderRequestError(502, `JumpServer MCP request failed: ${error.message}`, error);
+  }
+  if (isAbortError(error)) {
+    return new ProviderRequestError(504, "JumpServer MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `JumpServer MCP request failed: ${error.message}` : "JumpServer MCP request failed",
+    error,
+  );
+}
+
+function normalizeHostname(value: string): string {
+  const unwrapped = value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+  return unwrapped.toLowerCase().replace(/\.+$/u, "");
+}
+
+function isBlockedMetadataHost(hostname: string): boolean {
+  return blockedMetadataHosts.has(hostname) || hostname.endsWith(".metadata.google.internal");
+}
+
+function isUnsafeIpAddress(hostname: string): boolean {
+  if (hostname.includes(":")) return true;
+  const octets = parseIpv4(hostname);
+  if (!octets) return false;
+  const [first, second, third, fourth] = octets;
+  if (first === 127) return false;
+  return (
+    first === 0 ||
+    (first === 169 && second === 254) ||
+    (first === 192 && second === 0 && third === 0) ||
+    (first === 192 && second === 0 && third === 2) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && third === 100) ||
+    (first === 203 && second === 0 && third === 113) ||
+    first >= 224 ||
+    (first === 100 && second === 100 && third === 100 && fourth === 200)
+  );
+}
+
+function isTrustedPrivateHostname(hostname: string): boolean {
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".localdomain") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".home") ||
+    hostname.endsWith(".lan")
+  ) {
+    return true;
+  }
+  if (hostname.includes(":")) return false;
+
+  const octets = parseIpv4(hostname);
+  if (!octets) return false;
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function parseIpv4(hostname: string): [number, number, number, number] | undefined {
+  const parts = hostname.split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/u.test(part))) return undefined;
+  const octets = parts.map(Number);
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return undefined;
+  return octets as [number, number, number, number];
+}
+
+function credentialError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function inputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}

--- a/src/providers/jumpserver/runtime.ts
+++ b/src/providers/jumpserver/runtime.ts
@@ -6,8 +6,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport, SseError } from "@modelcontextprotocol/sdk/client/sse.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { createHash } from "node:crypto";
-import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { jumpServerMcpToolNames } from "./actions.ts";
 
 type JumpServerActionHandler = (input: Record<string, unknown>, context: JumpServerMcpContext) => Promise<unknown>;
 type JumpServerMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -19,42 +21,14 @@ export interface JumpServerMcpContext {
   signal?: AbortSignal;
 }
 
-interface JumpServerMcpToolSummary {
-  name: string;
-  description?: string;
-  inputSchema: Record<string, unknown>;
-  outputSchema?: Record<string, unknown>;
-}
-
-interface JumpServerMcpToolPage {
-  tools: JumpServerMcpToolSummary[];
-  nextCursor?: string;
-}
-
 const requestTimeoutMs = 60_000;
-const blockedMetadataHosts = new Set([
-  "100.100.100.200",
-  "169.254.169.254",
-  "fd00:ec2::254",
-  "instance-data.ec2.internal",
-  "metadata",
-  "metadata.azure.internal",
-  "metadata.google.internal",
-  "metadata.goog",
-]);
 
-export const jumpServerActionHandlers: Record<JumpServerActionName, JumpServerActionHandler> = {
-  list_tools(input, context) {
-    return listJumpServerMcpTools(context, optionalString(input.cursor));
-  },
-  call_tool(input, context) {
-    return callJumpServerMcpTool(
-      context,
-      requiredString(input.toolName, "toolName", inputError),
-      optionalRecord(input.arguments) ?? {},
-    );
-  },
-};
+export const jumpServerActionHandlers: Record<JumpServerActionName, JumpServerActionHandler> = Object.fromEntries(
+  jumpServerMcpToolNames.map((toolName) => [
+    toolName,
+    (input: Record<string, unknown>, context: JumpServerMcpContext) => callJumpServerMcpTool(context, toolName, input),
+  ]),
+) as Record<JumpServerActionName, JumpServerActionHandler>;
 
 export function createJumpServerMcpContext(
   values: Record<string, string>,
@@ -75,7 +49,8 @@ export async function validateJumpServerCredential(
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const context = createJumpServerMcpContext(values, fetcher, signal);
-  const page = await listJumpServerMcpTools(context);
+  const discoveredTools = await listJumpServerMcpTools(context);
+  const availableActions = jumpServerMcpToolNames.filter((toolName) => discoveredTools.includes(toolName));
   const endpointHash = createHash("sha256").update(context.endpoint.origin).digest("hex").slice(0, 16);
   return {
     profile: {
@@ -85,8 +60,8 @@ export async function validateJumpServerCredential(
     grantedScopes: [],
     metadata: {
       mcpEndpoint: context.endpoint.toString(),
-      discoveredToolCount: page.tools.length,
-      hasMoreTools: Boolean(page.nextCursor),
+      discoveredToolCount: discoveredTools.length,
+      availableActions,
     },
   };
 }
@@ -94,34 +69,25 @@ export async function validateJumpServerCredential(
 /**
  * Normalize a trusted self-hosted JumpServer MCP endpoint.
  *
- * Loopback and private-network HTTP endpoints are intentional for the official
- * Docker deployment. Public endpoints must use HTTPS, and cloud metadata
- * targets are always rejected.
+ * Private-network HTTP endpoints require the deployment-level private-network
+ * opt-in. Loopback, link-local, cloud metadata, reserved, multicast, and IPv6
+ * targets remain blocked by the shared provider egress policy.
  */
-export function normalizeJumpServerMcpEndpoint(value: unknown): URL {
+export function normalizeJumpServerMcpEndpoint(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): URL {
   const raw = requiredString(value, "mcpEndpoint", credentialError);
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    throw credentialError("mcpEndpoint must be a valid URL");
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw credentialError("mcpEndpoint must use http or https");
-  }
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "mcpEndpoint",
+    createError: credentialError,
+    allowPrivateNetwork,
+  });
   if (url.username || url.password) {
     throw credentialError("mcpEndpoint must not include credentials");
   }
-
-  const hostname = normalizeHostname(url.hostname);
-  if (isBlockedMetadataHost(hostname)) {
-    throw credentialError("mcpEndpoint must not target a cloud metadata service");
-  }
-  if (isUnsafeIpAddress(hostname)) {
-    throw credentialError("mcpEndpoint must not target a reserved, link-local, multicast, or IPv6 address");
-  }
-  if (url.protocol === "http:" && !isTrustedPrivateHostname(hostname)) {
-    throw credentialError("public mcpEndpoint URLs must use https");
+  if (url.protocol === "http:" && !allowPrivateNetwork) {
+    throw credentialError("http mcpEndpoint URLs require private-network access to be enabled");
   }
 
   url.hash = "";
@@ -130,24 +96,16 @@ export function normalizeJumpServerMcpEndpoint(value: unknown): URL {
   return url;
 }
 
-async function listJumpServerMcpTools(context: JumpServerMcpContext, cursor?: string): Promise<JumpServerMcpToolPage> {
+async function listJumpServerMcpTools(context: JumpServerMcpContext): Promise<string[]> {
   return withJumpServerMcpClient(context, async (client) => {
-    const result = await client.listTools(cursor ? { cursor } : {}, { timeout: requestTimeoutMs });
-    return {
-      tools: result.tools.map((tool) => ({
-        name: tool.name,
-        ...(tool.description ? { description: tool.description } : {}),
-        inputSchema: tool.inputSchema,
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
-      })),
-      ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
-    };
+    const result = await client.listTools({}, { timeout: requestTimeoutMs });
+    return result.tools.map((tool) => tool.name);
   });
 }
 
 async function callJumpServerMcpTool(
   context: JumpServerMcpContext,
-  toolName: string,
+  toolName: JumpServerActionName,
   args: Record<string, unknown>,
 ): Promise<unknown> {
   return withJumpServerMcpClient(context, async (client) => {
@@ -188,6 +146,16 @@ function normalizeJumpServerMcpToolResult(toolName: string, result: JumpServerMc
       `JumpServer MCP tool ${toolName} returned an error: ${formatMcpToolContent(result)}`,
       result,
     );
+  }
+  if (result.structuredContent) return result.structuredContent;
+
+  const textItems = result.content.filter((content) => content.type === "text");
+  if (textItems.length === 1) {
+    try {
+      return JSON.parse(textItems[0]!.text) as unknown;
+    } catch {
+      // Preserve the MCP content envelope when JumpServer returns plain text.
+    }
   }
   return result;
 }
@@ -233,73 +201,7 @@ function mapJumpServerMcpError(error: unknown): ProviderRequestError {
   );
 }
 
-function normalizeHostname(value: string): string {
-  const unwrapped = value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
-  return unwrapped.toLowerCase().replace(/\.+$/u, "");
-}
-
-function isBlockedMetadataHost(hostname: string): boolean {
-  return blockedMetadataHosts.has(hostname) || hostname.endsWith(".metadata.google.internal");
-}
-
-function isUnsafeIpAddress(hostname: string): boolean {
-  if (hostname.includes(":")) return true;
-  const octets = parseIpv4(hostname);
-  if (!octets) return false;
-  const [first, second, third, fourth] = octets;
-  if (first === 127) return false;
-  return (
-    first === 0 ||
-    (first === 169 && second === 254) ||
-    (first === 192 && second === 0 && third === 0) ||
-    (first === 192 && second === 0 && third === 2) ||
-    (first === 198 && (second === 18 || second === 19)) ||
-    (first === 198 && second === 51 && third === 100) ||
-    (first === 203 && second === 0 && third === 113) ||
-    first >= 224 ||
-    (first === 100 && second === 100 && third === 100 && fourth === 200)
-  );
-}
-
-function isTrustedPrivateHostname(hostname: string): boolean {
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname.endsWith(".local") ||
-    hostname.endsWith(".localdomain") ||
-    hostname.endsWith(".internal") ||
-    hostname.endsWith(".home") ||
-    hostname.endsWith(".lan")
-  ) {
-    return true;
-  }
-  if (hostname.includes(":")) return false;
-
-  const octets = parseIpv4(hostname);
-  if (!octets) return false;
-  const [first, second] = octets;
-  return (
-    first === 10 ||
-    first === 127 ||
-    (first === 100 && second >= 64 && second <= 127) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168)
-  );
-}
-
-function parseIpv4(hostname: string): [number, number, number, number] | undefined {
-  const parts = hostname.split(".");
-  if (parts.length !== 4 || parts.some((part) => !/^\d+$/u.test(part))) return undefined;
-  const octets = parts.map(Number);
-  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return undefined;
-  return octets as [number, number, number, number];
-}
-
 function credentialError(message: string): ProviderRequestError {
-  return new ProviderRequestError(400, message);
-}
-
-function inputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
 }
 


### PR DESCRIPTION
## Summary

- add a JumpServer provider backed by the official `jumpserver/mcp` SSE server
- expose six curated, read-only JumpServer MCP tools as first-class OpenConnector actions:
  - `assets_assets_list`
  - `assets_nodes_list`
  - `accounts_accounts_list`
  - `users_users_list`
  - `perms_asset_permissions_list`
  - `terminal_sessions_list`
- give every action its own static description, input schema, output schema, follow-up actions, and policy boundary
- validate credentials by connecting with the configured Bearer token and report which curated actions the instance exposes
- map MCP authentication, SSE, protocol, timeout, and tool-result failures to stable provider errors
- load the JumpServer MCP runtime lazily so catalog generation does not eagerly load the MCP SDK

## Static action model

The initial implementation exposed dynamic discovery through generic `list_tools` and `call_tool` actions. Following the maintainer guidance in this PR, this revision removes that unrestricted dispatcher and instead registers a curated set of static actions.

MCP remains the transport and execution boundary, but each selected JumpServer tool is now a first-class OpenConnector catalog action. This allows action-level discovery, schema validation, permissions, audit metadata, and governance policies to apply independently.

The first set is intentionally read-only and covers common asset-management workflows: assets, nodes, managed accounts, users, asset permissions, and terminal sessions. Additional tools can be added deliberately in later revisions.

## Network behavior

The provider follows the shared egress policy introduced on current `main`:

- public HTTPS endpoints work by default
- RFC 1918, CGNAT/Tailscale/NetBird, and private-hostname endpoints require the deployment-level `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` opt-in
- loopback, link-local, cloud metadata, reserved, multicast, and IPv6 targets remain blocked
- embedded URL credentials are rejected
- query and fragment components are removed from the configured SSE endpoint

## Validation

- rebased onto current `main`
- provider contract test confirms catalog/handler parity
- local SSE MCP round trip verifies Bearer authentication, credential validation, static tool execution, and JSON result normalization
- endpoint tests cover public HTTPS, opted-in private networks, private-network rejection by default, metadata services, loopback, reserved/multicast ranges, embedded credentials, and IPv6
- `npm run fix-check` passed
- catalog generation passed
- full test suite passed: 45 files / 357 tests
