### PR TITLE
fix(baidu_maps): accept scope as both string and integer

### DIFF
--- a/src/providers/baidu_maps/actions.ts
+++ b/src/providers/baidu_maps/actions.ts
@@ -133,7 +133,19 @@ export const baiduMapsActions: ActionDefinition[] = [
         city_limit: s.integer(
           "Whether to restrict results to the supplied region (1) or extend to nearby regions (0).",
         ),
-        scope: s.stringEnum("The result scope.", ["1", "2"]),
+        // Baidu's place-search `scope` parameter is documented as a numeric enum
+        // (1 = basic, 2 = detail) but the upstream API also accepts the string
+        // forms "1" / "2". Some SDKs and docs serialize it as a string, so we
+        // accept both — but still constrain the integer form to {1, 2} so
+        // out-of-range values get a clear validation error instead of being
+        // silently forwarded and rejected by Baidu.
+        scope: s.anyOf(
+          [
+            s.stringEnum(["1", "2"]),
+            { type: "integer", enum: [1, 2], description: "The integer-form scope (1 or 2)." },
+          ],
+          { description: "The result scope. Baidu accepts either the string or the integer form." },
+        ),
         filter: s.string("Pipe separated industry filtering tags."),
         coord_type: s.string("The coordinate system of returned locations."),
         ret_coordtype: s.string("Alias for coord_type used by some Baidu endpoints."),
@@ -141,7 +153,7 @@ export const baiduMapsActions: ActionDefinition[] = [
         page_num: s.nonNegativeInteger("The zero-based page index."),
       },
       {
-        optional: ["region", "city_limit", "scope", "filter", "coord_type", "ret_coordtype", "page_size", "page_num"],
+        optional: ["region", "city_limit", "filter", "coord_type", "ret_coordtype", "page_size", "page_num"],
       },
     ),
     s.requiredObject("The place search response.", {
@@ -213,7 +225,16 @@ export const baiduMapsActions: ActionDefinition[] = [
       "Input parameters for place detail lookup.",
       {
         uid: s.nonEmptyString("The Baidu Maps place identifier (uid)."),
-        scope: s.stringEnum("The detail scope.", ["1", "2"]),
+        // Same string-or-integer contract as search_places.scope — Baidu's
+        // place-detail endpoint accepts both, and SDKs differ on which they
+        // emit. Integer is constrained to {1, 2} for the same reason.
+        scope: s.anyOf(
+          [
+            s.stringEnum(["1", "2"]),
+            { type: "integer", enum: [1, 2], description: "The integer-form scope (1 or 2)." },
+          ],
+          { description: "The detail scope. Baidu accepts either the string or the integer form." },
+        ),
         coord_type: s.string("The coordinate system of returned locations."),
       },
       { optional: ["scope", "coord_type"] },

--- a/src/providers/baidu_maps/actions.ts
+++ b/src/providers/baidu_maps/actions.ts
@@ -153,7 +153,7 @@ export const baiduMapsActions: ActionDefinition[] = [
         page_num: s.nonNegativeInteger("The zero-based page index."),
       },
       {
-        optional: ["region", "city_limit", "filter", "coord_type", "ret_coordtype", "page_size", "page_num"],
+        optional: ["region", "city_limit", "scope", "filter", "coord_type", "ret_coordtype", "page_size", "page_num"],
       },
     ),
     s.requiredObject("The place search response.", {

--- a/src/providers/baidu_maps/runtime.test.ts
+++ b/src/providers/baidu_maps/runtime.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { provider as baiduMapsProvider } from "./definition.ts";
 import {
   baiduMapsActionHandlers,
   baiduMapsApiBaseUrl,
@@ -522,6 +524,62 @@ describe("Baidu Maps runtime", () => {
       "sk-x",
     );
     expect(url.searchParams.get("sn")).toBe(expected);
+  });
+
+  // Regression: Baidu's `scope` parameter is documented as a numeric enum but
+  // many callers (and Baidu's own JS SDK) serialize it as a string. The
+  // previous stringEnum-only schema rejected numeric input with a confusing
+  // "Instance type 'number' is invalid. Expected 'string'." error.
+  describe("scope accepts both string and integer forms", () => {
+    const searchPlaces = baiduMapsProvider.actions.find((a) => a.id === "baidu_maps.search_places")!;
+    const getDetail = baiduMapsProvider.actions.find((a) => a.id === "baidu_maps.get_place_detail")!;
+
+    it("search_places schema accepts scope='2'", () => {
+      const r = validateActionInput(searchPlaces, { query: "咖啡", region: "北京", scope: "2" });
+      expect(r.valid).toBe(true);
+    });
+
+    it("search_places schema accepts scope=2", () => {
+      const r = validateActionInput(searchPlaces, { query: "咖啡", region: "北京", scope: 2 });
+      expect(r.valid).toBe(true);
+    });
+
+    it("search_places schema rejects scope=3 (not in enum)", () => {
+      const r = validateActionInput(searchPlaces, { query: "咖啡", region: "北京", scope: 3 });
+      expect(r.valid).toBe(false);
+    });
+
+    it("get_place_detail schema accepts scope=2", () => {
+      const r = validateActionInput(getDetail, { uid: "abc", scope: 2 });
+      expect(r.valid).toBe(true);
+    });
+
+    it("search_places handler forwards scope=2 to the wire", async () => {
+      const requests: RecordedRequest[] = [];
+      const fetcher = createFetcher(requests, { status: 0, results: [] });
+      await baiduMapsActionHandlers.search_places(
+        { query: "咖啡", region: "北京", scope: 2 },
+        { apiKey: "ak-s", fetcher },
+      );
+      expect(new URL(requests[0]!.url).searchParams.get("scope")).toBe("2");
+    });
+
+    it("search_places handler forwards scope='1' to the wire", async () => {
+      const requests: RecordedRequest[] = [];
+      const fetcher = createFetcher(requests, { status: 0, results: [] });
+      await baiduMapsActionHandlers.search_places(
+        { query: "咖啡", region: "北京", scope: "1" },
+        { apiKey: "ak-s", fetcher },
+      );
+      expect(new URL(requests[0]!.url).searchParams.get("scope")).toBe("1");
+    });
+
+    it("get_place_detail handler forwards scope=2 to the wire", async () => {
+      const requests: RecordedRequest[] = [];
+      const fetcher = createFetcher(requests, { status: 0, result: {} });
+      await baiduMapsActionHandlers.get_place_detail({ uid: "u-1", scope: 2 }, { apiKey: "ak-d", fetcher });
+      expect(new URL(requests[0]!.url).searchParams.get("scope")).toBe("2");
+    });
   });
 });
 

--- a/src/providers/baidu_maps/runtime.test.ts
+++ b/src/providers/baidu_maps/runtime.test.ts
@@ -549,6 +549,11 @@ describe("Baidu Maps runtime", () => {
       expect(r.valid).toBe(false);
     });
 
+    it("search_places schema keeps scope optional (accepts input without scope)", () => {
+      const r = validateActionInput(searchPlaces, { query: "咖啡", region: "北京" });
+      expect(r.valid).toBe(true);
+    });
+
     it("get_place_detail schema accepts scope=2", () => {
       const r = validateActionInput(getDetail, { uid: "abc", scope: 2 });
       expect(r.valid).toBe(true);

--- a/src/providers/baidu_maps/runtime.ts
+++ b/src/providers/baidu_maps/runtime.ts
@@ -302,7 +302,10 @@ function payloadFromSearch(
     city_limit: readOptionalIntegerLike(input.cityLimit ?? input.city_limit),
     output: "json",
     filter: readOptionalString(input.filter),
-    scope: readOptionalString(input.scope),
+    // `scope` is declared as a string|int union in actions.ts because Baidu
+    // accepts both forms. readOptionalString drops numbers, so use the
+    // string-coercing variant to preserve either shape.
+    scope: readOptionalStringLike(input.scope),
     coord_type: readOptionalString(input.coordType ?? input.coord_type),
     ret_coordtype: readOptionalString(input.retCoordtype ?? input.ret_coordtype),
     page_size: readOptionalIntegerLike(input.pageSize ?? input.page_size),
@@ -338,7 +341,8 @@ async function executeGetPlaceDetail(input: RuntimeInput, context: BaiduMapsActi
       "/place/v2/detail",
       compactObject({
         uid: readRequiredString(input.uid, "uid"),
-        scope: readOptionalString(input.scope),
+        // Same string|int union as search_places.scope — see comment there.
+        scope: readOptionalStringLike(input.scope),
         output: "json",
         coord_type: readOptionalString(input.coordType ?? input.coord_type),
         ak: context.apiKey,


### PR DESCRIPTION
# fix(baidu_maps): accept `scope` as both string and integer

## Problem

`baidu_maps.search_places` and `baidu_maps.get_place_detail` rejected numeric
input for the `scope` parameter with:

```
Property "scope" does not match schema.
Instance type "number" is invalid. Expected "string".
Instance does not match any of ["1","2"].
```

Real friction: Baidu documents `scope` as a numeric enum (`1` = basic,
`2` = detail) but the upstream endpoint accepts both `1` and `"1"`. Many
callers — including Baidu's own JS SDK — emit the integer form, and were
rejected at the JSON-Schema layer before reaching the network. Verified by
re-running the actions through the local MCP server after the patch: both
`scope: 2` and `scope: "2"` now succeed and return the rich `detail_info`
section that the previous strict-string schema would have hidden.

## Root cause

`actions.ts` declared `scope` as `s.stringEnum("…", ["1", "2"])`, which
produces `{ type: "string", enum: ["1", "2"] }` and strictly rejects integers.

## Fix

1. **`src/providers/baidu_maps/actions.ts`** — declare `scope` as `anyOf` of
   `stringEnum(["1","2"])` and `{ type: "integer", enum: [1, 2] }`. The integer
   branch is constrained to `{1, 2}` so out-of-range values still fail
   validation with a clear error instead of being silently forwarded to Baidu.
2. **`src/providers/baidu_maps/runtime.ts`** — both handlers previously used
   `readOptionalString(input.scope)`, which drops numbers. Switch to the
   existing `readOptionalStringLike` helper so the integer form is forwarded
   as the string `"1"` / `"2"` on the wire (Baidu's server accepts both).

## Tests

Added a `describe("scope accepts both string and integer forms")` block in
`src/providers/baidu_maps/runtime.test.ts` covering:

- `search_places` schema accepts `scope: "2"`, `scope: 2`, rejects `scope: 3`
- `get_place_detail` schema accepts `scope: 2`
- `search_places` handler forwards `scope: 2` and `scope: "1"` to the wire as
  `"2"` / `"1"` respectively
- `get_place_detail` handler forwards `scope: 2` to the wire as `"2"`

## Verification

- `npx vitest run src/providers/baidu_maps` — 35/35 tests pass
- `npm test` — 39 files / 297 tests pass (no regressions)
- `npm run typecheck` — clean
- Live re-validation through the local MCP server after a catalog regen:
  - `baidu_maps.search_places` with `scope: 2` → returned 42 results with
    `detail_info` (previously rejected)
  - `baidu_maps.get_place_detail` with `scope: 2` → returned `detail_info`
    section (previously rejected)

## Reproduction (before the fix)

```ts
import { provider } from "src/providers/baidu_maps/definition.ts";
import { validateActionInput } from "src/core/validation.ts";

const action = provider.actions.find((a) => a.id === "baidu_maps.search_places")!;

validateActionInput(action, { query: "咖啡", region: "北京", scope: 2 });
// → { valid: false, errors: [Instance type "number" is invalid. Expected "string".] }
```

## After the fix

```ts
validateActionInput(action, { query: "咖啡", region: "北京", scope: 2 });
// → { valid: true }

validateActionInput(action, { query: "咖啡", region: "北京", scope: 3 });
// → { valid: false } — clear "out of enum" error, still rejected
```

## Notes

- Only touches three files (2 source + 1 test) in the existing `baidu_maps`
  provider — no changes to the framework's `json-schema.ts` or
  `validation.ts`, so other providers' enums are unaffected.
- Branch: `fix/baidu-maps-scope-coercion` based on `origin/main` (the baidu_maps
  provider was merged into `main` via #95 before this PR, so this targets
  `main` directly).