### PR TITLE
feat(aliyun-sls): add local provider

### DIFF
--- a/examples/aliyun-sls-query-logs.ts
+++ b/examples/aliyun-sls-query-logs.ts
@@ -1,0 +1,81 @@
+import type { ExecutionContext, ResolvedCredential } from "../src/core/types.ts";
+
+import { executors } from "../src/providers/aliyun_sls/executors.ts";
+import { parseAliyunSlsCredential, resolveAliyunSlsLogstoreTarget } from "../src/providers/aliyun_sls/resources.ts";
+
+const requiredEnvironment = [
+  "ALIYUN_SLS_ACCESS_KEY_ID",
+  "ALIYUN_SLS_ACCESS_KEY_SECRET",
+  "ALIYUN_SLS_ENDPOINT",
+] as const;
+
+async function main(): Promise<void> {
+  const missing = requiredEnvironment.filter((name) => !process.env[name]?.trim());
+  if (missing.length > 0) {
+    console.log(`Skip Alibaba Cloud SLS example: missing ${missing.join(", ")}.`);
+    return;
+  }
+
+  const values: Record<string, string> = {
+    accessKeyId: process.env.ALIYUN_SLS_ACCESS_KEY_ID!,
+    accessKeySecret: process.env.ALIYUN_SLS_ACCESS_KEY_SECRET!,
+    endpoint: process.env.ALIYUN_SLS_ENDPOINT!,
+  };
+  if (process.env.ALIYUN_SLS_SECURITY_TOKEN?.trim()) {
+    values.securityToken = process.env.ALIYUN_SLS_SECURITY_TOKEN;
+  }
+  if (process.env.ALIYUN_SLS_RESOURCE_SCOPE?.trim()) {
+    values.resourceScope = process.env.ALIYUN_SLS_RESOURCE_SCOPE;
+  }
+
+  const credential = parseAliyunSlsCredential(values);
+  let target;
+  try {
+    target = resolveAliyunSlsLogstoreTarget(
+      credential,
+      undefined,
+      process.env.ALIYUN_SLS_PROJECT,
+      process.env.ALIYUN_SLS_LOGSTORE,
+    );
+  } catch {
+    console.log(
+      "Skip Alibaba Cloud SLS example: set ALIYUN_SLS_PROJECT and ALIYUN_SLS_LOGSTORE, or configure resourceScope with exactly one candidate Project and Logstore.",
+    );
+    return;
+  }
+
+  const resolvedCredential: ResolvedCredential = {
+    authType: "custom_credential",
+    values,
+    profile: {
+      accountId: credential.accessKeyId,
+      displayName: `${credential.accessKeyId}@${credential.endpoint}`,
+      grantedScopes: [],
+    },
+    metadata: {},
+  };
+  const context: ExecutionContext = {
+    async getCredential(service) {
+      return service === "aliyun_sls" ? resolvedCredential : undefined;
+    },
+  };
+
+  const to = Math.floor(Date.now() / 1000);
+  const result = await executors["aliyun_sls.query_logs"]!(
+    {
+      endpoint: target.endpoint,
+      project: target.project,
+      logstore: target.logstore,
+      from: to - 900,
+      to,
+      query: process.env.ALIYUN_SLS_QUERY ?? "*",
+      line: 100,
+      reverse: true,
+    },
+    context,
+  );
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) process.exitCode = 1;
+}
+
+await main();

