### PR TITLE
fix(server): surface OAuth provider errors on callback

### DIFF
--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -820,6 +820,22 @@ describe("ConnectServer", () => {
     }
   });
 
+  it("surfaces provider errors returned on the OAuth callback", async () => {
+    const app = createTestServer([apiKeyProvider], { auth: { adminToken: "local-token" } }).createApp();
+
+    const response = await app.request(
+      "/oauth/callback?error=invalid_scope&error_description=The+requested+scope+is+invalid.&state=example-state",
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "oauth_provider_error",
+        message: 'OAuth provider returned error "invalid_scope": The requested scope is invalid.',
+      },
+    });
+  });
+
   it("accepts the shared OAuth callback route without a service path segment", async () => {
     const app = createTestServer([apiKeyProvider], { auth: { adminToken: "local-token" } }).createApp();
 

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -804,6 +804,25 @@ export class ConnectServer {
       hasCode: Boolean(code),
     };
     this.options.logger?.info(logContext, "oauth callback received");
+    const providerError = context.req.query("error");
+    if (providerError) {
+      const providerErrorDescription = context.req.query("error_description");
+      this.options.logger?.warn(
+        {
+          ...logContext,
+          errorCode: "oauth_provider_error",
+          providerError,
+          providerErrorDescription,
+        },
+        "oauth callback failed",
+      );
+      return jsonError(
+        context,
+        400,
+        "oauth_provider_error",
+        `OAuth provider returned error "${providerError}"${providerErrorDescription ? `: ${providerErrorDescription}` : "."}`,
+      );
+    }
     if (!state || !code) {
       this.options.logger?.warn(
         {


### PR DESCRIPTION
## Problem

When an OAuth provider redirects back to `/oauth/callback` with an error (per RFC 6749 §4.1.2.1, e.g. `?error=invalid_scope&error_description=...&state=...`), the callback handler only checks for `state` and `code` and responds with the generic:

```json
{"error":{"code":"invalid_oauth_callback","message":"OAuth callback requires state and code."}}
```

The provider's actual `error`/`error_description` are silently dropped, which makes misconfigurations hard to diagnose. Real-world example: a Cloudflare OAuth client missing the `zone.read` scope redirects with `error=invalid_scope&error_description=The OAuth 2.0 Client is not allowed to request scope 'zone.read'.` — but the user only ever sees "requires state and code".

## Fix

In `completeOAuth`, check the `error` query param before the state/code validation. If present, log it and return a 400 with the provider's error code and description:

```json
{"error":{"code":"oauth_provider_error","message":"OAuth provider returned error \"invalid_scope\": The requested scope is invalid."}}
```

## Verification

- New test `surfaces provider errors returned on the OAuth callback` in `connect-server.test.ts`
- `npx vitest run src/server/connect-server.test.ts` — 56 passed
- `npm run fix-check` passes