### PR TITLE
feat(web): manage multiple provider connections

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -159,6 +159,11 @@
       "notUsed": "Not used"
     },
     "connection": "Connection",
+    "savedConnection": "Saved connection",
+    "connectionName": "Connection name",
+    "connectionNamePlaceholder": "for example, work",
+    "connectionNameDescription": "Use this name to select the account when running actions.",
+    "connectionNameExists": "This name is already in use. Select that connection to reconnect it.",
     "connectionMethod": "Connection method",
     "connectionDescriptions": {
       "noSetup": "This provider can run without local credentials.",
@@ -201,6 +206,8 @@
       "configureOAuthClient": "Configure OAuth Client",
       "editOAuthClient": "Edit OAuth Client",
       "saveConnection": "Save Connection",
+      "addConnection": "Add Connection",
+      "cancel": "Cancel",
       "connect": "Connect",
       "details": "Details",
       "manageConnection": "Manage",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -159,6 +159,11 @@
       "notUsed": "Non utilisé"
     },
     "connection": "Connexion",
+    "savedConnection": "Connexion enregistrée",
+    "connectionName": "Nom de la connexion",
+    "connectionNamePlaceholder": "par exemple, work",
+    "connectionNameDescription": "Utilisez ce nom pour sélectionner le compte lors de l’exécution d’actions.",
+    "connectionNameExists": "Ce nom est déjà utilisé. Sélectionnez cette connexion pour la reconnecter.",
     "connectionMethod": "Méthode de connexion",
     "connectionDescriptions": {
       "noSetup": "Ce fournisseur peut s’exécuter sans identifiants locaux.",
@@ -201,6 +206,8 @@
       "configureOAuthClient": "Configurer le client OAuth",
       "editOAuthClient": "Modifier le client OAuth",
       "saveConnection": "Enregistrer la connexion",
+      "addConnection": "Ajouter une connexion",
+      "cancel": "Annuler",
       "connect": "Connecter",
       "details": "Détails",
       "manageConnection": "Gérer",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -159,6 +159,11 @@
       "notUsed": "未使用"
     },
     "connection": "接続",
+    "savedConnection": "保存済みの接続",
+    "connectionName": "接続名",
+    "connectionNamePlaceholder": "例: work",
+    "connectionNameDescription": "アクションの実行時に、この名前でアカウントを選択します。",
+    "connectionNameExists": "この名前はすでに使用されています。再接続するには既存の接続を選択してください。",
     "connectionMethod": "接続方式",
     "connectionDescriptions": {
       "noSetup": "このプロバイダーはローカル認証情報なしで実行できます。",
@@ -201,6 +206,8 @@
       "configureOAuthClient": "OAuth Client を設定",
       "editOAuthClient": "OAuth Client を編集",
       "saveConnection": "接続を保存",
+      "addConnection": "接続を追加",
+      "cancel": "キャンセル",
       "connect": "接続",
       "details": "詳細",
       "manageConnection": "管理",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -159,6 +159,11 @@
       "notUsed": "Не используется"
     },
     "connection": "Подключение",
+    "savedConnection": "Сохраненное подключение",
+    "connectionName": "Имя подключения",
+    "connectionNamePlaceholder": "например, work",
+    "connectionNameDescription": "Используйте это имя для выбора аккаунта при запуске действий.",
+    "connectionNameExists": "Это имя уже используется. Выберите существующее подключение, чтобы переподключить его.",
     "connectionMethod": "Способ подключения",
     "connectionDescriptions": {
       "noSetup": "Этот провайдер может работать без локальных учетных данных.",
@@ -201,6 +206,8 @@
       "configureOAuthClient": "Настроить OAuth Client",
       "editOAuthClient": "Изменить OAuth Client",
       "saveConnection": "Сохранить подключение",
+      "addConnection": "Добавить подключение",
+      "cancel": "Отмена",
       "connect": "Подключить",
       "details": "Детали",
       "manageConnection": "Управлять",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -159,6 +159,11 @@
       "notUsed": "未使用"
     },
     "connection": "连接",
