### PR TITLE
fix(proxy): stop action policy from denying provider proxies

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,7 +138,11 @@ responsibility for securing their deployment. At minimum:
   for 24 hours, but expired records are removed opportunistically rather than by a physical-deletion
   deadline.
 - **Reduce attack surface.** Use `OOMOL_CONNECT_ALLOWED_ACTIONS` / `OOMOL_CONNECT_BLOCKED_ACTIONS` to
-  limit which Actions can run.
+  limit which Actions can run. Restrict provider proxies separately with
+  `OOMOL_CONNECT_ALLOWED_PROXIES` / `OOMOL_CONNECT_BLOCKED_PROXIES`: `/v1/proxy/:service` can reach
+  provider API endpoints beyond the curated Action catalog, every proxy is allowed until one of those
+  variables restricts it, and the Action variables do not restrict it. Pin it to the services you
+  actually proxy, or set `OOMOL_CONNECT_BLOCKED_PROXIES="*"` to disable provider proxies entirely.
 - **Stay current.** Run a supported Node.js (22.18+ / 24) and update to the latest OpenConnector
   release for security fixes.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -289,8 +289,16 @@ npm run dev
 ```
 
 Provider proxy requests use separate service-level policy variables because `/v1/proxy/:service`
-can reach provider API endpoints beyond the curated action catalog. If any action policy is
-configured, proxy requests are denied by default unless the service is explicitly allowed:
+can reach provider API endpoints beyond the curated action catalog. Action policy and proxy policy
+are independent: the action variables never restrict proxies, and the proxy variables never restrict
+actions. Every provider proxy is allowed until you restrict it:
+
+```bash
+OOMOL_CONNECT_ALLOWED_PROXIES="github" npm run dev
+```
+
+Set `OOMOL_CONNECT_BLOCKED_PROXIES="*"` to disable `/v1/proxy/:service` entirely. Restrict both
+surfaces when you want both restricted:
 
 ```bash
 OOMOL_CONNECT_ALLOWED_ACTIONS="github.get_current_user" \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -188,5 +188,6 @@ Constrain executable actions with comma-separated action ids or provider wildcar
 OOMOL_CONNECT_ALLOWED_ACTIONS="hackernews.*,github.get_current_user" npm run dev
 ```
 
-When action policy is configured, provider proxy requests are denied unless the provider is
-explicitly included in `OOMOL_CONNECT_ALLOWED_PROXIES`.
+Provider proxies are controlled separately and are not affected by action policy. Every proxy is
+allowed until you restrict it with `OOMOL_CONNECT_ALLOWED_PROXIES="github"`, or turn them all off
+with `OOMOL_CONNECT_BLOCKED_PROXIES="*"`.

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -195,8 +195,9 @@ Successful responses use the standard `/v1` success envelope with `data.status`,
 `data.data`.
 
 Proxy requests are controlled by `OOMOL_CONNECT_ALLOWED_PROXIES` and
-`OOMOL_CONNECT_BLOCKED_PROXIES`. When action policy is configured, provider proxies are denied by
-default unless explicitly allowlisted.
+`OOMOL_CONNECT_BLOCKED_PROXIES`, and by nothing else: action policy does not affect them. Every
+provider proxy is allowed until one of those variables restricts it, and
+`OOMOL_CONNECT_BLOCKED_PROXIES="*"` disables provider proxies entirely.
 
 ## Local Admin Endpoints
 

--- a/src/core/action-policy.test.ts
+++ b/src/core/action-policy.test.ts
@@ -58,16 +58,26 @@ describe("ActionPolicyService", () => {
     expect(new ActionPolicyService().evaluateProxy("github")).toEqual({ allowed: true });
   });
 
-  it("requires explicit proxy allowlists when action policy is configured", () => {
+  it("ignores action policy when evaluating proxies", () => {
     expect(new ActionPolicyService({ allowedActions: ["github.get_current_user"] }).evaluateProxy("github")).toEqual({
-      allowed: false,
-      code: "proxy_not_allowed",
-      message: "github proxy must be explicitly allowed when local action policy is configured.",
+      allowed: true,
     });
     expect(new ActionPolicyService({ blockedActions: ["github.delete_repository"] }).evaluateProxy("github")).toEqual({
+      allowed: true,
+    });
+    expect(new ActionPolicyService({ allowedActions: ["*"] }).evaluateProxy("github")).toEqual({ allowed: true });
+    expect(new ActionPolicyService({ blockedActions: ["*"] }).evaluateProxy("github")).toEqual({ allowed: true });
+  });
+
+  it("ignores proxy policy when evaluating actions", () => {
+    expect(new ActionPolicyService({ blockedProxies: ["*"] }).evaluate(action)).toEqual({ allowed: true });
+    expect(new ActionPolicyService({ allowedProxies: ["slack"] }).evaluate(action)).toEqual({ allowed: true });
+  });
+
+  it("disables every proxy with a blocked wildcard", () => {
+    expect(new ActionPolicyService({ blockedProxies: ["*"] }).evaluateProxy("github")).toMatchObject({
       allowed: false,
-      code: "proxy_not_allowed",
-      message: "github proxy must be explicitly allowed when local action policy is configured.",
+      code: "proxy_blocked",
     });
   });
 

--- a/src/core/action-policy.ts
+++ b/src/core/action-policy.ts
@@ -17,20 +17,22 @@ export type ActionPolicyConfig = {
 
 /**
  * Local execution policy used before invoking provider executors.
+ *
+ * Action policy and proxy policy are independent: allowedActions/blockedActions
+ * decide Action execution only, and allowedProxies/blockedProxies decide
+ * provider proxies only. Neither pair reads the other.
  */
 export class ActionPolicyService {
   private readonly allowed: ActionMatcher[];
   private readonly blocked: ActionMatcher[];
   private readonly allowedProxies: ProxyMatcher[];
   private readonly blockedProxies: ProxyMatcher[];
-  private readonly restrictsActions: boolean;
 
   constructor(config: ActionPolicyConfig = {}) {
     this.allowed = (config.allowedActions ?? []).map(createMatcher);
     this.blocked = (config.blockedActions ?? []).map(createMatcher);
     this.allowedProxies = (config.allowedProxies ?? []).map(createProxyMatcher);
     this.blockedProxies = (config.blockedProxies ?? []).map(createProxyMatcher);
-    this.restrictsActions = this.allowed.length > 0 || this.blocked.length > 0;
   }
 
   evaluate(action: ActionDefinition): ActionPolicyDecision {
@@ -70,14 +72,6 @@ export class ActionPolicyService {
         allowed: false,
         code: "proxy_not_allowed",
         message: `${service} proxy is not included in the local proxy allowlist.`,
-      };
-    }
-
-    if (this.restrictsActions) {
-      return {
-        allowed: false,
-        code: "proxy_not_allowed",
-        message: `${service} proxy must be explicitly allowed when local action policy is configured.`,
       };
     }
 

--- a/src/server/proxy/proxy-runner.test.ts
+++ b/src/server/proxy/proxy-runner.test.ts
@@ -58,7 +58,7 @@ describe("ProxyRunner", () => {
     const loadProxyExecutor = vi.fn();
     const connections = createConnections();
     const runner = createRunner({
-      actionPolicy: new ActionPolicyService({ allowedActions: ["example.echo"] }),
+      actionPolicy: new ActionPolicyService({ allowedProxies: ["other"] }),
       connections,
       providerLoader: {
         loadActionExecutor: async () => undefined,
@@ -81,7 +81,7 @@ describe("ProxyRunner", () => {
     expect(connections.getConnectionSummary).not.toHaveBeenCalled();
   });
 
-  it("runs explicitly allowed proxies when action policy is configured", async () => {
+  it("runs allowlisted proxies regardless of action policy", async () => {
     const proxy: ProviderProxyExecutor = vi.fn(
       async (): Promise<ProxyExecutionResult> => ({
         ok: true,


### PR DESCRIPTION
restrictsActions was an OR over array length, so configuring any action policy denied every provider proxy unless OOMOL_CONNECT_ALLOWED_PROXIES was also set. Blacklisting a single Action was enough:

  BLOCKED_ACTIONS=github.delete_repository   -> every /v1/proxy/:service 403s

The 403 then blamed "local action policy", a policy the operator did not believe they had configured for proxies at all. Nothing about locking down one Action implies anything about provider proxies, and the length-based OR made even a one-entry denylist trip it.

Action policy and proxy policy are now independent. Proxy is decided by OOMOL_CONNECT_ALLOWED_PROXIES / OOMOL_CONNECT_BLOCKED_PROXIES and nothing else, which is what those variables already claimed to do. restrictsActions is deleted outright rather than switched off, so the coupling has nothing left to read. The environment variable surface is unchanged.

Behavior change for existing deployments: a deployment that sets any action policy and no proxy policy had every provider proxy denied and now has them allowed. /v1/proxy/:service reaches provider endpoints beyond the curated catalog, so operators who were relying on this side effect must now set the proxy variables explicitly. SECURITY.md recommended the action variables to reduce attack surface without mentioning that proxies need their own, and now says so.