### PR TITLE
fix(providers): use redirect:"manual" for upload-source downloads on Workers

### DIFF
--- a/src/providers/gladia/runtime.test.ts
+++ b/src/providers/gladia/runtime.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { gladiaActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+/**
+ * Fetch stub that mirrors the Cloudflare Workers runtime: `redirect: "error"`
+ * is not implemented there and throws, so a provider that still requests it
+ * fails on Workers while passing on Node. Redirects are never followed.
+ */
+function stubWorkersFetch(response: () => Response): { calls: string[]; fetcher: typeof fetch } {
+  const calls: string[] = [];
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.redirect === "error") {
+      throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+    }
+    calls.push(input instanceof Request ? input.url : String(input));
+    return response();
+  });
+  return { calls, fetcher: fetcher as unknown as typeof fetch };
+}
+
+describe("gladia upload source redirect handling", () => {
+  it("rejects a redirecting sourceUrl without following it, on Workers too", async () => {
+    const { calls, fetcher } = stubWorkersFetch(
+      () => new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/audio.mp3" } }),
+    );
+
+    await expect(
+      gladiaActionHandlers.upload_file!(
+        { sourceUrl: "https://files.example.com/audio.mp3" },
+        { apiKey: "key", fetcher },
+      ),
+    ).rejects.toThrow(/failed to download sourceUrl: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/audio.mp3"]);
+  });
+});

--- a/src/providers/gladia/runtime.ts
+++ b/src/providers/gladia/runtime.ts
@@ -349,7 +349,9 @@ async function downloadSourceBytes(
   });
   const response = await fetcher(url, {
     method: "GET",
-    redirect: "error",
+    // Workers has no "error" redirect mode; "manual" never follows either, and
+    // the !response.ok check below rejects any 3xx.
+    redirect: "manual",
     signal,
   });
   if (!response.ok) {

--- a/src/providers/klangio/runtime.test.ts
+++ b/src/providers/klangio/runtime.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { klangioActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+/**
+ * Fetch stub that mirrors the Cloudflare Workers runtime: `redirect: "error"`
+ * is not implemented there and throws, so a provider that still requests it
+ * fails on Workers while passing on Node. Redirects are never followed.
+ */
+function stubWorkersFetch(response: () => Response): { calls: string[]; fetcher: typeof fetch } {
+  const calls: string[] = [];
+  const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.redirect === "error") {
+      throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+    }
+    calls.push(input instanceof Request ? input.url : String(input));
+    return response();
+  });
+  return { calls, fetcher: fetcher as unknown as typeof fetch };
+}
+
+describe("klangio upload source redirect handling", () => {
+  it("rejects a redirecting file.url without following it, on Workers too", async () => {
+    const { calls, fetcher } = stubWorkersFetch(
+      () => new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/song.mp3" } }),
+    );
+
+    await expect(
+      klangioActionHandlers.create_transcription_job!(
+        { file: { url: "https://files.example.com/song.mp3" }, model: "piano", outputs: ["midi"] },
+        { apiKey: "key", fetcher },
+      ),
+    ).rejects.toThrow(/failed to fetch klangio upload source: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/song.mp3"]);
+  });
+});

--- a/src/providers/klangio/runtime.ts
+++ b/src/providers/klangio/runtime.ts
@@ -263,7 +263,9 @@ async function resolveKlangioUploadSource(
     });
     const response = await context.fetcher(url, {
       method: "GET",
-      redirect: "error",
+      // Workers has no "error" redirect mode; "manual" never follows either, and
+      // the !response.ok check below rejects any 3xx.
+      redirect: "manual",
       signal: context.signal,
     });
 

