### PR TITLE
feat(github): add 59 actions across repo, issue, PR, CI, release

### DIFF
--- a/src/providers/github/actions.ts
+++ b/src/providers/github/actions.ts
@@ -13,6 +13,13 @@ const optionalPaginationFields = {
   perPage: s.integer(),
   page: s.integer(),
 };
+const fullyQualifiedRefSchema = s.nonEmptyString(
+  "The fully qualified reference without the refs/ prefix, such as heads/main or tags/v1.0.0.",
+);
+const workflowIdSchema = s.anyOf("The workflow ID or workflow file name, such as ci.yml.", [
+  nonEmptyString,
+  s.integer({ minimum: 1 }),
+]);
 const githubRequiredInputFields: Record<string, string[]> = {
   create_repository: ["name"],
   list_branches: ["owner", "repo"],
@@ -95,6 +102,64 @@ const githubRequiredInputFields: Record<string, string[]> = {
   search_topics: ["query"],
   create_or_update_file: ["owner", "repo", "path", "message"],
   delete_file: ["owner", "repo", "path", "message", "sha"],
+  update_repository: ["owner", "repo"],
+  fork_repository: ["owner", "repo"],
+  list_repository_forks: ["owner", "repo"],
+  list_repository_tags: ["owner", "repo"],
+  list_repository_languages: ["owner", "repo"],
+  list_repository_contributors: ["owner", "repo"],
+  list_repository_topics: ["owner", "repo"],
+  replace_repository_topics: ["owner", "repo", "names"],
+  get_repository_readme: ["owner", "repo"],
+  list_organization_repositories: ["org"],
+  list_user_repositories: ["username"],
+  get_user: ["username"],
+  list_repository_collaborators: ["owner", "repo"],
+  add_repository_collaborator: ["owner", "repo", "username"],
+  remove_repository_collaborator: ["owner", "repo", "username"],
+  get_repository_permission_for_user: ["owner", "repo", "username"],
+  get_ref: ["owner", "repo", "ref"],
+  list_matching_refs: ["owner", "repo", "ref"],
+  update_ref: ["owner", "repo", "ref", "sha"],
+  delete_ref: ["owner", "repo", "ref"],
+  create_commit_comment: ["owner", "repo", "commitSha", "body"],
+  list_commit_comments: ["owner", "repo", "commitSha"],
+  star_repository: ["owner", "repo"],
+  unstar_repository: ["owner", "repo"],
+  check_repository_starred: ["owner", "repo"],
+  list_repository_stargazers: ["owner", "repo"],
+  list_repository_watchers: ["owner", "repo"],
+  list_milestones: ["owner", "repo"],
+  get_milestone: ["owner", "repo", "milestoneNumber"],
+  create_milestone: ["owner", "repo", "title"],
+  update_milestone: ["owner", "repo", "milestoneNumber"],
+  delete_milestone: ["owner", "repo", "milestoneNumber"],
+  get_issue_comment: ["owner", "repo", "commentId"],
+  update_issue_comment: ["owner", "repo", "commentId", "body"],
+  delete_issue_comment: ["owner", "repo", "commentId"],
+  get_label: ["owner", "repo", "name"],
+  update_label: ["owner", "repo", "name"],
+  delete_label: ["owner", "repo", "name"],
+  list_assignees: ["owner", "repo"],
+  create_issue_reaction: ["owner", "repo", "issueNumber", "content"],
+  create_issue_comment_reaction: ["owner", "repo", "commentId", "content"],
+  get_pull_request_review: ["owner", "repo", "pullNumber", "reviewId"],
+  dismiss_pull_request_review: ["owner", "repo", "pullNumber", "reviewId", "message"],
+  delete_pending_pull_request_review: ["owner", "repo", "pullNumber", "reviewId"],
+  update_pull_request_review_comment: ["owner", "repo", "commentId", "body"],
+  delete_pull_request_review_comment: ["owner", "repo", "commentId"],
+  get_workflow: ["owner", "repo", "workflowId"],
+  dispatch_workflow: ["owner", "repo", "workflowId", "ref"],
+  cancel_workflow_run: ["owner", "repo", "runId"],
+  rerun_failed_jobs: ["owner", "repo", "runId"],
+  enable_workflow: ["owner", "repo", "workflowId"],
+  disable_workflow: ["owner", "repo", "workflowId"],
+  list_workflow_run_artifacts: ["owner", "repo", "runId"],
+  update_release: ["owner", "repo", "releaseId"],
+  delete_release: ["owner", "repo", "releaseId"],
+  generate_release_notes: ["owner", "repo", "tagName"],
+  get_release_asset: ["owner", "repo", "assetId"],
+  delete_release_asset: ["owner", "repo", "assetId"],
 };
 
 const githubUserSummarySchema = s.looseObject({
@@ -153,7 +218,7 @@ const githubIssueCommentSchema = s.looseObject({
   id: s.integer(),
   html_url: s.string(),
   body: s.string(),
-  user: githubUserSummarySchema,
+  user: s.nullable(githubUserSummarySchema),
   created_at: s.string(),
   updated_at: s.string(),
 });
@@ -255,11 +320,11 @@ const githubCheckRunSchema = s.looseObject({
 
 const githubPullRequestReviewSchema = s.looseObject({
   id: s.integer(),
-  user: githubUserSummarySchema,
+  user: s.nullable(githubUserSummarySchema),
   body: nullableString,
   state: s.string(),
   html_url: s.string(),
-  commit_id: s.string(),
+  commit_id: nullableString,
   submitted_at: nullableString,
 });
 
@@ -267,15 +332,15 @@ const githubPullRequestReviewCommentSchema = s.looseObject({
   id: s.integer(),
   path: s.string(),
   body: s.string(),
-  user: githubUserSummarySchema,
+  user: s.nullable(githubUserSummarySchema),
   commit_id: s.string(),
   original_commit_id: s.string(),
   diff_hunk: s.string(),
   html_url: s.string(),
-  line: s.integer(),
-  start_line: s.integer(),
+  line: s.nullable(s.integer()),
+  start_line: s.nullable(s.integer()),
   side: s.string(),
-  start_side: s.string(),
+  start_side: nullableString,
 });
 
 const githubReviewCommentInputSchema = s.object({
@@ -342,8 +407,8 @@ const githubReleaseSchema = s.looseObject({
   prerelease: s.boolean(),
   html_url: s.string(),
   assets_url: s.string(),
-  tarball_url: s.string(),
-  zipball_url: s.string(),
+  tarball_url: nullableString,
+  zipball_url: nullableString,
   target_commitish: s.string(),
   author: githubUserSummarySchema,
   created_at: s.string(),
@@ -359,7 +424,7 @@ const githubReleaseAssetSchema = s.looseObject({
   size: s.integer(),
   download_count: s.integer(),
   browser_download_url: s.string(),
-  uploader: githubUserSummarySchema,
+  uploader: s.nullable(githubUserSummarySchema),
   created_at: s.string(),
   updated_at: s.string(),
 });
@@ -453,6 +518,86 @@ const githubContentsWriteResultSchema = s.object({
 const githubContentsDeleteResultSchema = s.object({
   content: githubContentEntrySchema,
   commit: anyObject,
+});
+
+const githubPublicUserSchema = extendObject(githubCurrentUserSchema, {
+  followers: s.integer(),
+  following: s.integer(),
+  public_repos: s.integer(),
+});
+
+const githubContributorSchema = s.looseObject({
+  contributions: s.integer(),
+  login: s.string(),
+  id: s.integer(),
+  avatar_url: s.string(),
+  html_url: s.string(),
+  type: s.string(),
+});
+
+const githubCollaboratorSchema = extendObject(githubUserSummarySchema, {
+  permissions: anyObject,
+  role_name: s.string(),
+});
+
+const githubRepositoryPermissionSchema = s.looseObject({
+  permission: s.string(),
+  role_name: s.string(),
+  user: s.nullable(githubUserSummarySchema),
+});
+
+const githubMilestoneSchema = s.looseObject({
+  id: s.integer(),
+  number: s.integer(),
+  title: s.string(),
+  state: s.string(),
+  description: nullableString,
+  due_on: nullableString,
+  open_issues: s.integer(),
+  closed_issues: s.integer(),
+  html_url: s.string(),
+});
+
+const githubReactionSchema = s.looseObject({
+  id: s.integer(),
+  content: s.string(),
+  user: s.nullable(githubUserSummarySchema),
+  created_at: s.string(),
+});
+
+const githubGitRefSchema = s.looseObject({
+  ref: s.string(),
+  node_id: s.string(),
+  url: s.string(),
+  object: anyObject,
+});
+
+const githubArtifactSchema = s.looseObject({
+  id: s.integer(),
+  name: s.string(),
+  size_in_bytes: s.integer(),
+  archive_download_url: s.string(),
+  expired: s.boolean(),
+  created_at: nullableString,
+  expires_at: nullableString,
+});
+
+const githubCommitCommentSchema = s.looseObject({
+  id: s.integer(),
+  body: s.string(),
+  html_url: s.string(),
+  path: nullableString,
+  position: s.nullable(s.integer()),
+  user: s.nullable(githubUserSummarySchema),
+  created_at: s.string(),
+  updated_at: s.string(),
+});
+
+const githubTagSummarySchema = s.looseObject({
+  name: s.string(),
+  commit: anyObject,
+  zipball_url: s.string(),
+  tarball_url: s.string(),
 });
 
 const githubMutationAckSchema = s.object({
@@ -1685,6 +1830,771 @@ export const githubActions: ActionDefinition[] = [
       branch: s.string(),
     }),
     outputSchema: githubContentsDeleteResultSchema,
+  }),
+  action({
+    name: "update_repository",
+    description: "Update settings and metadata for a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      name: s.string(),
+      description: s.string(),
+      homepage: s.string({ format: "uri" }),
+      private: s.boolean(),
+      visibility: s.stringEnum(["public", "private"]),
+      defaultBranch: s.string(),
+      hasIssues: s.boolean(),
+      hasProjects: s.boolean(),
+      hasWiki: s.boolean(),
+      hasDiscussions: s.boolean(),
+      allowSquashMerge: s.boolean(),
+      allowMergeCommit: s.boolean(),
+      allowRebaseMerge: s.boolean(),
+      allowAutoMerge: s.boolean(),
+      deleteBranchOnMerge: s.boolean(),
+      archived: s.boolean(),
+    }),
+    outputSchema: githubRepositorySchema,
+  }),
+  action({
+    name: "fork_repository",
+    description:
+      "Fork a GitHub repository. Forking happens asynchronously, so the returned repository may not be immediately ready.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      organization: s.string(),
+      name: s.string(),
+      defaultBranchOnly: s.boolean(),
+    }),
+    outputSchema: githubRepositorySchema,
+  }),
+  action({
+    name: "list_repository_forks",
+    description: "List forks of a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      sort: s.stringEnum(["newest", "oldest", "stargazers", "watchers"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      repositories: s.array(githubRepositorySchema),
+    }),
+  }),
+  action({
+    name: "list_repository_tags",
+    description: "List tags in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      tags: s.array(githubTagSummarySchema),
+    }),
+  }),
+  action({
+    name: "list_repository_languages",
+    description: "List languages used in a GitHub repository with byte counts.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+    }),
+    outputSchema: s.object({
+      languages: s.record(s.integer()),
+    }),
+  }),
+  action({
+    name: "list_repository_contributors",
+    description: "List contributors to a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      anon: s.boolean("Whether to include anonymous contributors."),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      contributors: s.array(githubContributorSchema),
+    }),
+  }),
+  action({
+    name: "list_repository_topics",
+    description: "List topics of a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      names: s.array(s.string()),
+    }),
+  }),
+  action({
+    name: "replace_repository_topics",
+    description: "Replace all topics of a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      names: s.array("The full set of lowercase topic names to set on the repository.", s.string()),
+    }),
+    outputSchema: s.object({
+      names: s.array(s.string()),
+    }),
+  }),
+  action({
+    name: "get_repository_readme",
+    description: "Get the README of a GitHub repository and return both base64 and decoded text when available.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ref: s.string(),
+    }),
+    outputSchema: githubFileContentSchema,
+  }),
+  action({
+    name: "list_organization_repositories",
+    description: "List repositories for a GitHub organization.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      org: nonEmptyString,
+      type: s.stringEnum(["all", "public", "private", "forks", "sources", "member"]),
+      sort: s.stringEnum(["created", "updated", "pushed", "full_name"]),
+      direction: s.stringEnum(["asc", "desc"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      repositories: s.array(githubRepositorySchema),
+    }),
+  }),
+  action({
+    name: "list_user_repositories",
+    description: "List public repositories for a GitHub user.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      username: nonEmptyString,
+      type: s.stringEnum(["all", "owner", "member"]),
+      sort: s.stringEnum(["created", "updated", "pushed", "full_name"]),
+      direction: s.stringEnum(["asc", "desc"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      repositories: s.array(githubRepositorySchema),
+    }),
+  }),
+  action({
+    name: "get_user",
+    description: "Get a GitHub user profile by username.",
+    requiredScopes: githubUserReadScopes,
+    inputSchema: s.object({
+      username: nonEmptyString,
+    }),
+    outputSchema: githubPublicUserSchema,
+  }),
+  action({
+    name: "list_repository_collaborators",
+    description: "List collaborators of a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      affiliation: s.stringEnum(["outside", "direct", "all"]),
+      permission: s.stringEnum(["pull", "triage", "push", "maintain", "admin"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      collaborators: s.array(githubCollaboratorSchema),
+    }),
+  }),
+  action({
+    name: "add_repository_collaborator",
+    description: "Add a collaborator to a GitHub repository or update their permission.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      username: nonEmptyString,
+      permission: s.string(
+        "The permission to grant: pull, triage, push, maintain, admin, or a custom repository role name.",
+      ),
+    }),
+    outputSchema: s.object({
+      invited: s.boolean(),
+      invitation: s.nullable(anyObject),
+    }),
+  }),
+  action({
+    name: "remove_repository_collaborator",
+    description: "Remove a collaborator from a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      username: nonEmptyString,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "get_repository_permission_for_user",
+    description: "Get the repository permission level of a GitHub user.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      username: nonEmptyString,
+    }),
+    outputSchema: githubRepositoryPermissionSchema,
+  }),
+  action({
+    name: "get_ref",
+    description: "Get a Git reference in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ref: fullyQualifiedRefSchema,
+    }),
+    outputSchema: githubGitRefSchema,
+  }),
+  action({
+    name: "list_matching_refs",
+    description: "List Git references matching a prefix in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ref: s.nonEmptyString(
+        "The reference prefix to match, such as heads/feature. The endpoint is not paginated and always returns all matching references.",
+      ),
+    }),
+    outputSchema: s.object({
+      refs: s.array(githubGitRefSchema),
+    }),
+  }),
+  action({
+    name: "update_ref",
+    description: "Update a Git reference in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ref: fullyQualifiedRefSchema,
+      sha: nonEmptyString,
+      force: s.boolean(),
+    }),
+    outputSchema: githubGitRefSchema,
+  }),
+  action({
+    name: "delete_ref",
+    description: "Delete a Git reference in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ref: fullyQualifiedRefSchema,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "create_commit_comment",
+    description: "Create a comment on a commit in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commitSha: nonEmptyString,
+      body: nonEmptyString,
+      path: s.string(),
+      position: s.integer({ minimum: 1, description: "The line index in the diff to comment on." }),
+    }),
+    outputSchema: githubCommitCommentSchema,
+  }),
+  action({
+    name: "list_commit_comments",
+    description: "List comments on a commit in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commitSha: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      comments: s.array(githubCommitCommentSchema),
+    }),
+  }),
+  action({
+    name: "star_repository",
+    description: "Star a GitHub repository for the authenticated user.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "unstar_repository",
+    description: "Unstar a GitHub repository for the authenticated user.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "check_repository_starred",
+    description: "Check whether the authenticated user has starred a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+    }),
+    outputSchema: s.object({
+      starred: s.boolean(),
+    }),
+  }),
+  action({
+    name: "list_repository_stargazers",
+    description: "List users who starred a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      stargazers: s.array(githubUserSummarySchema),
+    }),
+  }),
+  action({
+    name: "list_my_starred_repositories",
+    description: "List repositories starred by the authenticated GitHub user.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      sort: s.stringEnum(["created", "updated"]),
+      direction: s.stringEnum(["asc", "desc"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      repositories: s.array(githubRepositorySchema),
+    }),
+  }),
+  action({
+    name: "list_repository_watchers",
+    description: "List users watching a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      watchers: s.array(githubUserSummarySchema),
+    }),
+  }),
+  action({
+    name: "list_milestones",
+    description: "List milestones for a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      state: s.stringEnum(["open", "closed", "all"]),
+      sort: s.stringEnum(["due_on", "completeness"]),
+      direction: s.stringEnum(["asc", "desc"]),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      milestones: s.array(githubMilestoneSchema),
+    }),
+  }),
+  action({
+    name: "get_milestone",
+    description: "Get a GitHub milestone by number.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      milestoneNumber: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMilestoneSchema,
+  }),
+  action({
+    name: "create_milestone",
+    description: "Create a milestone in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      title: nonEmptyString,
+      state: s.stringEnum(["open", "closed"]),
+      description: s.string(),
+      dueOn: s.string({ format: "date-time" }),
+    }),
+    outputSchema: githubMilestoneSchema,
+  }),
+  action({
+    name: "update_milestone",
+    description: "Update a GitHub milestone by number.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      milestoneNumber: s.integer({ minimum: 1 }),
+      title: s.string(),
+      state: s.stringEnum(["open", "closed"]),
+      description: s.string(),
+      dueOn: s.string({ format: "date-time" }),
+    }),
+    outputSchema: githubMilestoneSchema,
+  }),
+  action({
+    name: "delete_milestone",
+    description: "Delete a GitHub milestone by number.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      milestoneNumber: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "get_issue_comment",
+    description: "Get a GitHub issue comment by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubIssueCommentSchema,
+  }),
+  action({
+    name: "update_issue_comment",
+    description: "Update a GitHub issue comment by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+      body: nonEmptyString,
+    }),
+    outputSchema: githubIssueCommentSchema,
+  }),
+  action({
+    name: "delete_issue_comment",
+    description: "Delete a GitHub issue comment by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "get_label",
+    description: "Get a GitHub label by name.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      name: nonEmptyString,
+    }),
+    outputSchema: githubLabelSchema,
+  }),
+  action({
+    name: "update_label",
+    description: "Update a GitHub label by name.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      name: nonEmptyString,
+      newName: s.string(),
+      color: s.string("The label color as a 6-character hex value without #."),
+      description: s.string(),
+    }),
+    outputSchema: githubLabelSchema,
+  }),
+  action({
+    name: "delete_label",
+    description: "Delete a GitHub label by name.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      name: nonEmptyString,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "list_assignees",
+    description: "List available assignees for issues in a GitHub repository.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      assignees: s.array(githubUserSummarySchema),
+    }),
+  }),
+  action({
+    name: "create_issue_reaction",
+    description: "Add a reaction to a GitHub issue.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      issueNumber: s.integer({ minimum: 1 }),
+      content: s.stringEnum(["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"]),
+    }),
+    outputSchema: githubReactionSchema,
+  }),
+  action({
+    name: "create_issue_comment_reaction",
+    description: "Add a reaction to a GitHub issue comment.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+      content: s.stringEnum(["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"]),
+    }),
+    outputSchema: githubReactionSchema,
+  }),
+  action({
+    name: "get_pull_request_review",
+    description: "Get a GitHub pull request review by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      pullNumber: s.integer({ minimum: 1 }),
+      reviewId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubPullRequestReviewSchema,
+  }),
+  action({
+    name: "dismiss_pull_request_review",
+    description: "Dismiss a GitHub pull request review.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      pullNumber: s.integer({ minimum: 1 }),
+      reviewId: s.integer({ minimum: 1 }),
+      message: nonEmptyString,
+    }),
+    outputSchema: githubPullRequestReviewSchema,
+  }),
+  action({
+    name: "delete_pending_pull_request_review",
+    description: "Delete a pending GitHub pull request review and return the deleted review.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      pullNumber: s.integer({ minimum: 1 }),
+      reviewId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubPullRequestReviewSchema,
+  }),
+  action({
+    name: "update_pull_request_review_comment",
+    description: "Update a GitHub pull request review comment by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+      body: nonEmptyString,
+    }),
+    outputSchema: githubPullRequestReviewCommentSchema,
+  }),
+  action({
+    name: "delete_pull_request_review_comment",
+    description: "Delete a GitHub pull request review comment by ID.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      commentId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "get_workflow",
+    description: "Get a GitHub Actions workflow by ID or file name.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      workflowId: workflowIdSchema,
+    }),
+    outputSchema: githubWorkflowSchema,
+  }),
+  action({
+    name: "dispatch_workflow",
+    description: "Trigger a GitHub Actions workflow dispatch event.",
+    requiredScopes: githubWorkflowScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      workflowId: workflowIdSchema,
+      ref: s.nonEmptyString("The branch or tag name to run the workflow on."),
+      inputs: s.record("The workflow inputs. All values must be strings.", s.string()),
+    }),
+    outputSchema: s.object({
+      dispatched: s.boolean(),
+    }),
+  }),
+  action({
+    name: "cancel_workflow_run",
+    description: "Cancel a GitHub Actions workflow run.",
+    requiredScopes: githubWorkflowScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      runId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: s.object({
+      cancel_requested: s.boolean(),
+    }),
+  }),
+  action({
+    name: "rerun_failed_jobs",
+    description: "Re-run failed jobs of a GitHub Actions workflow run.",
+    requiredScopes: githubWorkflowScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      runId: s.integer({ minimum: 1 }),
+      enableDebugLogging: s.boolean(),
+    }),
+    outputSchema: s.object({
+      rerun_requested: s.boolean(),
+    }),
+  }),
+  action({
+    name: "enable_workflow",
+    description: "Enable a GitHub Actions workflow.",
+    requiredScopes: githubWorkflowScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      workflowId: workflowIdSchema,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "disable_workflow",
+    description: "Disable a GitHub Actions workflow.",
+    requiredScopes: githubWorkflowScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      workflowId: workflowIdSchema,
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "list_workflow_run_artifacts",
+    description: "List artifacts for a GitHub Actions workflow run.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      runId: s.integer({ minimum: 1 }),
+      name: s.string("Filter artifacts by exact name."),
+      ...optionalPaginationFields,
+    }),
+    outputSchema: s.object({
+      total_count: s.integer(),
+      artifacts: s.array(githubArtifactSchema),
+    }),
+  }),
+  action({
+    name: "update_release",
+    description: "Update a GitHub release by numeric id.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      releaseId: s.integer({ minimum: 1 }),
+      tagName: s.string(),
+      targetCommitish: s.string(),
+      name: s.string(),
+      body: s.string(),
+      draft: s.boolean(),
+      prerelease: s.boolean(),
+      makeLatest: s.stringEnum(["true", "false", "legacy"]),
+    }),
+    outputSchema: githubReleaseSchema,
+  }),
+  action({
+    name: "delete_release",
+    description: "Delete a GitHub release by numeric id.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      releaseId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMutationAckSchema,
+  }),
+  action({
+    name: "generate_release_notes",
+    description: "Generate release notes content for a GitHub release.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      tagName: nonEmptyString,
+      targetCommitish: s.string(),
+      previousTagName: s.string(),
+      configurationFilePath: s.string(),
+    }),
+    outputSchema: s.object({
+      name: s.string(),
+      body: s.string(),
+    }),
+  }),
+  action({
+    name: "get_release_asset",
+    description: "Get a GitHub release asset by numeric id.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      assetId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubReleaseAssetSchema,
+  }),
+  action({
+    name: "delete_release_asset",
+    description: "Delete a GitHub release asset by numeric id.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      assetId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: githubMutationAckSchema,
   }),
 ];
 