--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -210,6 +210,7 @@ describe("createGuardedFetch redirects", () => {
         "x-api-key": "provider-secret",
         "x-auth-token": "tok",
         "x-seq-apikey": "seq-secret",
+        "x-acs-security-token": "aliyun-sts-secret",
         "x-trace": "keep",
         // Look-alike but non-credential headers must survive cross-origin.
         "idempotency-key": "abc",
@@ -221,12 +222,14 @@ describe("createGuardedFetch redirects", () => {
     expect(sameOriginHeaders.get("authorization")).toBe("Bearer secret");
     expect(sameOriginHeaders.get("x-api-key")).toBe("provider-secret");
     expect(sameOriginHeaders.get("x-seq-apikey")).toBe("seq-secret");
+    expect(sameOriginHeaders.get("x-acs-security-token")).toBe("aliyun-sts-secret");
     const crossOriginHeaders = new Headers(calls[2]?.init?.headers);
     expect(crossOriginHeaders.has("authorization")).toBe(false);
     expect(crossOriginHeaders.has("cookie")).toBe(false);
     expect(crossOriginHeaders.has("x-api-key")).toBe(false);
     expect(crossOriginHeaders.has("x-auth-token")).toBe(false);
     expect(crossOriginHeaders.has("x-seq-apikey")).toBe(false);
+    expect(crossOriginHeaders.has("x-acs-security-token")).toBe(false);
     expect(crossOriginHeaders.get("x-trace")).toBe("keep");
     expect(crossOriginHeaders.get("idempotency-key")).toBe("abc");
     expect(crossOriginHeaders.get("x-correlation-id")).toBe("cid");

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -94,6 +94,7 @@ const crossOriginCredentialHeaders = new Set([
   "x-csrf-token",
   "x-xsrf-token",
   "x-goog-api-key",
+  "x-acs-security-token",
   "x-amz-security-token",
 ]);
 /** Body-describing headers dropped when a redirect rewrites the method to GET, mirroring the fetch spec. */

--- a/src/providers/aliyun_sls/actions.ts
+++ b/src/providers/aliyun_sls/actions.ts
@@ -1,0 +1,238 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "aliyun_sls";
+
+const endpointSchema = s.nonEmptyString(
+  "The regional Simple Log Service endpoint, such as cn-hangzhou.log.aliyuncs.com. Defaults to the endpoint configured on the connection.",
+);
+
+const projectNameSchema = s.nonEmptyString(
+  "The Simple Log Service Project name. It may be omitted only when the connection resource scope has exactly one candidate Project for the selected endpoint.",
+);
+
+const logstoreNameSchema = s.nonEmptyString(
+  "The Simple Log Service Logstore name. It may be omitted only when the selected Project has exactly one allowed Logstore in the connection resource scope.",
+);
+
+const offsetSchema = s.nonNegativeInteger("The zero-based offset at which to start the page.", { default: 0 });
+const listProjectSizeSchema = s.integer("The number of Projects to return. The maximum is 500.", {
+  minimum: 1,
+  maximum: 500,
+  default: 100,
+});
+const listLogstoreSizeSchema = s.integer("The number of Logstores to return. The maximum is 500.", {
+  minimum: 1,
+  maximum: 500,
+  default: 200,
+});
+
+const projectSchema = s.object("One normalized Simple Log Service Project.", {
+  endpoint: s.string("The regional endpoint from which this Project was returned."),
+  projectName: s.string("The Project name."),
+  region: s.string("The Alibaba Cloud region that owns the Project."),
+  description: s.string("The Project description."),
+  status: s.string("The Project status."),
+  createTime: s.string("The Project creation time returned by Simple Log Service."),
+  lastModifyTime: s.string("The Project last modification time returned by Simple Log Service."),
+  resourceGroupId: s.nullableString("The Alibaba Cloud resource group ID, or null when absent."),
+  dataRedundancyType: s.nullableString("The Project data redundancy type, or null when absent."),
+  recycleBinEnabled: s.nullableBoolean("Whether the Project recycle bin is enabled, or null when absent."),
+  internetEndpoint: s.nullableString("The Project public endpoint, or null when absent."),
+  internalEndpoint: s.nullableString("The Project internal endpoint, or null when absent."),
+});
+
+const listProjectsOutputSchema = s.object("A page of Projects visible through the selected regional endpoint.", {
+  endpoint: s.string("The regional endpoint queried by this action."),
+  count: s.nonNegativeInteger("The number of Projects returned in this page."),
+  total: s.nonNegativeInteger("The total number of matching Projects reported for this result."),
+  projects: s.array("The matching Projects.", projectSchema),
+});
+
+const regionResultSchema = s.object("One successfully queried regional endpoint.", {
+  endpoint: s.string("The regional endpoint that was queried."),
+  count: s.nonNegativeInteger("The number of unique Projects returned from this endpoint."),
+});
+
+const regionFailureSchema = s.object("One regional endpoint that could not be queried.", {
+  endpoint: s.string("The regional endpoint that failed."),
+  status: s.integer("The normalized HTTP-style error status."),
+  message: s.string("The failure message returned by the connector or Simple Log Service."),
+});
+
+const listLogstoresOutputSchema = s.object("A page of Logstores in one Project.", {
+  endpoint: s.string("The regional endpoint queried by this action."),
+  project: s.string("The Project containing the returned Logstores."),
+  count: s.nonNegativeInteger("The number of Logstores returned in this page."),
+  total: s.nonNegativeInteger("The total number of matching Logstores reported for this result."),
+  logstores: s.array("The matching Logstore names.", s.string("One Logstore name.")),
+});
+
+const queryTargetProperties: Record<string, JsonSchema> = {
+  endpoint: endpointSchema,
+  project: projectNameSchema,
+  logstore: logstoreNameSchema,
+};
+
+const queryTimeProperties: Record<string, JsonSchema> = {
+  from: s.nonNegativeInteger(
+    "The inclusive start of the query interval as a Unix timestamp in seconds. Simple Log Service evaluates [from, to).",
+  ),
+  to: s.nonNegativeInteger(
+    "The exclusive end of the query interval as a Unix timestamp in seconds. It must be greater than from.",
+  ),
+  query: s.string("An optional Simple Log Service search or analytic statement."),
+};
+
+export type AliyunSlsActionName =
+  | "list_projects"
+  | "list_projects_across_regions"
+  | "list_logstores"
+  | "query_logs"
+  | "get_histograms";
+
+export const aliyunSlsActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_projects",
+    description: "List Projects visible through one Alibaba Cloud Simple Log Service regional endpoint.",
+    providerPermissions: ["log:ListProject"],
+    inputSchema: s.object(
+      "Filters and pagination for listing Projects in one region.",
+      {
+        endpoint: endpointSchema,
+        offset: offsetSchema,
+        size: listProjectSizeSchema,
+        projectName: s.nonEmptyString("A fuzzy Project name filter."),
+        resourceGroupId: s.nonEmptyString("An Alibaba Cloud resource group ID filter."),
+      },
+      { optional: ["endpoint", "offset", "size", "projectName", "resourceGroupId"] },
+    ),
+    outputSchema: listProjectsOutputSchema,
+    followUpActions: ["aliyun_sls.list_logstores"],
+  }),
+  defineProviderAction(service, {
+    name: "list_projects_across_regions",
+    description:
+      "List all Projects from the explicitly supplied regional endpoints with bounded concurrency and optional partial-failure results.",
+    providerPermissions: ["log:ListProject"],
+    inputSchema: s.object(
+      "Regional endpoints and optional filters for a multi-region Project listing.",
+      {
+        endpoints: {
+          ...s.array(
+            "The 1 to 50 distinct regional endpoints to query. Only these regions are covered.",
+            endpointSchema,
+            {
+              minItems: 1,
+              maxItems: 50,
+            },
+          ),
+          uniqueItems: true,
+        },
+        projectName: s.nonEmptyString("A fuzzy Project name filter applied in every region."),
+        resourceGroupId: s.nonEmptyString("An Alibaba Cloud resource group ID filter applied in every region."),
+        allowPartial: s.boolean({
+          description:
+            "Whether successful regions should be returned when another region fails. The default false fails the entire action.",
+          default: false,
+        }),
+      },
+      { optional: ["projectName", "resourceGroupId", "allowPartial"] },
+    ),
+    outputSchema: s.object("The unique Projects and per-region outcome for the supplied endpoints.", {
+      projects: s.array("Projects deduplicated by region and Project name.", projectSchema),
+      total: s.nonNegativeInteger("The number of unique Projects returned."),
+      regions: s.array("The regional endpoints queried successfully.", regionResultSchema),
+      failures: s.array("Regional endpoints that failed when allowPartial is true.", regionFailureSchema),
+      complete: s.boolean("Whether every supplied regional endpoint completed successfully."),
+    }),
+    followUpActions: ["aliyun_sls.list_logstores"],
+  }),
+  defineProviderAction(service, {
+    name: "list_logstores",
+    description: "List Logstores in one Simple Log Service Project.",
+    providerPermissions: ["log:ListLogStores"],
+    inputSchema: s.object(
+      "The Project, endpoint, filters, and pagination for listing Logstores.",
+      {
+        endpoint: endpointSchema,
+        project: projectNameSchema,
+        offset: offsetSchema,
+        size: listLogstoreSizeSchema,
+        logstoreName: s.nonEmptyString("A fuzzy Logstore name filter."),
+      },
+      { optional: ["endpoint", "project", "offset", "size", "logstoreName"] },
+    ),
+    outputSchema: listLogstoresOutputSchema,
+    followUpActions: ["aliyun_sls.query_logs", "aliyun_sls.get_histograms"],
+  }),
+  defineProviderAction(service, {
+    name: "query_logs",
+    description: "Query logs from one Simple Log Service Logstore with the GetLogs API.",
+    providerPermissions: ["log:GetLogStoreLogs"],
+    inputSchema: s.object(
+      "The Logstore target, time range, query, and GetLogs pagination controls.",
+      {
+        ...queryTargetProperties,
+        ...queryTimeProperties,
+        offset: s.nonNegativeInteger("The starting row for a search query.", { default: 0 }),
+        line: s.integer("The maximum number of logs to return. Simple Log Service accepts 0 to 100.", {
+          minimum: 0,
+          maximum: 100,
+          default: 100,
+        }),
+        reverse: s.boolean({
+          description: "Whether search results should be returned newest first.",
+          default: false,
+        }),
+        powerSql: s.boolean({
+          description: "Whether to use the Simple Log Service Exclusive SQL feature.",
+          default: false,
+        }),
+      },
+      { optional: ["endpoint", "project", "logstore", "query", "offset", "line", "reverse", "powerSql"] },
+    ),
+    outputSchema: s.object("The normalized GetLogs response.", {
+      endpoint: s.string("The regional endpoint queried by this action."),
+      project: s.string("The Project queried by this action."),
+      logstore: s.string("The Logstore queried by this action."),
+      progress: s.string("The Simple Log Service query progress, such as Complete or Incomplete."),
+      count: s.nonNegativeInteger("The number of log entries returned."),
+      processedRows: s.nullableInteger("The number of rows processed by the query, or null when unavailable."),
+      elapsedMilliseconds: s.nullableInteger("The provider-reported query duration, or null when unavailable."),
+      hasSql: s.nullableBoolean("Whether the query included an analytic statement, or null when unavailable."),
+      logs: s.array("The returned log entries.", s.looseObject("One Simple Log Service log entry.")),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_histograms",
+    description: "Query the time distribution of matching logs in one Simple Log Service Logstore.",
+    providerPermissions: ["log:GetLogStoreLogs"],
+    inputSchema: s.object(
+      "The Logstore target, time range, and search statement for a histogram query.",
+      {
+        ...queryTargetProperties,
+        ...queryTimeProperties,
+      },
+      { optional: ["endpoint", "project", "logstore", "query"] },
+    ),
+    outputSchema: s.object("The normalized GetHistograms response.", {
+      endpoint: s.string("The regional endpoint queried by this action."),
+      project: s.string("The Project queried by this action."),
+      logstore: s.string("The Logstore queried by this action."),
+      progress: s.string("The overall Simple Log Service histogram query progress."),
+      count: s.nonNegativeInteger("The total number of matching logs across the returned intervals."),
+      histograms: s.array(
+        "The stable histogram intervals returned by Simple Log Service.",
+        s.object("One histogram interval.", {
+          from: s.nonNegativeInteger("The inclusive interval start as a Unix timestamp in seconds."),
+          to: s.nonNegativeInteger("The exclusive interval end as a Unix timestamp in seconds."),
+          count: s.nonNegativeInteger("The number of matching logs in this interval."),
+          progress: s.string("The query progress for this interval."),
+        }),
+      ),
+    }),
+  }),
+];

--- a/src/providers/aliyun_sls/definition.ts
+++ b/src/providers/aliyun_sls/definition.ts
@@ -1,0 +1,70 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { aliyunSlsActions } from "./actions.ts";
+
+const service = "aliyun_sls";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Alibaba Cloud SLS",
+  description:
+    "Discover Alibaba Cloud Simple Log Service Projects and Logstores, query logs and histograms, and aggregate Project discovery across selected regions.",
+  categories: ["Data", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "accessKeyId",
+          label: "Access Key ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "LTAI...",
+          description:
+            "The Alibaba Cloud RAM AccessKey ID used to call Simple Log Service. Use a RAM identity with only the required SLS permissions.",
+        },
+        {
+          key: "accessKeySecret",
+          label: "Access Key Secret",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Your AccessKey secret",
+          description: "The AccessKey secret from the same Alibaba Cloud RAM AccessKey pair.",
+        },
+        {
+          key: "endpoint",
+          label: "Default Regional Endpoint",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "cn-hangzhou.log.aliyuncs.com",
+          description:
+            "The default regional Simple Log Service endpoint used for validation and actions that omit endpoint, for example cn-hangzhou.log.aliyuncs.com.",
+        },
+        {
+          key: "securityToken",
+          label: "Security Token",
+          inputType: "password",
+          required: false,
+          secret: true,
+          placeholder: "Optional STS token",
+          description: "An optional Alibaba Cloud STS security token used with temporary AccessKey credentials.",
+        },
+        {
+          key: "resourceScope",
+          label: "Resource Scope",
+          inputType: "json",
+          required: false,
+          secret: false,
+          description:
+            "Optional connector-local resource allowlist as a JSON array. Leave it blank to set no local resource restriction and use list_projects and list_logstores to discover resources allowed by RAM. Each item requires project; endpoint is optional and defaults to the connection endpoint. Omitting logstores allows every Logstore in that Project. When logstores is provided, it must contain only non-empty, unique Logstore names and only those Logstores are accessible. This local allowlist does not replace Alibaba Cloud RAM permissions.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.alibabacloud.com/product/log-service",
+  actions: aliyunSlsActions,
+};

--- a/src/providers/aliyun_sls/definition.ts
+++ b/src/providers/aliyun_sls/definition.ts
@@ -42,7 +42,7 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "cn-hangzhou.log.aliyuncs.com",
           description:
-            "The default regional Simple Log Service endpoint used for validation and actions that omit endpoint, for example cn-hangzhou.log.aliyuncs.com.",
+            "The default regional Simple Log Service endpoint used by actions that omit endpoint, for example cn-hangzhou.log.aliyuncs.com.",
         },
         {
           key: "securityToken",

--- a/src/providers/aliyun_sls/executors.ts
+++ b/src/providers/aliyun_sls/executors.ts
@@ -21,7 +21,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<AliyunSlsAct
 });
 
 export const credentialValidators: CredentialValidators = {
-  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    return validateAliyunSlsCredential(input.values, fetcher, signal);
+  async customCredential(input): Promise<CredentialValidationResult> {
+    return validateAliyunSlsCredential(input.values);
   },
 };

--- a/src/providers/aliyun_sls/executors.ts
+++ b/src/providers/aliyun_sls/executors.ts
@@ -1,0 +1,27 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { AliyunSlsActionContext } from "./runtime.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { aliyunSlsActionHandlers, createAliyunSlsContext, validateAliyunSlsCredential } from "./runtime.ts";
+
+const service = "aliyun_sls";
+
+export const executors: ProviderExecutors = defineProviderExecutors<AliyunSlsActionContext>({
+  service,
+  handlers: aliyunSlsActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AliyunSlsActionContext> {
+    const credential = await requireCustomCredential(context, service);
+    return createAliyunSlsContext(credential.values, fetcher, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateAliyunSlsCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/aliyun_sls/resources.test.ts
+++ b/src/providers/aliyun_sls/resources.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import {
+  normalizeAliyunSlsEndpoint,
+  parseAliyunSlsCredential,
+  parseAliyunSlsResourceScope,
+  resolveAliyunSlsLogstoreTarget,
+  resolveAliyunSlsProjectTarget,
+} from "./resources.ts";
+
+const endpoint = "cn-hangzhou.log.aliyuncs.com";
+
+describe("Alibaba Cloud SLS resourceScope", () => {
+  it("leaves a blank resourceScope unrestricted", () => {
+    expect(parseAliyunSlsResourceScope(undefined, endpoint)).toBeUndefined();
+    expect(parseAliyunSlsResourceScope("  ", endpoint)).toBeUndefined();
+  });
+
+  it("normalizes default and per-entry endpoints and preserves all-Logstore entries", () => {
+    expect(
+      parseAliyunSlsResourceScope(
+        JSON.stringify([
+          { project: "project-a", logstores: ["application", "nginx"] },
+          {
+            endpoint: "https://cn-shanghai.log.aliyuncs.com",
+            project: "project-b",
+          },
+        ]),
+        endpoint,
+      ),
+    ).toEqual([
+      {
+        endpoint,
+        project: "project-a",
+        logstores: ["application", "nginx"],
+      },
+      {
+        endpoint: "cn-shanghai.log.aliyuncs.com",
+        project: "project-b",
+      },
+    ]);
+  });
+
+  it.each([
+    ["invalid JSON", "{", "valid JSON"],
+    ["non-array JSON", "{}", "JSON array"],
+    ["empty array", "[]", "must not be an empty array"],
+    ["empty Project", '[{"project":""}]', "project is required"],
+    ["empty endpoint", '[{"endpoint":"","project":"project-a"}]', "endpoint is required"],
+    ["duplicate Project", '[{"project":"project-a"},{"project":"project-a"}]', "duplicate Project"],
+    ["empty Logstore list", '[{"project":"project-a","logstores":[]}]', "non-empty array"],
+    ["empty Logstore name", '[{"project":"project-a","logstores":[""]}]', "is required"],
+    ["duplicate Logstore", '[{"project":"project-a","logstores":["app","app"]}]', "duplicate Logstore"],
+  ])("rejects %s", (_name, value, message) => {
+    expect(() => parseAliyunSlsResourceScope(value, endpoint)).toThrow(message);
+  });
+
+  it.each([
+    "http://cn-hangzhou.log.aliyuncs.com",
+    "https://user:pass@cn-hangzhou.log.aliyuncs.com",
+    "https://cn-hangzhou.log.aliyuncs.com/path",
+    "https://cn-hangzhou.log.aliyuncs.com?query=1",
+    "https://cn-hangzhou.log.aliyuncs.com#hash",
+    "https://127.0.0.1",
+    "https://localhost",
+  ])("rejects unsafe endpoint %s", (value) => {
+    expect(() => normalizeAliyunSlsEndpoint(value)).toThrow(ProviderRequestError);
+  });
+
+  it("infers only unique scoped Projects and Logstores", () => {
+    const credential = parseAliyunSlsCredential({
+      accessKeyId: "id",
+      accessKeySecret: "secret",
+      endpoint,
+      resourceScope: '[{"project":"project-a","logstores":["application"]}]',
+    });
+    expect(resolveAliyunSlsProjectTarget(credential, undefined, undefined)).toMatchObject({
+      endpoint,
+      project: "project-a",
+    });
+    expect(resolveAliyunSlsLogstoreTarget(credential, undefined, undefined, undefined)).toMatchObject({
+      endpoint,
+      project: "project-a",
+      logstore: "application",
+    });
+  });
+
+  it("requires explicit resources when the candidates are ambiguous or unrestricted", () => {
+    const unrestricted = parseAliyunSlsCredential({
+      accessKeyId: "id",
+      accessKeySecret: "secret",
+      endpoint,
+    });
+    expect(() => resolveAliyunSlsProjectTarget(unrestricted, undefined, undefined)).toThrow("project is required");
+
+    const multipleProjects = parseAliyunSlsCredential({
+      accessKeyId: "id",
+      accessKeySecret: "secret",
+      endpoint,
+      resourceScope: '[{"project":"project-a"},{"project":"project-b"}]',
+    });
+    expect(() => resolveAliyunSlsProjectTarget(multipleProjects, undefined, undefined)).toThrow(
+      "multiple candidate Projects",
+    );
+
+    const allLogstores = parseAliyunSlsCredential({
+      accessKeyId: "id",
+      accessKeySecret: "secret",
+      endpoint,
+      resourceScope: '[{"project":"project-a"}]',
+    });
+    expect(() => resolveAliyunSlsLogstoreTarget(allLogstores, undefined, undefined, undefined)).toThrow(
+      "logstore is required",
+    );
+  });
+
+  it("returns explicit 403 errors for resources outside the allowlist", () => {
+    const credential = parseAliyunSlsCredential({
+      accessKeyId: "id",
+      accessKeySecret: "secret",
+      endpoint,
+      resourceScope: '[{"project":"project-a","logstores":["application"]}]',
+    });
+
+    for (const run of [
+      () => resolveAliyunSlsProjectTarget(credential, undefined, "project-b"),
+      () => resolveAliyunSlsProjectTarget(credential, "cn-shanghai.log.aliyuncs.com", "project-a"),
+      () => resolveAliyunSlsLogstoreTarget(credential, undefined, "project-a", "audit"),
+    ]) {
+      try {
+        run();
+        throw new Error("expected a resourceScope denial");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProviderRequestError);
+        expect((error as ProviderRequestError).status).toBe(403);
+        expect((error as Error).message).toContain("resourceScope allowlist");
+      }
+    }
+  });
+});

--- a/src/providers/aliyun_sls/resources.test.ts
+++ b/src/providers/aliyun_sls/resources.test.ts
@@ -63,9 +63,18 @@ describe("Alibaba Cloud SLS resourceScope", () => {
     "https://cn-hangzhou.log.aliyuncs.com#hash",
     "https://127.0.0.1",
     "https://localhost",
+    "https://example.com",
+    "https://cn-hangzhou.log.aliyuncs.com.example.com",
   ])("rejects unsafe endpoint %s", (value) => {
     expect(() => normalizeAliyunSlsEndpoint(value)).toThrow(ProviderRequestError);
   });
+
+  it.each(["cn-hangzhou-intranet.log.aliyuncs.com", "cn-shanghai-finance-1.log.aliyuncs.com"])(
+    "accepts official SLS endpoint variant %s",
+    (value) => {
+      expect(normalizeAliyunSlsEndpoint(value)).toBe(value);
+    },
+  );
 
   it("infers only unique scoped Projects and Logstores", () => {
     const credential = parseAliyunSlsCredential({

--- a/src/providers/aliyun_sls/resources.ts
+++ b/src/providers/aliyun_sls/resources.ts
@@ -29,6 +29,7 @@ export interface AliyunSlsLogstoreTarget extends AliyunSlsProjectTarget {
 }
 
 const resourceScopeKeys = new Set(["endpoint", "project", "logstores"]);
+const aliyunSlsEndpointPattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.log\.aliyuncs\.com$/;
 
 /** Parse and validate all user-configured SLS credential values. */
 export function parseAliyunSlsCredential(values: Record<string, string>): AliyunSlsCredential {
@@ -47,7 +48,7 @@ export function parseAliyunSlsCredential(values: Record<string, string>): Aliyun
   return credential;
 }
 
-/** Normalize a regional endpoint to a public HTTPS host without path state. */
+/** Normalize an official regional SLS endpoint to a public HTTPS host without path state. */
 export function normalizeAliyunSlsEndpoint(value: string, fieldName = "endpoint"): string {
   const raw = requiredString(value, fieldName, badRequest);
   const candidate = raw.includes("://") ? raw : `https://${raw}`;
@@ -64,7 +65,11 @@ export function normalizeAliyunSlsEndpoint(value: string, fieldName = "endpoint"
   if (url.pathname !== "/" || url.search || url.hash) {
     throw badRequest(`${fieldName} must not include a path, query, or hash`);
   }
-  return url.host.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
+  if (url.port || !aliyunSlsEndpointPattern.test(hostname)) {
+    throw badRequest(`${fieldName} must be an official Alibaba Cloud SLS endpoint under log.aliyuncs.com`);
+  }
+  return hostname;
 }
 
 /** Parse the optional connector-local SLS resource allowlist. */
@@ -103,7 +108,7 @@ export function parseAliyunSlsResourceScope(
       throw badRequest(`resourceScope[${index}] contains unsupported field ${unknownKey}`);
     }
 
-    const project = normalizeProjectName(record.project, `resourceScope[${index}].project`);
+    const project = normalizeAliyunSlsProjectName(record.project, `resourceScope[${index}].project`);
     const endpoint =
       "endpoint" in record
         ? normalizeAliyunSlsEndpoint(
@@ -170,7 +175,7 @@ export function resolveAliyunSlsProjectTarget(
   const explicitProject = optionalString(projectInput);
 
   if (explicitProject) {
-    const project = normalizeProjectName(explicitProject, "project");
+    const project = normalizeAliyunSlsProjectName(explicitProject, "project");
     const scopeEntry = entries?.find((entry) => entry.project === project);
     if (entries && !scopeEntry) {
       throw forbidden(`Project ${project} on endpoint ${endpoint} is outside the configured resourceScope allowlist`);
@@ -264,7 +269,7 @@ function parseScopedLogstores(record: Record<string, unknown>, index: number): s
   return logstores;
 }
 
-function normalizeProjectName(value: unknown, fieldName: string): string {
+export function normalizeAliyunSlsProjectName(value: unknown, fieldName: string): string {
   const project = requiredString(value, fieldName, badRequest);
   if (!/^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(project)) {
     throw badRequest(`${fieldName} must be a valid 3 to 63 character Simple Log Service Project name`);

--- a/src/providers/aliyun_sls/resources.ts
+++ b/src/providers/aliyun_sls/resources.ts
@@ -1,0 +1,281 @@
+import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+export interface AliyunSlsResourceScopeEntry {
+  endpoint: string;
+  project: string;
+  logstores?: string[];
+}
+
+export type AliyunSlsResourceScope = AliyunSlsResourceScopeEntry[];
+
+export interface AliyunSlsCredential {
+  accessKeyId: string;
+  accessKeySecret: string;
+  endpoint: string;
+  securityToken?: string;
+  resourceScope?: AliyunSlsResourceScope;
+}
+
+export interface AliyunSlsProjectTarget {
+  endpoint: string;
+  project: string;
+  scopeEntry?: AliyunSlsResourceScopeEntry;
+}
+
+export interface AliyunSlsLogstoreTarget extends AliyunSlsProjectTarget {
+  logstore: string;
+}
+
+const resourceScopeKeys = new Set(["endpoint", "project", "logstores"]);
+
+/** Parse and validate all user-configured SLS credential values. */
+export function parseAliyunSlsCredential(values: Record<string, string>): AliyunSlsCredential {
+  const accessKeyId = requiredString(values.accessKeyId, "accessKeyId", badRequest);
+  const accessKeySecret = requiredString(values.accessKeySecret, "accessKeySecret", badRequest);
+  const endpoint = normalizeAliyunSlsEndpoint(requiredString(values.endpoint, "endpoint", badRequest));
+  const securityToken = optionalString(values.securityToken);
+  const resourceScope = parseAliyunSlsResourceScope(values.resourceScope, endpoint);
+  const credential: AliyunSlsCredential = {
+    accessKeyId,
+    accessKeySecret,
+    endpoint,
+  };
+  if (securityToken) credential.securityToken = securityToken;
+  if (resourceScope) credential.resourceScope = resourceScope;
+  return credential;
+}
+
+/** Normalize a regional endpoint to a public HTTPS host without path state. */
+export function normalizeAliyunSlsEndpoint(value: string, fieldName = "endpoint"): string {
+  const raw = requiredString(value, fieldName, badRequest);
+  const candidate = raw.includes("://") ? raw : `https://${raw}`;
+  const url = assertPublicHttpUrl(candidate, {
+    fieldName,
+    createError: badRequest,
+  });
+  if (url.protocol !== "https:") {
+    throw badRequest(`${fieldName} must use https`);
+  }
+  if (url.username || url.password) {
+    throw badRequest(`${fieldName} must not include credentials`);
+  }
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw badRequest(`${fieldName} must not include a path, query, or hash`);
+  }
+  return url.host.toLowerCase();
+}
+
+/** Parse the optional connector-local SLS resource allowlist. */
+export function parseAliyunSlsResourceScope(
+  value: unknown,
+  defaultEndpoint: string,
+): AliyunSlsResourceScope | undefined {
+  if (value == null || (typeof value === "string" && value.trim() === "")) {
+    return undefined;
+  }
+
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value) as unknown;
+    } catch {
+      throw badRequest("resourceScope must be valid JSON");
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    throw badRequest("resourceScope must be a JSON array");
+  }
+  if (parsed.length === 0) {
+    throw badRequest("resourceScope must not be an empty array");
+  }
+
+  const entries: AliyunSlsResourceScope = [];
+  const projects = new Set<string>();
+  for (const [index, item] of parsed.entries()) {
+    const record = optionalRecord(item);
+    if (!record) {
+      throw badRequest(`resourceScope[${index}] must be an object`);
+    }
+    const unknownKey = Object.keys(record).find((key) => !resourceScopeKeys.has(key));
+    if (unknownKey) {
+      throw badRequest(`resourceScope[${index}] contains unsupported field ${unknownKey}`);
+    }
+
+    const project = normalizeProjectName(record.project, `resourceScope[${index}].project`);
+    const endpoint =
+      "endpoint" in record
+        ? normalizeAliyunSlsEndpoint(
+            requiredString(record.endpoint, `resourceScope[${index}].endpoint`, badRequest),
+            `resourceScope[${index}].endpoint`,
+          )
+        : defaultEndpoint;
+    const projectKey = `${endpoint}\u0000${project}`;
+    if (projects.has(projectKey)) {
+      throw badRequest(`resourceScope contains duplicate Project ${project} for endpoint ${endpoint}`);
+    }
+    projects.add(projectKey);
+
+    const logstores = parseScopedLogstores(record, index);
+    const entry: AliyunSlsResourceScopeEntry = { endpoint, project };
+    if (logstores) entry.logstores = logstores;
+    entries.push(entry);
+  }
+  return entries;
+}
+
+export function normalizeAliyunSlsEndpointList(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 50) {
+    throw badRequest("endpoints must contain between 1 and 50 regional endpoints");
+  }
+  const endpoints: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string") {
+      throw badRequest(`endpoints[${index}] must be a string`);
+    }
+    const endpoint = normalizeAliyunSlsEndpoint(item, `endpoints[${index}]`);
+    if (seen.has(endpoint)) {
+      throw badRequest(`endpoints contains duplicate endpoint ${endpoint}`);
+    }
+    seen.add(endpoint);
+    endpoints.push(endpoint);
+  }
+  return endpoints;
+}
+
+export function assertAliyunSlsEndpointAllowed(
+  scope: AliyunSlsResourceScope | undefined,
+  endpoint: string,
+): AliyunSlsResourceScopeEntry[] | undefined {
+  if (!scope) {
+    return undefined;
+  }
+  const entries = scope.filter((entry) => entry.endpoint === endpoint);
+  if (entries.length === 0) {
+    throw forbidden(`endpoint ${endpoint} is outside the configured resourceScope allowlist`);
+  }
+  return entries;
+}
+
+export function resolveAliyunSlsProjectTarget(
+  credential: AliyunSlsCredential,
+  endpointInput: unknown,
+  projectInput: unknown,
+): AliyunSlsProjectTarget {
+  const endpointValue = optionalString(endpointInput);
+  const endpoint = endpointValue ? normalizeAliyunSlsEndpoint(endpointValue) : credential.endpoint;
+  const entries = assertAliyunSlsEndpointAllowed(credential.resourceScope, endpoint);
+  const explicitProject = optionalString(projectInput);
+
+  if (explicitProject) {
+    const project = normalizeProjectName(explicitProject, "project");
+    const scopeEntry = entries?.find((entry) => entry.project === project);
+    if (entries && !scopeEntry) {
+      throw forbidden(`Project ${project} on endpoint ${endpoint} is outside the configured resourceScope allowlist`);
+    }
+    return scopeEntry ? { endpoint, project, scopeEntry } : { endpoint, project };
+  }
+
+  if (!entries) {
+    throw badRequest("project is required when resourceScope does not identify exactly one candidate Project");
+  }
+  if (entries.length !== 1) {
+    throw badRequest(`project is required because endpoint ${endpoint} has multiple candidate Projects`);
+  }
+  return {
+    endpoint,
+    project: entries[0]!.project,
+    scopeEntry: entries[0],
+  };
+}
+
+export function resolveAliyunSlsLogstoreTarget(
+  credential: AliyunSlsCredential,
+  endpointInput: unknown,
+  projectInput: unknown,
+  logstoreInput: unknown,
+): AliyunSlsLogstoreTarget {
+  const target = resolveAliyunSlsProjectTarget(credential, endpointInput, projectInput);
+  const explicitLogstore = optionalString(logstoreInput);
+  const allowedLogstores = target.scopeEntry?.logstores;
+
+  if (explicitLogstore) {
+    if (allowedLogstores && !allowedLogstores.includes(explicitLogstore)) {
+      throw forbidden(
+        `Logstore ${explicitLogstore} in Project ${target.project} is outside the configured resourceScope allowlist`,
+      );
+    }
+    return { ...target, logstore: explicitLogstore };
+  }
+
+  if (!allowedLogstores || allowedLogstores.length !== 1) {
+    throw badRequest(
+      `logstore is required when Project ${target.project} does not have exactly one candidate Logstore`,
+    );
+  }
+  return { ...target, logstore: allowedLogstores[0]! };
+}
+
+export function filterAliyunSlsProjects(
+  projects: Array<Record<string, unknown>>,
+  scopeEntries: AliyunSlsResourceScopeEntry[] | undefined,
+): Array<Record<string, unknown>> {
+  if (!scopeEntries) {
+    return projects;
+  }
+  const allowed = new Set(scopeEntries.map((entry) => entry.project));
+  return projects.filter((project) => {
+    const projectName = optionalString(project.projectName);
+    return projectName ? allowed.has(projectName) : false;
+  });
+}
+
+export function filterAliyunSlsLogstores(
+  logstores: string[],
+  scopeEntry: AliyunSlsResourceScopeEntry | undefined,
+): string[] {
+  if (!scopeEntry?.logstores) {
+    return logstores;
+  }
+  const allowed = new Set(scopeEntry.logstores);
+  return logstores.filter((logstore) => allowed.has(logstore));
+}
+
+function parseScopedLogstores(record: Record<string, unknown>, index: number): string[] | undefined {
+  if (!("logstores" in record)) {
+    return undefined;
+  }
+  if (!Array.isArray(record.logstores) || record.logstores.length === 0) {
+    throw badRequest(`resourceScope[${index}].logstores must be a non-empty array`);
+  }
+
+  const logstores: string[] = [];
+  const seen = new Set<string>();
+  for (const [logstoreIndex, item] of record.logstores.entries()) {
+    const logstore = requiredString(item, `resourceScope[${index}].logstores[${logstoreIndex}]`, badRequest);
+    if (seen.has(logstore)) {
+      throw badRequest(`resourceScope[${index}].logstores contains duplicate Logstore ${logstore}`);
+    }
+    seen.add(logstore);
+    logstores.push(logstore);
+  }
+  return logstores;
+}
+
+function normalizeProjectName(value: unknown, fieldName: string): string {
+  const project = requiredString(value, fieldName, badRequest);
+  if (!/^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(project)) {
+    throw badRequest(`${fieldName} must be a valid 3 to 63 character Simple Log Service Project name`);
+  }
+  return project;
+}
+
+function badRequest(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function forbidden(message: string): ProviderRequestError {
+  return new ProviderRequestError(403, message);
+}

--- a/src/providers/aliyun_sls/runtime.test.ts
+++ b/src/providers/aliyun_sls/runtime.test.ts
@@ -1,0 +1,364 @@
+import type { AliyunSlsActionContext } from "./runtime.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { parseAliyunSlsCredential } from "./resources.ts";
+import { aliyunSlsActionHandlers, requestAliyunSlsJson, validateAliyunSlsCredential } from "./runtime.ts";
+import { aliyunSlsUtf8Bytes } from "./signing.ts";
+
+const defaultEndpoint = "cn-hangzhou.log.aliyuncs.com";
+const fixedDate = new Date("2024-02-03T04:05:06Z");
+
+describe("Alibaba Cloud SLS runtime", () => {
+  it("lists Projects through the bare regional host with signed official pagination", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({
+        count: 1,
+        total: 1,
+        projects: [project("project-a", "cn-hangzhou")],
+      }),
+    );
+    const output = await aliyunSlsActionHandlers.list_projects(
+      {
+        offset: 0,
+        size: 10,
+        projectName: "project",
+        resourceGroupId: "rg-1",
+      },
+      context(fetchMock),
+    );
+
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0]!;
+    expect(requestUrl).toBe(
+      "https://cn-hangzhou.log.aliyuncs.com/?offset=0&projectName=project&resourceGroupId=rg-1&size=10",
+    );
+    const headers = new Headers(requestInit?.headers);
+    expect(headers.get("date")).toBe("Sat, 03 Feb 2024 04:05:06 GMT");
+    expect(headers.get("x-log-bodyrawsize")).toBe("0");
+    expect(headers.get("authorization")).toMatch(/^LOG access-key:/);
+    expect(output).toMatchObject({
+      endpoint: defaultEndpoint,
+      count: 1,
+      total: 1,
+      projects: [
+        {
+          endpoint: defaultEndpoint,
+          projectName: "project-a",
+          region: "cn-hangzhou",
+          recycleBinEnabled: false,
+        },
+      ],
+    });
+  });
+
+  it("filters scoped Projects and Logstores and uses the Project host", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/") {
+        return jsonResponse({
+          count: 2,
+          total: 2,
+          projects: [project("project-a", "cn-hangzhou"), project("project-b", "cn-hangzhou")],
+        });
+      }
+      return jsonResponse({ count: 3, total: 3, logstores: ["application", "audit", "other"] });
+    });
+    const scopedContext = context(fetchMock, {
+      resourceScope: '[{"project":"project-a","logstores":["application","audit"]}]',
+    });
+
+    const projects = await aliyunSlsActionHandlers.list_projects({}, scopedContext);
+    expect(projects).toMatchObject({ count: 1, total: 1 });
+    expect((projects as { projects: unknown[] }).projects).toHaveLength(1);
+
+    const logstores = await aliyunSlsActionHandlers.list_logstores(
+      { logstoreName: "a", offset: 0, size: 20 },
+      scopedContext,
+    );
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores?logstoreName=a&offset=0&size=20",
+    );
+    expect(logstores).toEqual({
+      endpoint: defaultEndpoint,
+      project: "project-a",
+      count: 2,
+      total: 2,
+      logstores: ["application", "audit"],
+    });
+  });
+
+  it("queries logs with inferred scope, official defaults, and stable response fields", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse([{ __time__: "1700000000", level: "error" }], 200, {
+        "x-log-progress": "Complete",
+        "x-log-processed-rows": "17",
+        "x-log-elapsed-millisecond": "25",
+        "x-log-has-sql": "false",
+      }),
+    );
+    const scopedContext = context(fetchMock, {
+      resourceScope: '[{"project":"project-a","logstores":["application"]}]',
+      securityToken: "temporary-token",
+    });
+    const output = await aliyunSlsActionHandlers.query_logs(
+      {
+        from: 1_700_000_000,
+        to: 1_700_000_900,
+        query: "status:500",
+        reverse: true,
+        powerSql: true,
+      },
+      scopedContext,
+    );
+
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores/application?from=1700000000&line=100&offset=0&powerSql=true&query=status%3A500&reverse=true&to=1700000900&type=log",
+    );
+    const headers = new Headers(fetchMock.mock.calls[0]![1]?.headers);
+    expect(headers.get("x-acs-security-token")).toBe("temporary-token");
+    expect(output).toEqual({
+      endpoint: defaultEndpoint,
+      project: "project-a",
+      logstore: "application",
+      progress: "Complete",
+      count: 1,
+      processedRows: 17,
+      elapsedMilliseconds: 25,
+      hasSql: false,
+      logs: [{ __time__: "1700000000", level: "error" }],
+    });
+  });
+
+  it("normalizes histogram intervals and totals", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse(
+        [
+          { from: 100, to: 150, count: 2, progress: "Complete" },
+          { from: 150, to: 200, count: 3, progress: "Complete" },
+        ],
+        200,
+        { "x-log-progress": "Complete" },
+      ),
+    );
+    const output = await aliyunSlsActionHandlers.get_histograms(
+      {
+        project: "project-a",
+        logstore: "application",
+        from: 100,
+        to: 200,
+        query: "level:error",
+      },
+      context(fetchMock),
+    );
+
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores/application/index?from=100&query=level%3Aerror&to=200&type=histogram",
+    );
+    expect(output).toMatchObject({
+      progress: "Complete",
+      count: 5,
+      histograms: [
+        { from: 100, to: 150, count: 2, progress: "Complete" },
+        { from: 150, to: 200, count: 3, progress: "Complete" },
+      ],
+    });
+  });
+
+  it("sends the same final POST bytes used by signing", async () => {
+    const bodyBytes = aliyunSlsUtf8Bytes('{"query":"状态"}');
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => jsonResponse({ ok: true }));
+    await requestAliyunSlsJson(context(fetchMock), {
+      operation: "test POST",
+      endpoint: defaultEndpoint,
+      project: "project-a",
+      method: "POST",
+      path: "/logstores/application/logs",
+      headers: { "content-type": "application/json" },
+      bodyBytes,
+    });
+
+    const init = fetchMock.mock.calls[0]![1]!;
+    expect(new Uint8Array(await new Response(init.body).arrayBuffer())).toEqual(bodyBytes);
+    const headers = new Headers(init.headers);
+    expect(headers.get("content-md5")).toBe("EF2643B9A23580637AD32EAE4284DD9C");
+    expect(headers.get("x-log-bodyrawsize")).toBe("18");
+  });
+
+  it("paginates every supplied region and deduplicates by region and Project name", async () => {
+    const seenOffsets: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      const offset = url.searchParams.get("offset")!;
+      seenOffsets.push(`${url.hostname}:${offset}`);
+      if (url.hostname === "cn-a.log.aliyuncs.com" && offset === "0") {
+        return jsonResponse({
+          count: 500,
+          total: 501,
+          projects: [project("shared-project", "region-a")],
+        });
+      }
+      if (url.hostname === "cn-a.log.aliyuncs.com") {
+        return jsonResponse({
+          count: 1,
+          total: 501,
+          projects: [project("last-project", "region-a")],
+        });
+      }
+      return jsonResponse({
+        count: 1,
+        total: 1,
+        projects: [project("shared-project", "region-a")],
+      });
+    });
+    const output = await aliyunSlsActionHandlers.list_projects_across_regions(
+      { endpoints: ["cn-a.log.aliyuncs.com", "cn-b.log.aliyuncs.com"] },
+      context(fetchMock, {
+        resourceScope: JSON.stringify([
+          { endpoint: "cn-a.log.aliyuncs.com", project: "shared-project" },
+          { endpoint: "cn-a.log.aliyuncs.com", project: "last-project" },
+          { endpoint: "cn-b.log.aliyuncs.com", project: "shared-project" },
+        ]),
+      }),
+    );
+
+    expect(seenOffsets).toContain("cn-a.log.aliyuncs.com:500");
+    expect(output).toMatchObject({
+      total: 2,
+      complete: true,
+      failures: [],
+      regions: [
+        { endpoint: "cn-a.log.aliyuncs.com", count: 2 },
+        { endpoint: "cn-b.log.aliyuncs.com", count: 1 },
+      ],
+    });
+  });
+
+  it("limits regional concurrency", async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      const hostname = new URL(String(input)).hostname;
+      return jsonResponse({ count: 1, total: 1, projects: [project(hostname.split(".")[0]!, hostname)] });
+    });
+    const endpoints = Array.from({ length: 8 }, (_, index) => `cn-${index + 1}.log.aliyuncs.com`);
+    await aliyunSlsActionHandlers.list_projects_across_regions({ endpoints }, context(fetchMock));
+
+    expect(maximumActive).toBeGreaterThan(1);
+    expect(maximumActive).toBeLessThanOrEqual(5);
+  });
+
+  it("fails all regions by default and reports failures when allowPartial is true", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const hostname = new URL(String(input)).hostname;
+      if (hostname.startsWith("cn-fail")) {
+        return jsonResponse({ errorCode: "Unauthorized", errorMessage: "RAM denied" }, 403);
+      }
+      return jsonResponse({ count: 1, total: 1, projects: [project("project-a", "region-a")] });
+    });
+    const input = { endpoints: ["cn-ok.log.aliyuncs.com", "cn-fail.log.aliyuncs.com"] };
+    await expect(aliyunSlsActionHandlers.list_projects_across_regions(input, context(fetchMock))).rejects.toMatchObject(
+      { status: 403 },
+    );
+
+    const partial = await aliyunSlsActionHandlers.list_projects_across_regions(
+      { ...input, allowPartial: true },
+      context(fetchMock),
+    );
+    expect(partial).toMatchObject({
+      total: 1,
+      complete: false,
+      regions: [{ endpoint: "cn-ok.log.aliyuncs.com", count: 1 }],
+      failures: [{ endpoint: "cn-fail.log.aliyuncs.com", status: 403 }],
+    });
+  });
+
+  it.each([
+    [400, "InvalidAccessKeyId", 401],
+    [403, "Unauthorized", 403],
+    [400, "Throttling", 429],
+  ])("maps SLS %s %s errors to status %s", async (httpStatus, errorCode, expectedStatus) => {
+    const fetchMock = vi.fn(async () => jsonResponse({ errorCode, errorMessage: "provider message" }, httpStatus));
+    await expect(aliyunSlsActionHandlers.list_projects({}, context(fetchMock))).rejects.toMatchObject({
+      status: expectedStatus,
+      message: expect.stringContaining(errorCode),
+    });
+  });
+
+  it("rejects invalid JSON from a successful provider response", async () => {
+    const fetchMock = vi.fn(async () => new Response("not-json", { status: 200 }));
+    await expect(aliyunSlsActionHandlers.list_projects({}, context(fetchMock))).rejects.toMatchObject({
+      status: 502,
+      message: expect.stringContaining("invalid JSON"),
+    });
+  });
+
+  it("validates credentials with one low-cost bare-host ListProject request", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ count: 0, total: 0, projects: [] }),
+    );
+    const result = await validateAliyunSlsCredential(
+      {
+        accessKeyId: "access-key",
+        accessKeySecret: "secret-key",
+        endpoint: defaultEndpoint,
+        resourceScope:
+          '[{"endpoint":"cn-shanghai.log.aliyuncs.com","project":"project-a","logstores":["application"]}]',
+      },
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("https://cn-hangzhou.log.aliyuncs.com/?offset=0&size=1");
+    expect(result).toEqual({
+      profile: {
+        accountId: "access-key",
+        displayName: "access-key@cn-hangzhou.log.aliyuncs.com",
+      },
+      grantedScopes: [],
+    });
+  });
+});
+
+function context(
+  fetchMock: ReturnType<typeof vi.fn>,
+  values: { resourceScope?: string; securityToken?: string } = {},
+): AliyunSlsActionContext {
+  return {
+    credential: parseAliyunSlsCredential({
+      accessKeyId: "access-key",
+      accessKeySecret: "secret-key",
+      endpoint: defaultEndpoint,
+      ...values,
+    }),
+    fetcher: fetchMock as unknown as typeof fetch,
+    now: () => fixedDate,
+  };
+}
+
+function jsonResponse(data: unknown, status = 200, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...Object.fromEntries(new Headers(headers).entries()),
+    },
+  });
+}
+
+function project(projectName: string, region: string): Record<string, unknown> {
+  return {
+    projectName,
+    region,
+    description: `${projectName} description`,
+    status: "Normal",
+    createTime: "2024-01-01 00:00:00",
+    lastModifyTime: "2024-01-02 00:00:00",
+    resourceGroupId: "rg-1",
+    dataRedundancyType: "LRS",
+    recycleBinEnabled: false,
+    internetEndpoint: "",
+    internalEndpoint: "",
+  };
+}

