### PR TITLE
feat(tailscale): expand read-only API coverage

### DIFF
--- a/src/providers/tailscale/actions.ts
+++ b/src/providers/tailscale/actions.ts
@@ -1,79 +1,17 @@
-import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+import type { ActionDefinition } from "../../core/types.ts";
 
-import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { tailscaleOperations } from "./operations.ts";
 
 const service = "tailscale";
 
-export type TailscaleActionName = "list_devices" | "get_device";
-
-export const tailscaleDeviceReadScope = "devices:core:read";
-
-const stringList = (description: string): JsonSchema => s.array(s.string("A Tailscale string value."), { description });
-
-const device = s.looseObject(
-  {
-    id: s.string("The legacy numeric device identifier."),
-    nodeId: s.string("The preferred stable device identifier."),
-    user: s.string("The user who registered the device."),
-    name: s.string("The device MagicDNS name."),
-    hostname: s.string("The device hostname shown in the admin console."),
-    addresses: stringList("Tailscale IPv4 and IPv6 addresses assigned to the device."),
-    clientVersion: s.string("The installed Tailscale client version."),
-    os: s.string("The operating system reported by the device."),
-    created: s.string("When the device joined the tailnet."),
-    connectedToControl: s.boolean("Whether the device recently connected to the Tailscale control server."),
-    lastSeen: s.string("When the device last connected to the Tailscale control server."),
-    expires: s.string("When the device key expires."),
-    authorized: s.boolean("Whether the device is authorized to join the tailnet."),
-    isExternal: s.boolean("Whether the device is shared into the tailnet."),
-    isEphemeral: s.boolean("Whether the device is ephemeral."),
-    updateAvailable: s.boolean("Whether a newer Tailscale client is available."),
-    keyExpiryDisabled: s.boolean("Whether key expiry is disabled for the device."),
-    blocksIncomingConnections: s.boolean("Whether the device blocks incoming Tailscale connections."),
-    enabledRoutes: stringList("Subnet routes enabled for the device."),
-    advertisedRoutes: stringList("Subnet routes advertised by the device."),
-    tags: stringList("ACL tags assigned to the device."),
-    sshEnabled: s.boolean("Whether Tailscale SSH is enabled for the device."),
-  },
-  { description: "A Tailscale device returned by the official API." },
+export const tailscaleActions: ActionDefinition[] = tailscaleOperations.map((operation) =>
+  defineProviderAction(service, {
+    name: operation.name,
+    description: operation.description,
+    requiredScopes: [...operation.requiredScopes],
+    providerPermissions: [...operation.requiredScopes],
+    inputSchema: operation.inputSchema,
+    outputSchema: operation.outputSchema,
+  }),
 );
-
-function action(input: {
-  name: TailscaleActionName;
-  description: string;
-  inputSchema: JsonSchema;
-  outputSchema: JsonSchema;
-}): ActionDefinition {
-  return defineProviderAction(service, {
-    ...input,
-    requiredScopes: [tailscaleDeviceReadScope],
-    providerPermissions: [tailscaleDeviceReadScope],
-  });
-}
-
-export const tailscaleActions: ActionDefinition[] = [
-  action({
-    name: "list_devices",
-    description: "List all devices in the configured Tailscale tailnet.",
-    inputSchema: s.actionInput({}, [], "Tailscale list devices input."),
-    outputSchema: s.object(
-      {
-        devices: s.array(device, { description: "Devices in the connected tailnet." }),
-      },
-      { required: ["devices"], description: "The devices returned by Tailscale." },
-    ),
-  }),
-  action({
-    name: "get_device",
-    description: "Get one Tailscale device by its preferred node ID or legacy device ID.",
-    inputSchema: s.actionInput(
-      {
-        deviceId: s.nonEmptyString("The preferred nodeId or legacy id of the device."),
-      },
-      ["deviceId"],
-      "Tailscale get device input.",
-    ),
-    outputSchema: device,
-  }),
-];

--- a/src/providers/tailscale/definition.ts
+++ b/src/providers/tailscale/definition.ts
@@ -7,7 +7,8 @@ const service = "tailscale";
 export const provider: ProviderDefinition = {
   service,
   displayName: "Tailscale",
-  description: "Manage devices in a Tailscale tailnet through the official REST API.",
+  description:
+    "Read devices, DNS, users, keys, policy files, logs, and settings from a Tailscale tailnet through the official REST API.",
   categories: ["Security", "Developer Tools"],
   authTypes: ["custom_credential"],
   auth: [

--- a/src/providers/tailscale/definition.ts
+++ b/src/providers/tailscale/definition.ts
@@ -46,10 +46,6 @@ export const provider: ProviderDefinition = {
             "Optional tailnet ID used in Tailscale API paths. Leave blank to use Tailscale's '-' shorthand for the OAuth client's tailnet.",
         },
       ],
-      testAction: {
-        actionName: "list_devices",
-        input: {},
-      },
     },
   ],
   homepageUrl: "https://tailscale.com",

--- a/src/providers/tailscale/executors.ts
+++ b/src/providers/tailscale/executors.ts
@@ -1,15 +1,16 @@
 import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
-import type { ProviderFetch } from "../provider-runtime.ts";
-import type { TailscaleActionName } from "./actions.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { TailscaleOperationDefinition } from "./operations.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
   ProviderRequestError,
   readProviderJsonBody,
+  readProviderTextBody,
   requireCustomCredential,
 } from "../provider-runtime.ts";
-import { tailscaleDeviceReadScope } from "./actions.ts";
+import { tailscaleDeviceReadScope, tailscaleOperations } from "./operations.ts";
 
 const service = "tailscale";
 const tailscaleApiBaseUrl = "https://api.tailscale.com/api/v2";
@@ -29,17 +30,9 @@ interface TailscaleAccessToken {
   tokenType: string;
 }
 
