### PR TITLE
refactor(core): use explicit allowlist for cross-origin header stripping

### DIFF
--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -210,6 +210,9 @@ describe("createGuardedFetch redirects", () => {
         "x-api-key": "provider-secret",
         "x-auth-token": "tok",
         "x-trace": "keep",
+        // Look-alike but non-credential headers must survive cross-origin.
+        "idempotency-key": "abc",
+        "x-correlation-id": "cid",
       },
     });
 
@@ -222,6 +225,8 @@ describe("createGuardedFetch redirects", () => {
     expect(crossOriginHeaders.has("x-api-key")).toBe(false);
     expect(crossOriginHeaders.has("x-auth-token")).toBe(false);
     expect(crossOriginHeaders.get("x-trace")).toBe("keep");
+    expect(crossOriginHeaders.get("idempotency-key")).toBe("abc");
+    expect(crossOriginHeaders.get("x-correlation-id")).toBe("cid");
   });
 
   it("passes through when the caller handles redirects manually", async () => {

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -52,14 +52,47 @@ export interface GuardedFetchOptions {
 const defaultMaxRedirects = 20;
 const redirectStatuses = new Set([301, 302, 303, 307, 308]);
 /**
- * Credential-bearing headers dropped when a redirect crosses origins. Covers the
+ * Credential-bearing request headers dropped when a redirect crosses origins, so
+ * a cross-origin redirect cannot exfiltrate a provider credential. Covers the
  * fetch-spec set (`authorization`/`cookie`/`proxy-authorization`) plus the
- * custom auth headers provider egress commonly sends (`x-api-key`, `api-key`,
- * `x-auth-token`, and similar key/token/secret headers), so a cross-origin
- * redirect cannot exfiltrate a provider credential.
+ * common custom auth headers provider egress sends. This is an explicit
+ * allowlist rather than a name pattern so it never strips look-alike but
+ * non-credential headers (e.g. `idempotency-key`, `x-correlation-id`); add a
+ * provider's header here if it authenticates with a name not already listed.
  */
-const crossOriginSensitiveHeaderPattern =
-  /^(authorization|cookie|proxy-authorization|(x-)?(api[-_]?key|auth[-_]?token|access[-_]?token|api[-_]?token|app[-_]?key|.*[-_](key|token|secret|password)))$/u;
+const crossOriginCredentialHeaders = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "api-key",
+  "apikey",
+  "x-api-key",
+  "x-apikey",
+  "api-token",
+  "x-api-token",
+  "auth-token",
+  "x-auth-token",
+  "x-auth-key",
+  "access-token",
+  "x-access-token",
+  "app-key",
+  "x-app-key",
+  "api-secret",
+  "x-api-secret",
+  "client-secret",
+  "x-client-secret",
+  "x-secret",
+  "token",
+  "x-token",
+  "session-token",
+  "x-session-token",
+  "private-token",
+  "x-private-token",
+  "x-csrf-token",
+  "x-xsrf-token",
+  "x-goog-api-key",
+  "x-amz-security-token",
+]);
 /** Body-describing headers dropped when a redirect rewrites the method to GET, mirroring the fetch spec. */
 const bodyHeaders = ["content-encoding", "content-language", "content-length", "content-location", "content-type"];
 
@@ -204,7 +237,7 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
       }
       if (guardedNext.origin !== url.origin) {
         for (const name of [...headers.keys()]) {
-          if (crossOriginSensitiveHeaderPattern.test(name)) {
+          if (crossOriginCredentialHeaders.has(name)) {
             headers.delete(name);
           }
         }


### PR DESCRIPTION
Follow-up to #97. The cross-origin redirect guard dropped credential headers by matching a broad `.*[-_](key|token|secret|password)$` pattern, which also caught look-alike but non-credential headers — `idempotency-key`, `x-idempotency-key` — and stripped them on cross-origin redirect hops. Losing an idempotency key mid-redirect is a silent correctness hazard for a request that was otherwise fine.

This replaces the pattern with an explicit `crossOriginCredentialHeaders` set of known credential header names (the fetch-spec `authorization`/`cookie`/`proxy-authorization` plus the common custom auth headers provider egress sends). It keeps the credential stripping that closes the exfiltration path while never touching headers that merely end in `-key`/`-token`, and a regression test now asserts `idempotency-key` and `x-correlation-id` survive a cross-origin redirect while `x-api-key`/`x-auth-token` are still dropped.

Trade-off: a provider authenticating with a credential header name not yet in the set won't have it stripped cross-origin — added to the set as needed, and noted in the doc comment. This is acceptable because provider egress rarely follows cross-origin redirects, and over-stripping a non-credential header is the more common real-world hazard.