### PR TITLE
feat(core): harden provider egress against SSRF redirect and DNS-rebinding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,15 @@
 - Avoid repeated action-name wiring. Define action handlers once and derive executor maps through shared provider runtime helpers.
 - Do not import provider definitions from executor modules just to reuse metadata; inject catalog metadata from the server/loader side when needed.
 
+## Provider Network Egress (SSRF)
+
+- All provider egress must go through the shared SSRF-guarded fetch, never the global `fetch`. Use `context.fetcher` (injected by `defineProviderExecutors`/`defineApiKeyProviderExecutors`/etc.) or, in a hand-written proxy, the exported `providerFetch` / `createProviderFetch`. The guard validates the request URL and every redirect `Location` with `assertPublicHttpUrl`, follows redirects manually, and (by default) validates DNS-resolved addresses.
+- DNS resolved-address validation is ON by default and runs once per request for hostname targets. Add `skipDnsValidation: true` (on `defineProviderExecutors`/`defineProviderProxy`/`createProviderFetch`) ONLY when the egress host is a hardcoded literal fully controlled by the code. NEVER add it when the host comes from credential/user input, when the base URL is a resolver, or when the provider fetches a user-supplied URL — there the DNS check is the SSRF defense, not redundant overhead.
+- Self-hosted providers whose instance host is user/credential-configured and may live on a private network pass `allowPrivateNetwork: isPrivateNetworkAccessAllowed` into their executors/proxy AND thread the same flag into their base-URL `assertPublicHttpUrl` call (see Dokploy for the reference pattern). It is deployment-gated by `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`; reserved, loopback, link-local, and cloud-metadata targets stay blocked even when it is enabled.
+- User-supplied content/download URLs (e.g. `fileUrl`, `sourceUrl`, `imageUrl`) must ALWAYS be validated public-only — call `assertPublicHttpUrl` without `allowPrivateNetwork` and download them with the public-only `providerFetch`, never a private-aware `context.fetcher`. The private-network opt-in covers only the trusted instance host.
+- Prefer the shared `assertPublicHttpUrl` / `isBlockedIpAddress` over a bespoke per-provider hostname guard; bespoke guards have missed the cloud-metadata blocklist and bracketed-IPv6 forms.
+- Gotcha: a provider that branches on `fetcher === fetch` (e.g. to gate rate limiting to production) must compare against `providerFetch`, since that is the fetcher the runtime now injects — not the global `fetch`.
+
 ## TypeScript And Tooling
 
 - Use native Node.js TypeScript execution. Do not add `tsx` or `--experimental-strip-types`.

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -14,6 +14,7 @@ import type { IOAuthCredentialRefresher } from "./oauth/oauth-credential-refresh
 import type { IProviderLoader } from "./providers/provider-loader.ts";
 
 import { normalizeCredentialValues } from "./core/credential-fields.ts";
+import { providerFetch } from "./providers/provider-runtime.ts";
 
 export const defaultConnectionName = "default";
 