-type TailscaleActionHandler = (input: Record<string, unknown>, context: TailscaleContext) => Promise<unknown>;
-
-export const tailscaleActionHandlers: Record<TailscaleActionName, TailscaleActionHandler> = {
-  async list_devices(_input, context) {
-    return tailscaleJsonRequest(`/tailnet/${encodeURIComponent(context.tailnet)}/devices`, context);
-  },
-  async get_device(input, context) {
-    const deviceId = requiredString(input.deviceId, "deviceId", (message) => new ProviderRequestError(400, message));
-    return tailscaleJsonRequest(`/device/${encodeURIComponent(deviceId)}`, context);
-  },
-};
+const tailscaleActionHandlers = Object.fromEntries(
+  tailscaleOperations.map((operation) => [operation.name, createOperationHandler(operation)]),
+) as Record<string, ProviderRuntimeHandler<TailscaleContext>>;
 
 export const executors: ProviderExecutors = defineProviderExecutors<TailscaleContext>({
   service,
@@ -54,7 +47,13 @@ export const executors: ProviderExecutors = defineProviderExecutors<TailscaleCon
 export const credentialValidators: CredentialValidators = {
   async customCredential(input, { fetcher, signal }) {
     const context = readTailscaleContext(input.values, fetcher, signal);
-    const payload = await tailscaleJsonRequest(`/tailnet/${encodeURIComponent(context.tailnet)}/devices`, context);
+    const payload = await tailscaleRequestUrl(
+      new URL(`${tailscaleApiBaseUrl}/tailnet/${encodeURIComponent(context.tailnet)}/devices`),
+      context,
+      { method: "GET" },
+      [tailscaleDeviceReadScope],
+      "json",
+    );
     const devices = optionalRecord(payload)?.devices;
     return {
       profile: {
@@ -70,6 +69,74 @@ export const credentialValidators: CredentialValidators = {
     };
   },
 };
+
+function createOperationHandler(operation: TailscaleOperationDefinition): ProviderRuntimeHandler<TailscaleContext> {
+  return async (input, context): Promise<unknown> => {
+    const path = resolveOperationPath(operation, input, context.tailnet);
+    const url = new URL(`${tailscaleApiBaseUrl}${path}`);
+    appendOperationQuery(url, operation, input);
+    return tailscaleRequestUrl(
+      url,
+      context,
+      createOperationRequestInit(operation, input),
+      operation.requiredScopes,
+      operation.responseFormat ?? "json",
+    );
+  };
+}
+
+function createOperationRequestInit(
+  operation: TailscaleOperationDefinition,
+  input: Record<string, unknown>,
+): RequestInit {
+  const init: RequestInit = { method: operation.method };
+  if (operation.bodyInputName) {
+    const body = input[operation.bodyInputName];
+    init.body = operation.bodyFormat === "text" ? String(body) : JSON.stringify(body);
+  } else if (operation.bodyFields) {
+    init.body = JSON.stringify(
+      Object.fromEntries(
+        operation.bodyFields.filter((field) => input[field] !== undefined).map((field) => [field, input[field]]),
+      ),
+    );
+  }
+  if (init.body !== undefined) {
+    init.headers = { "content-type": operation.contentType ?? "application/json" };
+  }
+  return init;
+}
+
+function resolveOperationPath(
+  operation: TailscaleOperationDefinition,
+  input: Record<string, unknown>,
+  tailnet: string,
+): string {
+  let path = operation.path.replace("/tailnet/-", `/tailnet/${encodeURIComponent(tailnet)}`);
+  for (const parameter of operation.pathParameters ?? []) {
+    const value = requiredString(input[parameter], parameter, (message) => new ProviderRequestError(400, message));
+    path = path.replace(`{${parameter}}`, encodeURIComponent(value));
+  }
+  return path;
+}
+
+function appendOperationQuery(url: URL, operation: TailscaleOperationDefinition, input: Record<string, unknown>): void {
+  for (const parameter of operation.queryParameters ?? []) {
+    const value = input[parameter.inputName];
+    if (value === undefined) {
+      continue;
+    }
+    if (parameter.repeated) {
+      if (!Array.isArray(value)) {
+        throw new ProviderRequestError(400, `${parameter.inputName} must be an array.`);
+      }
+      for (const item of value) {
+        url.searchParams.append(parameter.parameterName, String(item));
+      }
+      continue;
+    }
+    url.searchParams.set(parameter.parameterName, String(value));
+  }
+}
 
 function readTailscaleContext(
   values: Record<string, string>,
@@ -90,10 +157,13 @@ function readTailscaleContext(
   };
 }
 
-async function requestTailscaleAccessToken(context: TailscaleContext): Promise<TailscaleAccessToken> {
+async function requestTailscaleAccessToken(
+  context: TailscaleContext,
+  requiredScopes: readonly string[],
+): Promise<TailscaleAccessToken> {
   const body = new URLSearchParams({
     grant_type: "client_credentials",
-    scope: tailscaleDeviceReadScope,
+    scope: requiredScopes.join(" "),
     client_id: context.clientId,
     client_secret: context.clientSecret,
   });
@@ -123,21 +193,29 @@ async function requestTailscaleAccessToken(context: TailscaleContext): Promise<T
   };
 }
 
-async function tailscaleJsonRequest(path: string, context: TailscaleContext): Promise<unknown> {
-  const token = await requestTailscaleAccessToken(context);
-  const response = await context.fetcher(`${tailscaleApiBaseUrl}${path}`, {
-    headers: {
-      accept: "application/json",
-      authorization: `${token.tokenType} ${token.accessToken}`,
-    },
+async function tailscaleRequestUrl(
+  url: URL,
+  context: TailscaleContext,
+  init: RequestInit,
+  requiredScopes: readonly string[],
+  responseFormat: "json" | "text",
+): Promise<unknown> {
+  const token = await requestTailscaleAccessToken(context, requiredScopes);
+  const headers = new Headers(init.headers);
+  headers.set("accept", "application/json");
+  headers.set("authorization", `${token.tokenType} ${token.accessToken}`);
+  const response = await context.fetcher(url.toString(), {
+    ...init,
+    headers,
     signal: context.signal,
   });
+  if (response.ok && responseFormat === "text") {
+    return readProviderTextBody(response, "Tailscale text response");
+  }
   const payload = await readTailscaleJsonResponse(response);
-
   if (!response.ok) {
     throwTailscaleRequestError(response.status, payload, "Tailscale request failed");
   }
-
   return payload;
 }
 

--- a/src/providers/tailscale/executors.ts
+++ b/src/providers/tailscale/executors.ts
@@ -10,7 +10,7 @@ import {
   readProviderTextBody,
   requireCustomCredential,
 } from "../provider-runtime.ts";
-import { tailscaleDeviceReadScope, tailscaleOperations } from "./operations.ts";
+import { tailscaleOperations } from "./operations.ts";
 
 const service = "tailscale";
 const tailscaleApiBaseUrl = "https://api.tailscale.com/api/v2";
@@ -28,6 +28,7 @@ interface TailscaleContext {
 interface TailscaleAccessToken {
   accessToken: string;
   tokenType: string;
+  grantedScopes: string[];
 }
 
 const tailscaleActionHandlers = Object.fromEntries(
@@ -47,28 +48,50 @@ export const executors: ProviderExecutors = defineProviderExecutors<TailscaleCon
 export const credentialValidators: CredentialValidators = {
   async customCredential(input, { fetcher, signal }) {
     const context = readTailscaleContext(input.values, fetcher, signal);
-    const payload = await tailscaleRequestUrl(
-      new URL(`${tailscaleApiBaseUrl}/tailnet/${encodeURIComponent(context.tailnet)}/devices`),
-      context,
-      { method: "GET" },
-      [tailscaleDeviceReadScope],
-      "json",
-    );
-    const devices = optionalRecord(payload)?.devices;
+    const token = await requestTailscaleAccessToken(context, []);
+    const metadata: Record<string, unknown> = { tailnet: context.tailnet };
+    if (grantsTailscaleDeviceRead(token.grantedScopes)) {
+      metadata.verifiedDeviceCount = await countTailscaleDevices(context, token);
+    }
     return {
       profile: {
         accountId: `tailscale:${context.tailnet}`,
         displayName: context.tailnet === defaultTailnet ? "Tailscale tailnet" : context.tailnet,
-        grantedScopes: [tailscaleDeviceReadScope],
+        grantedScopes: token.grantedScopes,
       },
-      grantedScopes: [tailscaleDeviceReadScope],
-      metadata: {
-        tailnet: context.tailnet,
-        verifiedDeviceCount: Array.isArray(devices) ? devices.length : 0,
-      },
+      grantedScopes: token.grantedScopes,
+      metadata,
     };
   },
 };
+
+/**
+ * Whether a token can read devices, so validation only probes when the probe can succeed.
+ *
+ * Tailscale reports the coarse `devices` scope or a fine-grained `devices:core*` scope; a client
+ * scoped for only the DNS, policy, or logging actions has neither and skips the probe entirely.
+ */
+function grantsTailscaleDeviceRead(grantedScopes: readonly string[]): boolean {
+  return grantedScopes.some((scope) => scope === "devices" || scope.startsWith("devices:core"));
+}
+
+/**
+ * Count devices for connection metadata, reusing the validation token.
+ *
+ * Failures propagate: reaching this point means the token can read devices, so an error here is a
+ * real problem — a mistyped `tailnet` above all — and must fail the connection rather than hide.
+ */
+async function countTailscaleDevices(context: TailscaleContext, token: TailscaleAccessToken): Promise<number> {
+  const payload = await tailscaleRequestWithToken(
+    new URL(`${tailscaleApiBaseUrl}/tailnet/${encodeURIComponent(context.tailnet)}/devices`),
+    context,
+    { method: "GET" },
+    token,
+    "json",
+  );
+  const devices = optionalRecord(payload)?.devices;
+  return Array.isArray(devices) ? devices.length : 0;
+}
 
 function createOperationHandler(operation: TailscaleOperationDefinition): ProviderRuntimeHandler<TailscaleContext> {
   return async (input, context): Promise<unknown> => {
@@ -121,7 +144,7 @@ function resolveOperationPath(
 
 function appendOperationQuery(url: URL, operation: TailscaleOperationDefinition, input: Record<string, unknown>): void {
   for (const parameter of operation.queryParameters ?? []) {
-    const value = input[parameter.inputName];
+    const value = input[parameter.inputName] ?? parameter.defaultValue;
     if (value === undefined) {
       continue;
     }
@@ -163,10 +186,14 @@ async function requestTailscaleAccessToken(
 ): Promise<TailscaleAccessToken> {
   const body = new URLSearchParams({
     grant_type: "client_credentials",
-    scope: requiredScopes.join(" "),
     client_id: context.clientId,
     client_secret: context.clientSecret,
   });
+  // An empty scope list mints a token carrying every scope the OAuth client holds, which is how
+  // Tailscale's own clients verify a credential without assuming any particular scope.
+  if (requiredScopes.length > 0) {
+    body.set("scope", requiredScopes.join(" "));
+  }
   const response = await context.fetcher(tailscaleOAuthTokenUrl, {
     method: "POST",
     headers: {
@@ -190,6 +217,7 @@ async function requestTailscaleAccessToken(
   return {
     accessToken,
     tokenType: optionalString(record?.token_type) ?? "Bearer",
+    grantedScopes: optionalString(record?.scope)?.split(/\s+/).filter(Boolean) ?? [],
   };
 }
 
@@ -201,6 +229,16 @@ async function tailscaleRequestUrl(
   responseFormat: "json" | "text",
 ): Promise<unknown> {
   const token = await requestTailscaleAccessToken(context, requiredScopes);
+  return tailscaleRequestWithToken(url, context, init, token, responseFormat);
+}
+
+async function tailscaleRequestWithToken(
+  url: URL,
+  context: TailscaleContext,
+  init: RequestInit,
+  token: TailscaleAccessToken,
+  responseFormat: "json" | "text",
+): Promise<unknown> {
   const headers = new Headers(init.headers);
   headers.set("accept", "application/json");
   headers.set("authorization", `${token.tokenType} ${token.accessToken}`);

--- a/src/providers/tailscale/integration.test.ts
+++ b/src/providers/tailscale/integration.test.ts
@@ -49,7 +49,14 @@ describe("Tailscale provider integration", () => {
         return Response.json({ version: "1.0", tailnet: "example.ts.net", logs: [] });
       }
       if (url.startsWith("https://api.tailscale.com/api/v2/tailnet/-/acl/preview?") && init?.method === "POST") {
-        return Response.json([{ action: "accept", src: ["group:engineering"], dst: ["tag:server:22"] }]);
+        return Response.json({
+          matches: [{ users: ["group:engineering"], ports: ["tag:server:22"], lineNumber: 19 }],
+          type: "user",
+          previewFor: "alice@example.com",
+        });
+      }
+      if (url.startsWith("https://api.tailscale.com/api/v2/tailnet/-/users?")) {
+        return Response.json({ users: [{ id: "u1", loginName: "alice@example.com", type: "member" }] });
       }
       return Response.json({ message: "not found" }, { status: 404 });
     });
@@ -136,43 +143,70 @@ describe("Tailscale provider integration", () => {
         },
         connections.forConnection("production"),
       ),
-    ).resolves.toMatchObject({ ok: true, output: [{ action: "accept" }] });
+    ).resolves.toMatchObject({
+      ok: true,
+      output: { matches: [{ users: ["group:engineering"], ports: ["tag:server:22"], lineNumber: 19 }] },
+    });
+    // Output is never validated at runtime, so agents rely on this schema alone to read the result.
+    expect(previewAction.outputSchema).toMatchObject({
+      type: "object",
+      required: ["matches"],
+      properties: { matches: { type: "array" } },
+    });
 
-    expect(tokenRequests).toBe(5);
+    const usersAction = catalog.actionsById.get("tailscale.list_users")!;
+    const usersExecutor = await providerLoader.loadActionExecutor("tailscale", usersAction.id, provider.displayName);
+    await expect(
+      executeAction(usersAction, usersExecutor, {}, connections.forConnection("production")),
+    ).resolves.toMatchObject({ ok: true, output: { users: [{ id: "u1" }] } });
+
+    await expect(
+      executeAction(usersAction, usersExecutor, { type: "member" }, connections.forConnection("production")),
+    ).resolves.toMatchObject({ ok: true });
+    expect(apiUrls.at(-1)).toBe("https://api.tailscale.com/api/v2/tailnet/-/users?type=member");
+
+    expect(tokenRequests).toBe(7);
     expect(apiAuthorizations).toEqual([
       "Bearer tailscale-token-1",
       "Bearer tailscale-token-2",
       "Bearer tailscale-token-3",
       "Bearer tailscale-token-4",
       "Bearer tailscale-token-5",
+      "Bearer tailscale-token-6",
+      "Bearer tailscale-token-7",
     ]);
     const tokenBodies = fetcher.mock.calls
       .filter(([input]) => String(input) === "https://api.tailscale.com/api/v2/oauth/token")
       .map(([, init]) => Object.fromEntries(new URLSearchParams(String(init?.body))));
-    expect(tokenBodies.map((body) => body.scope)).toEqual([
-      "devices:core:read",
-      "devices:core:read",
-      "devices:core:read",
-      "logs:configuration:read",
-      "policy_file:read",
+    const credential = { grant_type: "client_credentials", client_id: "client-id", client_secret: "client-secret" };
+    // Credential validation omits `scope` entirely so that any OAuth client can connect; each action
+    // then requests exactly the scopes its own operation declares.
+    expect(tokenBodies).toEqual([
+      credential,
+      { ...credential, scope: "devices:core:read" },
+      { ...credential, scope: "devices:core:read" },
+      { ...credential, scope: "logs:configuration:read" },
+      { ...credential, scope: "policy_file:read" },
+      { ...credential, scope: "users:read" },
+      { ...credential, scope: "users:read" },
     ]);
-    expect(tokenBodies).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          grant_type: "client_credentials",
-          client_id: "client-id",
-          client_secret: "client-secret",
-        }),
-      ]),
-    );
-    expect(apiUrls.at(-2)).toBe(
+    expect(apiUrls).toEqual([
+      "https://api.tailscale.com/api/v2/tailnet/-/devices",
+      "https://api.tailscale.com/api/v2/tailnet/-/devices",
+      "https://api.tailscale.com/api/v2/device/n123",
       "https://api.tailscale.com/api/v2/tailnet/-/logging/configuration?start=2026-07-01T00%3A00%3A00Z&end=2026-07-02T00%3A00%3A00Z&actor=user-1&actor=%7Ealice&event=USER.CREATE",
-    );
-    expect(apiUrls.at(-1)).toBe(
       "https://api.tailscale.com/api/v2/tailnet/-/acl/preview?type=user&previewFor=alice%40example.com",
+      // Tailscale defaults `type` to `member`, so the operation sends `all` to keep an unfiltered
+      // call genuinely unfiltered instead of silently dropping shared users.
+      "https://api.tailscale.com/api/v2/tailnet/-/users?type=all",
+      // An explicit filter still wins over that default.
+      "https://api.tailscale.com/api/v2/tailnet/-/users?type=member",
+    ]);
+    expect(apiMethods).toEqual(["GET", "GET", "GET", "GET", "POST", "GET", "GET"]);
+    const previewCall = fetcher.mock.calls.find(([input]) =>
+      String(input).startsWith("https://api.tailscale.com/api/v2/tailnet/-/acl/preview?"),
     );
-    expect(apiMethods.at(-1)).toBe("POST");
-    expect(fetcher.mock.calls.at(-1)?.[1]).toEqual(
+    expect(previewCall?.[1]).toEqual(
       expect.objectContaining({
         body: JSON.stringify({
           acls: [{ action: "accept", src: ["group:engineering"], dst: ["tag:server:22"] }],
@@ -180,6 +214,88 @@ describe("Tailscale provider integration", () => {
       }),
     );
     expect(provider.actions).toHaveLength(32);
+  });
+
+  it("connects an OAuth client that was never granted device read access", async () => {
+    setDefaultGuardedFetchDnsLookup(null);
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+        // This client holds only dns:read, so Tailscale refuses to mint a token for any other
+        // scope. Omitting `scope` asks for nothing in particular and yields what the client holds.
+        const requestedScope = new URLSearchParams(String(init?.body)).get("scope");
+        if (requestedScope !== null && requestedScope !== "dns:read") {
+          return Response.json(
+            { error: "invalid_scope", error_description: `client is not permitted scope ${requestedScope}` },
+            { status: 400 },
+          );
+        }
+        return Response.json({ access_token: "dns-token", token_type: "Bearer", expires_in: 3600, scope: "dns:read" });
+      }
+      return Response.json({ message: "not found" }, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const catalog = createCatalogStore([provider], {
+      executableActionIds: provider.actions.map((action) => action.id),
+    });
+    const connectionStore = new MemoryConnectionStore();
+    const connections = new ConnectionService({
+      catalog,
+      providerLoader: new ProviderLoader({ tailscale: () => import("./executors.ts") }),
+      store: connectionStore,
+    });
+
+    // The scope-free token exchange proves the credential, so the connection succeeds and reports
+    // the scopes Tailscale actually granted rather than the device scope this client lacks.
+    await expect(
+      connections.connectWithCustomCredential("tailscale", {
+        connectionName: "dns-only",
+        values: { clientId: "client-id", clientSecret: "client-secret" },
+      }),
+    ).resolves.toMatchObject({
+      configured: true,
+      profile: { grantedScopes: ["dns:read"] },
+    });
+    const stored = await connectionStore.get("tailscale", "dns-only");
+    if (stored?.authType !== "custom_credential") {
+      throw new Error("expected a stored custom credential");
+    }
+    expect(stored.metadata).toEqual({ tailnet: "-" });
+    // The device probe is skipped rather than attempted-and-forgiven, so only the token exchange ran.
+    expect(fetcher.mock.calls.map(([url]) => String(url))).toEqual(["https://api.tailscale.com/api/v2/oauth/token"]);
+  });
+
+  it("rejects a credential whose tailnet does not exist", async () => {
+    setDefaultGuardedFetchDnsLookup(null);
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+        return Response.json({
+          access_token: "device-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "devices:core:read",
+        });
+      }
+      return Response.json({ message: "tailnet not found" }, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const connections = new ConnectionService({
+      catalog: createCatalogStore([provider], { executableActionIds: provider.actions.map((action) => action.id) }),
+      providerLoader: new ProviderLoader({ tailscale: () => import("./executors.ts") }),
+      store: new MemoryConnectionStore(),
+    });
+
+    // The token is valid and can read devices, so a failing probe is a real error — a mistyped
+    // tailnet must surface here instead of leaving every action to fail with an opaque 404.
+    await expect(
+      connections.connectWithCustomCredential("tailscale", {
+        connectionName: "typo",
+        values: { clientId: "client-id", clientSecret: "client-secret", tailnet: "typo.example.net" },
+      }),
+    ).rejects.toThrow(/tailnet not found/);
   });
 });
 

--- a/src/providers/tailscale/integration.test.ts
+++ b/src/providers/tailscale/integration.test.ts
@@ -296,6 +296,12 @@ describe("Tailscale provider integration", () => {
         values: { clientId: "client-id", clientSecret: "client-secret", tailnet: "typo.example.net" },
       }),
     ).rejects.toThrow(/tailnet not found/);
+    // The catch-all 404 would answer the default tailnet too, so pin the probed URL to prove the
+    // configured tailnet is what actually reached the API.
+    expect(fetcher.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.tailscale.com/api/v2/oauth/token",
+      "https://api.tailscale.com/api/v2/tailnet/typo.example.net/devices",
+    ]);
   });
 });
 

--- a/src/providers/tailscale/integration.test.ts
+++ b/src/providers/tailscale/integration.test.ts
@@ -16,10 +16,12 @@ afterEach(() => {
 });
 
 describe("Tailscale provider integration", () => {
-  it("verifies custom credentials and executes device actions with short-lived OAuth tokens", async () => {
+  it("verifies custom credentials and executes representative safe operations", async () => {
     setDefaultGuardedFetchDnsLookup(null);
     let tokenRequests = 0;
     const apiAuthorizations: string[] = [];
+    const apiUrls: string[] = [];
+    const apiMethods: string[] = [];
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url === "https://api.tailscale.com/api/v2/oauth/token") {
@@ -33,6 +35,8 @@ describe("Tailscale provider integration", () => {
       }
 
       apiAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      apiUrls.push(url);
+      apiMethods.push(init?.method ?? "GET");
       if (url === "https://api.tailscale.com/api/v2/tailnet/-/devices") {
         return Response.json({
           devices: [{ nodeId: "n123", hostname: "example-device", connectedToControl: true }],
@@ -40,6 +44,12 @@ describe("Tailscale provider integration", () => {
       }
       if (url === "https://api.tailscale.com/api/v2/device/n123") {
         return Response.json({ nodeId: "n123", hostname: "example-device", connectedToControl: true });
+      }
+      if (url.startsWith("https://api.tailscale.com/api/v2/tailnet/-/logging/configuration?")) {
+        return Response.json({ version: "1.0", tailnet: "example.ts.net", logs: [] });
+      }
+      if (url.startsWith("https://api.tailscale.com/api/v2/tailnet/-/acl/preview?") && init?.method === "POST") {
+        return Response.json([{ action: "accept", src: ["group:engineering"], dst: ["tag:server:22"] }]);
       }
       return Response.json({ message: "not found" }, { status: 404 });
     });
@@ -93,35 +103,83 @@ describe("Tailscale provider integration", () => {
       output: { nodeId: "n123", hostname: "example-device" },
     });
 
-    expect(tokenRequests).toBe(3);
+    const auditAction = catalog.actionsById.get("tailscale.list_configuration_audit_logs")!;
+    const auditExecutor = await providerLoader.loadActionExecutor("tailscale", auditAction.id, provider.displayName);
+    await expect(
+      executeAction(
+        auditAction,
+        auditExecutor,
+        {
+          start: "2026-07-01T00:00:00Z",
+          end: "2026-07-02T00:00:00Z",
+          actors: ["user-1", "~alice"],
+          events: ["USER.CREATE"],
+        },
+        connections.forConnection("production"),
+      ),
+    ).resolves.toMatchObject({ ok: true, output: { logs: [] } });
+
+    const previewAction = catalog.actionsById.get("tailscale.preview_policy_rule_matches")!;
+    const previewExecutor = await providerLoader.loadActionExecutor(
+      "tailscale",
+      previewAction.id,
+      provider.displayName,
+    );
+    await expect(
+      executeAction(
+        previewAction,
+        previewExecutor,
+        {
+          type: "user",
+          previewFor: "alice@example.com",
+          policy: { acls: [{ action: "accept", src: ["group:engineering"], dst: ["tag:server:22"] }] },
+        },
+        connections.forConnection("production"),
+      ),
+    ).resolves.toMatchObject({ ok: true, output: [{ action: "accept" }] });
+
+    expect(tokenRequests).toBe(5);
     expect(apiAuthorizations).toEqual([
       "Bearer tailscale-token-1",
       "Bearer tailscale-token-2",
       "Bearer tailscale-token-3",
+      "Bearer tailscale-token-4",
+      "Bearer tailscale-token-5",
     ]);
     const tokenBodies = fetcher.mock.calls
       .filter(([input]) => String(input) === "https://api.tailscale.com/api/v2/oauth/token")
       .map(([, init]) => Object.fromEntries(new URLSearchParams(String(init?.body))));
-    expect(tokenBodies).toEqual([
-      {
-        grant_type: "client_credentials",
-        scope: "devices:core:read",
-        client_id: "client-id",
-        client_secret: "client-secret",
-      },
-      {
-        grant_type: "client_credentials",
-        scope: "devices:core:read",
-        client_id: "client-id",
-        client_secret: "client-secret",
-      },
-      {
-        grant_type: "client_credentials",
-        scope: "devices:core:read",
-        client_id: "client-id",
-        client_secret: "client-secret",
-      },
+    expect(tokenBodies.map((body) => body.scope)).toEqual([
+      "devices:core:read",
+      "devices:core:read",
+      "devices:core:read",
+      "logs:configuration:read",
+      "policy_file:read",
     ]);
+    expect(tokenBodies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          grant_type: "client_credentials",
+          client_id: "client-id",
+          client_secret: "client-secret",
+        }),
+      ]),
+    );
+    expect(apiUrls.at(-2)).toBe(
+      "https://api.tailscale.com/api/v2/tailnet/-/logging/configuration?start=2026-07-01T00%3A00%3A00Z&end=2026-07-02T00%3A00%3A00Z&actor=user-1&actor=%7Ealice&event=USER.CREATE",
+    );
+    expect(apiUrls.at(-1)).toBe(
+      "https://api.tailscale.com/api/v2/tailnet/-/acl/preview?type=user&previewFor=alice%40example.com",
+    );
+    expect(apiMethods.at(-1)).toBe("POST");
+    expect(fetcher.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          acls: [{ action: "accept", src: ["group:engineering"], dst: ["tag:server:22"] }],
+        }),
+      }),
+    );
+    expect(provider.actions).toHaveLength(32);
   });
 });
 

--- a/src/providers/tailscale/operations.ts
+++ b/src/providers/tailscale/operations.ts
@@ -8,6 +8,8 @@ export interface TailscaleQueryParameter {
   inputName: string;
   parameterName: string;
   repeated?: boolean;
+  /** Sent when the caller omits the input, to override a Tailscale server-side default. */
+  defaultValue?: string;
 }
 
 export interface TailscaleOperationDefinition {
@@ -201,13 +203,15 @@ export const tailscaleOperations: readonly TailscaleOperationDefinition[] = [
     method: "GET",
     path: "/tailnet/-/users",
     queryParameters: [
-      { inputName: "type", parameterName: "type" },
+      { inputName: "type", parameterName: "type", defaultValue: "all" },
       { inputName: "role", parameterName: "role" },
     ],
     requiredScopes: ["users:read"],
     inputSchema: s.actionInput(
       {
-        type: s.stringEnum(["member", "shared", "all"], { description: "User type filter." }),
+        type: s.stringEnum(["member", "shared", "all"], {
+          description: "User type filter. Defaults to all users, including users shared into the tailnet.",
+        }),
         role: s.stringEnum(
           ["owner", "member", "admin", "it-admin", "network-admin", "billing-admin", "auditor", "all"],
           {
@@ -415,9 +419,24 @@ export const tailscaleOperations: readonly TailscaleOperationDefinition[] = [
       ["type", "previewFor", "policy"],
       "Tailscale policy rule preview input.",
     ),
-    outputSchema: s.array(objectOutput("A matching policy rule."), {
-      description: "The proposed policy rules matching the requested resource.",
-    }),
+    outputSchema: s.object(
+      {
+        matches: s.array(
+          s.looseObject(
+            {
+              users: stringList("Source entities affected by the rule."),
+              ports: stringList("Destinations that can be accessed."),
+              lineNumber: s.integer("The rule's location in the policy file."),
+            },
+            { description: "A matching policy rule." },
+          ),
+          { description: "The proposed policy rules matching the requested resource." },
+        ),
+        type: s.string("Echoes the resource type provided in the request."),
+        previewFor: s.string("Echoes the previewed user or IP address and port provided in the request."),
+      },
+      { required: ["matches"], description: "The proposed policy rules matching the requested resource." },
+    ),
   },
   {
     name: "validate_policy_file",

--- a/src/providers/tailscale/operations.ts
+++ b/src/providers/tailscale/operations.ts
@@ -1,0 +1,455 @@
+import type { JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+
+export const tailscaleDeviceReadScope = "devices:core:read";
+
+export interface TailscaleQueryParameter {
+  inputName: string;
+  parameterName: string;
+  repeated?: boolean;
+}
+
+export interface TailscaleOperationDefinition {
+  name: string;
+  description: string;
+  method: "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+  path: string;
+  pathParameters?: readonly string[];
+  queryParameters?: readonly TailscaleQueryParameter[];
+  bodyFields?: readonly string[];
+  bodyInputName?: string;
+  bodyFormat?: "json" | "text";
+  contentType?: string;
+  responseFormat?: "json" | "text";
+  requiredScopes: readonly string[];
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}
+
+const stringList = (description: string): JsonSchema => s.array(s.string("A Tailscale string value."), { description });
+
+const device = s.looseObject(
+  {
+    id: s.string("The legacy numeric device identifier."),
+    nodeId: s.string("The preferred stable device identifier."),
+    user: s.string("The user who registered the device."),
+    name: s.string("The device MagicDNS name."),
+    hostname: s.string("The device hostname shown in the admin console."),
+    addresses: stringList("Tailscale IPv4 and IPv6 addresses assigned to the device."),
+    clientVersion: s.string("The installed Tailscale client version."),
+    os: s.string("The operating system reported by the device."),
+    created: s.string("When the device joined the tailnet."),
+    connectedToControl: s.boolean("Whether the device recently connected to the Tailscale control server."),
+    lastSeen: s.string("When the device last connected to the Tailscale control server."),
+    expires: s.string("When the device key expires."),
+    authorized: s.boolean("Whether the device is authorized to join the tailnet."),
+    isExternal: s.boolean("Whether the device is shared into the tailnet."),
+    isEphemeral: s.boolean("Whether the device is ephemeral."),
+    updateAvailable: s.boolean("Whether a newer Tailscale client is available."),
+    keyExpiryDisabled: s.boolean("Whether key expiry is disabled for the device."),
+    blocksIncomingConnections: s.boolean("Whether the device blocks incoming Tailscale connections."),
+    enabledRoutes: stringList("Subnet routes enabled for the device."),
+    advertisedRoutes: stringList("Subnet routes advertised by the device."),
+    tags: stringList("ACL tags assigned to the device."),
+    sshEnabled: s.boolean("Whether Tailscale SSH is enabled for the device."),
+  },
+  { description: "A Tailscale device returned by the official API." },
+);
+
+const objectOutput = (description: string): JsonSchema => s.record(true, { description });
+const emptyInput = (description: string): JsonSchema => s.actionInput({}, [], description);
+const idInput = (name: string, description: string): JsonSchema =>
+  s.actionInput({ [name]: s.nonEmptyString(description) }, [name], "Tailscale action input.");
+const logTypeInput = s.actionInput(
+  {
+    logType: s.stringEnum(["configuration", "network"], {
+      description: "The Tailscale log type.",
+    }),
+  },
+  ["logType"],
+  "Tailscale log streaming status input.",
+);
+
+export const tailscaleOperations: readonly TailscaleOperationDefinition[] = [
+  {
+    name: "list_devices",
+    description: "List all devices in the configured Tailscale tailnet.",
+    method: "GET",
+    path: "/tailnet/-/devices",
+    requiredScopes: [tailscaleDeviceReadScope],
+    inputSchema: emptyInput("Tailscale list devices input."),
+    outputSchema: s.object(
+      { devices: s.array(device, { description: "Devices in the connected tailnet." }) },
+      { required: ["devices"], description: "The devices returned by Tailscale." },
+    ),
+  },
+  {
+    name: "get_device",
+    description: "Get one Tailscale device by its preferred node ID or legacy device ID.",
+    method: "GET",
+    path: "/device/{deviceId}",
+    pathParameters: ["deviceId"],
+    requiredScopes: [tailscaleDeviceReadScope],
+    inputSchema: idInput("deviceId", "The preferred nodeId or legacy id of the device."),
+    outputSchema: device,
+  },
+  {
+    name: "list_device_routes",
+    description: "List the subnet routes advertised and enabled for a Tailscale device.",
+    method: "GET",
+    path: "/device/{deviceId}/routes",
+    pathParameters: ["deviceId"],
+    requiredScopes: ["devices:routes:read"],
+    inputSchema: idInput("deviceId", "The preferred nodeId or legacy id of the device."),
+    outputSchema: objectOutput("Advertised and enabled routes for the device."),
+  },
+  {
+    name: "get_device_posture_attributes",
+    description: "Get the posture attributes currently reported for a Tailscale device.",
+    method: "GET",
+    path: "/device/{deviceId}/attributes",
+    pathParameters: ["deviceId"],
+    requiredScopes: ["devices:posture_attributes:read"],
+    inputSchema: idInput("deviceId", "The preferred nodeId or legacy id of the device."),
+    outputSchema: objectOutput("Posture attributes and expirations for the device."),
+  },
+  {
+    name: "list_configuration_audit_logs",
+    description: "List configuration audit logs for an RFC 3339 time window, with optional filters.",
+    method: "GET",
+    path: "/tailnet/-/logging/configuration",
+    queryParameters: [
+      { inputName: "start", parameterName: "start" },
+      { inputName: "end", parameterName: "end" },
+      { inputName: "actors", parameterName: "actor", repeated: true },
+      { inputName: "targets", parameterName: "target", repeated: true },
+      { inputName: "events", parameterName: "event", repeated: true },
+    ],
+    requiredScopes: ["logs:configuration:read"],
+    inputSchema: s.actionInput(
+      {
+        start: s.nonEmptyString("The start of the log window in RFC 3339 format."),
+        end: s.nonEmptyString("The end of the log window in RFC 3339 format."),
+        actors: stringList("Actor IDs or wildcard actor searches."),
+        targets: stringList("Target filters."),
+        events: stringList("Audit event type filters."),
+      },
+      ["start", "end"],
+      "Tailscale configuration audit log input.",
+    ),
+    outputSchema: objectOutput("Configuration audit log entries and tailnet metadata."),
+  },
+  {
+    name: "get_log_streaming_status",
+    description: "Get the current publishing status for configuration or network log streaming.",
+    method: "GET",
+    path: "/tailnet/-/logging/{logType}/stream/status",
+    pathParameters: ["logType"],
+    requiredScopes: ["log_streaming:read"],
+    inputSchema: logTypeInput,
+    outputSchema: objectOutput("Log streaming activity, throughput, and failure statistics."),
+  },
+  {
+    name: "list_dns_nameservers",
+    description: "List the global DNS nameservers configured for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/dns/nameservers",
+    requiredScopes: ["dns:read"],
+    inputSchema: emptyInput("Tailscale list DNS nameservers input."),
+    outputSchema: objectOutput("The configured global DNS nameservers."),
+  },
+  {
+    name: "get_dns_preferences",
+    description: "Get the tailnet DNS preferences, including MagicDNS state.",
+    method: "GET",
+    path: "/tailnet/-/dns/preferences",
+    requiredScopes: ["dns:read"],
+    inputSchema: emptyInput("Tailscale get DNS preferences input."),
+    outputSchema: objectOutput("The tailnet DNS preferences."),
+  },
+  {
+    name: "list_dns_search_paths",
+    description: "List the DNS search paths configured for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/dns/searchpaths",
+    requiredScopes: ["dns:read"],
+    inputSchema: emptyInput("Tailscale list DNS search paths input."),
+    outputSchema: objectOutput("The configured DNS search paths."),
+  },
+  {
+    name: "get_split_dns",
+    description: "Get the split DNS nameserver mapping for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/dns/split-dns",
+    requiredScopes: ["dns:read"],
+    inputSchema: emptyInput("Tailscale get split DNS input."),
+    outputSchema: objectOutput("The split DNS domain-to-nameserver mapping."),
+  },
+  {
+    name: "get_dns_configuration",
+    description: "Get the complete DNS configuration for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/dns/configuration",
+    requiredScopes: ["dns:read"],
+    inputSchema: emptyInput("Tailscale get DNS configuration input."),
+    outputSchema: objectOutput("The complete tailnet DNS configuration."),
+  },
+  {
+    name: "list_users",
+    description: "List tailnet users with optional user-type and role filters.",
+    method: "GET",
+    path: "/tailnet/-/users",
+    queryParameters: [
+      { inputName: "type", parameterName: "type" },
+      { inputName: "role", parameterName: "role" },
+    ],
+    requiredScopes: ["users:read"],
+    inputSchema: s.actionInput(
+      {
+        type: s.stringEnum(["member", "shared", "all"], { description: "User type filter." }),
+        role: s.stringEnum(
+          ["owner", "member", "admin", "it-admin", "network-admin", "billing-admin", "auditor", "all"],
+          {
+            description: "User role filter.",
+          },
+        ),
+      },
+      [],
+      "Tailscale list users input.",
+    ),
+    outputSchema: objectOutput("The users in the connected tailnet."),
+  },
+  {
+    name: "get_user",
+    description: "Get a Tailscale user by user ID.",
+    method: "GET",
+    path: "/users/{userId}",
+    pathParameters: ["userId"],
+    requiredScopes: ["users:read"],
+    inputSchema: idInput("userId", "The Tailscale user ID."),
+    outputSchema: objectOutput("The requested Tailscale user."),
+  },
+  {
+    name: "get_contacts",
+    description: "Get the account, support, and security contacts for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/contacts",
+    requiredScopes: ["account_settings:read"],
+    inputSchema: emptyInput("Tailscale get contacts input."),
+    outputSchema: objectOutput("The account, support, and security contacts."),
+  },
+  {
+    name: "get_tailnet_settings",
+    description: "Get the tailnet feature, logging, networking, and policy settings visible to the OAuth client.",
+    method: "GET",
+    path: "/tailnet/-/settings",
+    requiredScopes: ["feature_settings:read", "logs:network:read", "networking_settings:read", "policy_file:read"],
+    inputSchema: emptyInput("Tailscale get tailnet settings input."),
+    outputSchema: objectOutput("The visible tailnet settings."),
+  },
+  {
+    name: "list_services",
+    description: "List the Services configured in the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/services",
+    requiredScopes: ["services:read"],
+    inputSchema: emptyInput("Tailscale list Services input."),
+    outputSchema: objectOutput("The Services configured in the tailnet."),
+  },
+  {
+    name: "get_service",
+    description: "Get a Tailscale Service by name.",
+    method: "GET",
+    path: "/tailnet/-/services/{serviceName}",
+    pathParameters: ["serviceName"],
+    requiredScopes: ["services:read"],
+    inputSchema: idInput("serviceName", "The Tailscale Service name."),
+    outputSchema: objectOutput("The requested Tailscale Service."),
+  },
+  {
+    name: "get_log_streaming_configuration",
+    description: "Get the potentially sensitive destination configuration for a Tailscale log stream.",
+    method: "GET",
+    path: "/tailnet/-/logging/{logType}/stream",
+    pathParameters: ["logType"],
+    requiredScopes: ["log_streaming:read"],
+    inputSchema: logTypeInput,
+    outputSchema: objectOutput("The log streaming destination and credential configuration."),
+  },
+  {
+    name: "list_keys",
+    description: "List trust credentials and keys visible to the OAuth client.",
+    method: "GET",
+    path: "/tailnet/-/keys",
+    queryParameters: [{ inputName: "all", parameterName: "all" }],
+    requiredScopes: ["api_access_tokens:read", "auth_keys:read", "oauth_keys:read", "federated_keys:read"],
+    inputSchema: s.actionInput(
+      { all: s.boolean("Whether to include expired and revoked keys.") },
+      [],
+      "Tailscale list keys input.",
+    ),
+    outputSchema: objectOutput("The visible Tailscale trust credentials and keys."),
+  },
+  {
+    name: "get_key",
+    description: "Get metadata for a Tailscale trust credential or key.",
+    method: "GET",
+    path: "/tailnet/-/keys/{keyId}",
+    pathParameters: ["keyId"],
+    requiredScopes: ["api_access_tokens:read", "auth_keys:read", "oauth_keys:read", "federated_keys:read"],
+    inputSchema: idInput("keyId", "The Tailscale key ID."),
+    outputSchema: objectOutput("The requested key metadata."),
+  },
+  {
+    name: "get_policy_file",
+    description: "Get the current Tailscale policy file as JSON, optionally with validation details.",
+    method: "GET",
+    path: "/tailnet/-/acl",
+    queryParameters: [{ inputName: "details", parameterName: "details" }],
+    requiredScopes: ["policy_file:read"],
+    inputSchema: s.actionInput(
+      { details: s.boolean("Whether to include the encoded policy, warnings, and errors.") },
+      [],
+      "Tailscale get policy file input.",
+    ),
+    outputSchema: objectOutput("The current Tailscale policy file or detailed validation result."),
+  },
+  {
+    name: "list_webhooks",
+    description: "List webhook endpoints configured for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/webhooks",
+    requiredScopes: ["webhooks:read"],
+    inputSchema: emptyInput("Tailscale list webhooks input."),
+    outputSchema: objectOutput("The webhook endpoints configured for the tailnet."),
+  },
+  {
+    name: "get_webhook",
+    description: "Get a Tailscale webhook endpoint by ID.",
+    method: "GET",
+    path: "/webhooks/{endpointId}",
+    pathParameters: ["endpointId"],
+    requiredScopes: ["webhooks:read"],
+    inputSchema: idInput("endpointId", "The Tailscale webhook endpoint ID."),
+    outputSchema: objectOutput("The requested webhook endpoint."),
+  },
+  {
+    name: "list_oauth_apps",
+    description: "List OAuth applications configured for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/oauth-apps",
+    requiredScopes: ["oauth_apps:read"],
+    inputSchema: emptyInput("Tailscale list OAuth apps input."),
+    outputSchema: objectOutput("The OAuth applications configured for the tailnet."),
+  },
+  {
+    name: "get_oauth_app",
+    description: "Get a Tailscale OAuth application by app ID.",
+    method: "GET",
+    path: "/tailnet/-/oauth-apps/{appId}",
+    pathParameters: ["appId"],
+    requiredScopes: ["oauth_apps:read"],
+    inputSchema: idInput("appId", "The Tailscale OAuth app ID."),
+    outputSchema: objectOutput("The requested OAuth application."),
+  },
+  {
+    name: "list_device_invites",
+    description: "List all share invites for a Tailscale device.",
+    method: "GET",
+    path: "/device/{deviceId}/device-invites",
+    pathParameters: ["deviceId"],
+    requiredScopes: ["device_invites:read"],
+    inputSchema: idInput("deviceId", "The preferred nodeId or legacy id of the device."),
+    outputSchema: s.array(objectOutput("A device share invite."), {
+      description: "The device share invites returned by Tailscale.",
+    }),
+  },
+  {
+    name: "get_device_invite",
+    description: "Get one Tailscale device share invite.",
+    method: "GET",
+    path: "/device-invites/{deviceInviteId}",
+    pathParameters: ["deviceInviteId"],
+    requiredScopes: ["device_invites:read"],
+    inputSchema: idInput("deviceInviteId", "The Tailscale device invite ID."),
+    outputSchema: objectOutput("The requested device share invite."),
+  },
+  {
+    name: "list_network_flow_logs",
+    description: "List network flow logs for an RFC 3339 time window.",
+    method: "GET",
+    path: "/tailnet/-/logging/network",
+    queryParameters: [
+      { inputName: "start", parameterName: "start" },
+      { inputName: "end", parameterName: "end" },
+    ],
+    requiredScopes: ["logs:network:read"],
+    inputSchema: s.actionInput(
+      {
+        start: s.nonEmptyString("The start of the log window in RFC 3339 format."),
+        end: s.nonEmptyString("The end of the log window in RFC 3339 format."),
+      },
+      ["start", "end"],
+      "Tailscale network flow log input.",
+    ),
+    outputSchema: objectOutput("Network flow log entries and tailnet metadata."),
+  },
+  {
+    name: "preview_policy_rule_matches",
+    description: "Preview which rules in a proposed policy match a user or IP address and port without saving it.",
+    method: "POST",
+    path: "/tailnet/-/acl/preview",
+    queryParameters: [
+      { inputName: "type", parameterName: "type" },
+      { inputName: "previewFor", parameterName: "previewFor" },
+    ],
+    bodyInputName: "policy",
+    requiredScopes: ["policy_file:read"],
+    inputSchema: s.actionInput(
+      {
+        type: s.stringEnum(["user", "ipport"], { description: "The resource type to preview." }),
+        previewFor: s.nonEmptyString("A user email or an IP address and port, depending on type."),
+        policy: objectOutput("The proposed JSON policy document to evaluate."),
+      },
+      ["type", "previewFor", "policy"],
+      "Tailscale policy rule preview input.",
+    ),
+    outputSchema: s.array(objectOutput("A matching policy rule."), {
+      description: "The proposed policy rules matching the requested resource.",
+    }),
+  },
+  {
+    name: "validate_policy_file",
+    description: "Validate a proposed policy file or run ACL tests without changing the tailnet policy.",
+    method: "POST",
+    path: "/tailnet/-/acl/validate",
+    bodyInputName: "validation",
+    requiredScopes: ["policy_file:read"],
+    inputSchema: s.actionInput(
+      { validation: s.unknown("A JSON policy document, its JSON string representation, or an array of ACL tests.") },
+      ["validation"],
+      "Tailscale policy validation input.",
+    ),
+    outputSchema: objectOutput("Policy parsing errors, warnings, or ACL test results."),
+  },
+  {
+    name: "list_posture_integrations",
+    description: "List the device posture integrations configured for the tailnet.",
+    method: "GET",
+    path: "/tailnet/-/posture/integrations",
+    requiredScopes: ["feature_settings:read"],
+    inputSchema: emptyInput("Tailscale list posture integrations input."),
+    outputSchema: objectOutput("The configured device posture integrations."),
+  },
+  {
+    name: "get_posture_integration",
+    description: "Get one device posture integration by ID.",
+    method: "GET",
+    path: "/posture/integrations/{integrationId}",
+    pathParameters: ["integrationId"],
+    requiredScopes: ["feature_settings:read"],
+    inputSchema: idInput("integrationId", "The Tailscale posture integration ID."),
+    outputSchema: objectOutput("The requested device posture integration."),
+  },
+];


### PR DESCRIPTION
## Summary

Expand the Tailscale provider from its initial device actions to 32 read-only and non-mutating operations.

This adds coverage for devices, routes, posture attributes, audit and network logs, DNS, users, contacts, tailnet settings, Services, key metadata, policy inspection, webhooks, OAuth apps, device invites, and posture integrations.

## Implementation

- Define Tailscale operations as shared action and request-routing metadata.
- Support path parameters, repeated query parameters, JSON request bodies, and optional text responses.
- Request short-lived Tailscale tokens with each action's required OAuth scopes.
- Preserve custom Tailnet ID support from the existing provider.
- Keep mutating and write-scope operations out of this PR.

## Review follow-ups

- **Credential validation no longer requires `devices:core:read`.** It previously probed `/devices`, so an OAuth client scoped for only the DNS, policy, or logging actions could not connect at all. Validation now exchanges `client_credentials` with no `scope` — which mints a token carrying whatever the client holds, and is how Tailscale's own clients verify a credential — and reports those scopes instead of asserting one that may never have been granted. The device probe runs only when the token can read devices, so a mistyped tailnet still fails at connect time rather than leaving every action to 404.
- **`preview_policy_rule_matches` declared the wrong output shape.** It advertised a top-level array; the API returns `{matches, type, previewFor}`. Nothing validates output at runtime, so an agent trusting the schema read `undefined` and reported no matching rules. The test mock had encoded the same wrong shape.
- **Dropped the `testAction`.** No flow reads it today, and none could use this one: every action requires at least one of 20 distinct read scopes, so no action can smoke test a connection now that any scope subset is supported. Verifying the credential is the validator's job.
- Provider description still said "Manage devices".

## Behavior change

`list_users` now sends `type=all` when the caller passes no filter. Tailscale defaults that parameter to `member`, so an unfiltered call previously dropped shared users silently. Callers relying on the implicit members-only result will start seeing shared users. (A JSON Schema `default` would not work here — nothing injects it — so the default is applied when building the request.)

## Known trade-off

`list_keys`, `get_key`, and `get_tailnet_settings` declare their scopes conjunctively and request them as a single `scope=` on the token exchange, though Tailscale documents them as alternatives that each unlock part of the response. A client holding only a subset would be refused a token and must be granted the full set. Left as-is for now.

## Validation

- Registry and catalog generation
- Typecheck for `src`, scripts, and examples
- Full Vitest suite: 58 test files, 470 tests
- Each fix above is mutation-tested: reverting any one of them fails the suite