--- a/src/providers/aliyun_sls/runtime.test.ts
+++ b/src/providers/aliyun_sls/runtime.test.ts
@@ -75,7 +75,7 @@ describe("Alibaba Cloud SLS runtime", () => {
       scopedContext,
     );
     expect(fetchMock.mock.calls[1]![0]).toBe(
-      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores?logstoreName=a&offset=0&size=20",
+      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores?logstoreName=a&offset=0&size=500",
     );
     expect(logstores).toEqual({
       endpoint: defaultEndpoint,
@@ -84,6 +84,43 @@ describe("Alibaba Cloud SLS runtime", () => {
       total: 2,
       logstores: ["application", "audit"],
     });
+  });
+
+  it("filters scoped Projects and Logstores before applying caller pagination", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      const offset = url.searchParams.get("offset");
+      if (url.pathname === "/") {
+        return offset === "0"
+          ? jsonResponse({ count: 1, total: 2, projects: [project("project-b", "cn-hangzhou")] })
+          : jsonResponse({ count: 1, total: 2, projects: [project("project-a", "cn-hangzhou")] });
+      }
+      return offset === "0"
+        ? jsonResponse({ count: 1, total: 2, logstores: ["other"] })
+        : jsonResponse({ count: 1, total: 2, logstores: ["audit"] });
+    });
+    const scopedContext = context(fetchMock, {
+      resourceScope: '[{"project":"project-a","logstores":["audit"]}]',
+    });
+
+    const projects = await aliyunSlsActionHandlers.list_projects({ offset: 0, size: 1 }, scopedContext);
+    expect(projects).toMatchObject({ count: 1, total: 1 });
+    expect((projects as { projects: Array<{ projectName: string }> }).projects[0]?.projectName).toBe("project-a");
+
+    const logstores = await aliyunSlsActionHandlers.list_logstores({ offset: 0, size: 1 }, scopedContext);
+    expect(logstores).toEqual({
+      endpoint: defaultEndpoint,
+      project: "project-a",
+      count: 1,
+      total: 1,
+      logstores: ["audit"],
+    });
+    expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).searchParams.get("offset"))).toEqual([
+      "0",
+      "1",
+      "0",
+      "1",
+    ]);
   });
 
   it("queries logs with inferred scope, official defaults, and stable response fields", async () => {
@@ -151,7 +188,7 @@ describe("Alibaba Cloud SLS runtime", () => {
     );
 
     expect(fetchMock.mock.calls[0]![0]).toBe(
-      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores/application/index?from=100&query=level%3Aerror&to=200&type=histogram",
+      "https://project-a.cn-hangzhou.log.aliyuncs.com/logstores/application?from=100&query=level%3Aerror&to=200&type=histogram",
     );
     expect(output).toMatchObject({
       progress: "Complete",
@@ -183,6 +220,33 @@ describe("Alibaba Cloud SLS runtime", () => {
     expect(headers.get("x-log-bodyrawsize")).toBe("18");
   });
 
+  it("rejects non-SLS request targets before credentials can be sent", async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      requestAliyunSlsJson(context(fetchMock), {
+        operation: "unsafe request",
+        endpoint: "example.com",
+        method: "GET",
+        path: "/",
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsafe Project authority before credentials can be sent", async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      requestAliyunSlsJson(context(fetchMock), {
+        operation: "unsafe request",
+        endpoint: defaultEndpoint,
+        project: "example.com@attacker.example/path",
+        method: "GET",
+        path: "/",
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("paginates every supplied region and deduplicates by region and Project name", async () => {
     const seenOffsets: string[] = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
@@ -191,15 +255,15 @@ describe("Alibaba Cloud SLS runtime", () => {
       seenOffsets.push(`${url.hostname}:${offset}`);
       if (url.hostname === "cn-a.log.aliyuncs.com" && offset === "0") {
         return jsonResponse({
-          count: 500,
-          total: 501,
+          count: 1,
+          total: 2,
           projects: [project("shared-project", "region-a")],
         });
       }
       if (url.hostname === "cn-a.log.aliyuncs.com") {
         return jsonResponse({
           count: 1,
-          total: 501,
+          total: 2,
           projects: [project("last-project", "region-a")],
         });
       }
@@ -220,7 +284,7 @@ describe("Alibaba Cloud SLS runtime", () => {
       }),
     );
 
-    expect(seenOffsets).toContain("cn-a.log.aliyuncs.com:500");
+    expect(seenOffsets).toContain("cn-a.log.aliyuncs.com:1");
     expect(output).toMatchObject({
       total: 2,
       complete: true,
@@ -293,6 +357,66 @@ describe("Alibaba Cloud SLS runtime", () => {
       status: 502,
       message: expect.stringContaining("invalid JSON"),
     });
+  });
+
+  it.each([
+    [
+      "a count greater than the requested size",
+      { count: 501, total: 501, projects: [project("project-a", "region-a")] },
+      "exceeds requested size",
+    ],
+    [
+      "a count that does not match the returned array",
+      { count: 2, total: 2, projects: [project("project-a", "region-a")] },
+      "does not match",
+    ],
+    ["an empty page before total completion", { count: 0, total: 1, projects: [] }, "empty page"],
+    [
+      "a total above the collection item ceiling",
+      { count: 1, total: 10_001, projects: [project("project-a", "region-a")] },
+      "item limit",
+    ],
+  ])("rejects regional pagination with %s", async (_name, response, message) => {
+    const fetchMock = vi.fn(async () => jsonResponse(response));
+    await expect(
+      aliyunSlsActionHandlers.list_projects_across_regions(
+        { endpoints: ["cn-hangzhou.log.aliyuncs.com"] },
+        context(fetchMock),
+      ),
+    ).rejects.toMatchObject({ status: 502, message: expect.stringContaining(message) });
+  });
+
+  it("rejects regional pagination when total changes between pages", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const offset = new URL(String(input)).searchParams.get("offset");
+      return offset === "0"
+        ? jsonResponse({ count: 1, total: 2, projects: [project("project-a", "region-a")] })
+        : jsonResponse({ count: 1, total: 3, projects: [project("project-b", "region-a")] });
+    });
+    await expect(
+      aliyunSlsActionHandlers.list_projects_across_regions(
+        { endpoints: ["cn-hangzhou.log.aliyuncs.com"] },
+        context(fetchMock),
+      ),
+    ).rejects.toMatchObject({ status: 502, message: expect.stringContaining("total changed") });
+  });
+
+  it("rejects regional pagination that exceeds the page ceiling", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const offset = Number(new URL(String(input)).searchParams.get("offset"));
+      return jsonResponse({
+        count: 1,
+        total: 21,
+        projects: [project(`project-${offset}`, "region-a")],
+      });
+    });
+    await expect(
+      aliyunSlsActionHandlers.list_projects_across_regions(
+        { endpoints: ["cn-hangzhou.log.aliyuncs.com"] },
+        context(fetchMock),
+      ),
+    ).rejects.toMatchObject({ status: 502, message: expect.stringContaining("page pagination limit") });
+    expect(fetchMock).toHaveBeenCalledTimes(20);
   });
 
   it("validates credentials with one low-cost bare-host ListProject request", async () => {

--- a/src/providers/aliyun_sls/runtime.test.ts
+++ b/src/providers/aliyun_sls/runtime.test.ts
@@ -214,6 +214,7 @@ describe("Alibaba Cloud SLS runtime", () => {
     });
 
     const init = fetchMock.mock.calls[0]![1]!;
+    expect(init.redirect).toBe("error");
     expect(new Uint8Array(await new Response(init.body).arrayBuffer())).toEqual(bodyBytes);
     const headers = new Headers(init.headers);
     expect(headers.get("content-md5")).toBe("EF2643B9A23580637AD32EAE4284DD9C");
@@ -419,22 +420,14 @@ describe("Alibaba Cloud SLS runtime", () => {
     expect(fetchMock).toHaveBeenCalledTimes(20);
   });
 
-  it("validates credentials with one low-cost bare-host ListProject request", async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      jsonResponse({ count: 0, total: 0, projects: [] }),
-    );
-    const result = await validateAliyunSlsCredential(
-      {
-        accessKeyId: "access-key",
-        accessKeySecret: "secret-key",
-        endpoint: defaultEndpoint,
-        resourceScope:
-          '[{"endpoint":"cn-shanghai.log.aliyuncs.com","project":"project-a","logstores":["application"]}]',
-      },
-      fetchMock as unknown as typeof fetch,
-    );
+  it("validates credential structure without requiring ListProject permission", () => {
+    const result = validateAliyunSlsCredential({
+      accessKeyId: "access-key",
+      accessKeySecret: "secret-key",
+      endpoint: defaultEndpoint,
+      resourceScope: '[{"endpoint":"cn-shanghai.log.aliyuncs.com","project":"project-a","logstores":["application"]}]',
+    });
 
-    expect(fetchMock.mock.calls[0]![0]).toBe("https://cn-hangzhou.log.aliyuncs.com/?offset=0&size=1");
     expect(result).toEqual({
       profile: {
         accountId: "access-key",

--- a/src/providers/aliyun_sls/runtime.ts
+++ b/src/providers/aliyun_sls/runtime.ts
@@ -1,0 +1,676 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { AliyunSlsActionName } from "./actions.ts";
+import type { AliyunSlsCredential, AliyunSlsResourceScopeEntry } from "./resources.ts";
+
+import { Buffer } from "node:buffer";
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalIntegerLike,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+} from "../../core/cast.ts";
+import { providerUserAgent, ProviderRequestError, readProviderTextBody } from "../provider-runtime.ts";
+import {
+  assertAliyunSlsEndpointAllowed,
+  filterAliyunSlsLogstores,
+  filterAliyunSlsProjects,
+  normalizeAliyunSlsEndpoint,
+  normalizeAliyunSlsEndpointList,
+  parseAliyunSlsCredential,
+  resolveAliyunSlsLogstoreTarget,
+  resolveAliyunSlsProjectTarget,
+} from "./resources.ts";
+import { signAliyunSlsRequest } from "./signing.ts";
+
+const listProjectDefaultSize = 100;
+const listLogstoreDefaultSize = 200;
+const maximumListSize = 500;
+const maximumQueryLines = 100;
+const regionalConcurrency = 5;
+
+export interface AliyunSlsActionContext {
+  credential: AliyunSlsCredential;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+  now: () => Date;
+}
+
+export interface AliyunSlsRequestInput {
+  operation: string;
+  endpoint: string;
+  method: string;
+  path: string;
+  query?: Record<string, string>;
+  project?: string;
+  headers?: HeadersInit;
+  bodyBytes?: Uint8Array;
+}
+
+export interface AliyunSlsJsonResponse {
+  data: unknown;
+  headers: Headers;
+}
+
+interface AliyunSlsProjectPage {
+  count: number;
+  total: number;
+  providerTotal: number;
+  rawCount: number;
+  projects: Array<Record<string, unknown>>;
+}
+
+interface AliyunSlsRegionSuccess {
+  endpoint: string;
+  projects: Array<Record<string, unknown>>;
+}
+
+interface AliyunSlsRegionFailure {
+  endpoint: string;
+  error: ProviderRequestError;
+}
+
+interface AliyunSlsHistogram {
+  from: number;
+  to: number;
+  count: number;
+  progress: string;
+}
+
+type AliyunSlsActionHandler = (input: Record<string, unknown>, context: AliyunSlsActionContext) => Promise<unknown>;
+
+export const aliyunSlsActionHandlers: Record<AliyunSlsActionName, AliyunSlsActionHandler> = {
+  list_projects(input, context) {
+    return listProjects(input, context);
+  },
+  list_projects_across_regions(input, context) {
+    return listProjectsAcrossRegions(input, context);
+  },
+  list_logstores(input, context) {
+    return listLogstores(input, context);
+  },
+  query_logs(input, context) {
+    return queryLogs(input, context);
+  },
+  get_histograms(input, context) {
+    return getHistograms(input, context);
+  },
+};
+
+export function createAliyunSlsContext(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): AliyunSlsActionContext {
+  return {
+    credential: parseAliyunSlsCredential(values),
+    fetcher,
+    signal,
+    now: () => new Date(),
+  };
+}
+
+export async function validateAliyunSlsCredential(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createAliyunSlsContext(values, fetcher, signal);
+  await requestProjectPage(context, {
+    endpoint: context.credential.endpoint,
+    offset: 0,
+    size: 1,
+  });
+  return {
+    profile: {
+      accountId: context.credential.accessKeyId,
+      displayName: `${context.credential.accessKeyId}@${context.credential.endpoint}`,
+    },
+    grantedScopes: [],
+  };
+}
+
+/** Send one signed SLS request and return its parsed JSON and response headers. */
+export async function requestAliyunSlsJson(
+  context: AliyunSlsActionContext,
+  input: AliyunSlsRequestInput,
+): Promise<AliyunSlsJsonResponse> {
+  const url = buildAliyunSlsRequestUrl(input.endpoint, input.project, input.path, input.query);
+  const signed = signAliyunSlsRequest({
+    method: input.method,
+    path: input.path,
+    query: input.query,
+    credential: context.credential,
+    date: context.now(),
+    headers: {
+      accept: "application/json",
+      "user-agent": providerUserAgent,
+      ...headersToRecord(input.headers),
+    },
+    bodyBytes: input.bodyBytes,
+  });
+
+  const requestInit: RequestInit = {
+    method: input.method,
+    headers: signed.headers,
+    signal: context.signal,
+  };
+  if (signed.bodyBytes.byteLength > 0) {
+    requestInit.body = Buffer.from(signed.bodyBytes);
+  }
+
+  let response: Response;
+  try {
+    response = await context.fetcher(url, requestInit);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (context.signal?.aborted) {
+      throw new ProviderRequestError(499, `${input.operation} request was aborted`);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error
+        ? `${input.operation} request failed: ${error.message}`
+        : `${input.operation} request failed`,
+    );
+  }
+
+  const text = await readProviderTextBody(response, `${input.operation} response`);
+  if (!response.ok) {
+    throw createAliyunSlsResponseError(input.operation, response, text);
+  }
+  if (!text.trim()) {
+    throw new ProviderRequestError(502, `${input.operation} returned an empty response`);
+  }
+
+  try {
+    return {
+      data: JSON.parse(text) as unknown,
+      headers: response.headers,
+    };
+  } catch (error) {
+    throw new ProviderRequestError(502, `${input.operation} returned invalid JSON`, error);
+  }
+}
+
+export function buildAliyunSlsRequestUrl(
+  endpoint: string,
+  project: string | undefined,
+  path: string,
+  query?: Record<string, string>,
+): string {
+  const authority = project ? `${project}.${endpoint}` : endpoint;
+  const url = new URL(`https://${authority}`);
+  url.pathname = path;
+  for (const [key, value] of Object.entries(query ?? {}).sort(([left], [right]) => compareAscii(left, right))) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+async function listProjects(
+  input: Record<string, unknown>,
+  context: AliyunSlsActionContext,
+): Promise<Record<string, unknown>> {
+  const endpointInput = optionalString(input.endpoint);
+  const endpoint = endpointInput ? normalizeAliyunSlsEndpoint(endpointInput) : context.credential.endpoint;
+  const scopeEntries = assertAliyunSlsEndpointAllowed(context.credential.resourceScope, endpoint);
+  const page = await requestProjectPage(context, {
+    endpoint,
+    offset: readBoundedInteger(input.offset, "offset", 0, 0),
+    size: readBoundedInteger(input.size, "size", listProjectDefaultSize, 1, maximumListSize),
+    projectName: optionalString(input.projectName),
+    resourceGroupId: optionalString(input.resourceGroupId),
+    scopeEntries,
+  });
+  return {
+    endpoint,
+    count: page.count,
+    total: page.total,
+    projects: page.projects,
+  };
+}
+
+async function listProjectsAcrossRegions(
+  input: Record<string, unknown>,
+  context: AliyunSlsActionContext,
+): Promise<Record<string, unknown>> {
+  const endpoints = normalizeAliyunSlsEndpointList(input.endpoints);
+  for (const endpoint of endpoints) {
+    assertAliyunSlsEndpointAllowed(context.credential.resourceScope, endpoint);
+  }
+  const projectName = optionalString(input.projectName);
+  const resourceGroupId = optionalString(input.resourceGroupId);
+  const outcomes = await mapWithConcurrency(endpoints, regionalConcurrency, async (endpoint) => {
+    try {
+      return await listAllProjectsForEndpoint(context, endpoint, projectName, resourceGroupId);
+    } catch (error) {
+      return {
+        endpoint,
+        error: normalizeAliyunSlsRuntimeError(error, `list_projects failed for endpoint ${endpoint}`),
+      } satisfies AliyunSlsRegionFailure;
+    }
+  });
+  const failures = outcomes.filter((outcome): outcome is AliyunSlsRegionFailure => "error" in outcome);
+  if (failures.length > 0 && input.allowPartial !== true) {
+    throw failures[0]!.error;
+  }
+
+  const successes = outcomes.filter((outcome): outcome is AliyunSlsRegionSuccess => "projects" in outcome);
+  const uniqueProjects = new Map<string, Record<string, unknown>>();
+  for (const success of successes) {
+    for (const project of success.projects) {
+      const region = requireResponseString(project.region, "Project region");
+      const projectNameValue = requireResponseString(project.projectName, "Project name");
+      const key = `${region}\u0000${projectNameValue}`;
+      if (!uniqueProjects.has(key)) uniqueProjects.set(key, project);
+    }
+  }
+
+  const projects = [...uniqueProjects.values()];
+  return {
+    projects,
+    total: projects.length,
+    regions: successes.map((success) => ({ endpoint: success.endpoint, count: success.projects.length })),
+    failures: failures.map((failure) => ({
+      endpoint: failure.endpoint,
+      status: failure.error.status,
+      message: failure.error.message,
+    })),
+    complete: failures.length === 0,
+  };
+}
+
+async function listAllProjectsForEndpoint(
+  context: AliyunSlsActionContext,
+  endpoint: string,
+  projectName?: string,
+  resourceGroupId?: string,
+): Promise<AliyunSlsRegionSuccess> {
+  const scopeEntries = assertAliyunSlsEndpointAllowed(context.credential.resourceScope, endpoint);
+  const projects: Array<Record<string, unknown>> = [];
+  let offset = 0;
+  while (true) {
+    const page = await requestProjectPage(context, {
+      endpoint,
+      offset,
+      size: maximumListSize,
+      projectName,
+      resourceGroupId,
+      scopeEntries,
+    });
+    projects.push(...page.projects);
+    if (page.rawCount === 0 || offset + page.rawCount >= page.providerTotal) break;
+    offset += page.rawCount;
+  }
+  return { endpoint, projects };
+}
+
+interface RequestProjectPageOptions {
+  endpoint: string;
+  offset: number;
+  size: number;
+  projectName?: string;
+  resourceGroupId?: string;
+  scopeEntries?: AliyunSlsResourceScopeEntry[];
+}
+
+async function requestProjectPage(
+  context: AliyunSlsActionContext,
+  options: RequestProjectPageOptions,
+): Promise<AliyunSlsProjectPage> {
+  const query: Record<string, string> = {
+    offset: String(options.offset),
+    size: String(options.size),
+  };
+  if (options.projectName) query.projectName = options.projectName;
+  if (options.resourceGroupId) query.resourceGroupId = options.resourceGroupId;
+  const response = await requestAliyunSlsJson(context, {
+    operation: "Alibaba Cloud SLS ListProject",
+    endpoint: options.endpoint,
+    method: "GET",
+    path: "/",
+    query,
+  });
+  const payload = requireResponseRecord(response.data, "ListProject response");
+  const rawProjects = requireResponseObjectArray(payload.projects, "ListProject projects");
+  const projects = filterAliyunSlsProjects(
+    rawProjects.map((project) => normalizeProject(project, options.endpoint)),
+    options.scopeEntries,
+  );
+  const rawCount = readResponseInteger(payload.count, rawProjects.length, "ListProject count");
+  const providerTotal = readResponseInteger(payload.total, rawCount, "ListProject total");
+  return {
+    count: projects.length,
+    total: options.scopeEntries ? projects.length : providerTotal,
+    providerTotal,
+    rawCount,
+    projects,
+  };
+}
+
+async function listLogstores(
+  input: Record<string, unknown>,
+  context: AliyunSlsActionContext,
+): Promise<Record<string, unknown>> {
+  const target = resolveAliyunSlsProjectTarget(context.credential, input.endpoint, input.project);
+  const query: Record<string, string> = {
+    offset: String(readBoundedInteger(input.offset, "offset", 0, 0)),
+    size: String(readBoundedInteger(input.size, "size", listLogstoreDefaultSize, 1, maximumListSize)),
+  };
+  const logstoreName = optionalString(input.logstoreName);
+  if (logstoreName) query.logstoreName = logstoreName;
+  const response = await requestAliyunSlsJson(context, {
+    operation: "Alibaba Cloud SLS ListLogStores",
+    endpoint: target.endpoint,
+    project: target.project,
+    method: "GET",
+    path: "/logstores",
+    query,
+  });
+  const payload = requireResponseRecord(response.data, "ListLogStores response");
+  if (!Array.isArray(payload.logstores) || payload.logstores.some((value) => typeof value !== "string")) {
+    throw new ProviderRequestError(502, "ListLogStores returned invalid logstores");
+  }
+  const logstores = filterAliyunSlsLogstores(payload.logstores as string[], target.scopeEntry);
+  const total = target.scopeEntry?.logstores
+    ? logstores.length
+    : readResponseInteger(payload.total, logstores.length, "ListLogStores total");
+  return {
+    endpoint: target.endpoint,
+    project: target.project,
+    count: logstores.length,
+    total,
+    logstores,
+  };
+}
+
+async function queryLogs(
+  input: Record<string, unknown>,
+  context: AliyunSlsActionContext,
+): Promise<Record<string, unknown>> {
+  const target = resolveAliyunSlsLogstoreTarget(context.credential, input.endpoint, input.project, input.logstore);
+  const { from, to } = readQueryTimeRange(input);
+  const query: Record<string, string> = {
+    type: "log",
+    from: String(from),
+    to: String(to),
+    offset: String(readBoundedInteger(input.offset, "offset", 0, 0)),
+    line: String(readBoundedInteger(input.line, "line", maximumQueryLines, 0, maximumQueryLines)),
+    reverse: String(input.reverse === true),
+    powerSql: String(input.powerSql === true),
+  };
+  const queryStatement = optionalRawString(input.query);
+  if (queryStatement) query.query = queryStatement;
+  const response = await requestAliyunSlsJson(context, {
+    operation: "Alibaba Cloud SLS GetLogs",
+    endpoint: target.endpoint,
+    project: target.project,
+    method: "GET",
+    path: `/logstores/${encodeURIComponent(target.logstore)}`,
+    query,
+  });
+  const normalized = normalizeLogsResponse(response);
+  return {
+    endpoint: target.endpoint,
+    project: target.project,
+    logstore: target.logstore,
+    ...normalized,
+  };
+}
+
+async function getHistograms(
+  input: Record<string, unknown>,
+  context: AliyunSlsActionContext,
+): Promise<Record<string, unknown>> {
+  const target = resolveAliyunSlsLogstoreTarget(context.credential, input.endpoint, input.project, input.logstore);
+  const { from, to } = readQueryTimeRange(input);
+  const query: Record<string, string> = {
+    type: "histogram",
+    from: String(from),
+    to: String(to),
+  };
+  const queryStatement = optionalRawString(input.query);
+  if (queryStatement) query.query = queryStatement;
+  const response = await requestAliyunSlsJson(context, {
+    operation: "Alibaba Cloud SLS GetHistograms",
+    endpoint: target.endpoint,
+    project: target.project,
+    method: "GET",
+    path: `/logstores/${encodeURIComponent(target.logstore)}/index`,
+    query,
+  });
+  const histograms = normalizeHistograms(response.data);
+  return {
+    endpoint: target.endpoint,
+    project: target.project,
+    logstore: target.logstore,
+    progress: requireResponseHeader(response.headers, "x-log-progress", "GetHistograms progress"),
+    count: histograms.reduce((total, histogram) => total + histogram.count, 0),
+    histograms,
+  };
+}
+
+function normalizeProject(project: Record<string, unknown>, endpoint: string): Record<string, unknown> {
+  return {
+    endpoint,
+    projectName: requireResponseString(project.projectName, "Project projectName"),
+    region: requireResponseString(project.region, "Project region"),
+    description: responseString(project.description),
+    status: responseString(project.status),
+    createTime: responseString(project.createTime),
+    lastModifyTime: responseString(project.lastModifyTime),
+    resourceGroupId: responseNullableString(project.resourceGroupId),
+    dataRedundancyType: responseNullableString(project.dataRedundancyType),
+    recycleBinEnabled: optionalBoolean(project.recycleBinEnabled) ?? null,
+    internetEndpoint: responseNullableString(project.internetEndpoint),
+    internalEndpoint: responseNullableString(project.internalEndpoint),
+  };
+}
+
+function normalizeLogsResponse(response: AliyunSlsJsonResponse): Record<string, unknown> {
+  let logsValue = response.data;
+  let meta: Record<string, unknown> | undefined;
+  const record = optionalRecord(response.data);
+  if (record) {
+    logsValue = record.data;
+    meta = optionalRecord(record.meta);
+  }
+  const logs = requireResponseObjectArray(logsValue, "GetLogs data");
+  const progress =
+    optionalString(meta?.progress) ?? requireResponseHeader(response.headers, "x-log-progress", "GetLogs progress");
+  return {
+    progress,
+    count: readResponseInteger(meta?.count, logs.length, "GetLogs count"),
+    processedRows: readOptionalResponseInteger(meta?.processedRows ?? response.headers.get("x-log-processed-rows")),
+    elapsedMilliseconds: readOptionalResponseInteger(
+      meta?.elapsedMillisecond ?? response.headers.get("x-log-elapsed-millisecond"),
+    ),
+    hasSql: optionalBoolean(meta?.hasSQL) ?? readOptionalResponseBoolean(response.headers.get("x-log-has-sql")),
+    logs,
+  };
+}
+
+function normalizeHistograms(value: unknown): AliyunSlsHistogram[] {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, "GetHistograms returned invalid histogram data");
+  }
+  return value.map((item, index) => {
+    const record = requireResponseRecord(item, `GetHistograms histogram[${index}]`);
+    return {
+      from: readRequiredResponseInteger(record.from, `histogram[${index}].from`),
+      to: readRequiredResponseInteger(record.to, `histogram[${index}].to`),
+      count: readRequiredResponseInteger(record.count, `histogram[${index}].count`),
+      progress: requireResponseString(record.progress, `histogram[${index}].progress`),
+    };
+  });
+}
+
+function readQueryTimeRange(input: Record<string, unknown>): { from: number; to: number } {
+  const from = readRequiredInputInteger(input.from, "from");
+  const to = readRequiredInputInteger(input.to, "to");
+  if (from < 0 || to < 0) {
+    throw new ProviderRequestError(400, "from and to must be non-negative Unix timestamps in seconds");
+  }
+  if (from >= to) {
+    throw new ProviderRequestError(400, "to must be greater than from for the [from, to) query interval");
+  }
+  return { from, to };
+}
+
+function readBoundedInteger(
+  value: unknown,
+  fieldName: string,
+  defaultValue: number,
+  minimum: number,
+  maximum?: number,
+): number {
+  const resolved = value === undefined ? defaultValue : readRequiredInputInteger(value, fieldName);
+  if (resolved < minimum || (maximum !== undefined && resolved > maximum)) {
+    const range = maximum === undefined ? `at least ${minimum}` : `between ${minimum} and ${maximum}`;
+    throw new ProviderRequestError(400, `${fieldName} must be ${range}`);
+  }
+  return resolved;
+}
+
+function readRequiredInputInteger(value: unknown, fieldName: string): number {
+  const integer = optionalInteger(value);
+  if (integer === undefined) {
+    throw new ProviderRequestError(400, `${fieldName} must be an integer`);
+  }
+  return integer;
+}
+
+function readResponseInteger(value: unknown, fallback: number, fieldName: string): number {
+  if (value == null) return fallback;
+  return readRequiredResponseInteger(value, fieldName);
+}
+
+function readRequiredResponseInteger(value: unknown, fieldName: string): number {
+  try {
+    const resolved = optionalIntegerLike(value, fieldName);
+    if (resolved !== undefined && resolved >= 0) return resolved;
+  } catch {
+    // Normalize every malformed provider integer to the same protocol error.
+  }
+  throw new ProviderRequestError(502, `${fieldName} is not a non-negative integer`);
+}
+
+function readOptionalResponseInteger(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  try {
+    const resolved = optionalIntegerLike(value, "response integer");
+    return resolved !== undefined && resolved >= 0 ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function readOptionalResponseBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return null;
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+  return null;
+}
+
+function requireResponseRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  const record = optionalRecord(value);
+  if (!record) throw new ProviderRequestError(502, `${fieldName} is not an object`);
+  return record;
+}
+
+function requireResponseObjectArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, `${fieldName} is not an array`);
+  }
+  return value.map((item, index) => requireResponseRecord(item, `${fieldName}[${index}]`));
+}
+
+function requireResponseString(value: unknown, fieldName: string): string {
+  const resolved = optionalString(value);
+  if (!resolved) throw new ProviderRequestError(502, `${fieldName} is missing`);
+  return resolved;
+}
+
+function responseString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function responseNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function requireResponseHeader(headers: Headers, name: string, fieldName: string): string {
+  const value = optionalString(headers.get(name));
+  if (!value) throw new ProviderRequestError(502, `${fieldName} response header is missing`);
+  return value;
+}
+
+function createAliyunSlsResponseError(operation: string, response: Response, text: string): ProviderRequestError {
+  let details: unknown = text || undefined;
+  let errorCode: string | undefined;
+  let errorMessage: string | undefined;
+  if (text.trim()) {
+    try {
+      const payload = optionalRecord(JSON.parse(text) as unknown);
+      if (payload) {
+        details = payload;
+        errorCode = optionalString(payload.errorCode) ?? optionalString(payload.code);
+        errorMessage = optionalString(payload.errorMessage) ?? optionalString(payload.message);
+      }
+    } catch {
+      // The HTTP status remains authoritative when SLS returns a non-JSON error body.
+    }
+  }
+  const status = normalizeAliyunSlsErrorStatus(response.status, errorCode);
+  const providerMessage = [errorCode, errorMessage].filter(Boolean).join(": ");
+  return new ProviderRequestError(
+    status,
+    providerMessage ? `${operation} failed: ${providerMessage}` : `${operation} failed with HTTP ${response.status}`,
+    details,
+  );
+}
+
+function normalizeAliyunSlsErrorStatus(httpStatus: number, errorCode: string | undefined): number {
+  const code = errorCode?.toLowerCase() ?? "";
+  if (httpStatus === 429 || /throttl|too.?many|exceed.*quota|flow.?control/.test(code)) return 429;
+  if (/invalidaccesskey|signature.*match|missingaccesskey/.test(code)) return 401;
+  if (httpStatus === 401) return 401;
+  if (httpStatus === 403 || /unauthorized|permission|accessdenied|forbidden/.test(code)) return 403;
+  return httpStatus || 502;
+}
+
+function normalizeAliyunSlsRuntimeError(error: unknown, fallbackMessage: string): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  return new ProviderRequestError(502, error instanceof Error ? error.message : fallbackMessage);
+}
+
+function headersToRecord(value: HeadersInit | undefined): Record<string, string> {
+  return value ? Object.fromEntries(new Headers(value).entries()) : {};
+}
+
+function compareAscii(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+async function mapWithConcurrency<TInput, TOutput>(
+  inputs: TInput[],
+  concurrency: number,
+  worker: (input: TInput) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  const output = new Array<TOutput>(inputs.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, inputs.length) }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= inputs.length) return;
+      output[index] = await worker(inputs[index]!);
+    }
+  });
+  await Promise.all(workers);
+  return output;
+}

--- a/src/providers/aliyun_sls/runtime.ts
+++ b/src/providers/aliyun_sls/runtime.ts
@@ -1,15 +1,19 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 import type { AliyunSlsActionName } from "./actions.ts";
-import type { AliyunSlsCredential, AliyunSlsResourceScopeEntry } from "./resources.ts";
+import type { AliyunSlsCredential } from "./resources.ts";
 
 import { Buffer } from "node:buffer";
 import {
+  objectArray,
   optionalBoolean,
   optionalInteger,
   optionalIntegerLike,
   optionalRawString,
   optionalRecord,
   optionalString,
+  requiredRecord,
+  requiredString,
+  requiredStringArray,
 } from "../../core/cast.ts";
 import { providerUserAgent, ProviderRequestError, readProviderTextBody } from "../provider-runtime.ts";
 import {
@@ -18,6 +22,7 @@ import {
   filterAliyunSlsProjects,
   normalizeAliyunSlsEndpoint,
   normalizeAliyunSlsEndpointList,
+  normalizeAliyunSlsProjectName,
   parseAliyunSlsCredential,
   resolveAliyunSlsLogstoreTarget,
   resolveAliyunSlsProjectTarget,
@@ -28,6 +33,8 @@ const listProjectDefaultSize = 100;
 const listLogstoreDefaultSize = 200;
 const maximumListSize = 500;
 const maximumQueryLines = 100;
+const maximumPaginationPages = 20;
+const maximumPaginatedItems = maximumListSize * maximumPaginationPages;
 const regionalConcurrency = 5;
 
 export interface AliyunSlsActionContext {
@@ -53,12 +60,9 @@ export interface AliyunSlsJsonResponse {
   headers: Headers;
 }
 
-interface AliyunSlsProjectPage {
-  count: number;
+interface AliyunSlsPage<T> {
+  items: T[];
   total: number;
-  providerTotal: number;
-  rawCount: number;
-  projects: Array<Record<string, unknown>>;
 }
 
 interface AliyunSlsRegionSuccess {
@@ -136,7 +140,10 @@ export async function requestAliyunSlsJson(
   context: AliyunSlsActionContext,
   input: AliyunSlsRequestInput,
 ): Promise<AliyunSlsJsonResponse> {
-  const url = buildAliyunSlsRequestUrl(input.endpoint, input.project, input.path, input.query);
+  const endpoint = normalizeAliyunSlsEndpoint(input.endpoint);
+  const project =
+    input.project === undefined ? undefined : normalizeAliyunSlsProjectName(input.project, "request project");
+  const url = buildAliyunSlsRequestUrl(endpoint, project, input.path, input.query);
   const signed = signAliyunSlsRequest({
     method: input.method,
     path: input.path,
@@ -218,19 +225,32 @@ async function listProjects(
   const endpointInput = optionalString(input.endpoint);
   const endpoint = endpointInput ? normalizeAliyunSlsEndpoint(endpointInput) : context.credential.endpoint;
   const scopeEntries = assertAliyunSlsEndpointAllowed(context.credential.resourceScope, endpoint);
-  const page = await requestProjectPage(context, {
+  const offset = readBoundedInteger(input.offset, "offset", 0, 0);
+  const size = readBoundedInteger(input.size, "size", listProjectDefaultSize, 1, maximumListSize);
+  const queryOptions: AliyunSlsProjectQueryOptions = {
     endpoint,
-    offset: readBoundedInteger(input.offset, "offset", 0, 0),
-    size: readBoundedInteger(input.size, "size", listProjectDefaultSize, 1, maximumListSize),
     projectName: optionalString(input.projectName),
     resourceGroupId: optionalString(input.resourceGroupId),
-    scopeEntries,
-  });
+  };
+  let projects: Array<Record<string, unknown>>;
+  let total: number;
+  if (scopeEntries) {
+    const scopedProjects = filterAliyunSlsProjects(
+      await collectAllProjectsForEndpoint(context, queryOptions),
+      scopeEntries,
+    );
+    projects = scopedProjects.slice(offset, offset + size);
+    total = scopedProjects.length;
+  } else {
+    const page = await requestProjectPage(context, { ...queryOptions, offset, size });
+    projects = page.items;
+    total = page.total;
+  }
   return {
     endpoint,
-    count: page.count,
-    total: page.total,
-    projects: page.projects,
+    count: projects.length,
+    total,
+    projects,
   };
 }
 
@@ -263,8 +283,8 @@ async function listProjectsAcrossRegions(
   const uniqueProjects = new Map<string, Record<string, unknown>>();
   for (const success of successes) {
     for (const project of success.projects) {
-      const region = requireResponseString(project.region, "Project region");
-      const projectNameValue = requireResponseString(project.projectName, "Project name");
+      const region = requiredString(project.region, "Project region", badGateway);
+      const projectNameValue = requiredString(project.projectName, "Project name", badGateway);
       const key = `${region}\u0000${projectNameValue}`;
       if (!uniqueProjects.has(key)) uniqueProjects.set(key, project);
     }
@@ -291,37 +311,37 @@ async function listAllProjectsForEndpoint(
   resourceGroupId?: string,
 ): Promise<AliyunSlsRegionSuccess> {
   const scopeEntries = assertAliyunSlsEndpointAllowed(context.credential.resourceScope, endpoint);
-  const projects: Array<Record<string, unknown>> = [];
-  let offset = 0;
-  while (true) {
-    const page = await requestProjectPage(context, {
-      endpoint,
-      offset,
-      size: maximumListSize,
-      projectName,
-      resourceGroupId,
-      scopeEntries,
-    });
-    projects.push(...page.projects);
-    if (page.rawCount === 0 || offset + page.rawCount >= page.providerTotal) break;
-    offset += page.rawCount;
-  }
+  const projects = filterAliyunSlsProjects(
+    await collectAllProjectsForEndpoint(context, { endpoint, projectName, resourceGroupId }),
+    scopeEntries,
+  );
   return { endpoint, projects };
 }
 
-interface RequestProjectPageOptions {
+interface AliyunSlsProjectQueryOptions {
   endpoint: string;
-  offset: number;
-  size: number;
   projectName?: string;
   resourceGroupId?: string;
-  scopeEntries?: AliyunSlsResourceScopeEntry[];
+}
+
+interface RequestProjectPageOptions extends AliyunSlsProjectQueryOptions {
+  offset: number;
+  size: number;
+}
+
+async function collectAllProjectsForEndpoint(
+  context: AliyunSlsActionContext,
+  options: AliyunSlsProjectQueryOptions,
+): Promise<Array<Record<string, unknown>>> {
+  return collectAllAliyunSlsPages("ListProject", (offset, size) =>
+    requestProjectPage(context, { ...options, offset, size }),
+  );
 }
 
 async function requestProjectPage(
   context: AliyunSlsActionContext,
   options: RequestProjectPageOptions,
-): Promise<AliyunSlsProjectPage> {
+): Promise<AliyunSlsPage<Record<string, unknown>>> {
   const query: Record<string, string> = {
     offset: String(options.offset),
     size: String(options.size),
@@ -335,20 +355,19 @@ async function requestProjectPage(
     path: "/",
     query,
   });
-  const payload = requireResponseRecord(response.data, "ListProject response");
-  const rawProjects = requireResponseObjectArray(payload.projects, "ListProject projects");
-  const projects = filterAliyunSlsProjects(
-    rawProjects.map((project) => normalizeProject(project, options.endpoint)),
-    options.scopeEntries,
+  const payload = requiredRecord(response.data, "ListProject response", badGateway);
+  const rawProjects = objectArray(payload.projects, "ListProject projects", badGateway);
+  const page = validateAliyunSlsPage(
+    rawProjects,
+    payload.count,
+    payload.total,
+    "ListProject",
+    options.offset,
+    options.size,
   );
-  const rawCount = readResponseInteger(payload.count, rawProjects.length, "ListProject count");
-  const providerTotal = readResponseInteger(payload.total, rawCount, "ListProject total");
   return {
-    count: projects.length,
-    total: options.scopeEntries ? projects.length : providerTotal,
-    providerTotal,
-    rawCount,
-    projects,
+    items: page.items.map((project) => normalizeProject(project, options.endpoint)),
+    total: page.total,
   };
 }
 
@@ -357,28 +376,27 @@ async function listLogstores(
   context: AliyunSlsActionContext,
 ): Promise<Record<string, unknown>> {
   const target = resolveAliyunSlsProjectTarget(context.credential, input.endpoint, input.project);
-  const query: Record<string, string> = {
-    offset: String(readBoundedInteger(input.offset, "offset", 0, 0)),
-    size: String(readBoundedInteger(input.size, "size", listLogstoreDefaultSize, 1, maximumListSize)),
-  };
-  const logstoreName = optionalString(input.logstoreName);
-  if (logstoreName) query.logstoreName = logstoreName;
-  const response = await requestAliyunSlsJson(context, {
-    operation: "Alibaba Cloud SLS ListLogStores",
+  const offset = readBoundedInteger(input.offset, "offset", 0, 0);
+  const size = readBoundedInteger(input.size, "size", listLogstoreDefaultSize, 1, maximumListSize);
+  const queryOptions: AliyunSlsLogstoreQueryOptions = {
     endpoint: target.endpoint,
     project: target.project,
-    method: "GET",
-    path: "/logstores",
-    query,
-  });
-  const payload = requireResponseRecord(response.data, "ListLogStores response");
-  if (!Array.isArray(payload.logstores) || payload.logstores.some((value) => typeof value !== "string")) {
-    throw new ProviderRequestError(502, "ListLogStores returned invalid logstores");
+    logstoreName: optionalString(input.logstoreName),
+  };
+  let logstores: string[];
+  let total: number;
+  if (target.scopeEntry?.logstores) {
+    const scopedLogstores = filterAliyunSlsLogstores(
+      await collectAllLogstoresForProject(context, queryOptions),
+      target.scopeEntry,
+    );
+    logstores = scopedLogstores.slice(offset, offset + size);
+    total = scopedLogstores.length;
+  } else {
+    const page = await requestLogstorePage(context, { ...queryOptions, offset, size });
+    logstores = page.items;
+    total = page.total;
   }
-  const logstores = filterAliyunSlsLogstores(payload.logstores as string[], target.scopeEntry);
-  const total = target.scopeEntry?.logstores
-    ? logstores.length
-    : readResponseInteger(payload.total, logstores.length, "ListLogStores total");
   return {
     endpoint: target.endpoint,
     project: target.project,
@@ -386,6 +404,48 @@ async function listLogstores(
     total,
     logstores,
   };
+}
+
+interface AliyunSlsLogstoreQueryOptions {
+  endpoint: string;
+  project: string;
+  logstoreName?: string;
+}
+
+interface RequestLogstorePageOptions extends AliyunSlsLogstoreQueryOptions {
+  offset: number;
+  size: number;
+}
+
+async function collectAllLogstoresForProject(
+  context: AliyunSlsActionContext,
+  options: AliyunSlsLogstoreQueryOptions,
+): Promise<string[]> {
+  return collectAllAliyunSlsPages("ListLogStores", (offset, size) =>
+    requestLogstorePage(context, { ...options, offset, size }),
+  );
+}
+
+async function requestLogstorePage(
+  context: AliyunSlsActionContext,
+  options: RequestLogstorePageOptions,
+): Promise<AliyunSlsPage<string>> {
+  const query: Record<string, string> = {
+    offset: String(options.offset),
+    size: String(options.size),
+  };
+  if (options.logstoreName) query.logstoreName = options.logstoreName;
+  const response = await requestAliyunSlsJson(context, {
+    operation: "Alibaba Cloud SLS ListLogStores",
+    endpoint: options.endpoint,
+    project: options.project,
+    method: "GET",
+    path: "/logstores",
+    query,
+  });
+  const payload = requiredRecord(response.data, "ListLogStores response", badGateway);
+  const logstores = requiredStringArray(payload.logstores, "ListLogStores logstores", badGateway);
+  return validateAliyunSlsPage(logstores, payload.count, payload.total, "ListLogStores", options.offset, options.size);
 }
 
 async function queryLogs(
@@ -440,7 +500,7 @@ async function getHistograms(
     endpoint: target.endpoint,
     project: target.project,
     method: "GET",
-    path: `/logstores/${encodeURIComponent(target.logstore)}/index`,
+    path: `/logstores/${encodeURIComponent(target.logstore)}`,
     query,
   });
   const histograms = normalizeHistograms(response.data);
@@ -448,7 +508,7 @@ async function getHistograms(
     endpoint: target.endpoint,
     project: target.project,
     logstore: target.logstore,
-    progress: requireResponseHeader(response.headers, "x-log-progress", "GetHistograms progress"),
+    progress: requiredResponseHeader(response.headers, "x-log-progress", "GetHistograms progress"),
     count: histograms.reduce((total, histogram) => total + histogram.count, 0),
     histograms,
   };
@@ -457,8 +517,8 @@ async function getHistograms(
 function normalizeProject(project: Record<string, unknown>, endpoint: string): Record<string, unknown> {
   return {
     endpoint,
-    projectName: requireResponseString(project.projectName, "Project projectName"),
-    region: requireResponseString(project.region, "Project region"),
+    projectName: requiredString(project.projectName, "Project projectName", badGateway),
+    region: requiredString(project.region, "Project region", badGateway),
     description: responseString(project.description),
     status: responseString(project.status),
     createTime: responseString(project.createTime),
@@ -479,9 +539,9 @@ function normalizeLogsResponse(response: AliyunSlsJsonResponse): Record<string, 
     logsValue = record.data;
     meta = optionalRecord(record.meta);
   }
-  const logs = requireResponseObjectArray(logsValue, "GetLogs data");
+  const logs = objectArray(logsValue, "GetLogs data", badGateway);
   const progress =
-    optionalString(meta?.progress) ?? requireResponseHeader(response.headers, "x-log-progress", "GetLogs progress");
+    optionalString(meta?.progress) ?? requiredResponseHeader(response.headers, "x-log-progress", "GetLogs progress");
   return {
     progress,
     count: readResponseInteger(meta?.count, logs.length, "GetLogs count"),
@@ -495,16 +555,12 @@ function normalizeLogsResponse(response: AliyunSlsJsonResponse): Record<string, 
 }
 
 function normalizeHistograms(value: unknown): AliyunSlsHistogram[] {
-  if (!Array.isArray(value)) {
-    throw new ProviderRequestError(502, "GetHistograms returned invalid histogram data");
-  }
-  return value.map((item, index) => {
-    const record = requireResponseRecord(item, `GetHistograms histogram[${index}]`);
+  return objectArray(value, "GetHistograms histogram data", badGateway).map((record, index) => {
     return {
       from: readRequiredResponseInteger(record.from, `histogram[${index}].from`),
       to: readRequiredResponseInteger(record.to, `histogram[${index}].to`),
       count: readRequiredResponseInteger(record.count, `histogram[${index}].count`),
-      progress: requireResponseString(record.progress, `histogram[${index}].progress`),
+      progress: requiredString(record.progress, `histogram[${index}].progress`, badGateway),
     };
   });
 }
@@ -577,25 +633,6 @@ function readOptionalResponseBoolean(value: unknown): boolean | null {
   return null;
 }
 
-function requireResponseRecord(value: unknown, fieldName: string): Record<string, unknown> {
-  const record = optionalRecord(value);
-  if (!record) throw new ProviderRequestError(502, `${fieldName} is not an object`);
-  return record;
-}
-
-function requireResponseObjectArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
-  if (!Array.isArray(value)) {
-    throw new ProviderRequestError(502, `${fieldName} is not an array`);
-  }
-  return value.map((item, index) => requireResponseRecord(item, `${fieldName}[${index}]`));
-}
-
-function requireResponseString(value: unknown, fieldName: string): string {
-  const resolved = optionalString(value);
-  if (!resolved) throw new ProviderRequestError(502, `${fieldName} is missing`);
-  return resolved;
-}
-
 function responseString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
@@ -604,10 +641,61 @@ function responseNullableString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function requireResponseHeader(headers: Headers, name: string, fieldName: string): string {
-  const value = optionalString(headers.get(name));
-  if (!value) throw new ProviderRequestError(502, `${fieldName} response header is missing`);
-  return value;
+function requiredResponseHeader(headers: Headers, name: string, fieldName: string): string {
+  return requiredString(headers.get(name), `${fieldName} response header`, badGateway);
+}
+
+function validateAliyunSlsPage<T>(
+  items: T[],
+  countValue: unknown,
+  totalValue: unknown,
+  operation: string,
+  offset: number,
+  requestedSize: number,
+): AliyunSlsPage<T> {
+  const count = readRequiredResponseInteger(countValue, `${operation} count`);
+  const total = readRequiredResponseInteger(totalValue, `${operation} total`);
+  if (count > requestedSize) {
+    throw badGateway(`${operation} count ${count} exceeds requested size ${requestedSize}`);
+  }
+  if (count !== items.length) {
+    throw badGateway(`${operation} count ${count} does not match the ${items.length} returned items`);
+  }
+  if (count > 0 && offset + count > total) {
+    throw badGateway(`${operation} page exceeds its reported total ${total}`);
+  }
+  if (count === 0 && offset < total) {
+    throw badGateway(`${operation} returned an empty page before its reported total ${total} was reached`);
+  }
+  return { items, total };
+}
+
+async function collectAllAliyunSlsPages<T>(
+  operation: string,
+  requestPage: (offset: number, size: number) => Promise<AliyunSlsPage<T>>,
+): Promise<T[]> {
+  const items: T[] = [];
+  let expectedTotal: number | undefined;
+  for (let pageNumber = 0; pageNumber < maximumPaginationPages; pageNumber += 1) {
+    const page = await requestPage(items.length, maximumListSize);
+    if (expectedTotal === undefined) {
+      expectedTotal = page.total;
+      if (expectedTotal > maximumPaginatedItems) {
+        throw badGateway(`${operation} total ${expectedTotal} exceeds the ${maximumPaginatedItems} item limit`);
+      }
+    } else if (page.total !== expectedTotal) {
+      throw badGateway(`${operation} total changed from ${expectedTotal} to ${page.total} during pagination`);
+    }
+    items.push(...page.items);
+    if (items.length === expectedTotal) {
+      return items;
+    }
+  }
+  throw badGateway(`${operation} exceeded the ${maximumPaginationPages} page pagination limit`);
+}
+
+function badGateway(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
 }
 
 function createAliyunSlsResponseError(operation: string, response: Response, text: string): ProviderRequestError {

--- a/src/providers/aliyun_sls/runtime.ts
+++ b/src/providers/aliyun_sls/runtime.ts
@@ -115,21 +115,13 @@ export function createAliyunSlsContext(
   };
 }
 
-export async function validateAliyunSlsCredential(
-  values: Record<string, string>,
-  fetcher: typeof fetch,
-  signal?: AbortSignal,
-): Promise<CredentialValidationResult> {
-  const context = createAliyunSlsContext(values, fetcher, signal);
-  await requestProjectPage(context, {
-    endpoint: context.credential.endpoint,
-    offset: 0,
-    size: 1,
-  });
+/** Validate local credential structure without requiring a provider-wide RAM permission. */
+export function validateAliyunSlsCredential(values: Record<string, string>): CredentialValidationResult {
+  const credential = parseAliyunSlsCredential(values);
   return {
     profile: {
-      accountId: context.credential.accessKeyId,
-      displayName: `${context.credential.accessKeyId}@${context.credential.endpoint}`,
+      accountId: credential.accessKeyId,
+      displayName: `${credential.accessKeyId}@${credential.endpoint}`,
     },
     grantedScopes: [],
   };
@@ -161,6 +153,7 @@ export async function requestAliyunSlsJson(
   const requestInit: RequestInit = {
     method: input.method,
     headers: signed.headers,
+    redirect: "error",
     signal: context.signal,
   };
   if (signed.bodyBytes.byteLength > 0) {

--- a/src/providers/aliyun_sls/signing.test.ts
+++ b/src/providers/aliyun_sls/signing.test.ts
@@ -12,6 +12,7 @@ describe("Alibaba Cloud SLS request signing", () => {
         offset: "0",
       },
       headers: {
+        "x-log-date": "stale-proxy-date",
         "x-log-zeta": "z",
       },
       credential: {
@@ -37,6 +38,7 @@ describe("Alibaba Cloud SLS request signing", () => {
     expect(signed.contentMd5).toBeUndefined();
     expect(signed.signature).toBe("nuyu9oBaK4Q7R7/zSDoCjKepUok=");
     expect(signed.headers.get("authorization")).toBe("LOG testAccessKeyId:nuyu9oBaK4Q7R7/zSDoCjKepUok=");
+    expect(signed.headers.get("x-log-date")).toBe("Mon, 03 Jan 2022 04:05:06 GMT");
     expect(signed.headers.get("content-md5")).toBeNull();
   });
 

--- a/src/providers/aliyun_sls/signing.test.ts
+++ b/src/providers/aliyun_sls/signing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { aliyunSlsUtf8Bytes, buildAliyunSlsCanonicalResource, signAliyunSlsRequest } from "./signing.ts";
+
+describe("Alibaba Cloud SLS request signing", () => {
+  it("signs a GET request with sorted query parameters and canonical headers", () => {
+    const signed = signAliyunSlsRequest({
+      method: "GET",
+      path: "/logstores/example",
+      query: {
+        size: "100",
+        logstoreName: "",
+        offset: "0",
+      },
+      headers: {
+        "x-log-zeta": "z",
+      },
+      credential: {
+        accessKeyId: "testAccessKeyId",
+        accessKeySecret: "testAccessKeySecret",
+      },
+      date: new Date("2022-01-03T04:05:06Z"),
+    });
+
+    expect(signed.canonicalString).toBe(
+      [
+        "GET",
+        "",
+        "",
+        "Mon, 03 Jan 2022 04:05:06 GMT",
+        "x-log-apiversion:0.6.0",
+        "x-log-bodyrawsize:0",
+        "x-log-signaturemethod:hmac-sha1",
+        "x-log-zeta:z",
+        "/logstores/example?logstoreName=&offset=0&size=100",
+      ].join("\n"),
+    );
+    expect(signed.contentMd5).toBeUndefined();
+    expect(signed.signature).toBe("nuyu9oBaK4Q7R7/zSDoCjKepUok=");
+    expect(signed.headers.get("authorization")).toBe("LOG testAccessKeyId:nuyu9oBaK4Q7R7/zSDoCjKepUok=");
+    expect(signed.headers.get("content-md5")).toBeNull();
+  });
+
+  it("signs a POST from the final UTF-8 body bytes and includes an STS token", () => {
+    const bodyBytes = aliyunSlsUtf8Bytes('{"query":"状态"}');
+    const signed = signAliyunSlsRequest({
+      method: "POST",
+      path: "/logstores/example/logs",
+      query: { z: "last", a: "first" },
+      headers: {
+        "content-type": "application/json",
+        "x-log-alpha": "a",
+      },
+      bodyBytes,
+      credential: {
+        accessKeyId: "temporaryAccessKey",
+        accessKeySecret: "temporarySecret",
+        securityToken: "token-value",
+      },
+      date: new Date("2022-01-04T05:06:07Z"),
+    });
+
+    expect(signed.contentMd5).toBe("EF2643B9A23580637AD32EAE4284DD9C");
+    expect(signed.headers.get("x-log-bodyrawsize")).toBe("18");
+    expect(signed.headers.get("x-acs-security-token")).toBe("token-value");
+    expect(signed.canonicalString).toBe(
+      [
+        "POST",
+        "EF2643B9A23580637AD32EAE4284DD9C",
+        "application/json",
+        "Tue, 04 Jan 2022 05:06:07 GMT",
+        "x-acs-security-token:token-value",
+        "x-log-alpha:a",
+        "x-log-apiversion:0.6.0",
+        "x-log-bodyrawsize:18",
+        "x-log-signaturemethod:hmac-sha1",
+        "/logstores/example/logs?a=first&z=last",
+      ].join("\n"),
+    );
+    expect(signed.signature).toBe("qW8T7QYAGXU2xqy+puNpJs18sj4=");
+  });
+
+  it("sorts canonical query keys without URL-encoding their values", () => {
+    expect(buildAliyunSlsCanonicalResource("/", { z: "a b", a: "x/y" })).toBe("/?a=x/y&z=a b");
+  });
+});

--- a/src/providers/aliyun_sls/signing.ts
+++ b/src/providers/aliyun_sls/signing.ts
@@ -33,6 +33,7 @@ export function signAliyunSlsRequest(input: SignAliyunSlsRequestInput): SignedAl
   const headers = new Headers(input.headers);
   const date = input.date.toUTCString();
   headers.set("date", date);
+  headers.delete("x-log-date");
   headers.set("x-log-apiversion", aliyunSlsApiVersion);
   headers.set("x-log-signaturemethod", aliyunSlsSignatureMethod);
   headers.set("x-log-bodyrawsize", String(bodyBytes.byteLength));
@@ -61,6 +62,8 @@ export function signAliyunSlsRequest(input: SignAliyunSlsRequestInput): SignedAl
     .update(canonicalString, "utf8")
     .digest("base64");
   headers.set("authorization", `LOG ${input.credential.accessKeyId}:${signature}`);
+  // Official V1 SDKs add this after signing as a fallback for proxies that drop Date.
+  headers.set("x-log-date", date);
 
   const result: SignedAliyunSlsRequest = {
     headers,

--- a/src/providers/aliyun_sls/signing.ts
+++ b/src/providers/aliyun_sls/signing.ts
@@ -1,0 +1,116 @@
+import { createHash, createHmac } from "node:crypto";
+
+export interface AliyunSlsSigningCredential {
+  accessKeyId: string;
+  accessKeySecret: string;
+  securityToken?: string;
+}
+
+export interface SignAliyunSlsRequestInput {
+  method: string;
+  path: string;
+  credential: AliyunSlsSigningCredential;
+  date: Date;
+  query?: Record<string, string>;
+  headers?: HeadersInit;
+  bodyBytes?: Uint8Array;
+}
+
+export interface SignedAliyunSlsRequest {
+  headers: Headers;
+  bodyBytes: Uint8Array;
+  canonicalString: string;
+  signature: string;
+  contentMd5?: string;
+}
+
+export const aliyunSlsApiVersion = "0.6.0";
+export const aliyunSlsSignatureMethod = "hmac-sha1";
+
+/** Sign the exact bytes and request fields that will be sent to Simple Log Service. */
+export function signAliyunSlsRequest(input: SignAliyunSlsRequestInput): SignedAliyunSlsRequest {
+  const bodyBytes = input.bodyBytes ?? new Uint8Array();
+  const headers = new Headers(input.headers);
+  const date = input.date.toUTCString();
+  headers.set("date", date);
+  headers.set("x-log-apiversion", aliyunSlsApiVersion);
+  headers.set("x-log-signaturemethod", aliyunSlsSignatureMethod);
+  headers.set("x-log-bodyrawsize", String(bodyBytes.byteLength));
+
+  if (input.credential.securityToken) {
+    headers.set("x-acs-security-token", input.credential.securityToken);
+  } else {
+    headers.delete("x-acs-security-token");
+  }
+
+  let contentMd5: string | undefined;
+  if (bodyBytes.byteLength > 0) {
+    contentMd5 = createHash("md5").update(bodyBytes).digest("hex").toUpperCase();
+    headers.set("content-md5", contentMd5);
+  } else {
+    headers.delete("content-md5");
+  }
+
+  const canonicalString = buildAliyunSlsCanonicalString({
+    method: input.method,
+    path: input.path,
+    query: input.query,
+    headers,
+  });
+  const signature = createHmac("sha1", input.credential.accessKeySecret)
+    .update(canonicalString, "utf8")
+    .digest("base64");
+  headers.set("authorization", `LOG ${input.credential.accessKeyId}:${signature}`);
+
+  const result: SignedAliyunSlsRequest = {
+    headers,
+    bodyBytes,
+    canonicalString,
+    signature,
+  };
+  if (contentMd5) result.contentMd5 = contentMd5;
+  return result;
+}
+
+export interface BuildAliyunSlsCanonicalStringInput {
+  method: string;
+  path: string;
+  query?: Record<string, string>;
+  headers: Headers;
+}
+
+/** Build the SLS v1 canonical message without URL-encoding query values. */
+export function buildAliyunSlsCanonicalString(input: BuildAliyunSlsCanonicalStringInput): string {
+  const method = input.method.toUpperCase();
+  const contentMd5 = input.headers.get("content-md5") ?? "";
+  const contentType = input.headers.get("content-type") ?? "";
+  const date = input.headers.get("date") ?? "";
+  const canonicalHeaders = [...input.headers.entries()]
+    .filter(([name]) => isAliyunSlsCanonicalHeader(name))
+    .sort(([left], [right]) => compareAscii(left, right))
+    .map(([name, value]) => `${name.toLowerCase()}:${value.trim()}\n`)
+    .join("");
+  const canonicalResource = buildAliyunSlsCanonicalResource(input.path, input.query);
+  return `${method}\n${contentMd5}\n${contentType}\n${date}\n${canonicalHeaders}${canonicalResource}`;
+}
+
+export function buildAliyunSlsCanonicalResource(path: string, query?: Record<string, string>): string {
+  const entries = Object.entries(query ?? {}).sort(([left], [right]) => compareAscii(left, right));
+  if (entries.length === 0) {
+    return path;
+  }
+  return `${path}?${entries.map(([key, value]) => `${key}=${value}`).join("&")}`;
+}
+
+export function aliyunSlsUtf8Bytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function isAliyunSlsCanonicalHeader(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return normalized.startsWith("x-log-") || normalized.startsWith("x-acs-");
+}
+
+function compareAscii(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- add a complete, locally executable Alibaba Cloud SLS provider
- implement signed Project and Logstore discovery, log and histogram queries, and bounded multi-region Project aggregation
- enforce public HTTPS endpoints and connector-local resourceScope allowlists with deterministic resource inference
- include focused signing, runtime, resource-scope tests, and a runnable query example

## Testing

- npm run generate:catalog
- npx vitest run src/providers/aliyun_sls/signing.test.ts src/providers/aliyun_sls/resources.test.ts src/providers/aliyun_sls/runtime.test.ts
- RAYON_NUM_THREADS=1 npm run fix-check