+    "savedConnection": "已保存的连接",
+    "connectionName": "连接名称",
+    "connectionNamePlaceholder": "例如 work",
+    "connectionNameDescription": "运行操作时使用这个名称选择账号。",
+    "connectionNameExists": "这个名称已被使用；请选择已有连接进行重新连接。",
     "connectionMethod": "连接方式",
     "connectionDescriptions": {
       "noSetup": "这个提供商无需本地凭证即可运行。",
@@ -201,6 +206,8 @@
       "configureOAuthClient": "配置 OAuth Client",
       "editOAuthClient": "编辑 OAuth Client",
       "saveConnection": "保存连接",
+      "addConnection": "添加连接",
+      "cancel": "取消",
       "connect": "连接",
       "details": "详情",
       "manageConnection": "管理",

--- a/web/src/providers-page.test.ts
+++ b/web/src/providers-page.test.ts
@@ -7,6 +7,8 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppI18n } from "./i18n";
 import {
+  configurableConnectionsForProvider,
+  connectionDisplayLabel,
   connectionSubmitLabel,
   createOAuthPopupFeatures,
   isProviderLocallyAvailable,
@@ -54,6 +56,34 @@ describe("shouldShowConnectionActions", () => {
   it("shows connection actions when credentials or OAuth are required", () => {
     expect(shouldShowConnectionActions({ type: "api_key" })).toBe(true);
     expect(shouldShowConnectionActions({ type: "oauth2", scopes: [] })).toBe(true);
+  });
+});
+
+describe("provider connection management", () => {
+  it("keeps all saved connections for the selected provider", () => {
+    expect(
+      configurableConnectionsForProvider(
+        [
+          { service: "gmail", connectionName: "personal", authType: "oauth2", metadata: {} },
+          { service: "gmail", connectionName: "work", authType: "oauth2", metadata: {} },
+          { service: "github", connectionName: "work", authType: "oauth2", metadata: {} },
+          { service: "gmail", authType: "no_auth", virtual: true, metadata: {} },
+        ],
+        "gmail",
+      ).map((connection) => connection.connectionName),
+    ).toEqual(["personal", "work"]);
+  });
+
+  it("shows both the connection name and provider account identity", () => {
+    expect(
+      connectionDisplayLabel({
+        service: "gmail",
+        connectionName: "work",
+        authType: "oauth2",
+        profile: { displayName: "user@example.com" },
+        metadata: {},
+      }),
+    ).toBe("work · user@example.com");
   });
 });
 
@@ -131,6 +161,43 @@ describe("ProvidersPage route shell", () => {
     expect(markup).toContain("Back to providers");
     expect(markup).toContain("Connection");
     expect(markup).toContain("Scopes requested by this provider");
+  });
+
+  it("asks for a connection name before creating the first connection", () => {
+    const markup = renderProvidersPage(providerData, "/providers/gmail");
+
+    expect(markup).toContain("Connection name");
+    expect(markup).toContain('value="default"');
+  });
+
+  it("renders a saved connection selector and add action for multiple connections", () => {
+    const markup = renderProvidersPage(
+      {
+        ...providerData,
+        connections: [
+          {
+            service: "gmail",
+            connectionName: "default",
+            authType: "oauth2",
+            default: true,
+            profile: { displayName: "personal@example.com" },
+            metadata: {},
+          },
+          {
+            service: "gmail",
+            connectionName: "work",
+            authType: "oauth2",
+            profile: { displayName: "work@example.com" },
+            metadata: {},
+          },
+        ],
+      },
+      "/providers/gmail",
+    );
+
+    expect(markup).toContain("Saved connection");
+    expect(markup).toContain("default · personal@example.com");
+    expect(markup).toContain("Add Connection");
   });
 
   it("places provider connection status beside the detail title", () => {

--- a/web/src/providers-page.tsx
+++ b/web/src/providers-page.tsx
@@ -1,6 +1,7 @@
 import type {
   AppData,
   AuthDefinition,
+  ConnectionRecord,
   CredentialField,
   OAuthConfig,
   ProviderConnectionStatus,
@@ -18,6 +19,7 @@ import {
   CircleSlash2,
   ExternalLink,
   KeyRound,
+  Plus,
   Search,
   Settings,
   Trash2,
@@ -32,6 +34,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
@@ -42,7 +45,7 @@ interface ProvidersPageProps {
 
 interface ProviderDetailProps {
   provider: ProviderDefinition;
-  connection?: AppData["connections"][number];
+  connections: ConnectionRecord[];
   connectionStatus: ProviderConnectionStatus;
   oauthConfig?: OAuthConfig;
   onRefresh(): void;
@@ -60,10 +63,13 @@ interface ProviderCardProps {
 interface ConnectionFormProps {
   provider: ProviderDefinition;
   auth: AuthDefinition;
+  connectionName: string;
+  connectionNameAvailable: boolean;
   connection?: AppData["connections"][number];
   oauthConfig?: OAuthConfig;
   onRefresh(): void;
   onConfigureOAuthClient(): void;
+  onConnectionPendingChange?(connectionName?: string): void;
 }
 
 interface OAuthConfigFormProps {
@@ -75,6 +81,7 @@ interface OAuthConfigFormProps {
 type ProviderStatusFilter = "all" | "connected" | "not_connected" | "oauth_needs_config";
 
 const providerPageSize = 48;
+const defaultConnectionName = "default";
 const oauthRefreshPollingIntervalMs = 1_000;
 const oauthRefreshPollingMaxAttempts = 30;
 const compactNumberFormatter = Intl.NumberFormat(undefined, {
@@ -108,8 +115,9 @@ export function ProvidersPage(props: ProvidersPageProps): ReactNode {
 
   return (
     <ProviderDetail
+      key={routeProvider.service}
       provider={routeProvider}
-      connection={connectionStatus.connection}
+      connections={configurableConnectionsForProvider(props.data.connections, routeProvider.service)}
       connectionStatus={connectionStatus}
       oauthConfig={oauthConfigForProvider(props.data.oauthConfigs, routeProvider.service)}
       onRefresh={props.onRefresh}
@@ -449,29 +457,92 @@ function ProviderNotFound(props: { service: string }): ReactNode {
 
 function ProviderDetail(props: ProviderDetailProps): ReactNode {
   const t = useTranslate();
-  const [selectedAuthType, setSelectedAuthType] = useState(() => initialAuthType(props.provider, props.connection));
+  const initialConnectionName = preferredConnectionName(props.connections);
+  const [selectedConnectionName, setSelectedConnectionName] = useState(initialConnectionName);
+  const [creatingConnection, setCreatingConnection] = useState(props.connections.length === 0);
+  const [newConnectionName, setNewConnectionName] = useState(
+    props.connections.length === 0 ? defaultConnectionName : "",
+  );
+  const [pendingConnectionName, setPendingConnectionName] = useState<string>();
+  const selectedConnection = creatingConnection
+    ? undefined
+    : connectionByName(props.connections, selectedConnectionName);
+  const [selectedAuthType, setSelectedAuthType] = useState(() => initialAuthType(props.provider, selectedConnection));
   const [oauthClientExpanded, setOAuthClientExpanded] = useState(false);
   const selectedAuth = props.provider.auth.find((auth) => auth.type === selectedAuthType) ?? props.provider.auth[0];
   const oauthAuth = props.provider.auth.find((auth) => auth.type === "oauth2");
   const hasMultipleAuthMethods = props.provider.auth.length > 1;
   const locallyAvailable = isProviderLocallyAvailable(props.provider);
+  const supportsCredentialConnections = props.provider.auth.some((auth) => shouldShowConnectionActions(auth));
+  const formConnectionName = creatingConnection ? newConnectionName : selectedConnectionName;
+  const newConnectionNameExists =
+    creatingConnection && newConnectionName.trim().length > 0
+      ? connectionByName(props.connections, newConnectionName.trim()) != null
+      : false;
   const connectionDescription = !locallyAvailable
     ? t("providers.connectionDescriptions.unavailable")
     : props.connectionStatus.noSetupRequired
       ? t("providers.connectionDescriptions.noSetup")
       : props.connectionStatus.connected
-        ? t("providers.connectionDescriptions.connected", { authType: props.connection?.authType ?? "" })
+        ? t("providers.connectionDescriptions.connected", {
+            authType: selectedConnection?.authType ?? props.connectionStatus.connection?.authType ?? "",
+          })
         : props.connectionStatus.oauthClientRequired
           ? t("providers.connectionDescriptions.oauthClientRequired", { name: props.provider.displayName })
           : t("providers.connectionDescriptions.notConnected", { name: props.provider.displayName });
 
   useEffect(() => {
-    setSelectedAuthType(initialAuthType(props.provider, props.connection));
-  }, [props.provider.service, props.connection?.authType]);
+    if (creatingConnection && pendingConnectionName) {
+      const createdConnection = connectionByName(props.connections, pendingConnectionName);
+      if (createdConnection) {
+        setSelectedConnectionName(pendingConnectionName);
+        setCreatingConnection(false);
+        setNewConnectionName("");
+        setPendingConnectionName(undefined);
+        setSelectedAuthType(initialAuthType(props.provider, createdConnection));
+      }
+      return;
+    }
+
+    if (!creatingConnection && !connectionByName(props.connections, selectedConnectionName)) {
+      if (props.connections.length === 0) {
+        setCreatingConnection(true);
+        setNewConnectionName(defaultConnectionName);
+      } else {
+        const connectionName = preferredConnectionName(props.connections);
+        setSelectedConnectionName(connectionName);
+        setSelectedAuthType(initialAuthType(props.provider, connectionByName(props.connections, connectionName)));
+      }
+    }
+  }, [creatingConnection, pendingConnectionName, props.connections, props.provider, selectedConnectionName]);
+
+  useEffect(() => {
+    setSelectedAuthType(initialAuthType(props.provider, selectedConnection));
+  }, [props.provider.service, selectedConnection?.authType]);
 
   useEffect(() => {
     setOAuthClientExpanded(false);
   }, [props.provider.service, props.oauthConfig?.clientId]);
+
+  function selectConnection(connectionName: string): void {
+    const connection = connectionByName(props.connections, connectionName);
+    setSelectedConnectionName(connectionName);
+    setCreatingConnection(false);
+    setNewConnectionName("");
+    setSelectedAuthType(initialAuthType(props.provider, connection));
+  }
+
+  function startNewConnection(): void {
+    setCreatingConnection(true);
+    setNewConnectionName("");
+    setPendingConnectionName(undefined);
+  }
+
+  function cancelNewConnection(): void {
+    setCreatingConnection(false);
+    setNewConnectionName("");
+    setPendingConnectionName(undefined);
+  }
 
   return (
     <div className="provider-detail-page">
@@ -523,6 +594,20 @@ function ProviderDetail(props: ProviderDetailProps): ReactNode {
               <p>{connectionDescription}</p>
             </div>
           </div>
+          {supportsCredentialConnections && (locallyAvailable || props.connections.length > 0) ? (
+            <ConnectionManager
+              connections={props.connections}
+              selectedConnectionName={selectedConnectionName}
+              creating={creatingConnection}
+              newConnectionName={newConnectionName}
+              newConnectionNameExists={newConnectionNameExists}
+              canAdd={locallyAvailable}
+              onSelect={selectConnection}
+              onAdd={startNewConnection}
+              onCancel={cancelNewConnection}
+              onNewConnectionNameChange={setNewConnectionName}
+            />
+          ) : null}
           {locallyAvailable && hasMultipleAuthMethods ? (
             <ToggleGroup
               className="auth-method-control bg-muted p-[3px]"
@@ -546,18 +631,22 @@ function ProviderDetail(props: ProviderDetailProps): ReactNode {
           {!locallyAvailable ? (
             <UnavailableProviderConnection
               provider={props.provider}
-              connection={props.connection}
+              connection={selectedConnection}
+              connectionName={selectedConnectionName}
               onRefresh={props.onRefresh}
             />
           ) : selectedAuth ? (
             <ConnectionForm
-              key={selectedAuth.type}
+              key={`${selectedAuth.type}:${creatingConnection ? "new" : selectedConnectionName}`}
               provider={props.provider}
               auth={selectedAuth}
-              connection={props.connection}
+              connection={selectedConnection}
+              connectionName={formConnectionName}
+              connectionNameAvailable={!newConnectionNameExists}
               oauthConfig={props.oauthConfig}
               onRefresh={props.onRefresh}
               onConfigureOAuthClient={() => setOAuthClientExpanded(true)}
+              onConnectionPendingChange={creatingConnection ? setPendingConnectionName : undefined}
             />
           ) : (
             <EmptyState
@@ -725,9 +814,119 @@ function authTypeLabel(authType: string, t: (key: string) => string): string {
   return authType;
 }
 
+export function configurableConnectionsForProvider(
+  connections: ConnectionRecord[],
+  service: string,
+): ConnectionRecord[] {
+  return connections.filter((connection) => connection.service === service && connection.virtual !== true);
+}
+
+export function connectionDisplayLabel(connection: ConnectionRecord): string {
+  const connectionName = connectionNameOf(connection);
+  const displayName = connection.profile?.displayName;
+  return typeof displayName === "string" && displayName.trim() && displayName.trim() !== connectionName
+    ? `${connectionName} · ${displayName.trim()}`
+    : connectionName;
+}
+
+function connectionNameOf(connection: ConnectionRecord): string {
+  return connection.connectionName?.trim() || defaultConnectionName;
+}
+
+function preferredConnectionName(connections: ConnectionRecord[]): string {
+  const preferred =
+    connections.find((connection) => connection.default === true) ??
+    connections.find((connection) => connectionNameOf(connection) === defaultConnectionName) ??
+    connections[0];
+  return preferred ? connectionNameOf(preferred) : defaultConnectionName;
+}
+
+function connectionByName(connections: ConnectionRecord[], connectionName: string): ConnectionRecord | undefined {
+  return connections.find((connection) => connectionNameOf(connection) === connectionName);
+}
+
+function connectionDeletePath(service: string, connectionName: string): string {
+  return `/api/connections/${encodeURIComponent(service)}?connectionName=${encodeURIComponent(connectionName)}`;
+}
+
+function ConnectionManager(props: {
+  connections: ConnectionRecord[];
+  selectedConnectionName: string;
+  creating: boolean;
+  newConnectionName: string;
+  newConnectionNameExists: boolean;
+  canAdd: boolean;
+  onSelect(connectionName: string): void;
+  onAdd(): void;
+  onCancel(): void;
+  onNewConnectionNameChange(connectionName: string): void;
+}): ReactNode {
+  const t = useTranslate();
+  const selectedConnection = connectionByName(props.connections, props.selectedConnectionName);
+
+  if (props.creating) {
+    return (
+      <div className="connection-manager connection-manager-new">
+        <Label className="field">
+          <span>{t("providers.connectionName")}</span>
+          <Input
+            maxLength={64}
+            placeholder={t("providers.connectionNamePlaceholder")}
+            required
+            value={props.newConnectionName}
+            onChange={(event) => props.onNewConnectionNameChange(event.target.value)}
+          />
+          <small className={props.newConnectionNameExists ? "field-error" : undefined}>
+            {t(
+              props.newConnectionNameExists ? "providers.connectionNameExists" : "providers.connectionNameDescription",
+            )}
+          </small>
+        </Label>
+        {props.connections.length > 0 ? (
+          <Button variant="outline" type="button" onClick={props.onCancel}>
+            {t("providers.buttons.cancel")}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="connection-manager connection-manager-controls">
+      <div className="field connection-manager-select">
+        <span>{t("providers.savedConnection")}</span>
+        <Select value={props.selectedConnectionName} onValueChange={props.onSelect}>
+          <SelectTrigger>
+            <SelectValue placeholder={props.selectedConnectionName}>
+              {selectedConnection ? connectionDisplayLabel(selectedConnection) : props.selectedConnectionName}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {props.connections.map((connection) => {
+              const connectionName = connectionNameOf(connection);
+              return (
+                <SelectItem key={connectionName} value={connectionName}>
+                  {connectionDisplayLabel(connection)}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+      {props.canAdd ? (
+        <Button variant="outline" type="button" onClick={props.onAdd}>
+          <Plus size={16} />
+          {t("providers.buttons.addConnection")}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 function UnavailableProviderConnection(props: {
   provider: ProviderDefinition;
   connection?: AppData["connections"][number];
+  connectionName: string;
   onRefresh(): void;
 }): ReactNode {
   const t = useTranslate();
@@ -736,7 +935,7 @@ function UnavailableProviderConnection(props: {
   async function disconnect(): Promise<void> {
     setStatus(t("providers.connectionMessages.disconnecting"));
     try {
-      await apiDelete(`/api/connections/${props.provider.service}`);
+      await apiDelete(connectionDeletePath(props.provider.service, props.connectionName));
       setStatus(t("providers.connectionMessages.disconnected"));
       props.onRefresh();
     } catch (error) {
@@ -775,7 +974,10 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
   const showActions = shouldShowConnectionActions(props.auth);
   const connected = props.connection != null;
   const needsOAuthClient = props.auth.type === "oauth2" && !props.oauthConfig;
-  const canSubmit = shouldEnableConnectionSubmit(props.auth, props.oauthConfig);
+  const canSubmit =
+    props.connectionName.trim().length > 0 &&
+    props.connectionNameAvailable &&
+    shouldEnableConnectionSubmit(props.auth, props.oauthConfig);
   const submitLabel =
     props.auth.type === "oauth2"
       ? t(connected ? "providers.buttons.reconnectProvider" : "providers.buttons.connectProvider", {
@@ -799,25 +1001,42 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
 
   async function submit(event: FormEvent): Promise<void> {
     event.preventDefault();
+    if (!canSubmit) {
+      if (props.auth.type === "oauth2") {
+        setStatus(t("providers.connectionMessages.configureOAuthFirst"));
+      }
+      return;
+    }
+
+    const connectionName = props.connectionName.trim();
     setStatus(
       props.auth.type === "oauth2"
         ? t("providers.connectionMessages.openingOAuth")
         : t("providers.connectionMessages.saving"),
     );
+    props.onConnectionPendingChange?.(connectionName);
     try {
       if (props.auth.type === "no_auth") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "no_auth" });
+        await apiPut(`/api/connections/${props.provider.service}`, {
+          authType: "no_auth",
+          connectionName,
+        });
       } else if (props.auth.type === "api_key") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "api_key", values });
+        await apiPut(`/api/connections/${props.provider.service}`, {
+          authType: "api_key",
+          connectionName,
+          values,
+        });
       } else if (props.auth.type === "custom_credential") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "custom_credential", values });
+        await apiPut(`/api/connections/${props.provider.service}`, {
+          authType: "custom_credential",
+          connectionName,
+          values,
+        });
       } else {
-        if (!canSubmit) {
-          setStatus(t("providers.connectionMessages.configureOAuthFirst"));
-          return;
-        }
         const result = await apiPost<{ authorizationUrl?: string }>(`/api/oauth/authorizations`, {
           service: props.provider.service,
+          connectionName,
         });
         if (result.authorizationUrl) {
           window.open(
@@ -839,6 +1058,7 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
       setStatus(t("providers.connectionMessages.updated"));
       props.onRefresh();
     } catch (error) {
+      props.onConnectionPendingChange?.(undefined);
       setStatus(error instanceof Error ? error.message : t("providers.connectionMessages.failed"));
     }
   }
@@ -846,7 +1066,7 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
   async function disconnect(): Promise<void> {
     setStatus(t("providers.connectionMessages.disconnecting"));
     try {
-      await apiDelete(`/api/connections/${props.provider.service}`);
+      await apiDelete(connectionDeletePath(props.provider.service, props.connectionName));
       setStatus(t("providers.connectionMessages.disconnected"));
       props.onRefresh();
     } catch (error) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1725,6 +1725,7 @@ h3 {
 }
 
 .provider-connection-card > .auth-method-control,
+.provider-connection-card > .connection-manager,
 .provider-connection-card > .connection-form,
 .provider-inline-oauth-settings,
 .provider-detail-card > .tag-list,
@@ -1735,6 +1736,26 @@ h3 {
 
 .provider-connection-card > .auth-method-control {
   margin-bottom: 0;
+}
+
+.connection-manager {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 10px;
+  max-width: 760px;
+}
+
+.connection-manager-select [data-slot="select-trigger"] {
+  width: 100%;
+}
+
+.connection-manager .field-error {
+  color: var(--destructive);
+}
+
+.connection-manager-new > [data-slot="button"] {
+  margin-bottom: 20px;
 }
 
 .provider-inline-oauth-settings {
@@ -2828,6 +2849,16 @@ tr:last-child td {
   .button-row {
     align-items: stretch;
     flex-wrap: wrap;
+  }
+
+  .connection-manager {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .connection-manager-new > [data-slot="button"] {
+    justify-self: start;
+    margin-bottom: 0;
   }
 
   .provider-browser-header,


### PR DESCRIPTION
## Summary

- add a named-connection selector and add/cancel flow to provider details
- pass the selected connection name through credential saves, OAuth authorization, reconnect, and disconnect requests
- show provider account identity beside each connection name and reject duplicate names in the add flow
- localize the new controls in all supported console languages

## Why

The runtime already supports multiple named connections per provider, but the Web Console only operated on the default connection. Reconnecting a provider such as Gmail therefore replaced the existing default account instead of allowing another account to be added and selected.

## Validation

- `npm run fix-check`
- `npm run build --workspace web`
- `npx vitest run web/src/providers-page.test.ts web/src/providers-page-hooks.test.ts`
- exercised two temporary Gmail connections in the local console: selection, add/cancel, duplicate-name handling, and targeted disconnect

Created by Codex . GPT-5
