### PR TITLE
fix(web): sync <html lang> with selected language

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,11 @@ import "./style.css";
 
 const i18n = createAppI18n(readInitialLang());
 
+// Keep <html lang> in sync with the selected language (fires immediately for the initial lang).
+i18n.lang$.subscribe((lang) => {
+  document.documentElement.lang = lang;
+});
+
 createRoot(document.getElementById("root")!).render(
   <I18nProvider i18n={i18n}>
     <BrowserRouter>


### PR DESCRIPTION
## Problem

`web/index.html` hardcodes `<html lang="en">` and nothing updates `document.documentElement.lang` at runtime. With the UI language set to 简体中文 (or any non-English locale), the document still reports `lang="en"`, which affects screen readers, browser translation prompts, font selection, and CSS `:lang()`.

## Fix

Subscribe to `i18n.lang$` in `web/src/main.tsx` and mirror it onto `document.documentElement.lang`. `subscribe` emits immediately, so this covers both the initial language (stored/detected) and every runtime switch from the language selector — one place, no per-caller handling.

## Verification

- `npm run fix-check` passes
- `npm run build:web` passes
- Manually: with `oomol-connect.lang=zh-CN` stored, `document.documentElement.lang` is `zh-CN` on load and updates on switching languages