### PR TITLE
fix: handle bare wildcard in action policy matcher and improve error message

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,8 @@ OpenConnector is configured with environment variables.
 | `OOMOL_CONNECT_NEW_ENCRYPTION_KEY`       | unset                     | New key used by `runtime:data rotate-key`.                                     |
 | `OOMOL_CONNECT_ADMIN_TOKEN`              | unset                     | Requires bearer-token auth for local admin API, docs, and web console.         |
 | `OOMOL_CONNECT_RUNTIME_TOKEN`            | unset                     | Optional bootstrap runtime bearer token for `/v1` and MCP callers.             |
-| `OOMOL_CONNECT_ALLOWED_ACTIONS`          | unset                     | Comma-separated executable action allowlist. Supports `service.*`.             |
-| `OOMOL_CONNECT_BLOCKED_ACTIONS`          | unset                     | Comma-separated executable action denylist. Supports `service.*`.              |
+| `OOMOL_CONNECT_ALLOWED_ACTIONS`          | unset                     | Comma-separated executable action allowlist. Supports `service.*` and `*`.     |
+| `OOMOL_CONNECT_BLOCKED_ACTIONS`          | unset                     | Comma-separated executable action denylist. Supports `service.*` and `*`.      |
 | `OOMOL_CONNECT_ALLOWED_PROXIES`          | unset                     | Comma-separated provider proxy allowlist. Supports service names and `*`.      |
 | `OOMOL_CONNECT_BLOCKED_PROXIES`          | unset                     | Comma-separated provider proxy denylist. Supports service names and `*`.       |
 | `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`    | `false`                   | Allow self-hosted provider connections to target private networks. See below.  |

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -308,5 +308,5 @@ npm run dev
 ```
 
 Action policy entries are comma-separated action ids. A provider-wide wildcard such as `gmail.*`
-matches all actions for that provider. Proxy policy entries are comma-separated provider service
-names, or `*` for all provider proxies.
+matches all actions for that provider, and a bare `*` matches every action. Proxy policy entries are
+comma-separated provider service names, or `*` for all provider proxies.

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -601,7 +601,7 @@ export function normalizeConnectionName(value: string | undefined): string {
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(name)) {
     throw new ConnectionError(
       "invalid_connection_name",
-      "connectionName must start with a letter or digit and contain only letters, digits, underscores, or hyphens.",
+      "connectionName must start with a letter or digit, contain only letters, digits, underscores, or hyphens, and be at most 64 characters.",
     );
   }
 

--- a/src/core/action-policy.test.ts
+++ b/src/core/action-policy.test.ts
@@ -32,6 +32,16 @@ describe("ActionPolicyService", () => {
     });
   });
 
+  it("supports bare wildcard to match all actions", () => {
+    expect(new ActionPolicyService({ allowedActions: ["*"] }).evaluate(action)).toEqual({
+      allowed: true,
+    });
+    expect(new ActionPolicyService({ blockedActions: ["*"] }).evaluate(action)).toMatchObject({
+      allowed: false,
+      code: "action_blocked",
+    });
+  });
+
   it("blocks actions even when they are also allowed", () => {
     expect(
       new ActionPolicyService({

--- a/src/core/action-policy.ts
+++ b/src/core/action-policy.ts
@@ -96,6 +96,10 @@ export function parseActionPolicyList(value: string | undefined): string[] {
 }
 
 function createMatcher(pattern: string): ActionMatcher {
+  if (pattern === "*") {
+    return () => true;
+  }
+
   if (pattern.endsWith(".*")) {
     const prefix = pattern.slice(0, -1);
     return (actionId) => actionId.startsWith(prefix);


### PR DESCRIPTION
- Fix createMatcher to handle bare '*' wildcard pattern as a catch-all (previously treated as exact-match against literal '*')
- Add max length constraint to connection name validation error message
- Add test coverage for wildcard matching