### PR TITLE
fix(oauth): use redirect:"manual" for token exchange on Workers

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -1,34 +1,56 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { requestAuthorizationCodeToken } from "./oauth-token.ts";
 
+const authorizationCodeRequest = {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  code: "authorization-code",
+  createError: (message: string) => new Error(message),
+  redirectUri: "https://runtime.example.com/oauth/callback",
+  tokenEndpointAuthMethod: "client_secret_post" as const,
+  tokenUrl: "https://provider.example.com/oauth/token",
+};
+
 describe("OAuth token requests", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("configures redirect error mode while exchanging an authorization code", async () => {
+  it("exchanges an authorization code as a form POST that never follows redirects", async () => {
     const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
-      throw new TypeError("redirect rejected");
+      throw new TypeError("transport failed");
     });
     vi.stubGlobal("fetch", fetcher);
 
-    await expect(
-      requestAuthorizationCodeToken({
-        clientId: "client-id",
-        clientSecret: "client-secret",
-        code: "authorization-code",
-        createError: (message) => new Error(message),
-        redirectUri: "https://runtime.example.com/oauth/callback",
-        tokenEndpointAuthMethod: "client_secret_post",
-        tokenUrl: "https://provider.example.com/oauth/token",
-      }),
-    ).rejects.toThrow("OAuth token request failed.");
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token request failed.",
+    );
 
     expect(fetcher).toHaveBeenCalledOnce();
     const init = fetcher.mock.calls[0]?.[1];
     expect(init).toMatchObject({ method: "POST", redirect: "manual" });
     expect(String(init?.body)).toContain("client_secret=client-secret");
     expect(String(init?.body)).toContain("code=authorization-code");
+  });
+
+  it("rejects a redirecting token endpoint without following it, on Workers too", async () => {
+    const calls: string[] = [];
+    // Mirrors the Cloudflare Workers runtime: `redirect: "error"` is not
+    // implemented there and throws, so requesting it fails on Workers while
+    // passing on Node. Redirects are never followed.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.redirect === "error") {
+        throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+      }
+      calls.push(input instanceof Request ? input.url : String(input));
+      return new Response(null, { status: 302, headers: { location: "https://attacker.example.com/token" } });
+    });
+
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token request failed.",
+    );
+
+    expect(calls).toEqual(["https://provider.example.com/oauth/token"]);
   });
 
   it("preserves the token-request timeout error", async () => {
@@ -39,16 +61,8 @@ describe("OAuth token requests", () => {
       vi.fn(async () => Promise.reject(timeout)),
     );
 
-    await expect(
-      requestAuthorizationCodeToken({
-        clientId: "client-id",
-        clientSecret: "client-secret",
-        code: "authorization-code",
-        createError: (message) => new Error(message),
-        redirectUri: "https://runtime.example.com/oauth/callback",
-        tokenEndpointAuthMethod: "client_secret_post",
-        tokenUrl: "https://provider.example.com/oauth/token",
-      }),
-    ).rejects.toThrow("OAuth token request timed out.");
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token request timed out.",
+    );
   });
 });

--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -26,7 +26,7 @@ describe("OAuth token requests", () => {
 
     expect(fetcher).toHaveBeenCalledOnce();
     const init = fetcher.mock.calls[0]?.[1];
-    expect(init).toMatchObject({ method: "POST", redirect: "error" });
+    expect(init).toMatchObject({ method: "POST", redirect: "manual" });
     expect(String(init?.body)).toContain("client_secret=client-secret");
     expect(String(init?.body)).toContain("code=authorization-code");
   });

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -91,7 +91,10 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
       headers,
       body,
       signal: AbortSignal.timeout(oauthTokenRequestTimeoutMs),
