### PR TITLE
docs(core): document private-network guard tiers and RFC mapping

### DIFF
--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -141,8 +141,9 @@ const localHostnames = new Set(["localhost", "localhost.localdomain", "ip6-local
 const cloudMetadataHostnames = new Set(["instance-data.ec2.internal", "metadata.google.internal", "metadata.goog"]);
 // Always blocked: .localhost (RFC 6761 loopback) and the localhost.localdomain alias.
 const localHostnameSuffixes = [".localhost", ".localdomain"];
-// Flag-gated: private-use TLDs — .local (mDNS, RFC 6762), .internal (ICANN 2024 reservation),
-// .home/.lan (convention). Reachable only with the private-network opt-in.
+// Flag-gated: private hostname suffixes with mixed standards status — .local (mDNS special-use,
+// RFC 6762), .internal (ICANN 2024 private-use reservation), .home/.lan (convention only).
+// Reachable only with the private-network opt-in.
 const privateHostnameSuffixes = [".local", ".internal", ".home", ".lan"];
 // Flag-gated: RFC 1918 private-use (10/8, 172.16/12, 192.168/16) + RFC 6598 CGNAT (100.64/10).
 const privateIpv4Cidrs: Array<[number, number]> = [

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -120,16 +120,42 @@ export async function readBoundedResponseBytes(
   return bytes;
 }
 
+// Egress targets are classified into two tiers for the SSRF guard:
+//
+//   - "reserved" (localHostnames, cloudMetadataHostnames, localHostnameSuffixes,
+//     reservedIpv4Cidrs, reservedIpv6Cidrs): loopback, link-local, cloud-metadata,
+//     multicast, and other unsafe special-use ranges. ALWAYS blocked — the
+//     private-network opt-in never unblocks these, because they are the classic
+//     SSRF escalation targets ("don't let the deployment attack itself").
+//   - "private" (privateHostnameSuffixes, privateIpv4Cidrs, privateIpv6Cidrs):
+//     RFC 1918 / CGNAT / IPv6 ULA LAN ranges and private hostname suffixes.
+//     Blocked by default, but reachable once a self-hosted deployment opts in via
+//     OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK (see isPrivateNetworkAccessAllowed).
+//
+// So the flag toggles LAN/private-network reachability only; loopback and
+// link-local/metadata stay blocked in both states.
+
+// Always blocked: names that resolve to loopback, regardless of the flag.
 const localHostnames = new Set(["localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"]);
+// Always blocked: cloud instance-metadata endpoints (prime SSRF escalation targets).
 const cloudMetadataHostnames = new Set(["instance-data.ec2.internal", "metadata.google.internal", "metadata.goog"]);
+// Always blocked: .localhost (RFC 6761 loopback) and the localhost.localdomain alias.
 const localHostnameSuffixes = [".localhost", ".localdomain"];
+// Flag-gated: private-use TLDs — .local (mDNS, RFC 6762), .internal (ICANN 2024 reservation),
+// .home/.lan (convention). Reachable only with the private-network opt-in.
 const privateHostnameSuffixes = [".local", ".internal", ".home", ".lan"];
+// Flag-gated: RFC 1918 private-use (10/8, 172.16/12, 192.168/16) + RFC 6598 CGNAT (100.64/10).
 const privateIpv4Cidrs: Array<[number, number]> = [
   [ipv4ToNumber("10.0.0.0"), 8],
   [ipv4ToNumber("100.64.0.0"), 10],
   [ipv4ToNumber("172.16.0.0"), 12],
   [ipv4ToNumber("192.168.0.0"), 16],
 ];
+// Always blocked (opt-in never unblocks these): this-network (0/8), loopback (127/8),
+// link-local incl. the 169.254.169.254 metadata host (169.254/16), IANA protocol/documentation/
+// benchmark blocks, multicast (224/4), and future-use (240/4). 100.100.100.200/32 is the Alibaba
+// Cloud metadata endpoint — it sits inside CGNAT (100.64/10) but is pinned here so it stays
+// blocked even after opting into private networks.
 const reservedIpv4Cidrs: Array<[number, number]> = [
   [ipv4ToNumber("0.0.0.0"), 8],
   [ipv4ToNumber("100.100.100.200"), 32],
@@ -143,6 +169,8 @@ const reservedIpv4Cidrs: Array<[number, number]> = [
   [ipv4ToNumber("224.0.0.0"), 4],
   [ipv4ToNumber("240.0.0.0"), 4],
 ];
+// Always blocked: unspecified/loopback (::, ::1), link-local (fe80::/10), multicast (ff00::/8),
+// plus discard, documentation, benchmark, and other special-purpose IPv6 ranges (RFC 6890 registry).
 const reservedIpv6Cidrs: Array<[Uint8Array, number]> = [
   [ipv6ToBytes("::"), 128],
   [ipv6ToBytes("::1"), 128],
@@ -156,6 +184,8 @@ const reservedIpv6Cidrs: Array<[Uint8Array, number]> = [
   [ipv6ToBytes("fe80::"), 10],
   [ipv6ToBytes("ff00::"), 8],
 ];
+// Flag-gated: IPv6 ULA (fc00::/7, RFC 4193) and deprecated site-local (fec0::/10, RFC 3879).
+// Only reached via the resolved-address path — assertPublicHttpUrl rejects every literal IPv6 URL.
 const privateIpv6Cidrs: Array<[Uint8Array, number]> = [
   [ipv6ToBytes("fc00::"), 7],
   [ipv6ToBytes("fec0::"), 10],


### PR DESCRIPTION
The SSRF egress guard in `request.ts` sorts targets into two tiers, but the bare constant lists gave no hint which was which — so it was easy to read the `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` opt-in as "unblock everything local" when it only ever opens the private/LAN tier. This annotates each constant group so the distinction is visible at the definition site.

`localHostnames`, `cloudMetadataHostnames`, the `*HostnameSuffixes`, and the `*Ipv4Cidrs`/`*Ipv6Cidrs` groups are each marked as always-blocked "reserved" (loopback, link-local, cloud-metadata, multicast) or flag-gated "private" (RFC 1918, RFC 6598 CGNAT, RFC 4193 ULA, private hostname suffixes), with a header spelling out that the flag toggles LAN reachability only — loopback and link-local/metadata stay blocked in both states.

It also records the non-obvious range attributions inline: `100.100.100.200/32` is the Alibaba Cloud metadata endpoint, pinned as reserved even though it sits inside CGNAT space, and IPv6 ULA is reachable only via the resolved-address path because `assertPublicHttpUrl` rejects every literal IPv6 URL.

Comment-only change; no behavior change, and the existing `request`/`guarded-fetch` tests still pass.