@@ -430,7 +431,7 @@ export class ConnectionService {
 
   private createValidatorOptions() {
     return {
-      fetcher: fetch,
+      fetcher: providerFetch,
       logger: this.logger,
     };
   }

--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -1,0 +1,435 @@
+import type { GuardedFetchDnsLookup } from "./guarded-fetch.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { createGuardedFetch, unwrapGuardedFetch } from "./guarded-fetch.ts";
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit | undefined;
+  request: Request | undefined;
+}
+
+function createTransport(responses: Response[]): { transport: typeof fetch; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const transport = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    calls.push({
+      url: input instanceof Request ? input.url : String(input),
+      init,
+      request: input instanceof Request ? input : undefined,
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("transport received an unexpected extra request");
+    }
+    return response;
+  }) as typeof fetch;
+  return { transport, calls };
+}
+
+function redirectTo(location: string, status = 302): Response {
+  return new Response(null, { status, headers: { location } });
+}
+
+function lookupTable(entries: Record<string, Array<{ address: string; family: number }>>): GuardedFetchDnsLookup {
+  return async (hostname: string) => {
+    const result = entries[hostname];
+    if (!result) {
+      throw new Error(`no lookup entry for ${hostname}`);
+    }
+    return result;
+  };
+}
+
+describe("createGuardedFetch redirects", () => {
+  it("follows public redirects with manual hops and returns the final response", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://cdn.example.net/file"),
+      new Response("payload", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    const response = await guarded("https://api.example.com/download", { headers: { accept: "text/plain" } });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("payload");
+    expect(calls.map((call) => call.url)).toEqual(["https://api.example.com/download", "https://cdn.example.net/file"]);
+    expect(calls.every((call) => call.init?.redirect === "manual")).toBe(true);
+  });
+
+  it("resolves relative redirect locations against the current URL", async () => {
+    const { transport, calls } = createTransport([redirectTo("/v2/download"), new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await guarded("https://api.example.com/v1/download");
+
+    expect(calls[1]?.url).toBe("https://api.example.com/v2/download");
+  });
+
+  it("blocks redirects to metadata, loopback, link-local, and private targets by default", async () => {
+    for (const location of [
+      "http://169.254.169.254/latest/meta-data/",
+      "http://127.0.0.1:8080/admin",
+      "http://localhost:3000/",
+      "http://10.0.0.5/internal",
+      "http://metadata.google.internal/computeMetadata/v1/",
+      "https://[::1]/",
+    ]) {
+      const { transport, calls } = createTransport([redirectTo(location)]);
+      const guarded = createGuardedFetch({ fetch: transport });
+
+      await expect(guarded("https://attacker.example.com/api")).rejects.toThrow(/redirect location/u);
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  it("keeps reserved targets blocked on redirects even when private networks are allowed", async () => {
+    const { transport, calls } = createTransport([redirectTo("http://169.254.169.254/latest/meta-data/")]);
+    const guarded = createGuardedFetch({ fetch: transport, allowPrivateNetwork: () => true });
+
+    await expect(guarded("https://attacker.example.com/api")).rejects.toThrow(/redirect location/u);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("allows private redirect targets when the caller opted into private networks", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("http://10.0.0.5:3000/api"),
+      new Response("ok", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport, allowPrivateNetwork: () => true });
+
+    const response = await guarded("https://dokploy.example.com/api");
+
+    expect(response.status).toBe(200);
+    expect(calls[1]?.url).toBe("http://10.0.0.5:3000/api");
+  });
+
+  it("rejects non-http redirect schemes", async () => {
+    const { transport } = createTransport([redirectTo("ftp://files.example.com/x")]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await expect(guarded("https://api.example.com/")).rejects.toThrow(/redirect location/u);
+  });
+
+  it("fails after too many redirect hops", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://api.example.com/1"),
+      redirectTo("https://api.example.com/2"),
+      redirectTo("https://api.example.com/3"),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport, maxRedirects: 2 });
+
+    await expect(guarded("https://api.example.com/0")).rejects.toThrow("redirected too many times");
+    expect(calls).toHaveLength(3);
+  });
+
+  it("follows a long public redirect chain by default (parity with native follow)", async () => {
+    // Previously provider egress used native redirect:"follow" (up to ~20 hops);
+    // the default must not fail a legitimate 6-hop CDN/signed-URL chain.
+    const responses = [];
+    for (let i = 1; i <= 6; i++) {
+      responses.push(redirectTo(`https://cdn.example.net/${i}`));
+    }
+    responses.push(new Response("payload", { status: 200 }));
+    const { transport, calls } = createTransport(responses);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    const response = await guarded("https://api.example.com/download");
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(7);
+  });
+
+  it("returns redirect responses without a location header unchanged", async () => {
+    const { transport } = createTransport([new Response(null, { status: 302 })]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    const response = await guarded("https://api.example.com/");
+
+    expect(response.status).toBe(302);
+  });
+
+  it("rewrites POST to GET and drops the body on 301, 302, and 303 redirects", async () => {
+    for (const status of [301, 302, 303]) {
+      const { transport, calls } = createTransport([
+        redirectTo("https://api.example.com/next", status),
+        new Response("ok", { status: 200 }),
+      ]);
+      const guarded = createGuardedFetch({ fetch: transport });
+
+      await guarded("https://api.example.com/create", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ a: 1 }),
+      });
+
+      expect(calls[1]?.init?.method).toBe("GET");
+      expect(calls[1]?.init?.body).toBeUndefined();
+      expect(new Headers(calls[1]?.init?.headers).has("content-type")).toBe(false);
+    }
+  });
+
+  it("preserves method and body on 307 and 308 redirects", async () => {
+    for (const status of [307, 308]) {
+      const { transport, calls } = createTransport([
+        redirectTo("https://api.example.com/next", status),
+        new Response("ok", { status: 200 }),
+      ]);
+      const guarded = createGuardedFetch({ fetch: transport });
+
+      await guarded("https://api.example.com/create", { method: "POST", body: "payload" });
+
+      expect(calls[1]?.init?.method).toBe("POST");
+      expect(calls[1]?.init?.body).toBe("payload");
+    }
+  });
+
+  it("keeps non-POST methods on 301 and 302 redirects", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://api.example.com/next", 301),
+      new Response("ok", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await guarded("https://api.example.com/item", { method: "DELETE" });
+
+    expect(calls[1]?.init?.method).toBe("DELETE");
+  });
+
+  it("strips credential headers on cross-origin redirects and keeps them same-origin", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://api.example.com/moved"),
+      redirectTo("https://other.example.net/away"),
+      new Response("ok", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await guarded("https://api.example.com/", {
+      headers: { authorization: "Bearer secret", cookie: "sid=1", "x-trace": "keep" },
+    });
+
+    const sameOriginHeaders = new Headers(calls[1]?.init?.headers);
+    expect(sameOriginHeaders.get("authorization")).toBe("Bearer secret");
+    const crossOriginHeaders = new Headers(calls[2]?.init?.headers);
+    expect(crossOriginHeaders.has("authorization")).toBe(false);
+    expect(crossOriginHeaders.has("cookie")).toBe(false);
+    expect(crossOriginHeaders.get("x-trace")).toBe("keep");
+  });
+
+  it("passes through when the caller handles redirects manually", async () => {
+    const { transport, calls } = createTransport([redirectTo("http://169.254.169.254/")]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    const response = await guarded("https://api.example.com/", { redirect: "manual" });
+
+    expect(response.status).toBe(302);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.init?.redirect).toBe("manual");
+  });
+
+  it("passes redirect error mode through to the transport", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await guarded("https://api.example.com/", { redirect: "error" });
+
+    expect(calls[0]?.init?.redirect).toBe("error");
+  });
+});
+
+describe("createGuardedFetch request URL guard", () => {
+  it("blocks unsafe initial URLs before any request is issued", async () => {
+    const { transport, calls } = createTransport([]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    for (const url of ["http://127.0.0.1/", "http://169.254.169.254/", "http://10.0.0.5/", "file:///etc/passwd"]) {
+      await expect(guarded(url)).rejects.toThrow(/request URL/u);
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it("uses the caller error factory for guard violations", async () => {
+    class PolicyError extends Error {}
+    const { transport } = createTransport([]);
+    const guarded = createGuardedFetch({ fetch: transport, createError: (message) => new PolicyError(message) });
+
+    await expect(guarded("http://127.0.0.1/")).rejects.toBeInstanceOf(PolicyError);
+  });
+
+  it("resolves the global fetch per call so test stubs apply", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    vi.stubGlobal("fetch", transport);
+    try {
+      const guarded = createGuardedFetch();
+      await guarded("https://api.example.com/");
+      expect(calls).toHaveLength(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("createGuardedFetch resolved-address validation", () => {
+  it("blocks hostnames resolving to reserved or metadata addresses", async () => {
+    const { transport, calls } = createTransport([]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: lookupTable({ "metadata.attacker.com": [{ address: "169.254.169.254", family: 4 }] }),
+    });
+
+    await expect(guarded("http://metadata.attacker.com/latest/meta-data/")).rejects.toThrow(
+      "request URL must not resolve to private or reserved IP addresses",
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("blocks hostnames resolving to private addresses unless private networks are allowed", async () => {
+    const entries = { "internal.attacker.com": [{ address: "10.0.0.5", family: 4 }] };
+    const blocked = createGuardedFetch({ fetch: createTransport([]).transport, lookup: lookupTable(entries) });
+    await expect(blocked("http://internal.attacker.com/")).rejects.toThrow(/must not resolve/u);
+
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const allowed = createGuardedFetch({
+      fetch: transport,
+      lookup: lookupTable(entries),
+      allowPrivateNetwork: () => true,
+    });
+    await allowed("http://internal.attacker.com/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("blocks IPv6 loopback, unique-local, and v4-embedded reserved lookup results", async () => {
+    for (const address of ["::1", "fd00::1", "::ffff:169.254.169.254", "fe80::1"]) {
+      const guarded = createGuardedFetch({
+        fetch: createTransport([]).transport,
+        lookup: lookupTable({ "host.example.com": [{ address, family: 6 }] }),
+      });
+      await expect(guarded("https://host.example.com/")).rejects.toThrow(/must not resolve/u);
+    }
+  });
+
+  it("rejects when any resolved address is blocked even if others are public", async () => {
+    const guarded = createGuardedFetch({
+      fetch: createTransport([]).transport,
+      lookup: lookupTable({
+        "rebind.example.com": [
+          { address: "93.184.216.34", family: 4 },
+          { address: "127.0.0.1", family: 4 },
+        ],
+      }),
+    });
+
+    await expect(guarded("https://rebind.example.com/")).rejects.toThrow(/must not resolve/u);
+  });
+
+  it("allows hostnames resolving to public addresses", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: lookupTable({
+        "api.example.com": [
+          { address: "93.184.216.34", family: 4 },
+          { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+        ],
+      }),
+    });
+
+    await guarded("https://api.example.com/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("skips DNS resolution for canonical IPv4 literals already validated by the URL guard", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: async (hostname) => {
+        throw new Error(`lookup must not run for literal ${hostname}`);
+      },
+    });
+
+    await guarded("https://93.184.216.34/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("skips the resolved-address check when skipDnsValidation is set", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      skipDnsValidation: true,
+      lookup: () => {
+        throw new Error("lookup must not run when skipDnsValidation is set");
+      },
+    });
+
+    await guarded("https://api.example.com/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("still validates the request URL and redirects when skipDnsValidation is set", async () => {
+    const { transport, calls } = createTransport([redirectTo("http://169.254.169.254/latest/meta-data/")]);
+    const guarded = createGuardedFetch({ fetch: transport, skipDnsValidation: true });
+
+    // URL literal + redirect Location guards still run; only the DNS check is skipped.
+    await expect(guarded("https://api.example.com/")).rejects.toThrow(/redirect location/u);
+    await expect(guarded("http://127.0.0.1/")).rejects.toThrow(/request URL/u);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("falls through to the transport when the lookup fails", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: async () => {
+        throw new Error("ENOTFOUND");
+      },
+    });
+
+    await guarded("https://unresolvable.example.com/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("re-validates resolved addresses for every redirect hop", async () => {
+    const { transport, calls } = createTransport([redirectTo("https://metadata.attacker.com/creds")]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: lookupTable({
+        "api.example.com": [{ address: "93.184.216.34", family: 4 }],
+        "metadata.attacker.com": [{ address: "169.254.169.254", family: 4 }],
+      }),
+    });
+
+    await expect(guarded("https://api.example.com/")).rejects.toThrow(
+      "redirect location must not resolve to private or reserved IP addresses",
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  it("validates resolved addresses before manual-redirect passthrough requests", async () => {
+    const { transport, calls } = createTransport([]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      lookup: lookupTable({ "metadata.attacker.com": [{ address: "169.254.169.254", family: 4 }] }),
+    });
+
+    await expect(guarded("http://metadata.attacker.com/", { redirect: "manual" })).rejects.toThrow(/must not resolve/u);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("unwrapGuardedFetch", () => {
+  it("lets a private-network guard replace a public-only guard instead of stacking", async () => {
+    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+    const publicOnly = createGuardedFetch({ fetch: transport });
+    const privateAllowed = createGuardedFetch({ fetch: publicOnly, allowPrivateNetwork: () => true });
+
+    const response = await privateAllowed("http://10.0.0.2:3000/api");
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns non-guarded fetchers unchanged", () => {
+    const { transport } = createTransport([]);
+    expect(unwrapGuardedFetch(transport)).toBe(transport);
+    expect(unwrapGuardedFetch(undefined)).toBeUndefined();
+  });
+});

--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -204,14 +204,23 @@ describe("createGuardedFetch redirects", () => {
     const guarded = createGuardedFetch({ fetch: transport });
 
     await guarded("https://api.example.com/", {
-      headers: { authorization: "Bearer secret", cookie: "sid=1", "x-trace": "keep" },
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "sid=1",
+        "x-api-key": "provider-secret",
+        "x-auth-token": "tok",
+        "x-trace": "keep",
+      },
     });
 
     const sameOriginHeaders = new Headers(calls[1]?.init?.headers);
     expect(sameOriginHeaders.get("authorization")).toBe("Bearer secret");
+    expect(sameOriginHeaders.get("x-api-key")).toBe("provider-secret");
     const crossOriginHeaders = new Headers(calls[2]?.init?.headers);
     expect(crossOriginHeaders.has("authorization")).toBe(false);
     expect(crossOriginHeaders.has("cookie")).toBe(false);
+    expect(crossOriginHeaders.has("x-api-key")).toBe(false);
+    expect(crossOriginHeaders.has("x-auth-token")).toBe(false);
     expect(crossOriginHeaders.get("x-trace")).toBe("keep");
   });
 
@@ -374,8 +383,8 @@ describe("createGuardedFetch resolved-address validation", () => {
     expect(calls).toHaveLength(1);
   });
 
-  it("falls through to the transport when the lookup fails", async () => {
-    const { transport, calls } = createTransport([new Response("ok", { status: 200 })]);
+  it("fails closed and does not call the transport when an enabled lookup fails", async () => {
+    const { transport, calls } = createTransport([]);
     const guarded = createGuardedFetch({
       fetch: transport,
       lookup: async () => {
@@ -383,8 +392,8 @@ describe("createGuardedFetch resolved-address validation", () => {
       },
     });
 
-    await guarded("https://unresolvable.example.com/");
-    expect(calls).toHaveLength(1);
+    await expect(guarded("https://unresolvable.example.com/")).rejects.toThrow(/could not be resolved/u);
+    expect(calls).toHaveLength(0);
   });
 
   it("re-validates resolved addresses for every redirect hop", async () => {

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -1,0 +1,278 @@
+import { assertPublicHttpUrl, isBlockedIpAddress, isIpv4Address } from "./request.ts";
+
+/**
+ * Single resolved address returned by a DNS lookup, mirroring the shape of
+ * `node:dns` `lookup(hostname, { all: true })` entries.
+ */
+export interface ResolvedAddress {
+  address: string;
+  family: number;
+}
+
+/**
+ * DNS resolver used to validate the addresses a hostname resolves to before a
+ * request is issued.
+ */
+export type GuardedFetchDnsLookup = (hostname: string) => Promise<ResolvedAddress[]>;
+
+export interface GuardedFetchOptions {
+  /**
+   * Base transport issuing the actual requests. Defaults to the global fetch,
+   * resolved per call so test stubs installed later still apply.
+   */
+  fetch?: typeof fetch;
+  /**
+   * Allow RFC 1918, shared-address-space, and private targets for this fetch
+   * while retaining reserved/loopback/link-local/metadata guards. A function is
+   * re-evaluated on every request so deployment flags configured after module
+   * load are honored.
+   */
+  allowPrivateNetwork?: boolean | (() => boolean);
+  /** Error factory for guard violations. Defaults to TypeError. */
+  createError?: (message: string) => Error;
+  /** Maximum redirect hops followed before the request fails. */
+  maxRedirects?: number;
+  /**
+   * DNS lookup override: `null` disables resolved-address validation for this
+   * fetch, `undefined` uses the module default (`node:dns` when available).
+   */
+  lookup?: GuardedFetchDnsLookup | null;
+  /**
+   * Skip the DNS resolved-address check (the URL and redirect-`Location` guards
+   * still run). Only safe when the request host is fixed/code-controlled, never
+   * derived from user or credential input — there the check is redundant and
+   * only adds a per-request lookup. On by default.
+   */
+  skipDnsValidation?: boolean;
+}
+
+// Match the platform default for `redirect: "follow"` (undici/browsers follow up
+// to 20 hops) so wrapping the transport does not fail legitimate long redirect
+// chains that previously succeeded.
+const defaultMaxRedirects = 20;
+const redirectStatuses = new Set([301, 302, 303, 307, 308]);
+/** Credential-bearing headers dropped when a redirect crosses origins, mirroring the fetch spec. */
+const crossOriginSensitiveHeaders = ["authorization", "cookie", "proxy-authorization"];
+/** Body-describing headers dropped when a redirect rewrites the method to GET, mirroring the fetch spec. */
+const bodyHeaders = ["content-encoding", "content-language", "content-length", "content-location", "content-type"];
+
+/** Base transport behind each guarded fetch (undefined = global fetch) so re-wrapping never stacks guards. */
+const guardedFetchBases = new WeakMap<typeof fetch, typeof fetch | undefined>();
+
+let defaultLookupOverridden = false;
+let defaultLookupOverride: GuardedFetchDnsLookup | null = null;
+let nodeDnsLookupPromise: Promise<GuardedFetchDnsLookup | undefined> | undefined;
+
+/**
+ * Override the module-default DNS lookup used by guarded fetches that do not
+ * set their own `lookup` option: a function replaces it, `null` disables
+ * resolved-address validation, and `undefined` restores the automatic
+ * `node:dns` default. Tests use `null` so unit suites never touch real DNS.
+ */
+export function setDefaultGuardedFetchDnsLookup(lookup: GuardedFetchDnsLookup | null | undefined): void {
+  defaultLookupOverridden = lookup !== undefined;
+  defaultLookupOverride = lookup ?? null;
+}
+
+/**
+ * Return the raw transport behind a fetch produced by {@link createGuardedFetch}
+ * (undefined when it wraps the global fetch), or the input itself when it is
+ * not guarded. Lets callers re-wrap with a different policy without stacking
+ * two guards, e.g. Dokploy re-guarding a shared fetcher with its
+ * private-network opt-in.
+ */
+export function unwrapGuardedFetch(fetcher: typeof fetch | undefined): typeof fetch | undefined {
+  if (fetcher !== undefined && guardedFetchBases.has(fetcher)) {
+    return guardedFetchBases.get(fetcher);
+  }
+  return fetcher;
+}
+
+/**
+ * Create a fetch-compatible function that enforces the shared SSRF policy on
+ * every network hop instead of only on the caller-supplied URL:
+ *
+ * - The request URL and every redirect `Location` are validated with
+ *   {@link assertPublicHttpUrl}, so a public URL cannot redirect provider
+ *   egress into loopback/link-local/metadata/private targets.
+ * - Redirects are followed manually (bounded by `maxRedirects`) with
+ *   spec-equivalent method/body rewrites, and credential-bearing headers are
+ *   dropped on cross-origin hops.
+ * - When a DNS lookup is available, hostnames are resolved before each hop and
+ *   requests to names resolving to blocked addresses are rejected, closing the
+ *   static DNS name→private-IP bypass. Lookup failures fall through to the
+ *   transport so unreachable hosts still surface their natural network error.
+ *   (True time-of-check/time-of-use DNS rebinding with low-TTL records remains
+ *   possible because the transport re-resolves; full connection pinning is not
+ *   expressible over the fetch API.) The default lookup uses `node:dns`; on
+ *   runtimes without it (e.g. Cloudflare Workers) this layer degrades to a no-op
+ *   and only the URL-literal and redirect-`Location` checks apply.
+ *
+ * Callers that pass `redirect: "manual"` or `redirect: "error"` keep native
+ * semantics: the first response (or native redirect error) is returned after
+ * the initial URL and its resolved addresses are validated.
+ */
+export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fetch {
+  const baseFetch = unwrapGuardedFetch(options.fetch);
+  const createError = options.createError ?? ((message: string) => new TypeError(message));
+  const maxRedirects = options.maxRedirects ?? defaultMaxRedirects;
+
+  const guardedFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const transport = baseFetch ?? globalThis.fetch;
+    const allowPrivateNetwork =
+      typeof options.allowPrivateNetwork === "function"
+        ? options.allowPrivateNetwork()
+        : options.allowPrivateNetwork === true;
+    const lookup = options.skipDnsValidation
+      ? null
+      : options.lookup === undefined
+        ? await resolveDefaultLookup()
+        : options.lookup;
+    const guardHop = async (value: string, fieldName: string): Promise<URL> => {
+      const url = assertPublicHttpUrl(value, { fieldName, createError, allowPrivateNetwork });
+      await assertResolvedAddressesAllowed(url.hostname, fieldName, { allowPrivateNetwork, createError, lookup });
+      return url;
+    };
+
+    const request = input instanceof Request ? input : undefined;
+    let url = await guardHop(request?.url ?? (input instanceof URL ? input.href : String(input)), "request URL");
+
+    const redirectMode = init?.redirect ?? request?.redirect ?? "follow";
+    if (redirectMode !== "follow") {
+      return transport(input, init);
+    }
+
+    let method = (init?.method ?? request?.method ?? "GET").toUpperCase();
+    const headers = new Headers(init?.headers ?? request?.headers);
+    let body: BodyInit | null | undefined = init?.body !== undefined ? init.body : request?.body;
+
+    for (let redirects = 0; ; redirects++) {
+      const response =
+        redirects === 0
+          ? request
+            ? await transport(new Request(request, { ...init, redirect: "manual" }))
+            : await transport(url.toString(), { ...init, redirect: "manual" })
+          : await transport(url.toString(), {
+              ...init,
+              method,
+              // Clone per hop: later hops mutate `headers`, and a transport that
+              // captures the reference (rather than snapshotting) must not see
+              // those later edits on an already-issued request.
+              headers: new Headers(headers),
+              body: body ?? undefined,
+              redirect: "manual",
+              signal: init?.signal ?? request?.signal ?? null,
+            });
+
+      if (!redirectStatuses.has(response.status)) {
+        return response;
+      }
+      const location = response.headers.get("location");
+      if (location === null) {
+        return response;
+      }
+      await cancelResponseBody(response);
+      if (redirects >= maxRedirects) {
+        throw createError("request was redirected too many times");
+      }
+
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, url);
+      } catch {
+        throw createError("redirect location must be a valid URL");
+      }
+      const guardedNext = await guardHop(nextUrl.toString(), "redirect location");
+
+      if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === "POST")) {
+        if (method !== "GET" && method !== "HEAD") {
+          method = "GET";
+        }
+        body = undefined;
+        for (const name of bodyHeaders) {
+          headers.delete(name);
+        }
+      } else if (body !== undefined && body !== null && !isReplayableBody(body)) {
+        throw createError("redirect cannot be followed because the request body is not replayable");
+      }
+      if (guardedNext.origin !== url.origin) {
+        for (const name of crossOriginSensitiveHeaders) {
+          headers.delete(name);
+        }
+      }
+      url = guardedNext;
+    }
+  }) as typeof fetch;
+
+  guardedFetchBases.set(guardedFetch, baseFetch);
+  return guardedFetch;
+}
+
+interface ResolvedAddressPolicy {
+  allowPrivateNetwork: boolean;
+  createError: (message: string) => Error;
+  lookup: GuardedFetchDnsLookup | null | undefined;
+}
+
+async function assertResolvedAddressesAllowed(
+  hostname: string,
+  fieldName: string,
+  policy: ResolvedAddressPolicy,
+): Promise<void> {
+  // Skip resolution only for canonical IPv4 literals, which assertPublicHttpUrl
+  // has already address-validated. Looser numeric forms (octal, out-of-range)
+  // that it did not recognize as an IP must go through DNS validation, since a
+  // resolver may still interpret them as a reserved address.
+  if (!policy.lookup || isIpv4Address(hostname)) {
+    return;
+  }
+
+  let results: ResolvedAddress[];
+  try {
+    results = await policy.lookup(hostname);
+  } catch {
+    // Resolution failures surface through the transport as its natural network
+    // error; only successful resolutions are validated here.
+    return;
+  }
+  if (!Array.isArray(results)) {
+    return;
+  }
+  for (const entry of results) {
+    if (entry && typeof entry.address === "string" && isBlockedIpAddress(entry.address, policy.allowPrivateNetwork)) {
+      throw policy.createError(`${fieldName} must not resolve to private or reserved IP addresses`);
+    }
+  }
+}
+
+async function resolveDefaultLookup(): Promise<GuardedFetchDnsLookup | null | undefined> {
+  if (defaultLookupOverridden) {
+    return defaultLookupOverride;
+  }
+  nodeDnsLookupPromise ??= import("node:dns/promises").then(
+    ({ lookup }) =>
+      (hostname: string) =>
+        lookup(hostname, { all: true }),
+    () => undefined,
+  );
+  return nodeDnsLookupPromise;
+}
+
+function isReplayableBody(body: BodyInit): boolean {
+  return (
+    typeof body === "string" ||
+    body instanceof URLSearchParams ||
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body)
+  );
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Ignore cancellation failures; the body is abandoned either way.
+  }
+}

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -51,8 +51,15 @@ export interface GuardedFetchOptions {
 // chains that previously succeeded.
 const defaultMaxRedirects = 20;
 const redirectStatuses = new Set([301, 302, 303, 307, 308]);
-/** Credential-bearing headers dropped when a redirect crosses origins, mirroring the fetch spec. */
-const crossOriginSensitiveHeaders = ["authorization", "cookie", "proxy-authorization"];
+/**
+ * Credential-bearing headers dropped when a redirect crosses origins. Covers the
+ * fetch-spec set (`authorization`/`cookie`/`proxy-authorization`) plus the
+ * custom auth headers provider egress commonly sends (`x-api-key`, `api-key`,
+ * `x-auth-token`, and similar key/token/secret headers), so a cross-origin
+ * redirect cannot exfiltrate a provider credential.
+ */
+const crossOriginSensitiveHeaderPattern =
+  /^(authorization|cookie|proxy-authorization|(x-)?(api[-_]?key|auth[-_]?token|access[-_]?token|api[-_]?token|app[-_]?key|.*[-_](key|token|secret|password)))$/u;
 /** Body-describing headers dropped when a redirect rewrites the method to GET, mirroring the fetch spec. */
 const bodyHeaders = ["content-encoding", "content-language", "content-length", "content-location", "content-type"];
 
@@ -196,8 +203,10 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
         throw createError("redirect cannot be followed because the request body is not replayable");
       }
       if (guardedNext.origin !== url.origin) {
-        for (const name of crossOriginSensitiveHeaders) {
-          headers.delete(name);
+        for (const name of [...headers.keys()]) {
+          if (crossOriginSensitiveHeaderPattern.test(name)) {
+            headers.delete(name);
+          }
         }
       }
       url = guardedNext;
@@ -231,12 +240,14 @@ async function assertResolvedAddressesAllowed(
   try {
     results = await policy.lookup(hostname);
   } catch {
-    // Resolution failures surface through the transport as its natural network
-    // error; only successful resolutions are validated here.
-    return;
+    // Fail closed: once a lookup is enabled, a resolution failure must not
+    // silently skip address validation, or a forced-failure / split-resolver
+    // could bypass the guard. A genuinely unresolvable host fails here instead
+    // of at the transport, with the same net outcome (the request is rejected).
+    throw policy.createError(`${fieldName} could not be resolved for validation`);
   }
   if (!Array.isArray(results)) {
-    return;
+    throw policy.createError(`${fieldName} could not be resolved for validation`);
   }
   for (const entry of results) {
     if (entry && typeof entry.address === "string" && isBlockedIpAddress(entry.address, policy.allowPrivateNetwork)) {

--- a/src/core/request.test.ts
+++ b/src/core/request.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   assertPublicHttpUrl,
+  isBlockedIpAddress,
+  isIpv4Address,
   isPrivateNetworkAccessAllowed,
   parsePrivateNetworkAccessFlag,
   setPrivateNetworkAccessAllowed,
@@ -74,6 +76,95 @@ describe("assertPublicHttpUrl", () => {
       "http://[fd7a:115c:a1e0::1]/",
     ]) {
       expect(() => readPublicUrl(value, true)).toThrow();
+    }
+  });
+});
+
+describe("isBlockedIpAddress", () => {
+  it("blocks loopback, link-local, metadata, and other reserved IPv4 addresses", () => {
+    for (const address of [
+      "127.0.0.1",
+      "169.254.169.254",
+      "0.0.0.0",
+      "100.100.100.200",
+      "224.0.0.1",
+      "255.255.255.255",
+    ]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+      expect(isBlockedIpAddress(address, true)).toBe(true);
+    }
+  });
+
+  it("blocks private IPv4 addresses unless private networks are allowed", () => {
+    for (const address of ["10.0.0.5", "172.16.0.2", "192.168.1.1", "100.64.0.1"]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+      expect(isBlockedIpAddress(address, true)).toBe(false);
+    }
+  });
+
+  it("allows public IPv4 addresses", () => {
+    for (const address of ["1.1.1.1", "8.8.8.8", "93.184.216.34"]) {
+      expect(isBlockedIpAddress(address)).toBe(false);
+    }
+  });
+
+  it("blocks reserved IPv6 addresses regardless of the private-network flag", () => {
+    for (const address of ["::", "::1", "fe80::1", "ff02::1", "2001:db8::1", "100::1"]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+      expect(isBlockedIpAddress(address, true)).toBe(true);
+    }
+  });
+
+  it("blocks unique-local and site-local IPv6 unless private networks are allowed", () => {
+    for (const address of ["fd00::1", "fc00::1", "fec0::1", "fd7a:115c:a1e0::1"]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+      expect(isBlockedIpAddress(address, true)).toBe(false);
+    }
+  });
+
+  it("applies the IPv4 policy to v4-mapped, NAT64, and 6to4 IPv6 addresses", () => {
+    expect(isBlockedIpAddress("::ffff:169.254.169.254")).toBe(true);
+    expect(isBlockedIpAddress("::ffff:169.254.169.254", true)).toBe(true);
+    expect(isBlockedIpAddress("::ffff:10.0.0.5")).toBe(true);
+    expect(isBlockedIpAddress("::ffff:10.0.0.5", true)).toBe(false);
+    expect(isBlockedIpAddress("::ffff:8.8.8.8")).toBe(false);
+    // NAT64 well-known prefix embedding 127.0.0.1 (7f00:1).
+    expect(isBlockedIpAddress("64:ff9b::7f00:1")).toBe(true);
+    // 6to4 embedding 192.168.1.1 (c0a8:0101).
+    expect(isBlockedIpAddress("2002:c0a8:101::1")).toBe(true);
+    expect(isBlockedIpAddress("2002:c0a8:101::1", true)).toBe(false);
+  });
+
+  it("allows public IPv6 addresses and ignores zone suffixes", () => {
+    expect(isBlockedIpAddress("2606:4700:4700::1111")).toBe(false);
+    expect(isBlockedIpAddress("fe80::1%en0")).toBe(true);
+  });
+
+  it("treats unparseable addresses as blocked", () => {
+    for (const address of ["", "not-an-ip", "10.0.0", "1.2.3.4.5", ":::1", "fe80::1::2"]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+    }
+  });
+});
+
+describe("isIpv4Address", () => {
+  it("accepts canonical dotted-decimal IPv4 literals", () => {
+    for (const value of ["127.0.0.1", "10.0.0.5", "169.254.169.254", "0.0.0.0", "255.255.255.255"]) {
+      expect(isIpv4Address(value)).toBe(true);
+    }
+  });
+
+  it("rejects looser numeric forms that a resolver could still treat as an address", () => {
+    // Out-of-range or non-4-group numeric hosts must not be mistaken for a
+    // validated literal — they have to go through DNS resolved-address checks.
+    for (const value of ["0251.0376.0251.0376", "1.2.3.999", "300.1.1.1", "2130706433", "10.0.0", "1.2.3.4.5", ""]) {
+      expect(isIpv4Address(value)).toBe(false);
+    }
+  });
+
+  it("rejects hostnames and IPv6 literals", () => {
+    for (const value of ["example.com", "metadata.attacker.com", "::1", "fe80::1"]) {
+      expect(isIpv4Address(value)).toBe(false);
     }
   });
 });

--- a/src/core/request.test.ts
+++ b/src/core/request.test.ts
@@ -124,6 +124,8 @@ describe("isBlockedIpAddress", () => {
 
   it("blocks IANA special-purpose non-global IPv6 ranges regardless of the private-network flag", () => {
     for (const address of [
+      "100::1", // discard-only (RFC 6666)
+      "100:0:0:1::1", // discard-only extension
       "64:ff9b:1::1", // local-use IPv4/IPv6 translation (RFC 8215)
       "2001:2::1", // benchmarking (RFC 5180)
       "3fff::1", // documentation (RFC 9637)

--- a/src/core/request.test.ts
+++ b/src/core/request.test.ts
@@ -122,6 +122,18 @@ describe("isBlockedIpAddress", () => {
     }
   });
 
+  it("blocks IANA special-purpose non-global IPv6 ranges regardless of the private-network flag", () => {
+    for (const address of [
+      "64:ff9b:1::1", // local-use IPv4/IPv6 translation (RFC 8215)
+      "2001:2::1", // benchmarking (RFC 5180)
+      "3fff::1", // documentation (RFC 9637)
+      "5f00::1", // SRv6 SIDs (RFC 9602)
+    ]) {
+      expect(isBlockedIpAddress(address)).toBe(true);
+      expect(isBlockedIpAddress(address, true)).toBe(true);
+    }
+  });
+
   it("applies the IPv4 policy to v4-mapped, NAT64, and 6to4 IPv6 addresses", () => {
     expect(isBlockedIpAddress("::ffff:169.254.169.254")).toBe(true);
     expect(isBlockedIpAddress("::ffff:169.254.169.254", true)).toBe(true);

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -147,6 +147,7 @@ const reservedIpv6Cidrs: Array<[Uint8Array, number]> = [
   [ipv6ToBytes("::"), 128],
   [ipv6ToBytes("::1"), 128],
   [ipv6ToBytes("100::"), 64],
+  [ipv6ToBytes("100:0:0:1::"), 64],
   [ipv6ToBytes("64:ff9b:1::"), 48],
   [ipv6ToBytes("2001:2::"), 48],
   [ipv6ToBytes("2001:db8::"), 32],

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -143,6 +143,24 @@ const reservedIpv4Cidrs: Array<[number, number]> = [
   [ipv4ToNumber("224.0.0.0"), 4],
   [ipv4ToNumber("240.0.0.0"), 4],
 ];
+const reservedIpv6Cidrs: Array<[Uint8Array, number]> = [
+  [ipv6ToBytes("::"), 128],
+  [ipv6ToBytes("::1"), 128],
+  [ipv6ToBytes("100::"), 64],
+  [ipv6ToBytes("2001:db8::"), 32],
+  [ipv6ToBytes("fe80::"), 10],
+  [ipv6ToBytes("ff00::"), 8],
+];
+const privateIpv6Cidrs: Array<[Uint8Array, number]> = [
+  [ipv6ToBytes("fc00::"), 7],
+  [ipv6ToBytes("fec0::"), 10],
+];
+/** IPv6 ranges that embed an IPv4 address checked against the IPv4 policy: [prefix, bits, v4 byte offset]. */
+const ipv4EmbeddedIpv6Cidrs: Array<[Uint8Array, number, number]> = [
+  [ipv6ToBytes("::ffff:0:0"), 96, 12],
+  [ipv6ToBytes("64:ff9b::"), 96, 12],
+  [ipv6ToBytes("2002::"), 16, 2],
+];
 
 export interface PublicHttpUrlOptions {
   fieldName: string;
@@ -216,14 +234,7 @@ export function assertPublicHttpUrl(value: string, options: PublicHttpUrlOptions
   }
 
   const ipv4 = parseIpv4(hostname);
-  if (ipv4 !== undefined && reservedIpv4Cidrs.some(([network, bits]) => ipv4InCidr(ipv4, network, bits))) {
-    throw options.createError(`${options.fieldName} must not target private or reserved IP addresses`);
-  }
-  if (
-    ipv4 !== undefined &&
-    !options.allowPrivateNetwork &&
-    privateIpv4Cidrs.some(([network, bits]) => ipv4InCidr(ipv4, network, bits))
-  ) {
+  if (ipv4 !== undefined && isBlockedIpv4(ipv4, options.allowPrivateNetwork === true)) {
     throw options.createError(`${options.fieldName} must not target private or reserved IP addresses`);
   }
 
@@ -235,6 +246,62 @@ export function assertPublicHttpUrl(value: string, options: PublicHttpUrlOptions
     url.hostname = hostname;
   }
   return url;
+}
+
+/**
+ * Return whether a resolved IP address (IPv4 or IPv6 text form) is a private,
+ * reserved, loopback, link-local, or metadata target that provider egress must
+ * not reach.
+ *
+ * This complements {@link assertPublicHttpUrl}: the URL guard validates literal
+ * hostnames before a request, while this check validates the addresses a
+ * hostname actually resolves to (closing name→private-IP bypasses). IPv6
+ * ranges that embed an IPv4 address (v4-mapped, NAT64, 6to4) are checked
+ * against the IPv4 policy. Unparseable input is treated as blocked.
+ */
+export function isBlockedIpAddress(address: string, allowPrivateNetwork = false): boolean {
+  const ipv4 = parseIpv4(address);
+  if (ipv4 !== undefined) {
+    return isBlockedIpv4(ipv4, allowPrivateNetwork);
+  }
+
+  const ipv6 = parseIpv6(address);
+  if (ipv6 === undefined) {
+    return true;
+  }
+  if (reservedIpv6Cidrs.some(([network, bits]) => ipv6InCidr(ipv6, network, bits))) {
+    return true;
+  }
+  if (!allowPrivateNetwork && privateIpv6Cidrs.some(([network, bits]) => ipv6InCidr(ipv6, network, bits))) {
+    return true;
+  }
+  for (const [network, bits, offset] of ipv4EmbeddedIpv6Cidrs) {
+    if (ipv6InCidr(ipv6, network, bits)) {
+      const embedded =
+        ((ipv6[offset]! << 24) | (ipv6[offset + 1]! << 16) | (ipv6[offset + 2]! << 8) | ipv6[offset + 3]!) >>> 0;
+      return isBlockedIpv4(embedded, allowPrivateNetwork);
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether a hostname is a canonical dotted-decimal IPv4 literal (each octet
+ * 0-255), matching exactly what {@link assertPublicHttpUrl} validates as a
+ * literal IPv4. Callers use this to decide a hostname is already an
+ * address-validated literal and does not need DNS resolution — it must not
+ * over-match looser numeric forms (octal, out-of-range) that resolvers would
+ * still interpret as an address.
+ */
+export function isIpv4Address(hostname: string): boolean {
+  return parseIpv4(hostname) !== undefined;
+}
+
+function isBlockedIpv4(value: number, allowPrivateNetwork: boolean): boolean {
+  if (reservedIpv4Cidrs.some(([network, bits]) => ipv4InCidr(value, network, bits))) {
+    return true;
+  }
+  return !allowPrivateNetwork && privateIpv4Cidrs.some(([network, bits]) => ipv4InCidr(value, network, bits));
 }
 
 function normalizeHostname(value: string): string {
@@ -264,6 +331,100 @@ function parseIpv4(hostname: string): number | undefined {
   }
 
   return value >>> 0;
+}
+
+function parseIpv6(value: string): Uint8Array | undefined {
+  let input = value.toLowerCase();
+  const zoneIndex = input.indexOf("%");
+  if (zoneIndex !== -1) {
+    input = input.slice(0, zoneIndex);
+  }
+  if (input.startsWith("[") && input.endsWith("]")) {
+    input = input.slice(1, -1);
+  }
+  if (!input.includes(":")) {
+    return undefined;
+  }
+
+  let head = input;
+  let tail = "";
+  const compressedIndex = input.indexOf("::");
+  if (compressedIndex !== -1) {
+    if (input.includes("::", compressedIndex + 1)) {
+      return undefined;
+    }
+    head = input.slice(0, compressedIndex);
+    tail = input.slice(compressedIndex + 2);
+  }
+
+  const headWords = parseIpv6Words(head);
+  const tailWords = parseIpv6Words(tail);
+  if (headWords === undefined || tailWords === undefined) {
+    return undefined;
+  }
+  const missing = 8 - headWords.length - tailWords.length;
+  if (compressedIndex === -1 ? headWords.length !== 8 : missing < 1) {
+    return undefined;
+  }
+
+  const words =
+    compressedIndex === -1 ? headWords : [...headWords, ...new Array<number>(missing).fill(0), ...tailWords];
+  const bytes = new Uint8Array(16);
+  for (const [index, word] of words.entries()) {
+    bytes[index * 2] = word >>> 8;
+    bytes[index * 2 + 1] = word & 0xff;
+  }
+  return bytes;
+}
+
+function parseIpv6Words(value: string): number[] | undefined {
+  if (value === "") {
+    return [];
+  }
+
+  const words: number[] = [];
+  const parts = value.split(":");
+  for (const [index, part] of parts.entries()) {
+    if (part.includes(".")) {
+      if (index !== parts.length - 1) {
+        return undefined;
+      }
+      const ipv4 = parseIpv4(part);
+      if (ipv4 === undefined) {
+        return undefined;
+      }
+      words.push(ipv4 >>> 16, ipv4 & 0xffff);
+      continue;
+    }
+    if (!/^[0-9a-f]{1,4}$/u.test(part)) {
+      return undefined;
+    }
+    words.push(Number.parseInt(part, 16));
+  }
+  return words;
+}
+
+function ipv6ToBytes(value: string): Uint8Array {
+  const parsed = parseIpv6(value);
+  if (parsed === undefined) {
+    throw new Error(`invalid IPv6 CIDR base: ${value}`);
+  }
+  return parsed;
+}
+
+function ipv6InCidr(value: Uint8Array, network: Uint8Array, bits: number): boolean {
+  const fullBytes = Math.floor(bits / 8);
+  for (let index = 0; index < fullBytes; index++) {
+    if (value[index] !== network[index]) {
+      return false;
+    }
+  }
+  const remainderBits = bits % 8;
+  if (remainderBits === 0) {
+    return true;
+  }
+  const mask = (0xff << (8 - remainderBits)) & 0xff;
+  return (value[fullBytes]! & mask) === (network[fullBytes]! & mask);
 }
 
 function parseContentLength(value: string | null): number | undefined {

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -147,7 +147,11 @@ const reservedIpv6Cidrs: Array<[Uint8Array, number]> = [
   [ipv6ToBytes("::"), 128],
   [ipv6ToBytes("::1"), 128],
   [ipv6ToBytes("100::"), 64],
+  [ipv6ToBytes("64:ff9b:1::"), 48],
+  [ipv6ToBytes("2001:2::"), 48],
   [ipv6ToBytes("2001:db8::"), 32],
+  [ipv6ToBytes("3fff::"), 20],
+  [ipv6ToBytes("5f00::"), 16],
   [ipv6ToBytes("fe80::"), 10],
   [ipv6ToBytes("ff00::"), 8],
 ];

--- a/src/providers/aftership/executors.ts
+++ b/src/providers/aftership/executors.ts
@@ -12,14 +12,16 @@ import type { AftershipActionName } from "./actions.ts";
 import { CastError, compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
+  createProviderFetch,
   defineProviderProxy,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   requireApiKeyCredential,
 } from "../provider-runtime.ts";
 
 const service = "aftership";
 const aftershipApiBaseUrl = "https://api.aftership.com/tracking/2026-01";
+const aftershipFetch = createProviderFetch({ skipDnsValidation: true });
 
 type AftershipHttpMethod = "DELETE" | "GET" | "POST" | "PUT";
 type AftershipActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -140,6 +142,7 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: aftershipApiBaseUrl,
   auth: { type: "api_key_header", name: "as-api-key" },
+  skipDnsValidation: true,
   customizeRequest({ headers }) {
     if (!headers.has("accept")) {
       headers.set("accept", "application/json");
@@ -384,7 +387,7 @@ function createAftershipExecutor(handler: AftershipActionHandler): ActionExecuto
 function createAftershipContext(apiKey: string, executionContext: ExecutionContext): ApiKeyProviderContext {
   const context: ApiKeyProviderContext = {
     apiKey,
-    fetcher: fetch,
+    fetcher: aftershipFetch,
     signal: executionContext.signal,
   };
   if (executionContext.transitFiles) {

--- a/src/providers/agenty/runtime.ts
+++ b/src/providers/agenty/runtime.ts
@@ -3,7 +3,7 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 import type { AgentyActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const agentyApiBaseUrl = "https://api.agenty.com/v2";
 export const agentyBrowserBaseUrl = "https://browser.agenty.com/api";
@@ -117,7 +117,7 @@ export const agentyActionHandlers: Record<AgentyActionName, AgentyActionHandler>
 
 export async function validateAgentyApiKey(
   apiKey: string,
-  fetcher: ProviderFetch = fetch,
+  fetcher: ProviderFetch = providerFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const trimmedApiKey = apiKey.trim();

--- a/src/providers/agora/executors.ts
+++ b/src/providers/agora/executors.ts
@@ -8,11 +8,12 @@ import type {
 
 import { Buffer } from "node:buffer";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -21,10 +22,12 @@ import {
 import { agoraActionHandlers, agoraApiBaseUrl, readAgoraCustomerId, validateAgoraCredential } from "./runtime.ts";
 
 const service = "agora";
+const agoraFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: agoraActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -48,7 +51,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await agoraFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/aircall/executors.ts
+++ b/src/providers/aircall/executors.ts
@@ -8,6 +8,7 @@ import type {
 import type { AircallActionContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -26,10 +27,12 @@ import {
 } from "./runtime.ts";
 
 const service = "aircall";
+const aircallFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<AircallActionContext>({
   service,
   handlers: aircallActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AircallActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -55,7 +58,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await aircallFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/algolia/executors.ts
+++ b/src/providers/algolia/executors.ts
@@ -10,8 +10,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -48,7 +49,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -7,12 +7,14 @@ import type {
 } from "../../core/types.ts";
 
 import AliOss from "ali-oss";
-import { isIP } from "node:net";
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
+  providerFetch,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
@@ -23,6 +25,8 @@ import {
 const service = "aliyun_oss";
 const sourceFetchTimeoutMs = 15_000;
 const maxSourceBytes = 20 * 1024 * 1024;
+
+const proxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 type AliyunBucket = {
   name?: string;
@@ -258,7 +262,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       ),
     );
 
-    const response = await fetch(url, init);
+    const response = await proxyFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(
@@ -424,7 +428,10 @@ async function aliyunPutObject(input: Record<string, unknown>, context: AliyunOs
   const objectKey = requireAliyunField(input.objectKey, "objectKey");
   const client = createClientForAction(input, context, bucket);
   const sourceUrl = optionalString(input.sourceUrl);
-  const sourceFile = sourceUrl ? await downloadSourceFile(sourceUrl, context.fetcher, context.signal) : null;
+  // A user-supplied sourceUrl is downloaded with the public-only fetch even when
+  // the deployment allows private networks: the private-network opt-in covers the
+  // trusted OSS endpoint, never an arbitrary user-provided download URL.
+  const sourceFile = sourceUrl ? await downloadSourceFile(sourceUrl, providerFetch, context.signal) : null;
   const resolvedContentType = optionalString(input.contentType) ?? sourceFile?.contentType;
   const body =
     sourceFile?.bytes ??
@@ -699,7 +706,7 @@ function buildFallbackObjectUrl(endpoint: string, bucket: string, objectKey: str
   return url.toString();
 }
 
-function parseAndValidateEndpoint(value: string): URL {
+function parseAndValidateEndpoint(value: string, allowPrivateNetwork = isPrivateNetworkAccessAllowed()): URL {
   const url = parseUrl(value.includes("://") ? value : `https://${value}`, "endpoint");
   if (url.protocol !== "https:") {
     throw new ProviderRequestError(400, "endpoint must use https");
@@ -707,7 +714,15 @@ function parseAndValidateEndpoint(value: string): URL {
   if (url.pathname !== "/" || url.search || url.hash) {
     throw new ProviderRequestError(400, "endpoint must not include path, query, or hash");
   }
-  validatePublicHostname(url.hostname, "endpoint");
+  // SDK-based actions build an ali-oss client from this endpoint and bypass the
+  // guarded fetch, so this is the sole SSRF guard for those paths. Delegate to
+  // the shared policy (blocks metadata hostnames and IPv6 unconditionally,
+  // private targets unless the deployment opts in) instead of a bespoke check.
+  assertPublicHttpUrl(url.toString(), {
+    fieldName: "endpoint",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   return url;
 }
 
@@ -716,7 +731,13 @@ function validateSourceUrl(value: string): string {
   if (url.protocol !== "https:") {
     throw new ProviderRequestError(400, "sourceUrl must use https");
   }
-  validatePublicHostname(url.hostname, "sourceUrl");
+  // A user-supplied sourceUrl is always validated public-only, independent of the
+  // deployment's private-network opt-in (which only covers the trusted endpoint).
+  assertPublicHttpUrl(url.toString(), {
+    fieldName: "sourceUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork: false,
+  });
   return url.toString();
 }
 
@@ -732,20 +753,6 @@ function parseUrl(value: string, fieldName: "endpoint" | "sourceUrl"): URL {
       throw error;
     }
     throw new ProviderRequestError(400, `${fieldName} must be a valid URL`);
-  }
-}
-
-function validatePublicHostname(hostname: string, fieldName: "endpoint" | "sourceUrl"): void {
-  const normalizedHostname = hostname.toLowerCase();
-  if (
-    normalizedHostname === "localhost" ||
-    normalizedHostname.endsWith(".localhost") ||
-    normalizedHostname.endsWith(".local") ||
-    normalizedHostname.endsWith(".internal") ||
-    !normalizedHostname.includes(".") ||
-    isIP(normalizedHostname) !== 0
-  ) {
-    throw new ProviderRequestError(400, `${fieldName} must use a public hostname`);
   }
 }
 

--- a/src/providers/aliyun_oss/network-access.test.ts
+++ b/src/providers/aliyun_oss/network-access.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { credentialValidators } from "./executors.ts";
+
+// Endpoint SSRF validation runs before any network call, so blocked endpoints
+// reject synchronously without reaching the ali-oss SDK. Reset the deployment
+// flag after each case so state never leaks.
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+function validateEndpoint(endpoint: string): Promise<unknown> {
+  return credentialValidators.customCredential!(
+    { values: { accessKeyId: "id", accessKeySecret: "secret", endpoint } },
+    { fetcher: fetch },
+  );
+}
+
+describe("aliyun_oss endpoint SSRF guard", () => {
+  it("blocks private endpoints by default", async () => {
+    await expect(validateEndpoint("https://10.0.0.5")).rejects.toThrow(/private or reserved/u);
+  });
+
+  it("keeps cloud-metadata hostnames blocked even when private networks are allowed", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    for (const endpoint of ["https://metadata.google.internal", "https://instance-data.ec2.internal"]) {
+      await expect(validateEndpoint(endpoint)).rejects.toThrow(/cloud metadata/u);
+    }
+  });
+
+  it("keeps IPv6 loopback and link-local endpoints blocked even when private networks are allowed", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    for (const endpoint of ["https://[::1]", "https://[fe80::1]"]) {
+      await expect(validateEndpoint(endpoint)).rejects.toThrow(/IPv6/u);
+    }
+  });
+});

--- a/src/providers/aliyun_sts/executors.ts
+++ b/src/providers/aliyun_sts/executors.ts
@@ -14,6 +14,7 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -33,6 +34,7 @@ import {
 } from "./runtime.ts";
 
 const service = "aliyun_sts";
+const aliyunStsFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface AliyunStsContext {
   values: Record<string, string>;
@@ -42,6 +44,7 @@ interface AliyunStsContext {
 
 export const executors: ProviderExecutors = defineProviderExecutors<AliyunStsContext>({
   service,
+  skipDnsValidation: true,
   handlers: {
     assume_role(input, context) {
       const accessKeyId = requireCredentialField(context.values.accessKeyId, "accessKeyId");
@@ -99,7 +102,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     headers.set("content-type", "application/x-www-form-urlencoded");
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await aliyunStsFetch(url, {
       method: "POST",
       headers,
       body: buildAliyunStsSignedRpcBody(buildAliyunStsProxyParams(input, accessKeyId), accessKeySecret),

--- a/src/providers/alpaca/executors.ts
+++ b/src/providers/alpaca/executors.ts
@@ -7,11 +7,12 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -23,10 +24,12 @@ const service = "alpaca";
 const paperTradingBaseUrl = "https://paper-api.alpaca.markets";
 const liveTradingBaseUrl = "https://api.alpaca.markets";
 const dataBaseUrl = "https://data.alpaca.markets";
+const alpacaFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: alpacaActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -60,7 +63,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     headers.set("apca-api-secret-key", alpacaCredential.apiSecretKey);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await alpacaFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/amplitude/executors.ts
+++ b/src/providers/amplitude/executors.ts
@@ -21,6 +21,7 @@ const service = "amplitude";
 export const executors: ProviderExecutors = defineProviderExecutors<AmplitudeActionContext>({
   service,
   handlers: amplitudeActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<AmplitudeActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =
@@ -43,6 +44,7 @@ export const credentialValidators: CredentialValidators = {
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
+  skipDnsValidation: true,
   baseUrl: async (context) => {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =

--- a/src/providers/amplitude/runtime.ts
+++ b/src/providers/amplitude/runtime.ts
@@ -6,8 +6,9 @@ import { compactObject, optionalInteger, optionalRecord, requiredString } from "
 import {
   createProviderTimeout,
   isAbortLikeError,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
 } from "../provider-runtime.ts";
 
 export const amplitudeApiBaseUrl = "https://amplitude.com";
@@ -94,7 +95,7 @@ export const amplitudeActionHandlers: Record<AmplitudeActionName, AmplitudeActio
 
 export async function validateAmplitudeCredential(
   input: { apiKey: string; values: Record<string, string> },
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const secretKey = requireAmplitudeSecretKey(input.apiKey);

--- a/src/providers/appdrag/executors.ts
+++ b/src/providers/appdrag/executors.ts
@@ -8,11 +8,12 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -23,6 +24,7 @@ const service = "appdrag";
 const appdragHomepageUrl = "https://appdrag.com";
 const appdragDefaultRequestTimeoutMs = 30_000;
 const appdragResponseWrapperDescription = "/api/<folder>/<function>";
+const appdragFetch = createProviderFetch({ skipDnsValidation: true });
 
 type AppdragHttpMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
 type AppdragEnvironment = "default" | "dev" | "preprod" | "prod";
@@ -41,7 +43,9 @@ export const appdragActionHandlers: Record<string, AppdragActionHandler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, appdragActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, appdragActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -64,7 +68,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await appdragFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/arxiv/executors.ts
+++ b/src/providers/arxiv/executors.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
 
-import { defineProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
+import { defineProviderExecutors, providerFetch, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "arxiv";
 const arxivApiBaseUrl = "https://export.arxiv.org/api";
@@ -271,7 +271,7 @@ async function requestArxiv(options: QueryOptions, fetcher: typeof fetch): Promi
 }
 
 function throttleDefaultFetch(fetcher: typeof fetch): Promise<void> {
-  if (fetcher !== fetch) {
+  if (fetcher !== providerFetch) {
     return Promise.resolve();
   }
 

--- a/src/providers/autotask/executors.ts
+++ b/src/providers/autotask/executors.ts
@@ -11,8 +11,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -59,7 +60,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -13,6 +13,7 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
+  providerFetch,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyResponse,
@@ -134,7 +135,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       {
         values: credential.values,
         metadata: credential.metadata,
-        fetcher: fetch,
+        fetcher: providerFetch,
         signal: context.signal,
       },
     );
@@ -161,7 +162,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
         secretAccessKey: requireAwsField(credential.values.secretAccessKey, "secretAccessKey"),
         sessionToken: optionalString(credential.values.sessionToken)?.trim(),
         region,
-        fetcher: fetch,
+        fetcher: providerFetch,
       }),
       {
         method,
@@ -172,7 +173,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     );
     signedRequest.headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url.toString(), {
+    const response = await providerFetch(url.toString(), {
       method,
       headers: signedRequest.headers,
       ...(body === undefined ? {} : { body }),

--- a/src/providers/aws_sts/executors.ts
+++ b/src/providers/aws_sts/executors.ts
@@ -15,6 +15,7 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   ProviderRequestError,
@@ -29,6 +30,7 @@ const stsApiVersion = "2011-06-15";
 const awsServiceName = "sts";
 const defaultRegion = "ap-southeast-1";
 const defaultRoleSessionName = "oomol-connect";
+const awsStsFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface AwsStsContext {
   values: Record<string, string>;
@@ -85,6 +87,7 @@ export const awsStsActionHandlers: Record<string, AwsStsActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<AwsStsContext>({
   service,
   handlers: awsStsActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AwsStsContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {
@@ -122,7 +125,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       body,
     });
 
-    const response = await fetch(url, {
+    const response = await awsStsFetch(url, {
       method: "POST",
       headers,
       body,

--- a/src/providers/bark/executors.ts
+++ b/src/providers/bark/executors.ts
@@ -8,8 +8,9 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -24,6 +25,7 @@ import {
 const service = "bark";
 const barkDefaultBaseUrl = "https://api.day.app";
 const barkSuccessCode = 200;
+const barkProxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 interface BarkContext extends ApiKeyProviderContext {
   baseUrl: string;
@@ -62,6 +64,7 @@ export const barkActionHandlers: Record<string, BarkActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<BarkContext>({
   service,
   handlers: barkActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context, fetcher): Promise<BarkContext> {
     const credential = await requireApiKeyCredential(context, service);
     const resolved = resolveBarkCredential(
@@ -94,7 +97,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await barkProxyFetch(url, {
       method: input.method,
       headers,
       body,
@@ -113,9 +116,10 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
     const credential = resolveBarkCredential(input.apiKey, optionalString(input.values.baseUrl));
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     await requestBarkServerPing({
       baseUrl: credential.baseUrl,
-      fetcher,
+      fetcher: guardedFetcher,
       signal,
     });
 
@@ -270,24 +274,28 @@ async function requestBarkRaw(input: {
   return response;
 }
 
-function resolveBarkCredential(apiKey: string, baseUrlInput?: string): BarkCredential {
+function resolveBarkCredential(
+  apiKey: string,
+  baseUrlInput?: string,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): BarkCredential {
   const trimmedApiKey = apiKey.trim();
   if (!trimmedApiKey) {
     throw new ProviderRequestError(400, "Bark device key is required");
   }
 
-  const parsedFromUrl = parseBarkPushUrl(trimmedApiKey);
+  const parsedFromUrl = parseBarkPushUrl(trimmedApiKey, allowPrivateNetwork);
   if (parsedFromUrl) {
     return parsedFromUrl;
   }
 
   return {
     deviceKey: trimmedApiKey,
-    baseUrl: normalizeBarkBaseUrl(baseUrlInput),
+    baseUrl: normalizeBarkBaseUrl(baseUrlInput, allowPrivateNetwork),
   };
 }
 
-function parseBarkPushUrl(value: string): BarkCredential | undefined {
+function parseBarkPushUrl(value: string, allowPrivateNetwork: boolean): BarkCredential | undefined {
   if (!value.includes("://")) {
     return undefined;
   }
@@ -296,6 +304,7 @@ function parseBarkPushUrl(value: string): BarkCredential | undefined {
   try {
     url = assertPublicHttpUrl(value, {
       fieldName: "Bark push URL",
+      allowPrivateNetwork,
       createError: (message) => new ProviderRequestError(400, message),
     });
   } catch (error) {
@@ -321,14 +330,15 @@ function parseBarkPushUrl(value: string): BarkCredential | undefined {
 
   return {
     deviceKey,
-    baseUrl: normalizeBarkBaseUrl(`${url.origin}${basePath}`),
+    baseUrl: normalizeBarkBaseUrl(`${url.origin}${basePath}`, allowPrivateNetwork),
   };
 }
 
-function normalizeBarkBaseUrl(value?: string): string {
+function normalizeBarkBaseUrl(value?: string, allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed()): string {
   const candidate = value?.trim() || barkDefaultBaseUrl;
   const url = assertPublicHttpUrl(candidate, {
     fieldName: "Bark baseUrl",
+    allowPrivateNetwork,
     createError: (message) => new ProviderRequestError(400, message),
   });
 

--- a/src/providers/benchmark_email/executors.ts
+++ b/src/providers/benchmark_email/executors.ts
@@ -7,12 +7,14 @@ import type {
 } from "../../core/types.ts";
 import type { BenchmarkEmailContext } from "./runtime.ts";
 
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -26,9 +28,12 @@ import {
 
 const service = "benchmark_email";
 
+const benchmarkEmailFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors<BenchmarkEmailContext>({
   service,
   handlers: benchmarkEmailActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<BenchmarkEmailContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -54,7 +59,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await benchmarkEmailFetch(url, {
       method: input.method,
       headers,
       body:
@@ -73,6 +78,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
-    return validateBenchmarkEmailCredential(input, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateBenchmarkEmailCredential(input, guardedFetcher, signal);
   },
 };

--- a/src/providers/benchmark_email/runtime.ts
+++ b/src/providers/benchmark_email/runtime.ts
@@ -2,7 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -234,7 +234,7 @@ function readBenchmarkEmailErrorMessage(payload: unknown): string | undefined {
   );
 }
 
-function normalizeBaseUrl(value: unknown): string {
+function normalizeBaseUrl(value: unknown, allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed()): string {
   const text = optionalString(value);
   if (!text) {
     throw new ProviderRequestError(400, "baseUrl is required");
@@ -243,6 +243,7 @@ function normalizeBaseUrl(value: unknown): string {
   const url = assertPublicHttpUrl(text, {
     fieldName: "baseUrl",
     createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
   });
 
   if (url.protocol !== "https:") {

--- a/src/providers/bestbuy/executors.ts
+++ b/src/providers/bestbuy/executors.ts
@@ -6,11 +6,12 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -19,8 +20,11 @@ import {
 import { bestbuyActionHandlers, bestbuyApiOrigin, validateBestbuyCredential } from "./runtime.ts";
 
 const service = "bestbuy";
+const bestbuyFetch = createProviderFetch({ skipDnsValidation: true });
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, bestbuyActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, bestbuyActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -31,7 +35,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await bestbuyFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/blaze-meter-runtime.ts
+++ b/src/providers/blaze-meter-runtime.ts
@@ -4,8 +4,9 @@ import type { ProviderFetch, ProviderRuntimeHandler } from "./provider-runtime.t
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalScalarString, optionalString } from "../core/cast.ts";
 import {
-  createProviderTimeout,
+  createProviderFetch,
   createProviderProxyUrl,
+  createProviderTimeout,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
@@ -20,6 +21,7 @@ export const blazeMeterValidationPath = "/user";
 
 const blazeMeterRequestBaseUrl = "https://a.blazemeter.com/api/v4/";
 const blazeMeterDefaultTimeoutMs = 30_000;
+const blazeMeterFetch = createProviderFetch({ skipDnsValidation: true });
 
 export type BlazeMeterPhase = "validate" | "execute";
 export type BlazeMeterMethod = "GET" | "PUT";
@@ -158,7 +160,7 @@ export function createBlazeMeterProxyExecutor(service: string): ProviderProxyExe
         headers.set("content-type", "application/json");
       }
 
-      const response = await fetch(url, {
+      const response = await blazeMeterFetch(url, {
         method: input.method,
         headers,
         body:

--- a/src/providers/bluesky/executors.ts
+++ b/src/providers/bluesky/executors.ts
@@ -8,11 +8,12 @@ import type { BlueskyContext } from "./runtime.ts";
 
 import { optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -27,10 +28,12 @@ import {
 } from "./runtime.ts";
 
 const service = "bluesky";
+const blueskyFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<BlueskyContext>({
   service,
   handlers: blueskyActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<BlueskyContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -48,7 +51,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const session = await createBlueskySession({
       identifier: requireBlueskyHandle(optionalString(credential.values.handle)),
       appPassword: credential.apiKey,
-      fetcher: fetch,
+      fetcher: blueskyFetch,
       signal: context.signal,
       phase: "execute",
     });
@@ -60,7 +63,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await blueskyFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/btcpay_server/executors.ts
+++ b/src/providers/btcpay_server/executors.ts
@@ -7,7 +7,13 @@ import type {
 import type { BtcpayServerContext } from "./runtime.ts";
 
 import { optionalString } from "../../core/cast.ts";
-import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
 import { btcpayServerActionHandlers, normalizeBtcpayBaseUrl, validateBtcpayServerCredential } from "./runtime.ts";
 
 const service = "btcpay_server";
@@ -15,6 +21,7 @@ const service = "btcpay_server";
 export const executors: ProviderExecutors = defineProviderExecutors<BtcpayServerContext>({
   service,
   handlers: btcpayServerActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<BtcpayServerContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -37,16 +44,18 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     )}/api/v1`;
   },
   auth: { type: "api_key_authorization", prefix: "token " },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     return validateBtcpayServerCredential(
       {
         apiKey: input.apiKey,
         baseUrl: optionalString(input.values.baseUrl),
       },
-      fetcher,
+      guardedFetcher,
       signal,
     );
   },

--- a/src/providers/buildium/executors.ts
+++ b/src/providers/buildium/executors.ts
@@ -9,11 +9,12 @@ import type { BuildiumActionContext } from "./runtime.ts";
 
 import { requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -22,10 +23,12 @@ import {
 import { buildiumActionHandlers, buildiumApiBaseUrl, validateBuildiumCredential } from "./runtime.ts";
 
 const service = "buildium";
+const buildiumFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<BuildiumActionContext>({
   service,
   handlers: buildiumActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<BuildiumActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -46,7 +49,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     headers.set("x-buildium-client-secret", credential.apiKey);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await buildiumFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/canny/executors.ts
+++ b/src/providers/canny/executors.ts
@@ -8,11 +8,12 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -21,6 +22,7 @@ import {
 
 const service = "canny";
 const cannyApiBaseUrl = "https://canny.io/api";
+const cannyFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CannyActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -60,7 +62,9 @@ export const cannyActionHandlers: Record<string, CannyActionHandler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cannyActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cannyActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -69,7 +73,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("content-type", "application/json");
     headers.set("user-agent", providerUserAgent);
-    const response = await fetch(url.toString(), {
+    const response = await cannyFetch(url.toString(), {
       method: input.method,
       headers,
       body: JSON.stringify({ ...optionalRecord(input.body), apiKey: credential.apiKey }),

--- a/src/providers/chaserhq/executors.ts
+++ b/src/providers/chaserhq/executors.ts
@@ -12,11 +12,12 @@ import { Buffer } from "node:buffer";
 import { compactObject, optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -26,6 +27,7 @@ import {
 const service = "chaserhq";
 const apiBaseUrl = "https://openapi.chaserhq.com";
 const apiVersionBaseUrl = "https://openapi.chaserhq.com/v1";
+const chaserhqFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface ChaserContext {
   apiKey: string;
@@ -96,6 +98,7 @@ export const chaserhqActionHandlers: Record<string, Handler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<ChaserContext>({
   service,
   handlers: chaserhqActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ChaserContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -124,7 +127,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     headers.set("authorization", `Basic ${Buffer.from(`${credential.apiKey}:${apiSecret}`).toString("base64")}`);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await chaserhqFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/cin7_core/executors.ts
+++ b/src/providers/cin7_core/executors.ts
@@ -9,6 +9,7 @@ import type { Cin7CoreActionName } from "./actions.ts";
 
 import { compactObject, objectArray, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
@@ -24,6 +25,7 @@ import {
 
 const service = "cin7_core";
 const cin7CoreApiBaseUrl = "https://inventory.dearsystems.com/ExternalApi/v2/";
+const cin7CoreFetch = createProviderFetch({ skipDnsValidation: true });
 const cin7CoreValidationPath = "/me";
 const cin7CoreDefaultRequestTimeoutMs = 30_000;
 
@@ -155,6 +157,7 @@ const cin7CoreActionHandlers: Record<Cin7CoreActionName, Cin7CoreActionHandler> 
 export const executors: ProviderExecutors = defineProviderExecutors<Cin7CoreContext>({
   service,
   handlers: cin7CoreActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<Cin7CoreContext> {
     const credential = await requireApiKeyCredential(context, service);
     return readCin7CoreCredentials({
@@ -183,7 +186,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await cin7CoreFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/clickhouse/executors.ts
+++ b/src/providers/clickhouse/executors.ts
@@ -10,12 +10,14 @@ import type { ClickhouseActionName } from "./actions.ts";
 import type { ClickhouseActionContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -25,9 +27,12 @@ import { clickhouseActionHandlers, createClickhouseContext, validateClickhouseCr
 
 const service = "clickhouse";
 
+const clickhouseFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors<ClickhouseActionContext>({
   service,
   handlers: clickhouseActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ClickhouseActionContext> {
     const credential = await requireCustomCredential(context, service);
     return createClickhouseContext(credential.values, fetcher, context.signal);
@@ -38,7 +43,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<ClickhouseAc
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
     const credential = await requireCustomCredential(context, service);
-    const clickhouseContext = createClickhouseContext(credential.values, fetch, context.signal);
+    const clickhouseContext = createClickhouseContext(credential.values, clickhouseFetch, context.signal);
     const url = createProviderProxyUrl(clickhouseContext.baseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set(
@@ -50,7 +55,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", typeof input.body === "string" ? "text/plain; charset=utf-8" : "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await clickhouseFetch(url, {
       method: input.method,
       headers,
       body:
@@ -69,7 +74,8 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 
 export const credentialValidators: CredentialValidators = {
   customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    return validateClickhouseCredential(input.values, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateClickhouseCredential(input.values, guardedFetcher, signal);
   },
 };
 

--- a/src/providers/clicksend/executors.ts
+++ b/src/providers/clicksend/executors.ts
@@ -10,11 +10,12 @@ import type { ClicksendActionContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -23,10 +24,12 @@ import {
 import { clicksendActionHandlers, clicksendApiBaseUrl, validateClicksendCredential } from "./runtime.ts";
 
 const service = "clicksend";
+const clicksendFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<ClicksendActionContext>({
   service,
   handlers: clicksendActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ClicksendActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -53,7 +56,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await clicksendFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/clickup/executors.ts
+++ b/src/providers/clickup/executors.ts
@@ -11,8 +11,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -64,7 +65,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/clickup/runtime.ts
+++ b/src/providers/clickup/runtime.ts
@@ -9,7 +9,7 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface ClickupActionContext {
   authType: "api_key" | "oauth2";
@@ -69,7 +69,7 @@ export async function validateClickupCredential(
 export async function fetchClickupCurrentAccount(
   accessToken: string,
   authType: "api_key" | "oauth2",
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   mode: ClickupRequestMode = "execute",
   signal?: AbortSignal,
 ): Promise<{ accountId: string; displayName: string; metadata: Record<string, unknown> }> {

--- a/src/providers/cloudflare_r2/executors.ts
+++ b/src/providers/cloudflare_r2/executors.ts
@@ -9,6 +9,7 @@ import type { CloudflareR2Context } from "./runtime.ts";
 
 import { optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -26,10 +27,12 @@ import {
 } from "./runtime.ts";
 
 const service = "cloudflare_r2";
+const cloudflareR2Fetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<CloudflareR2Context>({
   service,
   handlers: cloudflareR2ActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<CloudflareR2Context> {
     const credential = await context.getCredential(service);
     if (credential?.authType === "custom_credential") {
@@ -94,7 +97,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await cloudflareR2Fetch(url, init);
     if (!response.ok) {
       throw new ProviderRequestError(
         response.status,

--- a/src/providers/cloudinary/executors.ts
+++ b/src/providers/cloudinary/executors.ts
@@ -11,11 +11,12 @@ import type { CloudinaryContext } from "./runtime.ts";
 import { Buffer } from "node:buffer";
 import { requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -24,10 +25,12 @@ import { cloudinaryActionHandlers, validateCloudinaryCredential } from "./runtim
 
 const service = "cloudinary";
 const cloudinaryApiBaseUrl = "https://api.cloudinary.com/v1_1";
+const cloudinaryFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<CloudinaryContext>({
   service,
   handlers: cloudinaryActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<CloudinaryContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "api_key") {
@@ -76,7 +79,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     headers.set("authorization", `Basic ${Buffer.from(`${credential.apiKey}:${apiSecret}`).toString("base64")}`);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await cloudinaryFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/coinbase/executors.ts
+++ b/src/providers/coinbase/executors.ts
@@ -11,6 +11,7 @@ import { createPrivateKey, createSign, randomBytes } from "node:crypto";
 import { optionalInteger, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -25,6 +26,7 @@ import {
 const service = "coinbase";
 const coinbaseApiBaseUrl = "https://api.coinbase.com";
 const accountsPath = "/api/v3/brokerage/accounts";
+const coinbaseFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CoinbaseRequestPhase = "validate" | "execute";
 type CoinbaseJwtBuilder = (input: { method: string; path: string }) => string;
@@ -54,6 +56,7 @@ export const coinbaseActionHandlers: Record<string, CoinbaseActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<CoinbaseActionContext>({
   service,
   handlers: coinbaseActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<CoinbaseActionContext> {
     return createCoinbaseContext(context, fetcher);
   },
@@ -85,7 +88,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await coinbaseFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Coinbase request failed with HTTP ${response.status}`);

--- a/src/providers/confluence/executors.ts
+++ b/src/providers/confluence/executors.ts
@@ -12,8 +12,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -57,7 +58,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/contentstack_content_delivery/executors.ts
+++ b/src/providers/contentstack_content_delivery/executors.ts
@@ -8,11 +8,12 @@ import type {
 
 import { optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -22,10 +23,12 @@ import { contentstackContentDeliveryActionHandlers, validateContentstackContentD
 
 const service = "contentstack_content_delivery";
 const contentstackContentDeliveryApiBaseUrl = "https://cdn.contentstack.io/v3";
+const contentstackContentDeliveryFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: contentstackContentDeliveryActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -58,7 +61,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await contentstackContentDeliveryFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/contentstack_content_management/executors.ts
+++ b/src/providers/contentstack_content_management/executors.ts
@@ -8,11 +8,12 @@ import type {
 
 import { optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -25,10 +26,12 @@ import {
 
 const service = "contentstack_content_management";
 const contentstackContentManagementApiBaseUrl = "https://api.contentstack.io/v3";
+const contentstackContentManagementFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: contentstackContentManagementActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -61,7 +64,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await contentstackContentManagementFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/crisp/executors.ts
+++ b/src/providers/crisp/executors.ts
@@ -19,11 +19,12 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -32,6 +33,7 @@ import {
 
 const service = "crisp";
 const crispApiBaseUrl = "https://api.crisp.chat/v1";
+const crispFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CrispRequestPhase = "validate" | "execute";
 type CrispTokenTier = "website" | "plugin";
@@ -107,6 +109,7 @@ export const crispActionHandlers: Record<CrispActionName, CrispActionHandler> = 
 export const executors: ProviderExecutors = defineProviderExecutors<CrispContext>({
   service,
   handlers: crispActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<CrispContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -137,7 +140,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await crispFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/cronitor/executors.ts
+++ b/src/providers/cronitor/executors.ts
@@ -10,13 +10,14 @@ import type { CronitorActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineApiKeyProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -27,6 +28,8 @@ const service = "cronitor";
 const cronitorApiBaseUrl = "https://cronitor.io/api";
 const cronitorApiVersion = "2025-11-28";
 const cronitorDefaultRequestTimeoutMs = 30_000;
+
+const cronitorFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CronitorPhase = "validate" | "execute";
 type CronitorMethod = "GET" | "POST" | "DELETE";
@@ -83,7 +86,9 @@ export const cronitorActionHandlers: Record<CronitorActionName, CronitorActionHa
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cronitorActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cronitorActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -97,7 +102,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await cronitorFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/cursor/executors.ts
+++ b/src/providers/cursor/executors.ts
@@ -5,7 +5,9 @@ import { cursorActionHandlers, validateCursorCredential } from "./runtime.ts";
 
 const service = "cursor";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cursorActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, cursorActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {

--- a/src/providers/cursor/runtime.ts
+++ b/src/providers/cursor/runtime.ts
@@ -4,7 +4,7 @@ import type { CursorActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 type CursorActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -93,7 +93,7 @@ export const cursorActionHandlers: Record<CursorActionName, CursorActionHandler>
 
 export async function validateCursorCredential(
   apiKey: string,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   signal?: AbortSignal,
 ): Promise<{
   profile: { accountId: string; displayName: string };

--- a/src/providers/customerio/executors.ts
+++ b/src/providers/customerio/executors.ts
@@ -12,8 +12,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -41,7 +42,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const credential = await requireCustomCredential(context, service);
     const customerioContext = resolveCustomerioCredentialContext(
       credential.values,
-      fetch,
+      providerFetch,
       context.signal,
       credential.metadata,
     );
@@ -56,7 +57,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/datadog/executors.ts
+++ b/src/providers/datadog/executors.ts
@@ -12,8 +12,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -198,7 +199,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await providerFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/dataforseo/executors.ts
+++ b/src/providers/dataforseo/executors.ts
@@ -9,11 +9,12 @@ import type {
 import { Buffer } from "node:buffer";
 import { optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -23,6 +24,8 @@ import { dataForSeoActionHandlers, dataForSeoApiBaseUrl, requestDataForSeoUserDa
 
 const service = "dataforseo";
 
+const dataForSeoFetch = createProviderFetch({ skipDnsValidation: true });
+
 interface DataForSeoContext {
   login: string;
   password: string;
@@ -31,6 +34,7 @@ interface DataForSeoContext {
 
 export const executors: ProviderExecutors = defineProviderExecutors<DataForSeoContext>({
   service,
+  skipDnsValidation: true,
   handlers: dataForSeoActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<DataForSeoContext> {
     const credential = await requireCustomCredential(context, service);
@@ -63,7 +67,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await dataForSeoFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/dingtalk_bot/executors.ts
+++ b/src/providers/dingtalk_bot/executors.ts
@@ -10,13 +10,14 @@ import type { DingtalkBotActionName } from "./actions.ts";
 import { createHash, createHmac } from "node:crypto";
 import { compactObject, objectArray, optionalNumber, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
+  createProviderFetch,
   createProviderProxyUrl,
+  createProviderTimeout,
   defineProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -29,6 +30,8 @@ const webhookPath = "/robot/send";
 const requestTimeoutMs = 30_000;
 const validationProbePayload = { msgtype: "__validation_probe__" };
 const validationSuccessCodes = new Set([40035, 400105]);
+
+const dingtalkBotFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface DingtalkBotContext {
   apiKey: string;
@@ -114,6 +117,7 @@ export const dingtalkBotActionHandlers: Record<DingtalkBotActionName, DingtalkBo
 
 export const executors: ProviderExecutors = defineProviderExecutors<DingtalkBotContext>({
   service,
+  skipDnsValidation: true,
   handlers: dingtalkBotActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<DingtalkBotContext> {
     const credential = await requireApiKeyCredential(context, service);
@@ -144,7 +148,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await dingtalkBotFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/discourse/executors.ts
+++ b/src/providers/discourse/executors.ts
@@ -10,10 +10,11 @@ import type { DiscourseActionName } from "./actions.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
-  createProviderTimeout,
+  createProviderFetch,
   createProviderProxyUrl,
+  createProviderTimeout,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
@@ -25,6 +26,8 @@ import {
 } from "../provider-runtime.ts";
 
 export const discourseDefaultRequestTimeoutMs = 30_000;
+
+const discourseProxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 type DiscourseHttpMethod = "GET" | "POST";
 type DiscoursePhase = "validate" | "execute";
@@ -203,6 +206,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<DiscourseAct
       signal: context.signal,
     };
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
@@ -225,7 +229,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await discourseProxyFetch(url, {
       method: input.method,
       headers,
       body:
@@ -244,12 +248,16 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
+    // Re-guard the shared validator fetcher with Discourse's private-network
+    // opt-in so validating a private baseUrl works when the deployment allows
+    // it (createProviderFetch unwraps an already-guarded fetcher).
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     return validateDiscourseCredential(
       {
         ...input.values,
         apiKey: input.apiKey,
       },
-      fetcher,
+      guardedFetcher,
       signal,
     );
   },
@@ -292,7 +300,20 @@ async function validateDiscourseCredential(
   };
 }
 
-export function normalizeDiscourseBaseUrl(value: unknown): string {
+/**
+ * Validates a Discourse instance URL, rejects embedded credentials and unsafe
+ * targets, and returns its origin.
+ *
+ * Private/overlay-network targets (RFC 1918, Tailscale, NetBird, private
+ * hostnames) are only accepted when the deployment opts in through
+ * `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`; otherwise the shared public-only SSRF
+ * guard applies. https is always required regardless of the opt-in.
+ * `allowPrivateNetwork` may be passed explicitly (used by tests).
+ */
+export function normalizeDiscourseBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   if (typeof value !== "string" || !value.trim()) {
     throw new ProviderRequestError(400, "baseUrl is required");
   }
@@ -302,6 +323,7 @@ export function normalizeDiscourseBaseUrl(value: unknown): string {
     url = assertPublicHttpUrl(value.trim(), {
       fieldName: "baseUrl",
       createError: (message) => new ProviderRequestError(400, message),
+      allowPrivateNetwork,
     });
   } catch (error) {
     if (error instanceof ProviderRequestError) {

--- a/src/providers/docker_hub/executors.ts
+++ b/src/providers/docker_hub/executors.ts
@@ -7,11 +7,12 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -22,8 +23,11 @@ import { createDockerHubActionContext, dockerHubActionHandlers, validateDockerHu
 const service = "docker_hub";
 const dockerHubApiBaseUrl = "https://hub.docker.com";
 
+const dockerHubFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
+  skipDnsValidation: true,
   handlers: dockerHubActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
@@ -34,7 +38,7 @@ export const executors: ProviderExecutors = defineProviderExecutors({
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
     const credential = await requireApiKeyCredential(context, service);
-    const dockerHubContext = await createDockerHubActionContext(credential.apiKey, fetch, context.signal);
+    const dockerHubContext = await createDockerHubActionContext(credential.apiKey, dockerHubFetch, context.signal);
     const url = createProviderProxyUrl(dockerHubApiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("authorization", `Bearer ${dockerHubContext.bearerToken}`);
@@ -43,7 +47,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await dockerHubFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/docmosis/executors.ts
+++ b/src/providers/docmosis/executors.ts
@@ -12,8 +12,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -61,7 +62,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/docsbot_ai/executors.ts
+++ b/src/providers/docsbot_ai/executors.ts
@@ -6,12 +6,13 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -26,7 +27,11 @@ import {
 
 const service = "docsbot_ai";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, docsbotAiActionHandlers);
+const docsbotAiFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, docsbotAiActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -40,7 +45,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await docsbotAiFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/dokploy/egress-guard.test.ts
+++ b/src/providers/dokploy/egress-guard.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { credentialValidators } from "./executors.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setPrivateNetworkAccessAllowed(false);
+});
+
+function stubFetchSequence(responses: Response[]): Array<{ url: string }> {
+  const calls: Array<{ url: string }> = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    calls.push({ url: input instanceof Request ? input.url : String(input) });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected extra request");
+    }
+    return response;
+  });
+  return calls;
+}
+
+describe("Dokploy validator egress guard", () => {
+  it("rejects a public baseUrl that redirects validation to a metadata target", async () => {
+    const calls = stubFetchSequence([
+      new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } }),
+    ]);
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "key", values: { baseUrl: "https://dokploy.example.com" } },
+        { fetcher: fetch },
+      ),
+    ).rejects.toThrow(/redirect location/u);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("still reaches a private baseUrl when the deployment allows private networks", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    const calls = stubFetchSequence([
+      new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } }),
+    ]);
+
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "key", values: { baseUrl: "http://10.0.0.5:3000" } },
+      { fetcher: fetch },
+    );
+
+    expect(result).toBeTruthy();
+    expect(calls[0]?.url).toContain("http://10.0.0.5:3000/api/project.search");
+  });
+});

--- a/src/providers/dokploy/executors.ts
+++ b/src/providers/dokploy/executors.ts
@@ -8,7 +8,9 @@ import type {
 import type { DokployActionContext } from "./runtime.ts";
 
 import { optionalString } from "../../core/cast.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   defineProviderExecutors,
   defineProviderProxy,
   ProviderRequestError,
@@ -31,6 +33,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<DokployActio
     return createDokployContext(credential.values, credential.apiKey, fetcher, context.signal, context.transitFiles);
   },
   fallbackMessage: "Dokploy request failed",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
@@ -52,10 +55,15 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
       headers.set("accept", "application/json");
     }
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    return validateDokployCredential(input.values, input.apiKey, fetcher, signal);
+    // Re-guard the shared validator fetcher with Dokploy's private-network
+    // opt-in so validating a private baseUrl works when the deployment allows
+    // it (createProviderFetch unwraps an already-guarded fetcher).
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateDokployCredential(input.values, input.apiKey, guardedFetcher, signal);
   },
 };

--- a/src/providers/dropbox/executors.ts
+++ b/src/providers/dropbox/executors.ts
@@ -9,6 +9,7 @@ import {
   requiredRecord,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineOAuthProviderExecutors,
   normalizeProviderProxyEndpoint,
@@ -22,6 +23,7 @@ import {
 
 const dropboxApiBaseUrl = "https://api.dropboxapi.com/2";
 const dropboxContentBaseUrl = "https://content.dropboxapi.com/2";
+const dropboxFetch = createProviderFetch({ skipDnsValidation: true });
 const dropboxMaxSimpleUploadBytes = 150 * 1024 * 1024;
 const dropboxContentEndpointPrefixes = [
   "/files/download",
@@ -123,7 +125,9 @@ export const dropboxActionHandlers: Record<string, ActionHandler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineOAuthProviderExecutors("dropbox", dropboxActionHandlers);
+export const executors: ProviderExecutors = defineOAuthProviderExecutors("dropbox", dropboxActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -146,7 +150,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await dropboxFetch(url, init);
     if (!response.ok) {
       throw await normalizeDropboxHttpError(response, "Dropbox request failed");
     }

--- a/src/providers/elasticsearch/executors.ts
+++ b/src/providers/elasticsearch/executors.ts
@@ -9,8 +9,9 @@ import type { ElasticsearchActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -23,6 +24,7 @@ import {
 } from "../provider-runtime.ts";
 import { elasticsearchExpandWildcardValues } from "./actions.ts";
 
+const elasticsearchFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 const elasticsearchUserAgent = providerUserAgent;
 const elasticsearchIndexInfoColumns = [
   "health",
@@ -86,6 +88,7 @@ export const elasticsearchActionHandlers: Record<ElasticsearchActionName, Elasti
 export const executors: ProviderExecutors = defineProviderExecutors<ElasticsearchActionContext>({
   service: "elasticsearch",
   handlers: elasticsearchActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ElasticsearchActionContext> {
     const credential = await context.getCredential("elasticsearch");
     if (credential?.authType === "api_key") {
@@ -146,7 +149,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await elasticsearchFetch(url, init);
     if (!response.ok) {
       throw new ProviderRequestError(response.status, await readElasticsearchError(response));
     }
@@ -162,13 +165,14 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     const baseUrl = normalizeElasticsearchBaseUrl(input.values.baseUrl);
     const { payload } = await elasticsearchRequest<Record<string, unknown>>({
       baseUrl,
       authorization: buildApiKeyAuthHeader(requireElasticsearchField(input.apiKey, "apiKey")),
       method: "GET",
       path: "/_security/_authenticate",
-      fetcher,
+      fetcher: guardedFetcher,
       signal,
       phase: "validate",
     });
@@ -195,6 +199,7 @@ export const credentialValidators: CredentialValidators = {
     };
   },
   async customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     const baseUrl = normalizeElasticsearchBaseUrl(input.values.baseUrl);
     const username = requireElasticsearchField(input.values.username, "username");
     const password = requireElasticsearchField(input.values.password, "password");
@@ -203,7 +208,7 @@ export const credentialValidators: CredentialValidators = {
       authorization: buildBasicAuthHeader(username, password),
       method: "GET",
       path: "/_security/_authenticate",
-      fetcher,
+      fetcher: guardedFetcher,
       signal,
       phase: "validate",
     });
@@ -514,7 +519,7 @@ function buildElasticsearchUrl(
   return url;
 }
 
-function normalizeElasticsearchBaseUrl(value: unknown) {
+function normalizeElasticsearchBaseUrl(value: unknown, allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed()) {
   const trimmed = optionalString(value);
   if (!trimmed) {
     throw new ProviderRequestError(400, "baseUrl is required");
@@ -524,6 +529,7 @@ function normalizeElasticsearchBaseUrl(value: unknown) {
   try {
     parsed = assertPublicHttpUrl(trimmed, {
       fieldName: "baseUrl",
+      allowPrivateNetwork,
       createError: (message) => new ProviderRequestError(400, message),
     });
   } catch (error) {

--- a/src/providers/erpnext/executors.ts
+++ b/src/providers/erpnext/executors.ts
@@ -7,13 +7,14 @@ import type {
 } from "../../core/types.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -21,6 +22,7 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "erpnext";
+const proxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 const erpnextLoggedUserMethod = "frappe.auth.get_logged_user";
 const erpnextGetCountMethod = "frappe.client.get_count";
 const erpnextGetValueMethod = "frappe.client.get_value";
@@ -203,6 +205,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<ErpnextActio
       signal: context.signal,
     };
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
@@ -220,7 +223,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await proxyFetch(url, {
       method: input.method,
       headers,
       body:
@@ -239,6 +242,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     const baseUrl = normalizeBaseUrl(input.values.baseUrl);
     const apiSecret = readRequiredString(input.values.apiSecret, "apiSecret");
     const payload = await requestErpnext({
@@ -247,7 +251,7 @@ export const credentialValidators: CredentialValidators = {
       apiSecret,
       path: buildMethodPath(erpnextLoggedUserMethod),
       method: "GET",
-      fetcher,
+      fetcher: guardedFetcher,
       signal,
       phase: "validate",
     });
@@ -294,7 +298,7 @@ async function requestErpnext(input: ErpnextRequestOptions): Promise<unknown> {
   return payload;
 }
 
-function normalizeBaseUrl(value: unknown): string {
+function normalizeBaseUrl(value: unknown, allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed()): string {
   const raw = optionalString(value);
   if (!raw) {
     throw new ProviderRequestError(400, "baseUrl is required");
@@ -302,6 +306,7 @@ function normalizeBaseUrl(value: unknown): string {
 
   const url = assertPublicHttpUrl(raw, {
     fieldName: "baseUrl",
+    allowPrivateNetwork,
     createError: (message) => new ProviderRequestError(400, message),
   });
 

--- a/src/providers/expofp/executors.ts
+++ b/src/providers/expofp/executors.ts
@@ -7,11 +7,12 @@ import type {
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -21,7 +22,11 @@ import { expofpActionHandlers, expofpApiBaseUrl, validateExpofpCredential } from
 
 const service = "expofp";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, expofpActionHandlers);
+const expofpFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, expofpActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -43,7 +48,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await expofpFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/feishu_app_bot/executors.ts
+++ b/src/providers/feishu_app_bot/executors.ts
@@ -14,8 +14,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -164,7 +165,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     const credential = await requireCustomCredential(context, service);
     const accessToken = await fetchTenantAccessToken(
       readFeishuAppBotCredential(credential.values),
-      fetch,
+      providerFetch,
       "execute",
       context.signal,
     );
@@ -187,7 +188,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
         }
       }
 
-      const response = await fetch(url, init);
+      const response = await providerFetch(url, init);
       if (!response.ok) {
         const rawText = await readProviderProxyErrorMessage(response, "");
         let envelope: FeishuApiEnvelope<unknown>;

--- a/src/providers/feishu_custom_bot/executors.ts
+++ b/src/providers/feishu_custom_bot/executors.ts
@@ -10,11 +10,12 @@ import { Buffer } from "node:buffer";
 import { createHash, createHmac } from "node:crypto";
 import { compactObject, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -27,6 +28,8 @@ const feishuCustomBotWebhookPathPrefix = "/open-apis/bot/v2/hook/";
 const feishuCustomBotAllowedWebhookHosts = new Set([new URL(feishuCustomBotApiBaseUrl).host]);
 const feishuCustomBotMaxPayloadBytes = 20 * 1024;
 const feishuCustomBotRequestTimeoutMs = 30_000;
+
+const feishuCustomBotFetch = createProviderFetch({ skipDnsValidation: true });
 const feishuCustomBotProbeBadRequestCode = 9499;
 const feishuCustomBotKeywordNotFoundCode = 19024;
 const feishuCustomBotProbePayload = {
@@ -134,6 +137,7 @@ export const feishuCustomBotActionHandlers: Record<FeishuCustomBotActionName, Fe
 
 export const executors: ProviderExecutors = defineProviderExecutors<FeishuCustomBotActionContext>({
   service,
+  skipDnsValidation: true,
   handlers: feishuCustomBotActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<FeishuCustomBotActionContext> {
     const credential = await requireApiKeyCredential(context, service);
@@ -181,7 +185,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
     const requestSignal = createFeishuCustomBotRequestSignal(context.signal);
     try {
-      const response = await fetch(webhook, {
+      const response = await feishuCustomBotFetch(webhook, {
         method: "POST",
         headers,
         body: requestBody,

--- a/src/providers/figma/executors.ts
+++ b/src/providers/figma/executors.ts
@@ -17,11 +17,12 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -30,6 +31,8 @@ import { figmaProviderScopes } from "./scopes.ts";
 
 const service = "figma";
 const figmaApiBaseUrl = "https://api.figma.com";
+
+const figmaFetch = createProviderFetch({ skipDnsValidation: true });
 
 type FigmaRequestPhase = "validate" | "execute";
 
@@ -144,6 +147,7 @@ export const figmaActionHandlers: Record<FigmaActionName, FigmaActionHandler> = 
 
 export const executors: ProviderExecutors = defineProviderExecutors<FigmaActionContext>({
   service,
+  skipDnsValidation: true,
   handlers: figmaActionHandlers,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<FigmaActionContext> {
     const credential = await context.getCredential(service);
@@ -183,7 +187,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await figmaFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/fivetran/executors.ts
+++ b/src/providers/fivetran/executors.ts
@@ -10,11 +10,12 @@ import type { FivetranContext } from "./runtime.ts";
 import { Buffer } from "node:buffer";
 import { requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -23,6 +24,7 @@ import {
 import { fivetranActionHandlers, fivetranApiBaseUrl, validateFivetranCredential } from "./runtime.ts";
 
 const service = "fivetran";
+const fivetranFetch = createProviderFetch({ skipDnsValidation: true });
 
 function readCredentialField(values: Record<string, string>, field: string): string {
   return requiredString(values[field], field, (message) => new ProviderRequestError(400, message));
@@ -31,6 +33,7 @@ function readCredentialField(values: Record<string, string>, field: string): str
 export const executors: ProviderExecutors = defineProviderExecutors<FivetranContext>({
   service,
   handlers: fivetranActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<FivetranContext> {
     const credential = await requireCustomCredential(context, service);
     return {
@@ -67,7 +70,7 @@ export const proxy: ProviderProxyExecutor = async (input, context: ExecutionCont
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await fivetranFetch(url, init);
     if (!response.ok) {
       throw new ProviderRequestError(
         response.status,

--- a/src/providers/flomo/executors.ts
+++ b/src/providers/flomo/executors.ts
@@ -17,8 +17,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   toProviderProxyError,
 } from "../provider-runtime.ts";
@@ -303,7 +304,7 @@ async function requestFlomoProxy(
   init.signal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   try {
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await response.text().catch(() => "");
       throw new ProviderRequestError(

--- a/src/providers/fraudlabspro/executors.ts
+++ b/src/providers/fraudlabspro/executors.ts
@@ -4,11 +4,12 @@ import type { FraudlabsproActionName } from "./actions.ts";
 
 import { optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   requireApiKeyCredential,
   toProviderProxyError,
@@ -16,6 +17,7 @@ import {
 
 const service = "fraudlabspro";
 const fraudlabsproApiBaseUrl = "https://api.fraudlabspro.com/v2";
+const fraudlabsproFetch = createProviderFetch({ skipDnsValidation: true });
 
 type FraudlabsproRequestMethod = "GET" | "POST";
 type FraudlabsproRequestValue = string | number | undefined;
@@ -83,7 +85,9 @@ export const fraudlabsproActionHandlers: Record<FraudlabsproActionName, Fraudlab
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, fraudlabsproActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, fraudlabsproActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -116,7 +120,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       });
     }
 
-    const response = await fetch(url, init);
+    const response = await fraudlabsproFetch(url, init);
     if (!response.ok) {
       throw buildFraudlabsproError(response.status, await readFraudlabsproPayload(response), "execute");
     }

--- a/src/providers/fuxin/executors.ts
+++ b/src/providers/fuxin/executors.ts
@@ -26,8 +26,9 @@ import {
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
   normalizeProviderProxyQuery,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   requireCustomCredential,
   toProviderProxyError,
@@ -207,7 +208,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const payload = await readFuxinPayload(response);
       throw normalizeFuxinError(response, payload, "execute");

--- a/src/providers/getnote/executors.ts
+++ b/src/providers/getnote/executors.ts
@@ -8,6 +8,7 @@ const service = "getnote";
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: getnoteActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     const clientId = readGetnoteClientId({

--- a/src/providers/getnote/runtime.ts
+++ b/src/providers/getnote/runtime.ts
@@ -9,7 +9,7 @@ import {
   optionalString,
   requiredRecord,
 } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const getnoteBaseUrl = "https://openapi.biji.com";
 const getnoteRequestTimeoutMs = 30_000;
@@ -42,7 +42,7 @@ export async function validateGetnoteCredential(
     apiKey: string;
     values?: Record<string, string>;
   },
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const apiKey = readGetnoteApiKey(input.apiKey);

--- a/src/providers/gong/executors.ts
+++ b/src/providers/gong/executors.ts
@@ -7,12 +7,14 @@ import type {
 import type { GongContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -22,9 +24,12 @@ import { gongActionHandlers, resolveGongCredentialContext, validateGongCredentia
 
 const service = "gong";
 
+const gongFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors<GongContext>({
   service,
   handlers: gongActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<GongContext> {
     const credential = await requireCustomCredential(context, service);
     return resolveGongCredentialContext(credential.values, fetcher, context.signal);
@@ -35,7 +40,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<GongContext>
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
     const credential = await requireCustomCredential(context, service);
-    const gongContext = resolveGongCredentialContext(credential.values, fetch, context.signal);
+    const gongContext = resolveGongCredentialContext(credential.values, gongFetch, context.signal);
     const url = createProviderProxyUrl(gongContext.apiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set(
@@ -56,7 +61,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await gongFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Gong request failed with HTTP ${response.status}`);
@@ -70,6 +75,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   customCredential(input, { fetcher, signal }) {
-    return validateGongCredential(input.values, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateGongCredential(input.values, guardedFetcher, signal);
   },
 };

--- a/src/providers/gorgias/executors.ts
+++ b/src/providers/gorgias/executors.ts
@@ -5,8 +5,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -58,7 +59,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Gorgias request failed with HTTP ${response.status}`);

--- a/src/providers/guru/executors.ts
+++ b/src/providers/guru/executors.ts
@@ -11,11 +11,12 @@ import { Buffer } from "node:buffer";
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { jsonObject } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   requireApiKeyCredential,
   toProviderProxyError,
@@ -23,6 +24,7 @@ import {
 
 const service = "guru";
 const guruApiBaseUrl = "https://api.getguru.com";
+const guruFetch = createProviderFetch({ skipDnsValidation: true });
 const guruValidationPath = "/api/v1/whoami";
 
 type GuruRequestPhase = "validate" | "execute";
@@ -80,6 +82,7 @@ export const guruActionHandlers: Record<GuruActionName, GuruActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<GuruActionContext>({
   service,
   handlers: guruActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<GuruActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -114,7 +117,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await guruFetch(url, init);
     if (!response.ok) {
       const payload = await readGuruPayload(response);
       throw createGuruError(response, payload, "execute");

--- a/src/providers/habitica/executors.ts
+++ b/src/providers/habitica/executors.ts
@@ -14,17 +14,19 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   requireApiKeyCredential,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "habitica";
 const habiticaApiBaseUrl = "https://habitica.com/api/v3";
+const habiticaFetch = createProviderFetch({ skipDnsValidation: true });
 const habiticaDefaultRequestTimeoutMs = 30_000;
 
 type HabiticaRequestPhase = "validate" | "execute";
@@ -100,6 +102,7 @@ export const habiticaActionHandlers: Record<HabiticaActionName, HabiticaActionHa
 export const executors: ProviderExecutors = defineProviderExecutors<HabiticaActionContext>({
   service,
   handlers: habiticaActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HabiticaActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -135,7 +138,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
     }
 
-    const response = await fetch(url, init);
+    const response = await habiticaFetch(url, init);
     const payload = await readHabiticaPayload(response);
     if (!response.ok) {
       throw createHabiticaError(response.status, payload, "execute");

--- a/src/providers/harvest/executors.ts
+++ b/src/providers/harvest/executors.ts
@@ -9,11 +9,12 @@ import type { HarvestActionName } from "./actions.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -23,6 +24,7 @@ import { harvestOAuthScopes } from "./scopes.ts";
 const service = "harvest";
 const harvestApiBaseUrl = "https://api.harvestapp.com";
 const harvestAccountsUrl = "https://id.getharvest.com/api/v2/accounts";
+const harvestFetch = createProviderFetch({ skipDnsValidation: true });
 const harvestValidationPath = "/v2/users/me";
 const harvestRequestTimeoutMs = 30_000;
 
@@ -116,6 +118,7 @@ export const harvestActionHandlers: Record<HarvestActionName, HarvestActionHandl
 export const executors: ProviderExecutors = defineProviderExecutors<HarvestActionContext>({
   service,
   handlers: harvestActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HarvestActionContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType === "api_key") {
@@ -161,7 +164,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await harvestFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw createHarvestError(response.status, parseHarvestPayload(text), text);

--- a/src/providers/higgsfield_ai/executors.ts
+++ b/src/providers/higgsfield_ai/executors.ts
@@ -2,11 +2,12 @@ import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } f
 import type { HiggsfieldAiContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -20,10 +21,12 @@ import {
 } from "./runtime.ts";
 
 const service = "higgsfield_ai";
+const higgsfieldAiFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<HiggsfieldAiContext>({
   service,
   handlers: higgsfieldAiActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<HiggsfieldAiContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -55,7 +58,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await higgsfieldAiFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(

--- a/src/providers/htmlcsstoimage/executors.ts
+++ b/src/providers/htmlcsstoimage/executors.ts
@@ -8,11 +8,12 @@ import type { HtmlCssToImageActionContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -26,10 +27,12 @@ import {
 } from "./runtime.ts";
 
 const service = "htmlcsstoimage";
+const htmlCssToImageFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<HtmlCssToImageActionContext>({
   service,
   handlers: htmlCssToImageActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HtmlCssToImageActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -70,7 +73,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await htmlCssToImageFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(

--- a/src/providers/ima/executors.ts
+++ b/src/providers/ima/executors.ts
@@ -10,8 +10,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -71,7 +72,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `IMA request failed with HTTP ${response.status}`);

--- a/src/providers/ipinfo_io/executors.ts
+++ b/src/providers/ipinfo_io/executors.ts
@@ -11,18 +11,20 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   requireApiKeyCredential,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "ipinfo_io";
+const ipinfoIoFetch = createProviderFetch({ skipDnsValidation: true });
 const ipinfoLegacyBaseUrl = "https://ipinfo.io";
 const ipinfoLiteBaseUrl = "https://api.ipinfo.io/lite";
 const ipinfoLookupBaseUrl = "https://api.ipinfo.io/lookup";
@@ -133,7 +135,9 @@ export const ipinfoIoActionHandlers: Record<IpinfoIoActionName, IpinfoIoActionHa
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, ipinfoIoActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, ipinfoIoActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -161,7 +165,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await ipinfoIoFetch(url, init);
     if (!response.ok) {
       throw createIpinfoError(response, await readIpinfoPayload(response, true), "execute");
     }

--- a/src/providers/ipqualityscore/executors.ts
+++ b/src/providers/ipqualityscore/executors.ts
@@ -5,12 +5,13 @@ import type { IpqualityscoreActionName } from "./actions.ts";
 import { isIP } from "node:net";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyResponse,
   requireApiKeyCredential,
   toProviderProxyError,
@@ -18,6 +19,7 @@ import {
 
 const service = "ipqualityscore";
 const ipqualityscoreApiBaseUrl = "https://www.ipqualityscore.com";
+const ipqualityscoreFetch = createProviderFetch({ skipDnsValidation: true });
 
 type IpqualityscoreRequestPhase = "validate" | "execute";
 type IpqualityscoreFamily = "email" | "ip" | "phone" | "url";
@@ -87,7 +89,9 @@ export const ipqualityscoreActionHandlers: Record<IpqualityscoreActionName, Ipqu
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, ipqualityscoreActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, ipqualityscoreActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -111,7 +115,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await ipqualityscoreFetch(url, {
       method: "GET",
       headers,
       signal: context.signal,

--- a/src/providers/jimeng_ai/executors.ts
+++ b/src/providers/jimeng_ai/executors.ts
@@ -10,13 +10,14 @@ import type { JimengAiActionName } from "./actions.ts";
 import { createHash, createHmac } from "node:crypto";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
   normalizeProviderProxyQuery,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -24,6 +25,7 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "jimeng_ai";
+const jimengAiFetch = createProviderFetch({ skipDnsValidation: true });
 const jimengApiHost = "visual.volcengineapi.com";
 const jimengApiOrigin = `https://${jimengApiHost}`;
 const jimengRegion = "cn-north-1";
@@ -164,6 +166,7 @@ export const jimengAiActionHandlers: Record<JimengAiActionName, JimengActionHand
 export const executors: ProviderExecutors = defineProviderExecutors<JimengActionContext>({
   service,
   handlers: jimengAiActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<JimengActionContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {
@@ -207,7 +210,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       init.body = body;
     }
 
-    const response = await fetch(url, init);
+    const response = await jimengAiFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Jimeng AI request failed with HTTP ${response.status}`);

--- a/src/providers/jumpcloud/executors.ts
+++ b/src/providers/jumpcloud/executors.ts
@@ -11,8 +11,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -108,7 +109,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `JumpCloud request failed with HTTP ${response.status}`);

--- a/src/providers/kaggle/executors.ts
+++ b/src/providers/kaggle/executors.ts
@@ -11,11 +11,12 @@ import type { KaggleActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -25,6 +26,7 @@ import {
 const service = "kaggle";
 const kaggleApiBaseUrl = "https://www.kaggle.com/api/v1";
 const kaggleValidationPath = "/competitions/list";
+const kaggleFetch = createProviderFetch({ skipDnsValidation: true });
 
 type KaggleRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | undefined;
@@ -67,6 +69,7 @@ const kaggleActionHandlers: Record<KaggleActionName, KaggleActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<KaggleContext>({
   service,
   handlers: kaggleActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<KaggleContext> {
     const credential = await requireApiKeyCredential(context, service);
     const kaggleContext: KaggleContext = {
@@ -94,7 +97,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await kaggleFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/klaviyo/executors.ts
+++ b/src/providers/klaviyo/executors.ts
@@ -9,11 +9,12 @@ import type { KlaviyoActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -24,6 +25,7 @@ const service = "klaviyo";
 const klaviyoApiBaseUrl = "https://a.klaviyo.com";
 const klaviyoApiRevision = "2026-04-15";
 const accountValidationPath = "/api/accounts/";
+const klaviyoFetch = createProviderFetch({ skipDnsValidation: true });
 
 type KlaviyoActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -51,7 +53,9 @@ export const klaviyoActionHandlers: Record<KlaviyoActionName, KlaviyoActionHandl
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, klaviyoActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, klaviyoActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -75,7 +79,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await klaviyoFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Klaviyo request failed with HTTP ${response.status}`);

--- a/src/providers/leexi/executors.ts
+++ b/src/providers/leexi/executors.ts
@@ -19,13 +19,14 @@ import {
   optionalStringOrNull,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -37,6 +38,7 @@ const leexiApiBaseUrl = "https://public-api.leexi.ai/v1";
 const leexiRequestBaseUrl = "https://public-api.leexi.ai/v1/";
 const leexiValidationPath = "/users";
 const leexiDefaultTimeoutMs = 30_000;
+const leexiFetch = createProviderFetch({ skipDnsValidation: true });
 
 type LeexiRequestPhase = "validate" | "execute";
 type LeexiActionHandler = (input: Record<string, unknown>, context: LeexiActionContext) => Promise<unknown>;
@@ -72,6 +74,7 @@ export const leexiActionHandlers: Record<LeexiActionName, LeexiActionHandler> = 
 export const executors: ProviderExecutors = defineProviderExecutors<LeexiActionContext>({
   service,
   handlers: leexiActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<LeexiActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -104,7 +107,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await leexiFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Leexi request failed with HTTP ${response.status}`);

--- a/src/providers/lemlist/executors.ts
+++ b/src/providers/lemlist/executors.ts
@@ -10,13 +10,14 @@ import type { LemlistActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineApiKeyProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -27,6 +28,7 @@ const service = "lemlist";
 const lemlistApiBaseUrl = "https://api.lemlist.com/api";
 const lemlistValidationPath = "/team";
 const lemlistDefaultRequestTimeoutMs = 30_000;
+const lemlistFetch = createProviderFetch({ skipDnsValidation: true });
 
 type LemlistRequestPhase = "validate" | "execute";
 type LemlistActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -102,7 +104,9 @@ export const lemlistActionHandlers: Record<LemlistActionName, LemlistActionHandl
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, lemlistActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, lemlistActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -124,7 +128,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await lemlistFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `lemlist request failed with HTTP ${response.status}`);

--- a/src/providers/linear/executors.ts
+++ b/src/providers/linear/executors.ts
@@ -8,10 +8,11 @@ import type { LinearActionName } from "./actions.ts";
 
 import { compactObject } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
-  ProviderRequestError,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
+  ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
@@ -20,6 +21,7 @@ import {
 
 const linearApiBaseUrl = "https://api.linear.app";
 const linearGraphqlUrl = "https://api.linear.app/graphql";
+const linearFetch = createProviderFetch({ skipDnsValidation: true });
 
 const pageInfoFields = `
   startCursor
@@ -1310,6 +1312,7 @@ export const linearActionHandlers: Record<LinearActionName, LinearActionHandler>
 export const executors: ProviderExecutors = defineProviderExecutors<LinearActionContext>({
   service: "linear",
   handlers: linearActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<LinearActionContext> {
     const credential = await context.getCredential("linear");
     if (credential?.authType === "oauth2") {
@@ -1358,7 +1361,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await linearFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `linear request failed with HTTP ${response.status}`);

--- a/src/providers/linguapop/executors.ts
+++ b/src/providers/linguapop/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -14,8 +15,11 @@ import {
 import { linguapopActionHandlers, linguapopApiBaseUrl, validateLinguapopCredential } from "./runtime.ts";
 
 const service = "linguapop";
+const linguapopFetch = createProviderFetch({ skipDnsValidation: true });
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, linguapopActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, linguapopActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -40,7 +44,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await linguapopFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `linguapop request failed with HTTP ${response.status}`);

--- a/src/providers/linkedin/executors.ts
+++ b/src/providers/linkedin/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineOAuthProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireOAuthCredential,
@@ -19,8 +20,11 @@ import {
 } from "./runtime.ts";
 
 const service = "linkedin";
+const linkedinFetch = createProviderFetch({ skipDnsValidation: true });
 
-export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, linkedinActionHandlers);
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, linkedinActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -44,7 +48,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await linkedinFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `LinkedIn request failed with HTTP ${response.status}`);

--- a/src/providers/mailchimp/executors.ts
+++ b/src/providers/mailchimp/executors.ts
@@ -21,8 +21,9 @@ import {
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -217,7 +218,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Mailchimp request failed with HTTP ${response.status}`);

--- a/src/providers/mailgun/executors.ts
+++ b/src/providers/mailgun/executors.ts
@@ -4,8 +4,9 @@ import { Buffer } from "node:buffer";
 import {
   createProviderProxyUrl,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -38,7 +39,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Mailgun request failed with HTTP ${response.status}`);

--- a/src/providers/mailjet/executors.ts
+++ b/src/providers/mailjet/executors.ts
@@ -10,11 +10,12 @@ import type { MailjetContext } from "./runtime.ts";
 import { Buffer } from "node:buffer";
 import { optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -24,10 +25,12 @@ import { mailjetActionHandlers, validateMailjetCredential } from "./runtime.ts";
 
 const service = "mailjet";
 const mailjetApiBaseUrl = "https://api.mailjet.com/v3/REST";
+const mailjetFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<MailjetContext>({
   service,
   handlers: mailjetActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<MailjetContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -60,7 +63,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await mailjetFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Mailjet request failed with HTTP ${response.status}`);

--- a/src/providers/mailosaur/executors.ts
+++ b/src/providers/mailosaur/executors.ts
@@ -2,11 +2,12 @@ import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } f
 
 import { Buffer } from "node:buffer";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -15,8 +16,11 @@ import {
 import { mailosaurActionHandlers, mailosaurApiBaseUrl, validateMailosaurCredential } from "./runtime.ts";
 
 const service = "mailosaur";
+const mailosaurFetch = createProviderFetch({ skipDnsValidation: true });
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, mailosaurActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, mailosaurActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -38,7 +42,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await mailosaurFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Mailosaur request failed with HTTP ${response.status}`);

--- a/src/providers/mixpanel/executors.ts
+++ b/src/providers/mixpanel/executors.ts
@@ -19,6 +19,7 @@ import {
   defineProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
+  providerFetch,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
@@ -163,7 +164,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `mixpanel request failed with HTTP ${response.status}`);

--- a/src/providers/moesif/executors.ts
+++ b/src/providers/moesif/executors.ts
@@ -10,7 +10,9 @@ import { moesifActionHandlers, moesifApiBaseUrl, validateMoesifCredential } from
 
 const service = "moesif";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, moesifActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, moesifActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
@@ -21,6 +23,7 @@ export const credentialValidators: CredentialValidators = {
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: moesifApiBaseUrl,
+  skipDnsValidation: true,
   auth: { type: "api_key_authorization", prefix: "Bearer " },
   customizeRequest({ headers }) {
     headers.set("accept", "application/json");

--- a/src/providers/moesif/runtime.ts
+++ b/src/providers/moesif/runtime.ts
@@ -14,8 +14,9 @@ import { queryParams } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
 } from "../provider-runtime.ts";
 
 export const moesifApiBaseUrl = "https://api.moesif.com/v1";
@@ -141,7 +142,7 @@ export const moesifActionHandlers: Record<MoesifActionName, MoesifActionHandler>
 
 export async function validateMoesifCredential(
   apiKey: string,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const payload = await requestMoesifJson({

--- a/src/providers/monday/executors.ts
+++ b/src/providers/monday/executors.ts
@@ -4,11 +4,12 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 import type { MondayActionHandler } from "./runtime-common.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireBearerCredential,
@@ -25,6 +26,7 @@ import { mondayStructureActionHandlers } from "./runtime-structure.ts";
 import { getMondayAuthorizationScopes, parseMondayScopeString } from "./scopes.ts";
 
 const service = "monday";
+const mondayFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface MondayActionContext {
   apiKey: string;
@@ -59,6 +61,7 @@ const actionHandlers = Object.fromEntries(
 export const executors: ProviderExecutors = defineProviderExecutors<MondayActionContext>({
   service,
   handlers: actionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<MondayActionContext> {
     const credential = await requireBearerCredential(context, service);
     return {
@@ -89,7 +92,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await mondayFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `monday request failed with HTTP ${response.status}`);

--- a/src/providers/monday/runtime-common.ts
+++ b/src/providers/monday/runtime-common.ts
@@ -4,6 +4,7 @@ import { compactObject, optionalRecord as asOptionalObject, optionalString } fro
 import {
   createProviderTimeout,
   isAbortLikeError,
+  providerFetch,
   ProviderRequestError,
   providerUserAgent,
 } from "../provider-runtime.ts";
@@ -82,7 +83,7 @@ export function mondayProviderError(_code: string, message: string, status = 502
 
 export async function validateMondayCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
   options: MondayCredentialValidationOptions = {},
 ): Promise<CredentialValidationResult> {
   const apiKey = optionalString(input.apiKey);

--- a/src/providers/mongo_db_atlas_administration/executors.ts
+++ b/src/providers/mongo_db_atlas_administration/executors.ts
@@ -13,13 +13,14 @@ import { createHash } from "node:crypto";
 import { optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { jsonObject } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -27,6 +28,7 @@ import {
 
 const service = "mongo_db_atlas_administration";
 const mongoDbAtlasAdministrationApiBaseUrl = "https://cloud.mongodb.com/api/atlas/v2";
+const atlasFetch = createProviderFetch({ skipDnsValidation: true });
 const atlasAcceptHeader = "application/vnd.atlas.2024-08-05+json";
 const defaultRequestTimeoutMs = 30_000;
 
@@ -104,6 +106,7 @@ export const mongoDbAtlasAdministrationActionHandlers: Record<
 export const executors: ProviderExecutors = defineProviderExecutors<AtlasActionContext>({
   service,
   handlers: mongoDbAtlasAdministrationActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<AtlasActionContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "api_key") {
@@ -140,7 +143,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       signal: context.signal,
     };
 
-    const unauthenticatedResponse = await fetch(url, init);
+    const unauthenticatedResponse = await atlasFetch(url, init);
     if (unauthenticatedResponse.status !== 401) {
       if (!unauthenticatedResponse.ok) {
         const text = await unauthenticatedResponse.text().catch(() => "");
@@ -165,7 +168,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }),
     );
 
-    const response = await fetch(url, {
+    const response = await atlasFetch(url, {
       ...init,
       headers: authorizedHeaders,
     });

--- a/src/providers/mopinion/executors.ts
+++ b/src/providers/mopinion/executors.ts
@@ -12,12 +12,13 @@ import { Buffer } from "node:buffer";
 import { createHmac } from "node:crypto";
 import { optionalRecord, optionalScalarString, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -26,6 +27,7 @@ import {
 
 const service = "mopinion";
 const mopinionApiBaseUrl = "https://api.mopinion.com";
+const mopinionFetch = createProviderFetch({ skipDnsValidation: true });
 const mopinionApiVersion = "3.0.0";
 const accountPath = "/account";
 
@@ -189,6 +191,7 @@ export const mopinionActionHandlers: Record<MopinionActionName, MopinionActionHa
 export const executors: ProviderExecutors = defineProviderExecutors<MopinionActionContext>({
   service,
   handlers: mopinionActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<MopinionActionContext> {
     const credential = await requireCustomCredential(context, service);
     return {
@@ -229,7 +232,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, init);
+    const response = await mopinionFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Mopinion request failed with HTTP ${response.status}`);

--- a/src/providers/nethunt/executors.ts
+++ b/src/providers/nethunt/executors.ts
@@ -16,11 +16,12 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -29,6 +30,7 @@ import {
 
 const service = "nethunt";
 const nethuntApiBaseUrl = "https://nethunt.com/api/v1/zapier";
+const nethuntFetch = createProviderFetch({ skipDnsValidation: true });
 const nethuntAuthTestPath = "/triggers/auth-test";
 
 type NethuntRequestPhase = "validate" | "execute";
@@ -156,6 +158,7 @@ export const nethuntActionHandlers: Record<string, NethuntActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<NethuntContext>({
   service,
   handlers: nethuntActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<NethuntContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -187,7 +190,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await nethuntFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `NetHunt request failed with HTTP ${response.status}`);

--- a/src/providers/netsuite/executors.ts
+++ b/src/providers/netsuite/executors.ts
@@ -10,8 +10,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -42,7 +43,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     const netsuiteContext = resolveNetsuiteCredentialContext(
       credential.values,
       credential.metadata,
-      fetch,
+      providerFetch,
       context.signal,
     );
     const url = createProviderProxyUrl(netsuiteContext.restBaseUrl, input.endpoint, input.query);
@@ -70,7 +71,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }),
     );
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `NetSuite request failed with HTTP ${response.status}`);

--- a/src/providers/northbeam/executors.ts
+++ b/src/providers/northbeam/executors.ts
@@ -7,11 +7,12 @@ import type {
 import type { NorthbeamContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -25,10 +26,12 @@ import {
 } from "./runtime.ts";
 
 const service = "northbeam";
+const northbeamFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<NorthbeamContext>({
   service,
   handlers: northbeamActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<NorthbeamContext> {
     const credential = await requireApiKeyCredential(context, service);
     return resolveNorthbeamCredentialContext(
@@ -49,7 +52,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       credential.apiKey,
       credential.values,
       credential.metadata,
-      fetch,
+      northbeamFetch,
       context.signal,
     );
     const url = createProviderProxyUrl(northbeamApiBaseUrl, input.endpoint, input.query);
@@ -70,7 +73,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await northbeamFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Northbeam request failed with HTTP ${response.status}`);

--- a/src/providers/notion/executors.ts
+++ b/src/providers/notion/executors.ts
@@ -7,6 +7,7 @@ import type {
 
 import { compactObject } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -20,6 +21,7 @@ import {
 
 const service = "notion";
 const notionApiBaseUrl = "https://api.notion.com/v1";
+const notionFetch = createProviderFetch({ skipDnsValidation: true });
 const notionCoreVersion = "2026-03-11";
 
 type NotionObject = Record<string, unknown>;
@@ -119,6 +121,7 @@ export const notionActionHandlers: Record<string, NotionActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<NotionActionContext>({
   service,
   handlers: notionActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<NotionActionContext> {
     const credential = await requireBearerCredential(context, service);
     return { accessToken: credential.accessToken, fetcher };
@@ -146,7 +149,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await notionFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Notion request failed with HTTP ${response.status}`);

--- a/src/providers/oksign/executors.ts
+++ b/src/providers/oksign/executors.ts
@@ -7,11 +7,12 @@ import type {
 import type { OksignActionContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -25,10 +26,12 @@ import {
 } from "./runtime.ts";
 
 const service = "oksign";
+const oksignFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<OksignActionContext>({
   service,
   handlers: oksignActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<OksignActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -70,7 +73,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await oksignFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `OKSign request failed with HTTP ${response.status}`);

--- a/src/providers/one_page_crm/executors.ts
+++ b/src/providers/one_page_crm/executors.ts
@@ -8,11 +8,12 @@ import type { OnePageCrmActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -21,6 +22,7 @@ import {
 
 const service = "one_page_crm";
 const onePageCrmApiBaseUrl = "https://app.onepagecrm.com/api/v3";
+const onePageCrmFetch = createProviderFetch({ skipDnsValidation: true });
 const onePageCrmValidationPath = "/users";
 
 interface OnePageCrmCredential {
@@ -102,6 +104,7 @@ export const onePageCrmActionHandlers: Record<OnePageCrmActionName, OnePageCrmAc
 export const executors: ProviderExecutors = defineProviderExecutors<OnePageCrmActionContext>({
   service,
   handlers: onePageCrmActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<OnePageCrmActionContext> {
     const credential = await requireCustomCredential(context, service);
     return {
@@ -133,7 +136,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await onePageCrmFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `OnePageCRM request failed with HTTP ${response.status}`);

--- a/src/providers/ossinsight/executors.ts
+++ b/src/providers/ossinsight/executors.ts
@@ -8,11 +8,12 @@ import type { OssinsightActionName } from "./actions.ts";
 
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -20,6 +21,7 @@ import {
 
 const service = "ossinsight";
 const ossinsightBaseUrl = "https://api.ossinsight.io/v1";
+const ossinsightFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface OssinsightSqlColumn {
   col: string;
@@ -239,6 +241,7 @@ export const ossinsightActionHandlers: Record<OssinsightActionName, OssinsightAc
 export const executors: ProviderExecutors = defineProviderExecutors<OssinsightActionContext>({
   service,
   handlers: ossinsightActionHandlers,
+  skipDnsValidation: true,
   createContext(context: ExecutionContext, fetcher: typeof fetch): OssinsightActionContext {
     return {
       fetcher,
@@ -261,7 +264,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     }
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await ossinsightFetch(url, {
       method: "GET",
       headers,
       signal: context.signal,

--- a/src/providers/partnerstack/executors.ts
+++ b/src/providers/partnerstack/executors.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidators, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
@@ -15,6 +16,7 @@ import { buildBasicAuthHeader, executors, partnerstackApiBaseUrl, validatePartne
 export { executors };
 
 const service = "partnerstack";
+const partnerstackFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -36,7 +38,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await partnerstackFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(

--- a/src/providers/partnerstack/runtime.ts
+++ b/src/providers/partnerstack/runtime.ts
@@ -67,6 +67,7 @@ export const partnerstackActionHandlers: Record<PartnerstackActionName, Partners
 export const executors: ProviderExecutors = defineProviderExecutors<PartnerstackContext>({
   service: "partnerstack",
   handlers: partnerstackActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<PartnerstackContext> {
     const credential = await requireApiKeyCredential(context, "partnerstack");
     return {

--- a/src/providers/prerender/executors.ts
+++ b/src/providers/prerender/executors.ts
@@ -9,6 +9,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
@@ -23,6 +24,7 @@ import {
 
 const service = "prerender";
 const prerenderApiBaseUrl = "https://api.prerender.io";
+const prerenderFetch = createProviderFetch({ skipDnsValidation: true });
 const validationEndpoint = "/cache-clear-status/{prerenderToken}";
 
 type PrerenderPhase = "validate" | "execute";
@@ -77,7 +79,9 @@ export const prerenderActionHandlers: Record<string, PrerenderActionHandler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, prerenderActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, prerenderActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (
   input: ProxyRequestInput,
@@ -104,7 +108,7 @@ export const proxy: ProviderProxyExecutor = async (
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await prerenderFetch(url, init);
     if (!response.ok) {
       throw new ProviderRequestError(
         response.status,

--- a/src/providers/productive/executors.ts
+++ b/src/providers/productive/executors.ts
@@ -8,6 +8,7 @@ export { executors };
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service: "productive",
+  skipDnsValidation: true,
   baseUrl: productiveApiBaseUrl,
   auth: { type: "api_key_header", name: "x-auth-token" },
   customizeRequest({ headers, credential }) {

--- a/src/providers/productive/runtime.ts
+++ b/src/providers/productive/runtime.ts
@@ -4,6 +4,7 @@ import type { ProductiveActionName } from "./actions.ts";
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  providerFetch,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
@@ -47,7 +48,7 @@ export const productiveActionHandlers: Record<ProductiveActionName, ProductiveAc
 
 export async function validateProductiveCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
 ): Promise<CredentialValidationResult> {
   const apiKey = readRequiredApiKey(input.apiKey);
   const organizationId = readRequiredOrganizationId(input);
@@ -107,6 +108,7 @@ export async function executeProductiveAction(
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service: "productive",
+  skipDnsValidation: true,
   handlers: productiveActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, "productive");

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -1,0 +1,105 @@
+import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../core/request.ts";
+import { defineProviderExecutors, defineProviderProxy, providerFetch } from "./provider-runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setPrivateNetworkAccessAllowed(false);
+});
+
+const apiKeyCredential: ResolvedCredential = {
+  authType: "api_key",
+  apiKey: "test-key",
+  values: {},
+  profile: { accountId: "acct", displayName: "Test", grantedScopes: [] },
+  metadata: {},
+};
+
+const executionContext: ExecutionContext = {
+  getCredential: async () => apiKeyCredential,
+};
+
+function stubFetchSequence(responses: Response[]): Array<{ url: string; init: RequestInit | undefined }> {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: input instanceof Request ? input.url : String(input), init });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected extra request");
+    }
+    return response;
+  });
+  return calls;
+}
+
+describe("provider egress SSRF guard", () => {
+  it("blocks proxy responses redirecting to metadata targets", async () => {
+    const calls = stubFetchSequence([
+      new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } }),
+    ]);
+    const proxy = defineProviderProxy({
+      service: "test_service",
+      baseUrl: "https://api.example.com",
+      auth: { type: "bearer" },
+    });
+
+    const result = await proxy({ method: "GET", endpoint: "/items" }, executionContext);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error.message).toContain("redirect location");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("follows public proxy redirects", async () => {
+    const calls = stubFetchSequence([
+      new Response(null, { status: 302, headers: { location: "https://cdn.example.net/items" } }),
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
+    ]);
+    const proxy = defineProviderProxy({
+      service: "test_service",
+      baseUrl: "https://api.example.com",
+      auth: { type: "bearer" },
+    });
+
+    const result = await proxy({ method: "GET", endpoint: "/items" }, executionContext);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    expect(result.response.data).toEqual({ ok: true });
+    expect(calls.map((call) => call.url)).toEqual(["https://api.example.com/items", "https://cdn.example.net/items"]);
+  });
+
+  it("gives executor contexts a fetcher that blocks redirects to loopback targets", async () => {
+    const calls = stubFetchSequence([
+      new Response(null, { status: 302, headers: { location: "http://127.0.0.1:8080/admin" } }),
+    ]);
+    const executors = defineProviderExecutors<{ fetcher: typeof fetch }>({
+      service: "test_service",
+      handlers: {
+        async probe(_input, context) {
+          const response = await context.fetcher("https://api.example.com/resource");
+          return { status: response.status };
+        },
+      },
+      createContext: (_context, fetcher) => ({ fetcher }),
+    });
+
+    const result = await executors["test_service.probe"]!({}, executionContext);
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("redirect location");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("keeps caller manual-redirect handling intact through providerFetch", async () => {
+    const calls = stubFetchSequence([new Response(null, { status: 302, headers: { location: "http://127.0.0.1/" } })]);
+
+    const response = await providerFetch("https://api.example.com/report", { redirect: "manual" });
+
+    expect(response.status).toBe(302);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -13,12 +13,48 @@ import type {
 
 import { Buffer } from "node:buffer";
 import { CastError, optionalRecord, optionalScalarString, optionalString, requiredString } from "../core/cast.ts";
+import { createGuardedFetch } from "../core/guarded-fetch.ts";
 import { readBoundedResponseBytes } from "../core/request.ts";
 
 /**
  * Fetch-compatible function accepted by provider runtime helpers and tests.
  */
 export type ProviderFetch = typeof fetch;
+
+export interface ProviderFetchOptions {
+  /** Base transport; defaults to the global fetch. A guarded fetch is unwrapped so guards never stack. */
+  fetch?: ProviderFetch;
+  /** Allow private-network targets for this provider's egress (see `assertPublicHttpUrl`); default public-only. */
+  allowPrivateNetwork?: () => boolean;
+  /**
+   * Skip the DNS resolved-address check (URL and redirect guards still apply).
+   * Only pass for providers whose egress host is a hardcoded literal, never
+   * derived from user/credential input. See {@link GuardedFetchOptions.skipDnsValidation}.
+   */
+  skipDnsValidation?: boolean;
+}
+
+/**
+ * Create the SSRF-guarded fetch used for all provider egress: the request URL,
+ * every redirect hop, and (when DNS is available) every resolved address are
+ * validated against the shared public-URL policy, so a provider-reachable URL
+ * cannot redirect or resolve into loopback/link-local/metadata/private targets.
+ */
+export function createProviderFetch(options: ProviderFetchOptions = {}): ProviderFetch {
+  return createGuardedFetch({
+    fetch: options.fetch,
+    allowPrivateNetwork: options.allowPrivateNetwork,
+    skipDnsValidation: options.skipDnsValidation,
+    createError: (message) => new ProviderRequestError(502, message),
+  });
+}
+
+/**
+ * Shared public-only SSRF-guarded fetch for provider egress. Providers that
+ * issue their own requests (custom proxy executors, context builders) must use
+ * this instead of the global fetch.
+ */
+export const providerFetch: ProviderFetch = createProviderFetch();
 
 /**
  * Default User-Agent sent by local provider executors.
@@ -44,6 +80,10 @@ export interface ProviderExecutorDefinition<TContext> {
   handlers: Record<string, ProviderRuntimeHandler<TContext>>;
   createContext: ProviderRuntimeContextFactory<TContext>;
   fallbackMessage?: string;
+  /** Deployment-gated private-network opt-in applied to this provider's egress fetch (currently Dokploy). */
+  allowPrivateNetwork?: () => boolean;
+  /** Skip the redundant DNS resolved-address check; only for hardcoded-host providers. */
+  skipDnsValidation?: boolean;
 }
 
 export interface BearerCredential {
@@ -143,6 +183,10 @@ export interface ProviderProxyDefinition {
   auth: ProviderProxyAuth;
   allowedEndpoint?: (endpoint: string) => boolean;
   customizeRequest?: (input: ProviderProxyRequestCustomizationInput) => Promise<void> | void;
+  /** Deployment-gated private-network opt-in applied to this proxy's egress fetch (currently Dokploy). */
+  allowPrivateNetwork?: () => boolean;
+  /** Skip the redundant DNS resolved-address check; only for hardcoded-base-URL proxies. */
+  skipDnsValidation?: boolean;
 }
 
 const blockedProxyRequestHeaders = new Set([
@@ -313,6 +357,13 @@ export function toProviderProxyError(error: unknown, fallbackMessage: string): P
 }
 
 export function defineProviderProxy(input: ProviderProxyDefinition): ProviderProxyExecutor {
+  const egressFetch =
+    input.allowPrivateNetwork || input.skipDnsValidation
+      ? createProviderFetch({
+          allowPrivateNetwork: input.allowPrivateNetwork,
+          skipDnsValidation: input.skipDnsValidation,
+        })
+      : providerFetch;
   return async (proxyInput: ProxyRequestInput, context: ExecutionContext): Promise<ProxyExecutionResult> => {
     try {
       const endpoint = normalizeProviderProxyEndpoint(proxyInput.endpoint);
@@ -349,7 +400,7 @@ export function defineProviderProxy(input: ProviderProxyDefinition): ProviderPro
         }
       }
 
-      const response = await fetch(url, init);
+      const response = await egressFetch(url, init);
       if (!response.ok) {
         throw new ProviderRequestError(
           response.status,
@@ -704,6 +755,13 @@ export function toProviderExecutionError(error: unknown, fallbackMessage: string
 export function defineProviderExecutors<TContext>(input: ProviderExecutorDefinition<TContext>): ProviderExecutors {
   const executors: ProviderExecutors = {};
   const fallbackMessage = input.fallbackMessage ?? "provider request failed";
+  const egressFetch =
+    input.allowPrivateNetwork || input.skipDnsValidation
+      ? createProviderFetch({
+          allowPrivateNetwork: input.allowPrivateNetwork,
+          skipDnsValidation: input.skipDnsValidation,
+        })
+      : providerFetch;
   for (const [name, handler] of Object.entries(input.handlers)) {
     executors[`${input.service}.${name}`] = async (actionInput, executionContext): Promise<ExecutionResult> => {
       try {
@@ -711,7 +769,7 @@ export function defineProviderExecutors<TContext>(input: ProviderExecutorDefinit
           ok: true,
           output: await handler(
             actionInput as Record<string, unknown>,
-            await input.createContext(executionContext, fetch),
+            await input.createContext(executionContext, egressFetch),
           ),
         };
       } catch (error) {
@@ -723,16 +781,27 @@ export function defineProviderExecutors<TContext>(input: ProviderExecutorDefinit
   return executors;
 }
 
+/** Egress-guard options shared by the credential-typed executor helpers. */
+export interface ProviderExecutorEgressOptions {
+  /** Deployment-gated private-network opt-in (see {@link ProviderExecutorDefinition.allowPrivateNetwork}). */
+  allowPrivateNetwork?: () => boolean;
+  /** Skip the redundant DNS resolved-address check; only for hardcoded-host providers. */
+  skipDnsValidation?: boolean;
+}
+
 /**
  * Define executors for providers that use the built-in API key credential.
  */
 export function defineApiKeyProviderExecutors(
   service: string,
   handlers: Record<string, ProviderRuntimeHandler<ApiKeyProviderContext>>,
+  options: ProviderExecutorEgressOptions = {},
 ): ProviderExecutors {
   return defineProviderExecutors<ApiKeyProviderContext>({
     service,
     handlers,
+    allowPrivateNetwork: options.allowPrivateNetwork,
+    skipDnsValidation: options.skipDnsValidation,
     async createContext(context, fetcher): Promise<ApiKeyProviderContext> {
       const credential = await requireApiKeyCredential(context, service);
       const providerContext: ApiKeyProviderContext = {
@@ -754,10 +823,13 @@ export function defineApiKeyProviderExecutors(
 export function defineOAuthProviderExecutors(
   service: string,
   handlers: Record<string, ProviderRuntimeHandler<OAuthProviderContext>>,
+  options: ProviderExecutorEgressOptions = {},
 ): ProviderExecutors {
   return defineProviderExecutors<OAuthProviderContext>({
     service,
     handlers,
+    allowPrivateNetwork: options.allowPrivateNetwork,
+    skipDnsValidation: options.skipDnsValidation,
     async createContext(context, fetcher): Promise<OAuthProviderContext> {
       const credential = await requireOAuthCredential(context, service);
       const providerContext: OAuthProviderContext = {
@@ -780,10 +852,13 @@ export function defineOAuthProviderExecutors(
 export function defineBearerProviderExecutors(
   service: string,
   handlers: Record<string, ProviderRuntimeHandler<BearerProviderContext>>,
+  options: ProviderExecutorEgressOptions = {},
 ): ProviderExecutors {
   return defineProviderExecutors<BearerProviderContext>({
     service,
     handlers,
+    allowPrivateNetwork: options.allowPrivateNetwork,
+    skipDnsValidation: options.skipDnsValidation,
     async createContext(context, fetcher): Promise<BearerProviderContext> {
       const credential = await requireBearerCredential(context, service);
       const providerContext: BearerProviderContext = {

--- a/src/providers/pubmed/runtime.ts
+++ b/src/providers/pubmed/runtime.ts
@@ -15,7 +15,7 @@ import {
   requiredStringArray,
 } from "../../core/cast.ts";
 import { readBoundedResponseBytes } from "../../core/request.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { createProviderTimeout, providerFetch, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 import { parsePubmedArticleSet } from "./runtime-xml.ts";
 
 type PubmedSort = "first_author" | "journal" | "publication_date" | "relevance";
@@ -414,8 +414,10 @@ interface CreatePubmedActionContextOptions {
 export function createPubmedActionContext(options: CreatePubmedActionContextOptions): PubmedActionContext {
   return {
     ...options,
-    requestGate: options.fetcher === fetch ? requestGateFor(options.apiKey) : { wait: immediateDelay },
-    sleep: options.fetcher === fetch ? delay : immediateDelay,
+    // The real NCBI request gate and Retry-After backoff apply to the shared
+    // production fetcher; test stubs pass a different fetcher and skip throttling.
+    requestGate: options.fetcher === providerFetch ? requestGateFor(options.apiKey) : { wait: immediateDelay },
+    sleep: options.fetcher === providerFetch ? delay : immediateDelay,
   };
 }
 

--- a/src/providers/pushover/executors.ts
+++ b/src/providers/pushover/executors.ts
@@ -2,6 +2,7 @@ import type { CredentialValidators, ProviderProxyExecutor } from "../../core/typ
 
 import { optionalRecord } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
@@ -16,6 +17,7 @@ import { executors, pushoverVersionedApiBaseUrl, validatePushoverCredential } fr
 export { executors };
 
 const service = "pushover";
+const pushoverFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher }) {
@@ -43,7 +45,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       init.body = createPushoverProxyBody(input.body, credential.apiKey, headers);
     }
 
-    const response = await fetch(url, init);
+    const response = await pushoverFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/pushover/runtime.ts
+++ b/src/providers/pushover/runtime.ts
@@ -234,6 +234,7 @@ export const executors: ProviderExecutors = defineApiKeyProviderExecutors(
         handler({ apiKey: context.apiKey, values: {}, input, transitFiles: context.transitFiles }, context.fetcher),
     ]),
   ) as Record<string, (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>>,
+  { skipDnsValidation: true },
 );
 
 async function sendPushoverMessage(input: PushoverActionInput, fetcher: typeof fetch) {

--- a/src/providers/qianfan/executors.ts
+++ b/src/providers/qianfan/executors.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidators, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
@@ -16,6 +17,7 @@ import { executors, qianfanApiBaseUrl, qianfanApiOrigin, validateQianfanCredenti
 export { executors };
 
 const service = "qianfan";
+const qianfanFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher }) {
@@ -47,7 +49,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await qianfanFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/qianfan/runtime.ts
+++ b/src/providers/qianfan/runtime.ts
@@ -131,6 +131,7 @@ export const executors: ProviderExecutors = defineApiKeyProviderExecutors(
         handler({ apiKey: context.apiKey, input, transitFiles: context.transitFiles }, context.fetcher),
     ]),
   ),
+  { skipDnsValidation: true },
 );
 
 export async function validateQianfanCredential(

--- a/src/providers/quickbase/executors.ts
+++ b/src/providers/quickbase/executors.ts
@@ -14,6 +14,7 @@ import {
 import { encodePathSegment } from "../../core/request.ts";
 import { arrayPayload, firstString, objectPayload, requestJson } from "../http-json-runtime.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -27,6 +28,7 @@ import {
 
 const service = "quickbase";
 const apiBaseUrl = "https://api.quickbase.com/v1";
+const quickbaseFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface QuickbaseContext {
   apiKey: string;
@@ -134,6 +136,7 @@ export const quickbaseActionHandlers: Record<string, Handler> = {
 
 export const executors: ProviderExecutors = defineProviderExecutors<QuickbaseContext>({
   service,
+  skipDnsValidation: true,
   handlers: quickbaseActionHandlers,
   async createContext(context, fetcher) {
     const credential = await requireApiKeyCredential(context, service);
@@ -170,7 +173,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await quickbaseFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/razorpay/executors.ts
+++ b/src/providers/razorpay/executors.ts
@@ -7,6 +7,7 @@ import type {
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -20,6 +21,7 @@ import {
 import { razorpayActionHandlers, razorpayApiBaseUrl, validateRazorpayCredential } from "./runtime.ts";
 
 const service = "razorpay";
+const razorpayFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface RazorpayExecutorContext {
   keyId: string;
@@ -29,6 +31,7 @@ interface RazorpayExecutorContext {
 
 export const executors: ProviderExecutors = defineProviderExecutors<RazorpayExecutorContext>({
   service,
+  skipDnsValidation: true,
   handlers: razorpayActionHandlers,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<RazorpayExecutorContext> {
     const credential = await context.getCredential(service);
@@ -75,7 +78,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await razorpayFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/razorpay/runtime.ts
+++ b/src/providers/razorpay/runtime.ts
@@ -3,7 +3,7 @@ import type { RazorpayActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const razorpayApiBaseUrl = "https://api.razorpay.com/v1";
 const razorpayValidationPath = "/payments";
@@ -72,7 +72,7 @@ export const razorpayActionHandlers: Record<RazorpayActionName, RazorpayActionHa
 
 export async function validateRazorpayCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
 ): Promise<CredentialValidationResult> {
   const keySecret = input.apiKey;
   const keyId = requireRazorpayKeyId(input);

--- a/src/providers/roam_scim/executors.ts
+++ b/src/providers/roam_scim/executors.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../core/types.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
-import { defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { createProviderFetch, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
 import {
   roamScimActionHandlers,
   roamScimApiBaseUrl,
@@ -15,9 +15,11 @@ import {
 } from "./runtime.ts";
 
 const service = "roam_scim";
+const roamScimFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
+  skipDnsValidation: true,
   baseUrl: roamScimApiBaseUrl,
   auth: { type: "api_key_authorization", prefix: "Bearer " },
 });
@@ -30,7 +32,7 @@ export const executors: ProviderExecutors = Object.fromEntries(
         const credential = await requireApiKeyCredential(context, service);
         const providerContext: ApiKeyProviderContext = {
           apiKey: credential.apiKey,
-          fetcher: fetch,
+          fetcher: roamScimFetch,
           signal: context.signal,
         };
         if (context.transitFiles) {

--- a/src/providers/rocket_chat/executors.ts
+++ b/src/providers/rocket_chat/executors.ts
@@ -10,8 +10,9 @@ import type { RocketChatActionName } from "./actions.ts";
 
 import { isIP } from "node:net";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -25,6 +26,8 @@ import {
 const service = "rocket_chat";
 const requestTimeoutMs = 30_000;
 const validationPath = "/me";
+
+const privateAwareFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 interface RocketChatCredential {
   baseUrl: string;
@@ -162,6 +165,7 @@ export const rocketChatActionHandlers: Record<RocketChatActionName, RocketChatAc
 export const executors: ProviderExecutors = defineProviderExecutors<RocketChatContext>({
   service,
   handlers: rocketChatActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<RocketChatContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {
@@ -178,9 +182,10 @@ export const executors: ProviderExecutors = defineProviderExecutors<RocketChatCo
 export const credentialValidators: CredentialValidators = {
   async customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
     const credential = readRocketChatCredential(input.values);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     const payload = await requestRocketChatObject({
       credential,
-      fetcher,
+      fetcher: guardedFetcher,
       signal,
       path: validationPath,
       phase: "validate",
@@ -233,7 +238,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await privateAwareFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
@@ -352,8 +357,11 @@ function createRocketChatError(
   return new ProviderRequestError(status || 502, message, payload);
 }
 
-function readRocketChatCredential(input: Record<string, string>): RocketChatCredential {
-  const baseUrl = normalizeRocketChatBaseUrl(readCredentialString(input, "baseUrl"));
+function readRocketChatCredential(
+  input: Record<string, string>,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): RocketChatCredential {
+  const baseUrl = normalizeRocketChatBaseUrl(readCredentialString(input, "baseUrl"), allowPrivateNetwork);
   const userId = readCredentialString(input, "userId");
   const authToken = readCredentialString(input, "authToken");
   return {
@@ -372,9 +380,13 @@ function readCredentialString(input: Record<string, string>, key: string): strin
   return value.trim();
 }
 
-function normalizeRocketChatBaseUrl(input: string): string {
+function normalizeRocketChatBaseUrl(
+  input: string,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const url = assertPublicHttpUrl(input, {
     fieldName: "baseUrl",
+    allowPrivateNetwork,
     createError: (message) => new ProviderRequestError(400, message),
   });
   if (url.protocol !== "https:") {
@@ -383,7 +395,9 @@ function normalizeRocketChatBaseUrl(input: string): string {
   if (url.username || url.password) {
     throw new ProviderRequestError(400, "baseUrl must not include credentials");
   }
-  validateRocketChatHostname(url.hostname);
+  if (!allowPrivateNetwork) {
+    validateRocketChatHostname(url.hostname);
+  }
   url.hash = "";
   url.search = "";
   url.pathname = trimTrailingSlashes(url.pathname);

--- a/src/providers/sage_sales_management/executors.ts
+++ b/src/providers/sage_sales_management/executors.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -24,9 +25,11 @@ import {
 } from "./runtime.ts";
 
 const service = "sage_sales_management";
+const sageSalesManagementFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
+  skipDnsValidation: true,
   handlers: sageSalesManagementActionHandlers,
   async createContext(context, fetcher) {
     const credential = await requireCustomCredential(context, service);
@@ -37,7 +40,11 @@ export const executors: ProviderExecutors = defineProviderExecutors({
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
     const credential = await requireCustomCredential(context, service);
-    const sageContext = await createSageSalesManagementActionContext(credential.values, fetch, context.signal);
+    const sageContext = await createSageSalesManagementActionContext(
+      credential.values,
+      sageSalesManagementFetch,
+      context.signal,
+    );
     const url = createProviderProxyUrl(sageSalesManagementApiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("user-agent", providerUserAgent);
@@ -55,7 +62,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await sageSalesManagementFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/salesmate/executors.ts
+++ b/src/providers/salesmate/executors.ts
@@ -10,13 +10,14 @@ import type { SalesmateActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   createProviderProxyUrl,
+  createProviderTimeout,
   defineProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -136,7 +137,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/segment/executors.ts
+++ b/src/providers/segment/executors.ts
@@ -9,6 +9,7 @@ import type { SegmentActionName } from "./actions.ts";
 
 import { compactObject, optionalRawString, optionalRecord, requiredRecord } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -22,6 +23,7 @@ import {
 
 const service = "segment";
 const segmentApiBaseUrl = "https://api.segment.io/v1";
+const segmentFetch = createProviderFetch({ skipDnsValidation: true });
 
 type SegmentActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type SegmentActionHandler = (input: Record<string, unknown>, context: SegmentActionContext) => Promise<unknown>;
@@ -51,7 +53,9 @@ export const segmentActionHandlers: Record<SegmentActionName, SegmentActionHandl
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, segmentActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, segmentActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -62,7 +66,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     headers.set("content-type", "application/json");
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(url, {
+    const response = await segmentFetch(url, {
       method: input.method,
       headers,
       body: JSON.stringify(withWriteKey(optionalRecord(input.body) ?? {}, credential.apiKey)),

--- a/src/providers/sendspark/executors.ts
+++ b/src/providers/sendspark/executors.ts
@@ -7,6 +7,7 @@ import type {
 
 import { requiredString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
@@ -19,6 +20,7 @@ import {
 import { defineSendsparkExecutors, sendsparkApiBaseUrl, validateSendsparkCredential } from "./runtime.ts";
 
 const service = "sendspark";
+const sendsparkFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineSendsparkExecutors();
 
@@ -51,7 +53,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await sendsparkFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/sendspark/runtime.ts
+++ b/src/providers/sendspark/runtime.ts
@@ -58,6 +58,7 @@ export const sendsparkActionHandlers: Record<SendsparkActionName, SendsparkActio
 
 export const sendsparkExecutorDefinition: ProviderExecutorDefinition<SendsparkContext> = {
   service: "sendspark",
+  skipDnsValidation: true,
   handlers: sendsparkActionHandlers,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<SendsparkContext> {
     return createSendsparkContext(await requireApiKeyCredential(context, service), fetcher, context.signal);

--- a/src/providers/shippo/executors.ts
+++ b/src/providers/shippo/executors.ts
@@ -9,13 +9,14 @@ import type { ShippoActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
+  createProviderFetch,
   createProviderProxyUrl,
+  createProviderTimeout,
   defineApiKeyProviderExecutors,
   isAbortLikeError,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -27,6 +28,7 @@ const shippoApiBaseUrl = "https://api.goshippo.com";
 const shippoApiVersion = "2018-02-08";
 const shippoDefaultRequestTimeoutMs = 30_000;
 const shippoValidationEndpoint = "/addresses/";
+const shippoFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface ShippoRequestInput {
   path: string;
@@ -121,7 +123,9 @@ export const shippoActionHandlers: Record<ShippoActionName, ShippoActionHandler>
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, shippoActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, shippoActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
@@ -147,7 +151,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await shippoFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/shortcut/executors.ts
+++ b/src/providers/shortcut/executors.ts
@@ -3,7 +3,9 @@ import type { CredentialValidators, ProviderExecutors } from "../../core/types.t
 import { defineApiKeyProviderExecutors } from "../provider-runtime.ts";
 import { shortcutActionHandlers, validateShortcutCredential } from "./runtime.ts";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors("shortcut", shortcutActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors("shortcut", shortcutActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher }): ReturnType<typeof validateShortcutCredential> {

--- a/src/providers/shortcut/runtime.ts
+++ b/src/providers/shortcut/runtime.ts
@@ -2,7 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ShortcutActionName } from "./actions.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const shortcutApiBaseUrl = "https://api.app.shortcut.com/api/v3/";
 const shortcutValidatePath = "member";
@@ -63,7 +63,7 @@ export const shortcutActionHandlers: Record<ShortcutActionName, ShortcutActionHa
 
 export async function validateShortcutCredential(
   input: { apiKey?: string },
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
 ): Promise<CredentialValidationResult> {
   const apiKey = readRequiredApiKey(input.apiKey);
   const payload = await shortcutGetJson(shortcutValidatePath, apiKey, fetcher, "validate");

--- a/src/providers/simple_analytics/executors.ts
+++ b/src/providers/simple_analytics/executors.ts
@@ -8,6 +8,7 @@ import type {
 import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -22,6 +23,8 @@ import { simpleAnalyticsActionHandlers, simpleAnalyticsBaseUrl, validateSimpleAn
 
 const service = "simple_analytics";
 
+const simpleAnalyticsFetch = createProviderFetch({ skipDnsValidation: true });
+
 interface SimpleAnalyticsContext extends ApiKeyProviderContext {
   userId?: string;
 }
@@ -29,6 +32,7 @@ interface SimpleAnalyticsContext extends ApiKeyProviderContext {
 export const executors: ProviderExecutors = defineProviderExecutors<SimpleAnalyticsContext>({
   service,
   handlers: simpleAnalyticsActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<SimpleAnalyticsContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -66,7 +70,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await simpleAnalyticsFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/snipe_it/executors.ts
+++ b/src/providers/snipe_it/executors.ts
@@ -5,7 +5,14 @@ import type {
   ProviderProxyExecutor,
 } from "../../core/types.ts";
 
-import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  providerFetch,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
 import { resolveSnipeItContext, snipeItActionHandlers, validateSnipeItCredential } from "./runtime.ts";
 
 const service = "snipe_it";
@@ -13,6 +20,7 @@ const service = "snipe_it";
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: snipeItActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return resolveSnipeItContext({ ...credential.values, apiKey: credential.apiKey }, fetcher, context.signal);
@@ -22,15 +30,18 @@ export const executors: ProviderExecutors = defineProviderExecutors({
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   baseUrl: async (context) => {
     const credential = await requireApiKeyCredential(context, service);
-    return resolveSnipeItContext({ ...credential.values, apiKey: credential.apiKey }, fetch, context.signal).apiBaseUrl;
+    return resolveSnipeItContext({ ...credential.values, apiKey: credential.apiKey }, providerFetch, context.signal)
+      .apiBaseUrl;
   },
   auth: { type: "api_key_authorization", prefix: "Bearer " },
 });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
-    return validateSnipeItCredential({ ...input.values, apiKey: input.apiKey }, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateSnipeItCredential({ ...input.values, apiKey: input.apiKey }, guardedFetcher, signal);
   },
 };

--- a/src/providers/snipe_it/runtime.ts
+++ b/src/providers/snipe_it/runtime.ts
@@ -3,7 +3,7 @@ import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.t
 import type { SnipeItActionName } from "./actions.ts";
 
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { assertPublicHttpUrl, queryParams } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed, queryParams } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const snipeItValidationPath = "/users/me";
@@ -342,10 +342,14 @@ function stringifyFilter(value: unknown): string | undefined {
   return value === undefined ? undefined : JSON.stringify(value);
 }
 
-function resolveSnipeItUrls(rawInstanceUrl: unknown): { instanceUrl: string; apiBaseUrl: string } {
+function resolveSnipeItUrls(
+  rawInstanceUrl: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): { instanceUrl: string; apiBaseUrl: string } {
   const instanceUrl = normalizeSnipeItInstanceUrl(rawInstanceUrl);
   assertPublicHttpUrl(instanceUrl, {
     fieldName: "instanceUrl",
+    allowPrivateNetwork,
     createError: (message) => new ProviderRequestError(400, message),
   });
   return {

--- a/src/providers/sslmate_cert_spotter_api/executors.ts
+++ b/src/providers/sslmate_cert_spotter_api/executors.ts
@@ -1,12 +1,13 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -22,7 +23,11 @@ import {
 const service = "sslmate_cert_spotter_api";
 const ctSearchProxyPrefix = "/ct-search";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, certSpotterActionHandlers);
+const certSpotterFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, certSpotterActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -46,7 +51,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await certSpotterFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(

--- a/src/providers/stack_ai/executors.ts
+++ b/src/providers/stack_ai/executors.ts
@@ -8,6 +8,7 @@ import type { StackAiActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
@@ -24,6 +25,8 @@ import {
 const service = "stack_ai";
 const stackAiInferenceBaseUrl = "https://stack-inference.com";
 const stackAiRequestTimeoutMs = 30_000;
+
+const stackAiFetch = createProviderFetch({ skipDnsValidation: true });
 
 type StackAiPhase = "validate" | "execute";
 
@@ -50,12 +53,13 @@ export const executors: ProviderExecutors = defineProviderExecutors<StackAiConte
   service,
   handlers: stackAiActionHandlers,
   createContext: createStackAiContext,
+  skipDnsValidation: true,
 });
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
     const credential = await requireCustomCredential(context, service);
-    const stackAiContext = readStackAiCredential(credential.values, fetch, context.signal);
+    const stackAiContext = readStackAiCredential(credential.values, stackAiFetch, context.signal);
     const baseUrl = new URL(
       buildRunPath(stackAiContext.organizationId, stackAiContext.flowId),
       stackAiInferenceBaseUrl,
@@ -77,7 +81,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await stackAiFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `StackAI request failed with HTTP ${response.status}`);

--- a/src/providers/tanium/executors.ts
+++ b/src/providers/tanium/executors.ts
@@ -7,12 +7,14 @@ import type {
 import type { TaniumContext } from "./runtime.ts";
 
 import { optionalString } from "../../core/cast.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -22,9 +24,12 @@ import { normalizeTaniumGatewayUrl, taniumActionHandlers, validateTaniumCredenti
 
 const service = "tanium";
 
+const egressFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors<TaniumContext>({
   service,
   handlers: taniumActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<TaniumContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -66,7 +71,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(gatewayUrl, init);
+    const response = await egressFetch(gatewayUrl, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(
@@ -82,12 +87,13 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     return validateTaniumCredential(
       {
         apiKey: input.apiKey,
         gatewayUrl: input.values.gatewayUrl,
       },
-      fetcher,
+      guardedFetcher,
       signal,
     );
   },

--- a/src/providers/tanium/runtime.ts
+++ b/src/providers/tanium/runtime.ts
@@ -4,7 +4,7 @@ import type { TaniumActionName } from "./actions.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -89,7 +89,11 @@ export async function validateTaniumCredential(
   };
 }
 
-export function normalizeTaniumGatewayUrl(value: unknown): string {
+// Private-network egress is gated by deployment config; see isPrivateNetworkAccessAllowed.
+export function normalizeTaniumGatewayUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   if (typeof value !== "string" || !value.trim()) {
     throw new ProviderRequestError(400, "gatewayUrl is required");
   }
@@ -121,6 +125,7 @@ export function normalizeTaniumGatewayUrl(value: unknown): string {
   return assertPublicHttpUrl(url.toString(), {
     fieldName: "gatewayUrl",
     createError: requestInputError,
+    allowPrivateNetwork,
   }).toString();
 }
 

--- a/src/providers/tencent_docs/executors.ts
+++ b/src/providers/tencent_docs/executors.ts
@@ -9,10 +9,11 @@ import type {
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireOAuthCredential,
@@ -22,6 +23,8 @@ import {
 import { tencentDocsActionHandlers, tencentDocsApiBaseUrl } from "./runtime.ts";
 
 const service = "tencent_docs";
+
+const tencentDocsFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = Object.fromEntries(
   Object.entries(tencentDocsActionHandlers).map(([name, handler]) => [
@@ -53,7 +56,7 @@ export const executors: ProviderExecutors = Object.fromEntries(
             accessToken: credential.accessToken,
             clientId: clientId ?? "",
             openID: openID ?? "",
-            fetcher: fetch,
+            fetcher: tencentDocsFetch,
             signal: context.signal,
           }),
         };
@@ -101,7 +104,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await tencentDocsFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(

--- a/src/providers/tidb/executors.ts
+++ b/src/providers/tidb/executors.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
@@ -15,9 +16,12 @@ import { requestTiDBProxy, resolveTiDBProxyTarget, tidbActionHandlers, validateT
 
 const service = "tidb";
 
+const tidbFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: tidbActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireCustomCredential(context, service);
     return {
@@ -50,7 +54,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       body,
       publicKey: credential.values.publicKey,
       privateKey: credential.values.privateKey,
-      fetcher: fetch,
+      fetcher: tidbFetch,
       signal: context.signal,
     });
 

--- a/src/providers/tidb/runtime.ts
+++ b/src/providers/tidb/runtime.ts
@@ -7,7 +7,7 @@ import {
   optionalString as asOptionalString,
   stringArray as asStringArray,
 } from "../../core/cast.ts";
-import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const tidbApiBaseUrlByFamily = {
   starter_essential: "https://serverless.tidbapi.com/v1beta1",
@@ -138,7 +138,7 @@ export const tidbActionHandlers: Record<TiDBActionName, TiDBActionHandler> = {
 
 export async function validateTiDBCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch = providerFetch,
 ): Promise<CredentialValidationResult> {
   const context = {
     publicKey: requireTiDBCredentialField(input.publicKey, "publicKey"),

--- a/src/providers/tinypng/executors.ts
+++ b/src/providers/tinypng/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -20,7 +21,11 @@ import {
 
 const service = "tinypng";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, tinypngActionHandlers);
+const tinypngFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, tinypngActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -42,7 +47,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await tinypngFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `tinypng request failed with HTTP ${response.status}`);

--- a/src/providers/toggl/executors.ts
+++ b/src/providers/toggl/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -20,7 +21,11 @@ import {
 
 const service = "toggl";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, togglActionHandlers);
+const togglFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, togglActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -42,7 +47,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await togglFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `toggl request failed with HTTP ${response.status}`);

--- a/src/providers/tomba/executors.ts
+++ b/src/providers/tomba/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -15,9 +16,12 @@ import { tombaActionHandlers, tombaApiBaseUrl, validateTombaCredential } from ".
 
 const service = "tomba";
 
+const tombaFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: tombaActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireApiKeyCredential(context, service);
     const apiSecret = credential.values.apiSecret || credential.values.secret;
@@ -61,7 +65,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await tombaFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Tomba request failed with HTTP ${response.status}`);

--- a/src/providers/trello/executors.ts
+++ b/src/providers/trello/executors.ts
@@ -7,11 +7,12 @@ import type {
 import type { TrelloActionContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -21,9 +22,12 @@ import { trelloActionHandlers, trelloApiBaseUrl, validateTrelloCredential } from
 
 const service = "trello";
 
+const trelloFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors<TrelloActionContext>({
   service,
   handlers: trelloActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<TrelloActionContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {
@@ -59,7 +63,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await trelloFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Trello request failed with HTTP ${response.status}`);

--- a/src/providers/tushare/executors.ts
+++ b/src/providers/tushare/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -15,7 +16,11 @@ import { tushareActionHandlers, tushareApiBaseUrl, validateTushareCredential } f
 
 const service = "tushare";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, tushareActionHandlers);
+const tushareFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, tushareActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -30,7 +35,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     headers.set("content-type", "application/json");
     headers.set("user-agent", providerUserAgent);
 
-    const response = await fetch(new URL(tushareApiBaseUrl), {
+    const response = await tushareFetch(new URL(tushareApiBaseUrl), {
       method: input.method,
       headers,
       body: JSON.stringify({ ...body, token: credential.apiKey }),

--- a/src/providers/twilio/executors.ts
+++ b/src/providers/twilio/executors.ts
@@ -1,11 +1,12 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -20,9 +21,12 @@ import {
 
 const service = "twilio";
 
+const twilioFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: twilioActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireCustomCredential(context, service);
     return {
@@ -57,7 +61,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await twilioFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Twilio request failed with HTTP ${response.status}`);

--- a/src/providers/twitter/executors.ts
+++ b/src/providers/twitter/executors.ts
@@ -10,11 +10,12 @@ import type { TwitterActionContext } from "./runtime.ts";
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   toProviderProxyError,
@@ -22,6 +23,9 @@ import {
 import { fetchTwitterCurrentAccount, twitterActionHandlers, twitterApiBaseUrl } from "./runtime.ts";
 
 const service = "twitter";
+
+// Fixed-host proxy egress (twitterApiBaseUrl); DNS-rebinding check is redundant here.
+const twitterFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<TwitterActionContext>({
   service,
@@ -70,7 +74,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await twitterFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Twitter request failed with HTTP ${response.status}`);

--- a/src/providers/uploadcare/executors.ts
+++ b/src/providers/uploadcare/executors.ts
@@ -7,11 +7,12 @@ import type {
 import type { UploadcareContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -29,9 +30,13 @@ import {
 
 const service = "uploadcare";
 
+// Fixed-host proxy egress (uploadcareApiBaseUrl); DNS-rebinding check is redundant here.
+const uploadcareFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors<UploadcareContext>({
   service,
   handlers: uploadcareActionHandlers,
+  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<UploadcareContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -74,7 +79,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       init.body = body;
     }
 
-    const response = await fetch(url, init);
+    const response = await uploadcareFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Uploadcare request failed with HTTP ${response.status}`);

--- a/src/providers/uptimerobot/executors.ts
+++ b/src/providers/uptimerobot/executors.ts
@@ -3,6 +3,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   createProviderTimeout,
   defineApiKeyProviderExecutors,
@@ -20,6 +21,9 @@ import {
 const service = "uptimerobot";
 const uptimerobotApiBaseUrl = "https://api.uptimerobot.com/v2";
 const uptimerobotDefaultRequestTimeoutMs = 30_000;
+
+// Fixed-host proxy egress (uptimerobotApiBaseUrl); DNS-rebinding check is redundant here.
+const uptimerobotProxyFetch = createProviderFetch({ skipDnsValidation: true });
 
 type UptimerobotRequestPhase = "validate" | "execute";
 type UptimerobotActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -93,7 +97,9 @@ export const uptimerobotActionHandlers: Record<string, UptimerobotActionHandler>
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, uptimerobotActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, uptimerobotActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -111,7 +117,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     body.set("api_key", credential.apiKey);
     body.set("format", "json");
 
-    const response = await fetch(url, {
+    const response = await uptimerobotProxyFetch(url, {
       method: input.method,
       headers,
       body,

--- a/src/providers/voiceflow/executors.ts
+++ b/src/providers/voiceflow/executors.ts
@@ -16,13 +16,14 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
+  createProviderFetch,
   createProviderProxyUrl,
+  createProviderTimeout,
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -34,6 +35,9 @@ const generalRuntimeBaseUrl = "https://general-runtime.voiceflow.com";
 const realtimeBaseUrl = "https://realtime-api.voiceflow.com";
 const defaultEnvironmentAlias = "main";
 const voiceflowRequestTimeoutMs = 30_000;
+
+// Fixed-host proxy egress (generalRuntimeBaseUrl / realtimeBaseUrl); DNS-rebinding check is redundant here.
+const voiceflowFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface VoiceflowActionContext {
   apiKey: string;
@@ -86,6 +90,7 @@ export const voiceflowActionHandlers: Record<VoiceflowActionName, VoiceflowActio
 export const executors: ProviderExecutors = defineProviderExecutors<VoiceflowActionContext>({
   service,
   handlers: voiceflowActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<VoiceflowActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -127,7 +132,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await voiceflowFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);

--- a/src/providers/vtex/executors.ts
+++ b/src/providers/vtex/executors.ts
@@ -10,8 +10,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -67,7 +68,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `vtex request failed with HTTP ${response.status}`);

--- a/src/providers/wachete/executors.ts
+++ b/src/providers/wachete/executors.ts
@@ -8,11 +8,12 @@ import type {
 import type { WacheteContext } from "./runtime.ts";
 
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -28,9 +29,13 @@ import {
 
 const service = "wachete";
 
+// Fixed-host proxy egress (wacheteApiBaseUrl); DNS-rebinding check is redundant here.
+const wacheteFetch = createProviderFetch({ skipDnsValidation: true });
+
 export const executors: ProviderExecutors = defineProviderExecutors<WacheteContext>({
   service,
   handlers: wacheteActionHandlers,
+  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<WacheteContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -48,7 +53,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
     const token = await requestWacheteToken({
       apiKey: credential.apiKey,
       userId: resolveWacheteUserId(credential),
-      fetcher: fetch,
+      fetcher: wacheteFetch,
       signal: context.signal,
       phase: "execute",
     });
@@ -61,7 +66,7 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
       headers.set("content-type", "application/json");
     }
 
-    const response = await fetch(url, {
+    const response = await wacheteFetch(url, {
       method: input.method,
       headers,
       body:

--- a/src/providers/woocommerce/executors.ts
+++ b/src/providers/woocommerce/executors.ts
@@ -5,12 +5,14 @@ import type {
   ProviderProxyExecutor,
 } from "../../core/types.ts";
 
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireCustomCredential,
@@ -24,6 +26,8 @@ import {
 
 const service = "woocommerce";
 
+const proxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: woocommerceActionHandlers,
@@ -32,6 +36,7 @@ export const executors: ProviderExecutors = defineProviderExecutors({
     return resolveWooCommerceCredentialContext(credential.values, fetcher, context.signal, context.transitFiles);
   },
   fallbackMessage: "woocommerce request failed",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
@@ -39,7 +44,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     const credential = await requireCustomCredential(context, service);
     const credentialContext = resolveWooCommerceCredentialContext(
       credential.values,
-      fetch,
+      proxyFetch,
       context.signal,
       context.transitFiles,
     );
@@ -63,7 +68,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await proxyFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(
@@ -79,6 +84,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   customCredential(input, { fetcher, signal }) {
-    return validateWooCommerceCredential(input.values, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateWooCommerceCredential(input.values, guardedFetcher, signal);
   },
 };

--- a/src/providers/woocommerce/runtime.ts
+++ b/src/providers/woocommerce/runtime.ts
@@ -14,7 +14,7 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError, readTransitFileInput } from "../provider-runtime.ts";
+import { providerFetch, providerUserAgent, ProviderRequestError, readTransitFileInput } from "../provider-runtime.ts";
 
 const maxMediaUploadSourceBytes = 20 * 1024 * 1024;
 
@@ -749,7 +749,7 @@ async function resolveMediaUploadSource(
 }
 
 async function downloadSourceBytes(sourceUrl: string, context: WooCommerceCredentialContext): Promise<Uint8Array> {
-  const response = await context.fetcher(sourceUrl, {
+  const response = await providerFetch(sourceUrl, {
     method: "GET",
     redirect: "error",
     signal: context.signal,

--- a/src/providers/wordpress/executors.ts
+++ b/src/providers/wordpress/executors.ts
@@ -5,12 +5,14 @@ import type {
   ProviderProxyExecutor,
 } from "../../core/types.ts";
 
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -25,9 +27,12 @@ import {
 
 const service = "wordpress";
 
+const guardedProviderFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: wordpressActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, service);
     return createWordpressContext(credential.apiKey, credential.values, fetcher, context.signal);
@@ -37,7 +42,12 @@ export const executors: ProviderExecutors = defineProviderExecutors({
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
     const credential = await requireApiKeyCredential(context, service);
-    const wordpressContext = createWordpressContext(credential.apiKey, credential.values, fetch, context.signal);
+    const wordpressContext = createWordpressContext(
+      credential.apiKey,
+      credential.values,
+      guardedProviderFetch,
+      context.signal,
+    );
     const url = createProviderProxyUrl(buildWordpressApiBaseUrl(wordpressContext.siteUrl), input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("authorization", `Basic ${btoa(`${wordpressContext.username}:${wordpressContext.apiKey}`)}`);
@@ -55,7 +65,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await guardedProviderFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `WordPress request failed with HTTP ${response.status}`);
@@ -68,6 +78,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
-    return validateWordpressCredential(input, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateWordpressCredential(input, guardedFetcher, signal);
   },
 };

--- a/src/providers/wordpress/runtime.ts
+++ b/src/providers/wordpress/runtime.ts
@@ -3,7 +3,7 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 import type { WordpressActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const wordpressValidationPath = "/users/me";
@@ -146,7 +146,16 @@ export function createWordpressContext(
   };
 }
 
-export function normalizeWordpressSiteUrl(value: string | undefined): string {
+/**
+ * Normalizes and SSRF-guards the WordPress site URL. By default only public
+ * hosts are allowed; set OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK to opt a
+ * deployment into private/LAN instances (reserved/loopback/metadata/IPv6
+ * ranges stay blocked regardless).
+ */
+export function normalizeWordpressSiteUrl(
+  value: string | undefined,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const raw = value?.trim();
   if (!raw) {
     throw new ProviderRequestError(400, "siteUrl is required");
@@ -179,6 +188,7 @@ export function normalizeWordpressSiteUrl(value: string | undefined): string {
   const normalized = `${parsed.origin}${parsed.pathname === "/" ? "" : parsed.pathname}`;
   assertPublicHttpUrl(normalized, {
     fieldName: "siteUrl",
+    allowPrivateNetwork,
     createError: (message) => new ProviderRequestError(400, message),
   });
   return normalized;

--- a/src/providers/zendesk/executors.ts
+++ b/src/providers/zendesk/executors.ts
@@ -9,8 +9,9 @@ import {
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
+  providerFetch,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -70,7 +71,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await providerFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Zendesk request failed with HTTP ${response.status}`);

--- a/src/providers/zorus/executors.ts
+++ b/src/providers/zorus/executors.ts
@@ -3,11 +3,12 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { arrayPayload, requestJson } from "../http-json-runtime.ts";
 import {
+  createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
   normalizeProviderProxyHeaders,
-  providerUserAgent,
   ProviderRequestError,
+  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
@@ -18,6 +19,9 @@ const service = "zorus";
 const apiBaseUrl = "https://developer.zorustech.com";
 const apiVersion = "1.0";
 const validationPath = "/api/customers/search";
+
+// Fixed-host proxy egress (apiBaseUrl); DNS-rebinding check is redundant here.
+const zorusFetch = createProviderFetch({ skipDnsValidation: true });
 
 type Handler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -47,7 +51,9 @@ export const zorusActionHandlers: Record<string, Handler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, zorusActionHandlers);
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, zorusActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
@@ -70,7 +76,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
       }
     }
 
-    const response = await fetch(url, init);
+    const response = await zorusFetch(url, init);
     if (!response.ok) {
       const text = await readProviderProxyErrorMessage(response, "");
       throw new ProviderRequestError(response.status, text || `Zorus request failed with HTTP ${response.status}`);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.test.ts", "scripts/**/*.test.ts", "web/src/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { setDefaultGuardedFetchDnsLookup } from "./src/core/guarded-fetch.ts";
+
+// Unit tests must never depend on real DNS resolution: disable the module
+// default (node:dns) lookup used by guarded provider fetches. Guard-specific
+// tests inject their own lookup through createGuardedFetch({ lookup }).
+setDefaultGuardedFetchDnsLookup(null);


### PR DESCRIPTION
`assertPublicHttpUrl` was a first-hop, string-based SSRF guard: it validated only the literal hostname of the initial URL, did no DNS resolution, and provider `fetch` calls defaulted to `redirect: "follow"`. A URL that passed the guard could still redirect to `169.254.169.254` / `127.0.0.1` / an RFC-1918 address, or a public hostname could resolve to a reserved IP — defeating the reserved-CIDR and cloud-metadata blocks the guard is meant to enforce, across all ~78 provider egress callers.

This adds a shared SSRF-guarded fetch and routes every provider's egress through it. `createGuardedFetch` (exposed to providers as `providerFetch` / `createProviderFetch`) validates the request URL **and every redirect `Location`** with `assertPublicHttpUrl`, follows redirects manually with spec-equivalent method/body rewrites and cross-origin credential-header stripping, and resolves each hostname to check its addresses against a shared v4/v6 blocked-address policy (`isBlockedIpAddress`, with new IPv6 parsing covering v4-mapped, NAT64, and 6to4 forms). The `defineProviderExecutors` / `defineProviderProxy` helpers inject the guarded fetch as `context.fetcher`, and a codemod moves the providers that called global `fetch` directly onto it.

Two follow-on concerns fall out of routing everything through one guard:

- **Self-hosted providers** whose instance host comes from credentials (`clickhouse`, `wordpress`, `elasticsearch`, `rocket_chat`, `btcpay_server`, and others) would otherwise lose access to private/LAN instances. They opt into private networks with `allowPrivateNetwork: isPrivateNetworkAccessAllowed`, gated by `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` (same mechanism as Dokploy). Reserved, loopback, link-local, and cloud-metadata targets stay blocked even when the opt-in is enabled, and user-supplied content URLs (`sourceUrl`, `fileUrl`) stay public-only regardless.
- **DNS resolved-address validation** runs once per request. It is on by default; fixed-host providers whose egress host is a hardcoded literal pass `skipDnsValidation: true` to skip the redundant lookup (the URL and redirect guards still run). It is never applied where the host is user- or credential-influenced.

Also folded in from review: `aliyun_oss` now reuses the shared `assertPublicHttpUrl` instead of a bespoke hostname check that missed cloud-metadata names and bracketed IPv6, and `pubmed` compares its rate-limit gate against `providerFetch` rather than the global `fetch` the runtime no longer injects.

Regression tests cover redirect-to-metadata, name→reserved-IP across the shared egress path, the private-network opt-in, and the `skipDnsValidation` boundary. `AGENTS.md` documents the egress rules for future providers.

Closes #94