### PR TITLE
fix: preserve Workers fetch receiver in provider runtimes

### DIFF
--- a/src/connection-service.test.ts
+++ b/src/connection-service.test.ts
@@ -330,6 +330,38 @@ describe("ConnectionService", () => {
     expect(logger.info).toHaveBeenCalledWith({ service: "uptimerobot" }, "validator log");
   });
 
+  it("passes a receiver-safe fetcher to credential validators", async () => {
+    let nativeFetchThis: unknown = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(function (this: unknown) {
+        nativeFetchThis = this;
+        if (this !== undefined) {
+          throw new TypeError("Illegal invocation: function called with incorrect `this` reference");
+        }
+        return Promise.resolve(Response.json({ ok: true }));
+      }),
+    );
+    const service = createService([apiKeyProvider], {
+      providerLoader: new FakeProviderLoader({
+        async apiKey(_input, { fetcher }) {
+          const context = { fetcher };
+          await context.fetcher("https://example.com/validate");
+        },
+      }),
+    });
+
+    await expect(
+      service.connectWithApiKey("uptimerobot", {
+        values: {
+          apiKey: "valid-key",
+          accountId: "account-1",
+        },
+      }),
+    ).resolves.toMatchObject({ service: "uptimerobot", configured: true });
+    expect(nativeFetchThis).toBeUndefined();
+  });
+
   it("exposes connection profiles to local users and agents", async () => {
     const service = createService([apiKeyProvider], {
       providerLoader: new FakeProviderLoader({

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -14,6 +14,7 @@ import type { IOAuthCredentialRefresher } from "./oauth/oauth-credential-refresh
 import type { IProviderLoader } from "./providers/provider-loader.ts";
 
 import { normalizeCredentialValues } from "./core/credential-fields.ts";
+import { providerFetch } from "./providers/provider-runtime.ts";
 
 export const defaultConnectionName = "default";
 
@@ -430,7 +431,7 @@ export class ConnectionService {
 
   private createValidatorOptions() {
     return {
-      fetcher: fetch,
+      fetcher: providerFetch,
       logger: this.logger,
     };
   }

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -1,0 +1,47 @@
+import type { ExecutionContext } from "../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defineProviderExecutors } from "./provider-runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("provider runtime fetch", () => {
+  it("does not forward the provider context as the native fetch receiver", async () => {
+    let nativeFetchThis: unknown = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(function (this: unknown) {
+        nativeFetchThis = this;
+        if (this !== undefined) {
+          throw new TypeError("Illegal invocation: function called with incorrect `this` reference");
+        }
+        return Promise.resolve(Response.json({ ok: true }));
+      }),
+    );
+    const executors = defineProviderExecutors<{ fetcher: typeof fetch }>({
+      service: "receiver_test",
+      handlers: {
+        async request(_input, context) {
+          const response = await context.fetcher("https://example.com/action");
+          return response.json();
+        },
+      },
+      createContext(_context, fetcher) {
+        return { fetcher };
+      },
+    });
+    const executionContext: ExecutionContext = {
+      async getCredential() {
+        return undefined;
+      },
+    };
+
+    await expect(executors["receiver_test.request"]!({}, executionContext)).resolves.toEqual({
+      ok: true,
+      output: { ok: true },
+    });
+    expect(nativeFetchThis).toBeUndefined();
+  });
+});

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -21,6 +21,16 @@ import { readBoundedResponseBytes } from "../core/request.ts";
 export type ProviderFetch = typeof fetch;
 
 /**
+ * Receiver-safe wrapper for the platform fetch implementation.
+ *
+ * Provider runtimes commonly store this function on a context object before
+ * invoking it. Calling the Workers-native fetch function that way forwards the
+ * context object as `this` and causes an Illegal invocation error. This wrapper
+ * keeps the native call lexical while remaining easy to replace in tests.
+ */
+export const providerFetch: ProviderFetch = (input, init) => fetch(input, init);
+
+/**
  * Default User-Agent sent by local provider executors.
  */
 export const providerUserAgent = "oomol-connect/0.1";
@@ -711,7 +721,7 @@ export function defineProviderExecutors<TContext>(input: ProviderExecutorDefinit
           ok: true,
           output: await handler(
             actionInput as Record<string, unknown>,
-            await input.createContext(executionContext, fetch),
+            await input.createContext(executionContext, providerFetch),
           ),
         };
       } catch (error) {


### PR DESCRIPTION
## Summary

- wrap the platform `fetch` implementation before passing it into provider contexts
- use the receiver-safe wrapper for credential validation and shared action execution
- add regressions for both connection validation and provider actions

## Root cause

Cloudflare Workers' native `fetch` rejects calls made with an incorrect `this` reference. The shared runtime passed the native function through as a value, and providers commonly stored it on a context before calling `context.fetcher(...)`. That method call supplied the provider context as `this`, producing `Illegal invocation: function called with incorrect this reference` before the outbound request was made.

Wrapping the platform call fixes providers that use the shared validator and executor infrastructure.

Cloudflare documents the underlying runtime behavior here: https://developers.cloudflare.com/workers/observability/errors/#illegal-invocation-errors

## User impact

Providers using the shared credential validator or action runtime can make outbound requests on Cloudflare Workers without failing before the request reaches the provider API.

## Validation

- regression tests fail against the previous implementation and pass with this change
- full test suite: 41 files, 278 tests passed
- typechecked `src`, `scripts-all`, and `examples`
- `oxlint .`
- `oxfmt --check .`