--- a/src/providers/github/actions.ts
+++ b/src/providers/github/actions.ts
@@ -1994,7 +1994,7 @@ export const githubActions: ActionDefinition[] = [
   action({
     name: "get_user",
     description: "Get a GitHub user profile by username.",
-    requiredScopes: githubUserReadScopes,
+    requiredScopes: [],
     inputSchema: s.object({
       username: nonEmptyString,
     }),

--- a/src/providers/github/runtime-activity.ts
+++ b/src/providers/github/runtime-activity.ts
@@ -1,7 +1,15 @@
 import type { GitHubActionHandler } from "./runtime-shared.ts";
 
-import { optionalInteger } from "../../core/cast.ts";
-import { compactObject, githubRequestJson } from "./runtime-shared.ts";
+import { optionalInteger, optionalString } from "../../core/cast.ts";
+import {
+  buildGitHubUrl,
+  compactObject,
+  githubHeaders,
+  githubRequestJson,
+  githubRequestNoContent,
+  normalizeGitHubError,
+  readJsonResponse,
+} from "./runtime-shared.ts";
 
 export const activityActionHandlers: Record<string, GitHubActionHandler> = {
   list_public_events(input, { accessToken, fetcher }) {
@@ -52,6 +60,30 @@ export const activityActionHandlers: Record<string, GitHubActionHandler> = {
       fetcher,
     );
   },
+
+  star_repository(input, { accessToken, fetcher }) {
+    return starRepository(input, accessToken, fetcher);
+  },
+
+  unstar_repository(input, { accessToken, fetcher }) {
+    return unstarRepository(input, accessToken, fetcher);
+  },
+
+  check_repository_starred(input, { accessToken, fetcher }) {
+    return checkRepositoryStarred(input, accessToken, fetcher);
+  },
+
+  list_repository_stargazers(input, { accessToken, fetcher }) {
+    return listRepositoryStargazers(input, accessToken, fetcher);
+  },
+
+  list_my_starred_repositories(input, { accessToken, fetcher }) {
+    return listMyStarredRepositories(input, accessToken, fetcher);
+  },
+
+  list_repository_watchers(input, { accessToken, fetcher }) {
+    return listRepositoryWatchers(input, accessToken, fetcher);
+  },
 };
 
 async function listActivityEvents(
@@ -71,4 +103,96 @@ async function listActivityEvents(
   });
 
   return { events };
+}
+
+async function starRepository(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "PUT",
+    path: `/user/starred/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function unstarRepository(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/user/starred/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function checkRepositoryStarred(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const response = await fetcher(
+    buildGitHubUrl(
+      `/user/starred/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}`,
+    ),
+    {
+      method: "GET",
+      headers: githubHeaders(accessToken, false),
+    },
+  );
+
+  if (response.status === 204) {
+    return { starred: true };
+  }
+  if (response.status === 404) {
+    return { starred: false };
+  }
+
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw normalizeGitHubError(response, payload, "github api request failed");
+  }
+
+  throw normalizeGitHubError(response, payload, "unexpected github star-status");
+}
+
+async function listRepositoryStargazers(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const stargazers = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/stargazers`,
+    query: compactObject({
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { stargazers };
+}
+
+async function listMyStarredRepositories(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const repositories = await githubRequestJson<Record<string, unknown>[]>({
+    path: "/user/starred",
+    query: compactObject({
+      sort: optionalString(input.sort),
+      direction: optionalString(input.direction),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { repositories };
+}
+
+async function listRepositoryWatchers(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const watchers = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/subscribers`,
+    query: compactObject({
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { watchers };
 }

--- a/src/providers/github/runtime-issue.ts
+++ b/src/providers/github/runtime-issue.ts
@@ -1,6 +1,7 @@
 import type { GitHubActionHandler } from "./runtime-shared.ts";
 
 import { nullableInteger, optionalInteger, optionalRawString, optionalString } from "../../core/cast.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
 import {
   buildIssueAndPullRequestSearchQuery,
   compactObject,
@@ -154,6 +155,120 @@ export const issueActionHandlers: Record<string, GitHubActionHandler> = {
 
   list_repository_issue_events(input, { accessToken, fetcher }) {
     return listRepositoryIssueEvents(input, accessToken, fetcher);
+  },
+
+  list_milestones(input, { accessToken, fetcher }) {
+    return listMilestones(input, accessToken, fetcher);
+  },
+
+  get_milestone(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/milestones/${String(input.milestoneNumber)}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  create_milestone(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "POST",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/milestones`,
+      body: compactObject({
+        title: String(input.title),
+        state: optionalString(input.state),
+        description: optionalRawString(input.description),
+        due_on: optionalString(input.dueOn),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  update_milestone(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PATCH",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/milestones/${String(input.milestoneNumber)}`,
+      body: compactObject({
+        title: optionalRawString(input.title),
+        state: optionalString(input.state),
+        description: optionalRawString(input.description),
+        due_on: optionalString(input.dueOn),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_milestone(input, { accessToken, fetcher }) {
+    return deleteMilestone(input, accessToken, fetcher);
+  },
+
+  get_issue_comment(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues/comments/${String(input.commentId)}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  update_issue_comment(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PATCH",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues/comments/${String(input.commentId)}`,
+      body: {
+        body: String(input.body),
+      },
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_issue_comment(input, { accessToken, fetcher }) {
+    return deleteIssueComment(input, accessToken, fetcher);
+  },
+
+  get_label(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/labels/${encodeURIComponent(String(input.name))}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  update_label(input, { accessToken, fetcher }) {
+    return updateLabel(input, accessToken, fetcher);
+  },
+
+  delete_label(input, { accessToken, fetcher }) {
+    return deleteLabel(input, accessToken, fetcher);
+  },
+
+  list_assignees(input, { accessToken, fetcher }) {
+    return listAssignees(input, accessToken, fetcher);
+  },
+
+  create_issue_reaction(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "POST",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues/${String(input.issueNumber)}/reactions`,
+      body: {
+        content: String(input.content),
+      },
+      accessToken,
+      fetcher,
+    });
+  },
+
+  create_issue_comment_reaction(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "POST",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues/comments/${String(input.commentId)}/reactions`,
+      body: {
+        content: String(input.content),
+      },
+      accessToken,
+      fetcher,
+    });
   },
 };
 
@@ -356,4 +471,87 @@ async function listRepositoryIssueEvents(input: Record<string, unknown>, accessT
   });
 
   return { events };
+}
+
+async function listMilestones(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const milestones = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/milestones`,
+    query: compactObject({
+      state: optionalString(input.state),
+      sort: optionalString(input.sort),
+      direction: optionalString(input.direction),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { milestones };
+}
+
+async function deleteMilestone(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/milestones/${String(input.milestoneNumber)}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function deleteIssueComment(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues/comments/${String(input.commentId)}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function updateLabel(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const color = optionalRawString(input.color);
+  if (color !== undefined && !/^[0-9a-fA-F]{6}$/u.test(color)) {
+    throw new ProviderRequestError(400, "color must be a 6-character hex color without #");
+  }
+
+  return githubRequestJson<Record<string, unknown>>({
+    method: "PATCH",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/labels/${encodeURIComponent(String(input.name))}`,
+    body: compactObject({
+      new_name: optionalRawString(input.newName),
+      color,
+      description: optionalRawString(input.description),
+    }),
+    accessToken,
+    fetcher,
+  });
+}
+
+async function deleteLabel(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/labels/${encodeURIComponent(String(input.name))}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function listAssignees(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const assignees = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/assignees`,
+    query: compactObject({
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { assignees };
 }

--- a/src/providers/github/runtime-pull-request.ts
+++ b/src/providers/github/runtime-pull-request.ts
@@ -1,6 +1,12 @@
 import type { GitHubActionHandler } from "./runtime-shared.ts";
 
-import { optionalBoolean, optionalInteger, optionalRawString, optionalString } from "../../core/cast.ts";
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+} from "../../core/cast.ts";
 import {
   buildGitHubUrl,
   compactObject,
@@ -72,6 +78,35 @@ export const pullRequestActionHandlers: Record<string, GitHubActionHandler> = {
     });
   },
 
+  get_pull_request_review(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/pulls/${String(input.pullNumber)}/reviews/${String(input.reviewId)}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  dismiss_pull_request_review(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PUT",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/pulls/${String(input.pullNumber)}/reviews/${String(input.reviewId)}/dismissals`,
+      body: {
+        message: String(input.message),
+      },
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_pending_pull_request_review(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "DELETE",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/pulls/${String(input.pullNumber)}/reviews/${String(input.reviewId)}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
   create_pull_request_review_comment(input, { accessToken, fetcher }) {
     return githubRequestJson<Record<string, unknown>>({
       method: "POST",
@@ -100,6 +135,22 @@ export const pullRequestActionHandlers: Record<string, GitHubActionHandler> = {
       accessToken,
       fetcher,
     });
+  },
+
+  update_pull_request_review_comment(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PATCH",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/pulls/comments/${String(input.commentId)}`,
+      body: {
+        body: String(input.body),
+      },
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_pull_request_review_comment(input, { accessToken, fetcher }) {
+    return deletePullRequestReviewComment(input, accessToken, fetcher);
   },
 
   get_pull_request(input, { accessToken, fetcher }) {
@@ -209,6 +260,26 @@ export const pullRequestActionHandlers: Record<string, GitHubActionHandler> = {
     return listRepositoryWorkflows(input, accessToken, fetcher);
   },
 
+  get_workflow(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/workflows/${encodeURIComponent(String(input.workflowId))}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  dispatch_workflow(input, { accessToken, fetcher }) {
+    return dispatchWorkflow(input, accessToken, fetcher);
+  },
+
+  enable_workflow(input, { accessToken, fetcher }) {
+    return enableWorkflow(input, accessToken, fetcher);
+  },
+
+  disable_workflow(input, { accessToken, fetcher }) {
+    return disableWorkflow(input, accessToken, fetcher);
+  },
+
   list_workflow_runs(input, { accessToken, fetcher }) {
     return listWorkflowRuns(input, accessToken, fetcher);
   },
@@ -227,6 +298,18 @@ export const pullRequestActionHandlers: Record<string, GitHubActionHandler> = {
 
   rerun_workflow(input, { accessToken, fetcher }) {
     return rerunWorkflow(input, accessToken, fetcher);
+  },
+
+  rerun_failed_jobs(input, { accessToken, fetcher }) {
+    return rerunFailedJobs(input, accessToken, fetcher);
+  },
+
+  cancel_workflow_run(input, { accessToken, fetcher }) {
+    return cancelWorkflowRun(input, accessToken, fetcher);
+  },
+
+  list_workflow_run_artifacts(input, { accessToken, fetcher }) {
+    return listWorkflowRunArtifacts(input, accessToken, fetcher);
   },
 };
 
@@ -345,6 +428,21 @@ async function listPullRequestReviewComments(
   });
 
   return { comments };
+}
+
+async function deletePullRequestReviewComment(
+  input: Record<string, unknown>,
+  accessToken: string,
+  fetcher: typeof fetch,
+) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/pulls/comments/${String(input.commentId)}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
 }
 
 async function updatePullRequestBranch(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
@@ -494,6 +592,43 @@ async function listRepositoryWorkflows(input: Record<string, unknown>, accessTok
   };
 }
 
+async function dispatchWorkflow(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "POST",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/workflows/${encodeURIComponent(String(input.workflowId))}/dispatches`,
+    body: compactObject({
+      ref: String(input.ref),
+      inputs: optionalRecord(input.inputs),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { dispatched: true };
+}
+
+async function enableWorkflow(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "PUT",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/workflows/${encodeURIComponent(String(input.workflowId))}/enable`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function disableWorkflow(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "PUT",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/workflows/${encodeURIComponent(String(input.workflowId))}/disable`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
 async function listWorkflowRuns(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
   const response = await githubRequestJson<Record<string, unknown>>({
     path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/runs`,
@@ -549,4 +684,47 @@ async function rerunWorkflow(input: Record<string, unknown>, accessToken: string
   });
 
   return { rerun_requested: true };
+}
+
+async function rerunFailedJobs(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "POST",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/runs/${String(input.runId)}/rerun-failed-jobs`,
+    body: compactObject({
+      enable_debug_logging: optionalBoolean(input.enableDebugLogging),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { rerun_requested: true };
+}
+
+async function cancelWorkflowRun(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "POST",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/runs/${String(input.runId)}/cancel`,
+    accessToken,
+    fetcher,
+  });
+
+  return { cancel_requested: true };
+}
+
+async function listWorkflowRunArtifacts(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const response = await githubRequestJson<Record<string, unknown>>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/runs/${String(input.runId)}/artifacts`,
+    query: compactObject({
+      name: optionalString(input.name),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return {
+    total_count: Number(response.total_count ?? 0),
+    artifacts: Array.isArray(response.artifacts) ? (response.artifacts as Record<string, unknown>[]) : [],
+  };
 }

--- a/src/providers/github/runtime-release.ts
+++ b/src/providers/github/runtime-release.ts
@@ -1,7 +1,7 @@
 import type { GitHubActionHandler } from "./runtime-shared.ts";
 
 import { optionalBoolean, optionalInteger, optionalRawString, optionalString } from "../../core/cast.ts";
-import { compactObject, githubRequestJson } from "./runtime-shared.ts";
+import { compactObject, githubRequestJson, githubRequestNoContent } from "./runtime-shared.ts";
 
 export const releaseActionHandlers: Record<string, GitHubActionHandler> = {
   list_releases(input, { accessToken, fetcher }) {
@@ -54,6 +54,44 @@ export const releaseActionHandlers: Record<string, GitHubActionHandler> = {
   list_release_assets(input, { accessToken, fetcher }) {
     return listReleaseAssets(input, accessToken, fetcher);
   },
+
+  update_release(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PATCH",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/releases/${String(input.releaseId)}`,
+      body: compactObject({
+        tag_name: optionalString(input.tagName),
+        target_commitish: optionalString(input.targetCommitish),
+        name: optionalRawString(input.name),
+        body: optionalRawString(input.body),
+        draft: optionalBoolean(input.draft),
+        prerelease: optionalBoolean(input.prerelease),
+        make_latest: optionalString(input.makeLatest),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_release(input, { accessToken, fetcher }) {
+    return deleteRelease(input, accessToken, fetcher);
+  },
+
+  generate_release_notes(input, { accessToken, fetcher }) {
+    return generateReleaseNotes(input, accessToken, fetcher);
+  },
+
+  get_release_asset(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/releases/assets/${String(input.assetId)}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  delete_release_asset(input, { accessToken, fetcher }) {
+    return deleteReleaseAsset(input, accessToken, fetcher);
+  },
 };
 
 async function listReleases(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
@@ -82,4 +120,46 @@ async function listReleaseAssets(input: Record<string, unknown>, accessToken: st
   });
 
   return { assets };
+}
+
+async function deleteRelease(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/releases/${String(input.releaseId)}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function generateReleaseNotes(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const payload = await githubRequestJson<Record<string, unknown>>({
+    method: "POST",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/releases/generate-notes`,
+    body: compactObject({
+      tag_name: String(input.tagName),
+      target_commitish: optionalString(input.targetCommitish),
+      previous_tag_name: optionalString(input.previousTagName),
+      configuration_file_path: optionalString(input.configurationFilePath),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return {
+    name: String(payload.name ?? ""),
+    body: String(payload.body ?? ""),
+  };
+}
+
+async function deleteReleaseAsset(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/releases/assets/${String(input.assetId)}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
 }

--- a/src/providers/github/runtime-repository.ts
+++ b/src/providers/github/runtime-repository.ts
@@ -512,7 +512,13 @@ async function listRepositoryContributors(input: Record<string, unknown>, access
   });
 
   // Upstream returns 204 with no body for an empty repository; normalize to an empty list.
-  return { contributors: Array.isArray(payload) ? payload : [] };
+  if (payload === null) {
+    return { contributors: [] };
+  }
+  if (!Array.isArray(payload)) {
+    throw new ProviderRequestError(500, "unexpected github contributors response");
+  }
+  return { contributors: payload };
 }
 
 async function getRepositoryReadme(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {

--- a/src/providers/github/runtime-repository.ts
+++ b/src/providers/github/runtime-repository.ts
@@ -3,11 +3,15 @@ import type { GitHubActionHandler } from "./runtime-shared.ts";
 import { optionalBoolean, optionalInteger, optionalRawString, optionalString } from "../../core/cast.ts";
 import { ProviderRequestError } from "../provider-runtime.ts";
 import {
+  buildGitHubUrl,
   buildRepoContentsPath,
   compactObject,
   decodeGitHubContent,
+  githubHeaders,
   githubRequestJson,
   githubRequestNoContent,
+  normalizeGitHubError,
+  readJsonResponse,
   resolveGitHubWriteContent,
 } from "./runtime-shared.ts";
 
@@ -173,6 +177,161 @@ export const repositoryActionHandlers: Record<string, GitHubActionHandler> = {
       fetcher,
     });
   },
+
+  update_repository(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PATCH",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}`,
+      body: compactObject({
+        name: optionalRawString(input.name),
+        description: optionalRawString(input.description),
+        homepage: optionalRawString(input.homepage),
+        private: optionalBoolean(input.private),
+        visibility: optionalString(input.visibility),
+        default_branch: optionalString(input.defaultBranch),
+        has_issues: optionalBoolean(input.hasIssues),
+        has_projects: optionalBoolean(input.hasProjects),
+        has_wiki: optionalBoolean(input.hasWiki),
+        has_discussions: optionalBoolean(input.hasDiscussions),
+        allow_squash_merge: optionalBoolean(input.allowSquashMerge),
+        allow_merge_commit: optionalBoolean(input.allowMergeCommit),
+        allow_rebase_merge: optionalBoolean(input.allowRebaseMerge),
+        allow_auto_merge: optionalBoolean(input.allowAutoMerge),
+        delete_branch_on_merge: optionalBoolean(input.deleteBranchOnMerge),
+        archived: optionalBoolean(input.archived),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  fork_repository(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "POST",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/forks`,
+      body: compactObject({
+        organization: optionalString(input.organization),
+        name: optionalString(input.name),
+        default_branch_only: optionalBoolean(input.defaultBranchOnly),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  list_repository_forks(input, { accessToken, fetcher }) {
+    return listRepositoryForks(input, accessToken, fetcher);
+  },
+
+  list_repository_tags(input, { accessToken, fetcher }) {
+    return listRepositoryTags(input, accessToken, fetcher);
+  },
+
+  list_repository_languages(input, { accessToken, fetcher }) {
+    return listRepositoryLanguages(input, accessToken, fetcher);
+  },
+
+  list_repository_contributors(input, { accessToken, fetcher }) {
+    return listRepositoryContributors(input, accessToken, fetcher);
+  },
+
+  list_repository_topics(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/topics`,
+      query: compactObject({
+        per_page: optionalInteger(input.perPage),
+        page: optionalInteger(input.page),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  replace_repository_topics(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "PUT",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/topics`,
+      body: {
+        names: (input.names as unknown[]).map(String),
+      },
+      accessToken,
+      fetcher,
+    });
+  },
+
+  get_repository_readme(input, { accessToken, fetcher }) {
+    return getRepositoryReadme(input, accessToken, fetcher);
+  },
+
+  list_organization_repositories(input, { accessToken, fetcher }) {
+    return listOrganizationRepositories(input, accessToken, fetcher);
+  },
+
+  list_user_repositories(input, { accessToken, fetcher }) {
+    return listUserRepositories(input, accessToken, fetcher);
+  },
+
+  get_user(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/users/${encodeURIComponent(String(input.username))}`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  list_repository_collaborators(input, { accessToken, fetcher }) {
+    return listRepositoryCollaborators(input, accessToken, fetcher);
+  },
+
+  add_repository_collaborator(input, { accessToken, fetcher }) {
+    return addRepositoryCollaborator(input, accessToken, fetcher);
+  },
+
+  remove_repository_collaborator(input, { accessToken, fetcher }) {
+    return removeRepositoryCollaborator(input, accessToken, fetcher);
+  },
+
+  get_repository_permission_for_user(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/collaborators/${encodeURIComponent(String(input.username))}/permission`,
+      accessToken,
+      fetcher,
+    });
+  },
+
+  get_ref(input, { accessToken, fetcher }) {
+    return getRef(input, accessToken, fetcher);
+  },
+
+  list_matching_refs(input, { accessToken, fetcher }) {
+    return listMatchingRefs(input, accessToken, fetcher);
+  },
+
+  update_ref(input, { accessToken, fetcher }) {
+    return updateRef(input, accessToken, fetcher);
+  },
+
+  delete_ref(input, { accessToken, fetcher }) {
+    return deleteRef(input, accessToken, fetcher);
+  },
+
+  create_commit_comment(input, { accessToken, fetcher }) {
+    return githubRequestJson<Record<string, unknown>>({
+      method: "POST",
+      path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/commits/${encodeURIComponent(String(input.commitSha))}/comments`,
+      body: compactObject({
+        body: String(input.body),
+        path: optionalString(input.path),
+        position: optionalInteger(input.position),
+      }),
+      accessToken,
+      fetcher,
+    });
+  },
+
+  list_commit_comments(input, { accessToken, fetcher }) {
+    return listCommitComments(input, accessToken, fetcher);
+  },
 };
 
 async function listMyRepositories(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
@@ -299,4 +458,249 @@ async function getFileContents(input: Record<string, unknown>, accessToken: stri
     content_base64: rawContent,
     decoded_content: decodeGitHubContent(rawContent, encoding),
   };
+}
+
+async function listRepositoryForks(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const repositories = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/forks`,
+    query: compactObject({
+      sort: optionalString(input.sort),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { repositories };
+}
+
+async function listRepositoryTags(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const tags = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/tags`,
+    query: compactObject({
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { tags };
+}
+
+async function listRepositoryLanguages(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const languages = await githubRequestJson<Record<string, unknown>>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/languages`,
+    accessToken,
+    fetcher,
+  });
+
+  return { languages };
+}
+
+async function listRepositoryContributors(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const payload = await githubRequestJson<Record<string, unknown>[] | null>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/contributors`,
+    query: compactObject({
+      anon: optionalBoolean(input.anon),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  // Upstream returns 204 with no body for an empty repository; normalize to an empty list.
+  return { contributors: Array.isArray(payload) ? payload : [] };
+}
+
+async function getRepositoryReadme(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const response = await githubRequestJson<Record<string, unknown>>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/readme`,
+    query: compactObject({
+      ref: optionalString(input.ref),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  if (response.type !== "file") {
+    throw new ProviderRequestError(400, "readme does not resolve to a regular file");
+  }
+
+  const encoding = optionalString(response.encoding);
+  const rawContent = optionalRawString(response.content)?.replace(/\n/g, "") ?? "";
+  return {
+    ...response,
+    content_base64: rawContent,
+    decoded_content: decodeGitHubContent(rawContent, encoding),
+  };
+}
+
+async function listOrganizationRepositories(
+  input: Record<string, unknown>,
+  accessToken: string,
+  fetcher: typeof fetch,
+) {
+  const repositories = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/orgs/${encodeURIComponent(String(input.org))}/repos`,
+    query: compactObject({
+      type: optionalString(input.type),
+      sort: optionalString(input.sort),
+      direction: optionalString(input.direction),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { repositories };
+}
+
+async function listUserRepositories(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const repositories = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/users/${encodeURIComponent(String(input.username))}/repos`,
+    query: compactObject({
+      type: optionalString(input.type),
+      sort: optionalString(input.sort),
+      direction: optionalString(input.direction),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { repositories };
+}
+
+async function listRepositoryCollaborators(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const collaborators = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/collaborators`,
+    query: compactObject({
+      affiliation: optionalString(input.affiliation),
+      permission: optionalString(input.permission),
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { collaborators };
+}
+
+async function addRepositoryCollaborator(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const response = await fetcher(
+    buildGitHubUrl(
+      `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/collaborators/${encodeURIComponent(String(input.username))}`,
+    ),
+    {
+      method: "PUT",
+      headers: githubHeaders(accessToken, true),
+      body: JSON.stringify(
+        compactObject({
+          permission: optionalRawString(input.permission),
+        }),
+      ),
+    },
+  );
+
+  if (response.status === 204) {
+    return { invited: false, invitation: null };
+  }
+
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw normalizeGitHubError(response, payload, "github api request failed");
+  }
+  if (response.status === 201) {
+    return { invited: true, invitation: payload };
+  }
+
+  throw normalizeGitHubError(response, payload, "unexpected github collaborator response");
+}
+
+async function removeRepositoryCollaborator(
+  input: Record<string, unknown>,
+  accessToken: string,
+  fetcher: typeof fetch,
+) {
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/collaborators/${encodeURIComponent(String(input.username))}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+function requireBranchOrTagRef(input: Record<string, unknown>): string {
+  const ref = String(input.ref);
+  if (!ref.startsWith("heads/") && !ref.startsWith("tags/")) {
+    throw new ProviderRequestError(400, "ref must start with heads/ or tags/");
+  }
+  return ref;
+}
+
+async function getRef(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const ref = requireBranchOrTagRef(input);
+  return githubRequestJson<Record<string, unknown>>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/git/ref/${ref.split("/").map(encodeURIComponent).join("/")}`,
+    accessToken,
+    fetcher,
+  });
+}
+
+async function listMatchingRefs(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const refs = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/git/matching-refs/${String(input.ref).split("/").map(encodeURIComponent).join("/")}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { refs };
+}
+
+async function updateRef(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const ref = requireBranchOrTagRef(input);
+  return githubRequestJson<Record<string, unknown>>({
+    method: "PATCH",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/git/refs/${ref.split("/").map(encodeURIComponent).join("/")}`,
+    body: compactObject({
+      sha: String(input.sha),
+      force: optionalBoolean(input.force),
+    }),
+    accessToken,
+    fetcher,
+  });
+}
+
+async function deleteRef(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const ref = requireBranchOrTagRef(input);
+  await githubRequestNoContent({
+    method: "DELETE",
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/git/refs/${ref.split("/").map(encodeURIComponent).join("/")}`,
+    accessToken,
+    fetcher,
+  });
+
+  return { ok: true };
+}
+
+async function listCommitComments(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const comments = await githubRequestJson<Record<string, unknown>[]>({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/commits/${encodeURIComponent(String(input.commitSha))}/comments`,
+    query: compactObject({
+      per_page: optionalInteger(input.perPage),
+      page: optionalInteger(input.page),
+    }),
+    accessToken,
+    fetcher,
+  });
+
+  return { comments };
 }


### PR DESCRIPTION
Expand the GitHub provider to 145 actions: repository settings, forks, topics, collaborators, README readback, full git refs coverage, commit comments, stars/watchers, milestones, label and issue-comment management, reactions, PR review lifecycle (dismiss/delete pending), workflow dispatch/cancel/enable/disable/rerun-failed-jobs with artifacts, and release update/delete/generate-notes plus asset read/delete.

Align existing response schemas with GitHub's OpenAPI nullability (user/uploader/tarball_url/zipball_url, review comment line fields) and enforce git ref prefix and label color validation in the runtime before any request is sent.