### PR TITLE
fix(oauth): guard token exchanges

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requestAuthorizationCodeToken } from "./oauth-token.ts";
+
+describe("OAuth token requests", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("configures redirect error mode while exchanging an authorization code", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      throw new TypeError("redirect rejected");
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      requestAuthorizationCodeToken({
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "authorization-code",
+        createError: (message) => new Error(message),
+        redirectUri: "https://runtime.example.com/oauth/callback",
+        tokenEndpointAuthMethod: "client_secret_post",
+        tokenUrl: "https://provider.example.com/oauth/token",
+      }),
+    ).rejects.toThrow("OAuth token request failed.");
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    const init = fetcher.mock.calls[0]?.[1];
+    expect(init).toMatchObject({ method: "POST", redirect: "error" });
+    expect(String(init?.body)).toContain("client_secret=client-secret");
+    expect(String(init?.body)).toContain("code=authorization-code");
+  });
+
+  it("preserves the token-request timeout error", async () => {
+    const timeout = new Error("request timed out");
+    timeout.name = "TimeoutError";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(timeout)),
+    );
+
+    await expect(
+      requestAuthorizationCodeToken({
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "authorization-code",
+        createError: (message) => new Error(message),
+        redirectUri: "https://runtime.example.com/oauth/callback",
+        tokenEndpointAuthMethod: "client_secret_post",
+        tokenUrl: "https://provider.example.com/oauth/token",
+      }),
+    ).rejects.toThrow("OAuth token request timed out.");
+  });
+});

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -2,6 +2,7 @@ import type { OAuth2AuthDefinition, ResolvedCredential } from "../core/types.ts"
 
 import { optionalString, requiredString } from "../core/cast.ts";
 import { readBoundedResponseBytes } from "../core/request.ts";
+import { providerFetch } from "../providers/provider-runtime.ts";
 
 const oauthTokenRequestTimeoutMs = 30_000;
 const oauthTokenResponseMaxBytes = 1024 * 1024;
@@ -85,11 +86,12 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
 
   let response: Response;
   try {
-    response = await fetch(input.tokenUrl, {
+    response = await providerFetch(input.tokenUrl, {
       method: "POST",
       headers,
       body,
       signal: AbortSignal.timeout(oauthTokenRequestTimeoutMs),
+      redirect: "error",
     });
   } catch (error) {
     throw input.createError(


### PR DESCRIPTION
## Summary

- Route OAuth token exchanges through the shared provider egress guard.
- Reject token endpoint redirects so credential-bearing POST requests are never replayed to another origin.

## Root cause

The token client used the platform fetch default redirect behavior. A 307 or 308 response could replay OAuth credentials to a redirect target, and configured token endpoints bypassed DNS-backed egress validation.

## Validation

- npx vitest run src/oauth/oauth-token.test.ts
- npm test
- npm run typecheck
- npx oxlint src/oauth/oauth-token.ts src/oauth/oauth-token.test.ts
- npx oxfmt --check src/oauth/oauth-token.ts src/oauth/oauth-token.test.ts
