### PR TITLE
refactor(breeze): validate configured base URL with shared public-URL guard

### DIFF
--- a/src/providers/breeze/runtime.test.ts
+++ b/src/providers/breeze/runtime.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { buildBreezeBaseUrl, normalizeBreezeBaseUrl, normalizeBreezeSubdomain } from "./runtime.ts";
+
+describe("normalizeBreezeBaseUrl", () => {
+  it("accepts an https Breeze subdomain URL and strips path, query, and port", () => {
+    expect(normalizeBreezeBaseUrl("https://mychurch.breezechms.com")).toBe("https://mychurch.breezechms.com");
+    expect(normalizeBreezeBaseUrl("https://mychurch.breezechms.com/api/people?x=1")).toBe(
+      "https://mychurch.breezechms.com",
+    );
+    expect(normalizeBreezeBaseUrl("https://mychurch.breezechms.com:8443/path")).toBe("https://mychurch.breezechms.com");
+  });
+
+  it("normalizes hostnames the shared public-URL guard normalizes", () => {
+    expect(normalizeBreezeBaseUrl("https://MyChurch.BreezeChms.com")).toBe("https://mychurch.breezechms.com");
+    expect(normalizeBreezeBaseUrl("https://mychurch.breezechms.com.")).toBe("https://mychurch.breezechms.com");
+  });
+
+  it("rejects non-https and non-Breeze hosts", () => {
+    expect(normalizeBreezeBaseUrl("http://mychurch.breezechms.com")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("https://example.com")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("https://evilbreezechms.com")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("https://breezechms.com.attacker.example")).toBeUndefined();
+  });
+
+  it("rejects values the shared public-URL guard blocks", () => {
+    expect(normalizeBreezeBaseUrl("ftp://mychurch.breezechms.com")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("https://localhost")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("https://169.254.169.254")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("not a url")).toBeUndefined();
+  });
+
+  it("returns undefined for missing values", () => {
+    expect(normalizeBreezeBaseUrl(undefined)).toBeUndefined();
+    expect(normalizeBreezeBaseUrl("")).toBeUndefined();
+    expect(normalizeBreezeBaseUrl(42)).toBeUndefined();
+  });
+});
+
+describe("normalizeBreezeSubdomain", () => {
+  it("accepts plain subdomains and lowercases them", () => {
+    expect(normalizeBreezeSubdomain("MyChurch")).toBe("mychurch");
+    expect(normalizeBreezeSubdomain("my-church2")).toBe("my-church2");
+  });
+
+  it("accepts full Breeze URLs and hostnames", () => {
+    expect(normalizeBreezeSubdomain("https://mychurch.breezechms.com")).toBe("mychurch");
+    expect(normalizeBreezeSubdomain("mychurch.breezechms.com")).toBe("mychurch");
+  });
+
+  it("rejects empty and malformed values", () => {
+    expect(() => normalizeBreezeSubdomain(undefined)).toThrow(ProviderRequestError);
+    expect(() => normalizeBreezeSubdomain("   ")).toThrow(ProviderRequestError);
+    expect(() => normalizeBreezeSubdomain("bad subdomain!")).toThrow(ProviderRequestError);
+    expect(() => normalizeBreezeSubdomain("https://")).toThrow(ProviderRequestError);
+  });
+});
+
+describe("buildBreezeBaseUrl", () => {
+  it("builds the canonical Breeze base URL", () => {
+    expect(buildBreezeBaseUrl("mychurch")).toBe("https://mychurch.breezechms.com");
+  });
+});

--- a/src/providers/breeze/runtime.ts
+++ b/src/providers/breeze/runtime.ts
@@ -2,6 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, positiveInteger } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const breezeApiPathPrefix = "/api";
@@ -293,15 +294,20 @@ export function normalizeBreezeBaseUrl(value: unknown): string | undefined {
     return undefined;
   }
 
+  let url: URL;
   try {
-    const url = new URL(input);
-    if (url.protocol !== "https:" || !url.hostname.endsWith(".breezechms.com")) {
-      return undefined;
-    }
-    return `${url.protocol}//${url.hostname}`;
+    url = assertPublicHttpUrl(input, {
+      fieldName: "baseUrl",
+      createError: (message) => new ProviderRequestError(400, message),
+    });
   } catch {
     return undefined;
   }
+
+  if (url.protocol !== "https:" || !url.hostname.endsWith(".breezechms.com")) {
+    return undefined;
+  }
+  return `${url.protocol}//${url.hostname}`;
 }
 
 export function normalizeBreezeSubdomain(value: unknown): string {


### PR DESCRIPTION
## Summary

- `normalizeBreezeBaseUrl` hand-rolled its `protocol !== "https:" || !hostname.endsWith(".breezechms.com")` check. AGENTS.md prefers the shared `assertPublicHttpUrl` / `isBlockedIpAddress` guards over bespoke per-provider hostname checks, since bespoke guards have historically missed the cloud-metadata blocklist and hostname normalization.
- The configured base URL now goes through `assertPublicHttpUrl` first, then the existing https + `*.breezechms.com` allowlist. Invalid values still return `undefined` so the executor falls back to `buildBreezeBaseUrl(subdomain)` exactly as before.
- Side benefit: hostnames the shared guard normalizes (e.g. trailing-dot FQDNs like `mychurch.breezechms.com.`) now normalize instead of silently falling back.
- Adds `src/providers/breeze/runtime.test.ts` covering `normalizeBreezeBaseUrl`, `normalizeBreezeSubdomain`, and `buildBreezeBaseUrl` (same convention as baidu_maps/datalust/jumpserver runtime tests).

## Testing

- `npm run fix-check`
- `npm test` (48 files / 401 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)