-      redirect: "error",
+      // Workers has no "error" redirect mode; "manual" surfaces any 3xx as a
+      // non-ok response, which the check below rejects. Same intent as "error"
+      // (never follow a redirect from the token endpoint), edge-compatible.
+      redirect: "manual",
     });
   } catch (error) {
     throw input.createError(

--- a/src/providers/gladia/runtime.test.ts
+++ b/src/providers/gladia/runtime.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { gladiaActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+/**
+ * Fetch stub that mirrors the Cloudflare Workers runtime: `redirect: "error"`
+ * is not implemented there and throws, so a provider that still requests it
+ * fails on Workers while passing on Node. Redirects are never followed.
+ */
+function stubWorkersFetch(response: () => Response): { calls: string[]; fetcher: typeof fetch } {
+  const calls: string[] = [];
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.redirect === "error") {
+      throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+    }
+    calls.push(input instanceof Request ? input.url : String(input));
+    return response();
+  });
+  return { calls, fetcher: fetcher as unknown as typeof fetch };
+}
+
+describe("gladia upload source redirect handling", () => {
+  it("rejects a redirecting sourceUrl without following it, on Workers too", async () => {
+    const { calls, fetcher } = stubWorkersFetch(
+      () => new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/audio.mp3" } }),
+    );
+
+    await expect(
+      gladiaActionHandlers.upload_file!(
+        { sourceUrl: "https://files.example.com/audio.mp3" },
+        { apiKey: "key", fetcher },
+      ),
+    ).rejects.toThrow(/failed to download sourceUrl: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/audio.mp3"]);
+  });
+});

--- a/src/providers/gladia/runtime.ts
+++ b/src/providers/gladia/runtime.ts
@@ -349,7 +349,9 @@ async function downloadSourceBytes(
   });
   const response = await fetcher(url, {
     method: "GET",
-    redirect: "error",
+    // Workers has no "error" redirect mode; "manual" never follows either, and
+    // the !response.ok check below rejects any 3xx.
+    redirect: "manual",
     signal,
   });
   if (!response.ok) {

--- a/src/providers/klangio/runtime.test.ts
+++ b/src/providers/klangio/runtime.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { klangioActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+/**
+ * Fetch stub that mirrors the Cloudflare Workers runtime: `redirect: "error"`
+ * is not implemented there and throws, so a provider that still requests it
+ * fails on Workers while passing on Node. Redirects are never followed.
+ */
+function stubWorkersFetch(response: () => Response): { calls: string[]; fetcher: typeof fetch } {
+  const calls: string[] = [];
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.redirect === "error") {
+      throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+    }
+    calls.push(input instanceof Request ? input.url : String(input));
+    return response();
+  });
+  return { calls, fetcher: fetcher as unknown as typeof fetch };
+}
+
+describe("klangio upload source redirect handling", () => {
+  it("rejects a redirecting file.url without following it, on Workers too", async () => {
+    const { calls, fetcher } = stubWorkersFetch(
+      () => new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/song.mp3" } }),
+    );
+
+    await expect(
+      klangioActionHandlers.create_transcription_job!(
+        { file: { url: "https://files.example.com/song.mp3" }, model: "piano", outputs: ["midi"] },
+        { apiKey: "key", fetcher },
+      ),
+    ).rejects.toThrow(/failed to fetch klangio upload source: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/song.mp3"]);
+  });
+});

--- a/src/providers/klangio/runtime.ts
+++ b/src/providers/klangio/runtime.ts
@@ -263,7 +263,9 @@ async function resolveKlangioUploadSource(
     });
     const response = await context.fetcher(url, {
       method: "GET",
-      redirect: "error",
+      // Workers has no "error" redirect mode; "manual" never follows either, and
+      // the !response.ok check below rejects any 3xx.
+      redirect: "manual",
       signal: context.signal,
     });
 

--- a/src/providers/woocommerce/runtime.test.ts
+++ b/src/providers/woocommerce/runtime.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveWooCommerceCredentialContext, woocommerceActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("woocommerce upload source redirect handling", () => {
+  it("rejects a redirecting fileUrl without following it, on Workers too", async () => {
+    const calls: string[] = [];
+    // Mirrors the Cloudflare Workers runtime: `redirect: "error"` is not
+    // implemented there and throws, so a provider that still requests it fails
+    // on Workers while passing on Node. Redirects are never followed.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.redirect === "error") {
+        throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+      }
+      calls.push(input instanceof Request ? input.url : String(input));
+      return new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/logo.png" } });
+    });
+
+    const context = resolveWooCommerceCredentialContext(
+      {
+        storeUrl: "https://store.example.com",
+        consumerKey: "ck",
+        consumerSecret: "cs",
+        wordpressUsername: "user",
+        wordpressApplicationPassword: "pass",
+      },
+      globalThis.fetch,
+    );
+
+    await expect(
+      woocommerceActionHandlers.upload_media!(
+        { fileUrl: "https://files.example.com/logo.png", fileName: "logo.png" },
+        context,
+      ),
+    ).rejects.toThrow(/failed to fetch upload source: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/logo.png"]);
+  });
+});

--- a/src/providers/woocommerce/runtime.ts
+++ b/src/providers/woocommerce/runtime.ts
@@ -751,7 +751,9 @@ async function resolveMediaUploadSource(
 async function downloadSourceBytes(sourceUrl: string, context: WooCommerceCredentialContext): Promise<Uint8Array> {
   const response = await providerFetch(sourceUrl, {
     method: "GET",
-    redirect: "error",
+    // Workers has no "error" redirect mode; "manual" never follows either, and
+    // the !response.ok check below rejects any 3xx.
+    redirect: "manual",
     signal: context.signal,
   });
   if (!response.ok) throw new ProviderRequestError(502, `failed to fetch upload source: ${response.status}`);


### PR DESCRIPTION
## Problem

Every OAuth authorization fails on the **Cloudflare Workers** runtime with a generic `oauth_token_exchange_failed` / "OAuth token request failed." The Node runtime is unaffected, so the failure only shows up after deploying to Workers.

Root cause: the token exchange in `src/oauth/oauth-token.ts` hard-codes `redirect: "error"`. Workers' `fetch` does not implement that mode and throws:

```
TypeError: Invalid redirect value, must be one of "follow" or "manual"
("error" won't be implemented since it does not make sense at the edge;
 use "manual" and check the response status code).
```

The throw is swallowed by the surrounding `catch`, which rethrows the generic message, so the real cause is invisible without runtime log inspection (`wrangler tail`).

Confirmed live on a self-hosted Workers deployment: with this change, `googledrive` (and the rest of the Google family) complete authorization and real API calls succeed end-to-end.

## Fix

Use `redirect: "manual"`, which preserves the original intent — never follow a redirect from the token endpoint. A 3xx now surfaces as a non-ok response and is rejected by the existing `!response.ok` check, so behaviour is equivalent on Node while also working at the edge. The refresh-token path shares `requestToken`, so it is fixed too.

Unit test updated to assert `redirect: "manual"`.

## Verification

- `vitest run src/oauth` → 17 passed
- `oxlint` / `oxfmt --check` clean