--- a/src/providers/woocommerce/runtime.test.ts
+++ b/src/providers/woocommerce/runtime.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveWooCommerceCredentialContext, woocommerceActionHandlers } from "./runtime.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("woocommerce upload source redirect handling", () => {
+  it("rejects a redirecting fileUrl without following it, on Workers too", async () => {
+    const calls: string[] = [];
+    // Mirrors the Cloudflare Workers runtime: `redirect: "error"` is not
+    // implemented there and throws, so a provider that still requests it fails
+    // on Workers while passing on Node. Redirects are never followed.
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.redirect === "error") {
+        throw new TypeError('Invalid redirect value, must be one of "follow" or "manual"');
+      }
+      calls.push(input instanceof Request ? input.url : String(input));
+      return new Response(null, { status: 302, headers: { location: "https://elsewhere.example.com/logo.png" } });
+    });
+
+    const context = resolveWooCommerceCredentialContext(
+      {
+        storeUrl: "https://store.example.com",
+        consumerKey: "ck",
+        consumerSecret: "cs",
+        wordpressUsername: "user",
+        wordpressApplicationPassword: "pass",
+      },
+      globalThis.fetch,
+    );
+
+    await expect(
+      woocommerceActionHandlers.upload_media!(
+        { fileUrl: "https://files.example.com/logo.png", fileName: "logo.png" },
+        context,
+      ),
+    ).rejects.toThrow(/failed to fetch upload source: 302/u);
+
+    expect(calls).toEqual(["https://files.example.com/logo.png"]);
+  });
+});

--- a/src/providers/woocommerce/runtime.ts
+++ b/src/providers/woocommerce/runtime.ts
@@ -751,7 +751,9 @@ async function resolveMediaUploadSource(
 async function downloadSourceBytes(sourceUrl: string, context: WooCommerceCredentialContext): Promise<Uint8Array> {
   const response = await providerFetch(sourceUrl, {
     method: "GET",
-    redirect: "error",
+    // Workers has no "error" redirect mode; "manual" never follows either, and
+    // the !response.ok check below rejects any 3xx.
+    redirect: "manual",
     signal: context.signal,
   });
   if (!response.ok) throw new ProviderRequestError(502, `failed to fetch upload source: ${response.status}`);


### PR DESCRIPTION
## Problem

Follow-up to #123, found while reviewing it.

Cloudflare Workers is a supported deploy target (`npm run deploy:cloudflare`), and its `fetch` does not implement `redirect: "error"` — it throws:

```
TypeError: Invalid redirect value, must be one of "follow" or "manual"
```

#123 fixes the OAuth token exchange, but the identical Workers-fatal mode remained in three upload-source download paths:

| Site | Reachable via |
|---|---|
| `src/providers/woocommerce/runtime.ts` | `upload_media` (`fileUrl`) |
| `src/providers/gladia/runtime.ts` | `upload_file` (`sourceUrl`) |
| `src/providers/klangio/runtime.ts` | every job action (`file.url`) |

All three still fail on Workers. As in #123, the `TypeError` surfaces only as a generic provider error, so it is invisible without `wrangler tail`.

## Fix

Switch all three to `redirect: "manual"`, preserving the original intent — never follow a redirect from a user-supplied content URL. A 3xx now surfaces as a non-ok response and is rejected by the `!response.ok` check each call site already has, so behaviour is unchanged on Node while also working at the edge.

**No SSRF change.** `createGuardedFetch` hands any non-`"follow"` mode straight to the transport after validating the initial URL (`guarded-fetch.ts:180-182`), so `"error"` and `"manual"` take the same path and neither follows a redirect.

## Tests

A regression test per provider drives the **real action handler** through a fetch stub that mirrors the Workers runtime (throws on `redirect: "error"`), asserting the 3xx is rejected and never followed (exactly one hop).

Each test was verified to **fail against the previous `redirect: "error"` code** with the exact Workers `TypeError` — they lock in the bug, not just the string.

These three providers had no test files before; this adds their first.

## Verification

- `vitest run` → 56 files, 455 passed (3 new)
- `npx tsc --noEmit` clean, `oxlint` clean, `oxfmt --check` clean

> `npm run typecheck` fails locally on `ERR_UNKNOWN_FILE_EXTENSION` for `scripts/*.ts` — pre-existing on a clean `main`, unrelated to this change.