### PR TITLE
feat: add Oracle Cloud provider

### DIFF
--- a/src/providers/oracle_cloud/actions.ts
+++ b/src/providers/oracle_cloud/actions.ts
@@ -31,7 +31,8 @@ const listMetadata = {
   nextPage: s.nullableString("Token for the next page, or null."),
 };
 
-function input(description: string, properties: Record<string, JsonSchema>, optional: string[] = []): JsonSchema {
+/** Every call must name its optional properties; `s.object` treats an empty list as "all required". */
+function input(description: string, properties: Record<string, JsonSchema>, optional: string[]): JsonSchema {
   return s.object(description, properties, { optional });
 }
 
@@ -202,11 +203,15 @@ export const oracleCloudActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "create_vcn",
     description: "Create a virtual cloud network.",
-    inputSchema: input("VCN creation.", {
-      compartmentId,
-      cidrBlock: s.nonEmptyString("IPv4 CIDR block."),
-      displayName: s.nonEmptyString("VCN display name."),
-    }),
+    inputSchema: input(
+      "VCN creation.",
+      {
+        compartmentId,
+        cidrBlock: s.nonEmptyString("IPv4 CIDR block."),
+        displayName: s.nonEmptyString("VCN display name."),
+      },
+      ["compartmentId"],
+    ),
     outputSchema: entityOutput("vcn"),
   }),
   defineProviderAction(service, {
@@ -229,12 +234,16 @@ export const oracleCloudActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "create_subnet",
     description: "Create a subnet in a VCN.",
-    inputSchema: input("Subnet creation.", {
-      vcnId: ocid("VCN OCID."),
-      compartmentId,
-      cidrBlock: s.nonEmptyString("Subnet IPv4 CIDR block."),
-      displayName: s.nonEmptyString("Subnet display name."),
-    }),
+    inputSchema: input(
+      "Subnet creation.",
+      {
+        vcnId: ocid("VCN OCID."),
+        compartmentId,
+        cidrBlock: s.nonEmptyString("Subnet IPv4 CIDR block."),
+        displayName: s.nonEmptyString("Subnet display name."),
+      },
+      ["compartmentId"],
+    ),
     outputSchema: entityOutput("subnet"),
   }),
   defineProviderAction(service, {
@@ -349,7 +358,8 @@ export const oracleCloudActions: ActionDefinition[] = [
         compartmentIdInSubtree: s.boolean("Traverse the entire tenancy subtree."),
         accessLevel: s.stringEnum("Permission filtering mode.", ["ANY", "ACCESSIBLE"]),
         includeRoot: s.boolean({
-          description: "Include the tenancy root compartment on the first page.",
+          description:
+            "Include the tenancy root compartment on the first page. Applies only when listing the tenancy itself.",
           default: true,
         }),
         ...pagination,

--- a/src/providers/oracle_cloud/actions.ts
+++ b/src/providers/oracle_cloud/actions.ts
@@ -1,0 +1,428 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "oracle_cloud";
+
+export const oracleInstanceActions: string[] = [
+  "START",
+  "STOP",
+  "RESET",
+  "SOFTSTOP",
+  "SOFTRESET",
+  "SENDDIAGNOSTICINTERRUPT",
+  "DIAGNOSTICREBOOT",
+  "REBOOTMIGRATE",
+];
+
+const ocid = (description: string): JsonSchema => s.nonEmptyString(description);
+const compartmentId = ocid("Compartment or tenancy OCID. Defaults to the connection's default compartment.");
+const instanceId = ocid("Compute instance OCID.");
+const page = s.nonEmptyString("Opaque OCI pagination token.");
+const limit = s.integer("Maximum resources to return.", { minimum: 1, maximum: 1_000 });
+const resource = s.looseObject("OCI resource. Additional official response fields are preserved.");
+const requestMetadata = {
+  opcRequestId: s.nullableString("Oracle request identifier."),
+};
+const listMetadata = {
+  ...requestMetadata,
+  nextPage: s.nullableString("Token for the next page, or null."),
+};
+
+function input(description: string, properties: Record<string, JsonSchema>, optional: string[] = []): JsonSchema {
+  return s.object(description, properties, { optional });
+}
+
+function entityOutput(name: string): JsonSchema {
+  return s.requiredObject(`OCI ${name} response.`, { [name]: resource, ...requestMetadata });
+}
+
+function listOutput(name: string): JsonSchema {
+  return s.requiredObject(`OCI ${name} list response.`, {
+    [name]: s.array(`Returned ${name}.`, resource),
+    ...listMetadata,
+  });
+}
+
+function responseOutput(description: string): JsonSchema {
+  return s.requiredObject(description, {
+    status: s.integer("HTTP response status."),
+    ...requestMetadata,
+  });
+}
+
+const pagination = { limit, page };
+
+export const oracleCloudActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_instances",
+    description: "List OCI compute instances in a compartment.",
+    inputSchema: input(
+      "Instance filters.",
+      {
+        compartmentId,
+        lifecycleState: s.stringEnum("Instance lifecycle state.", [
+          "MOVING",
+          "PROVISIONING",
+          "RUNNING",
+          "STARTING",
+          "STOPPING",
+          "STOPPED",
+          "CREATING_IMAGE",
+          "TERMINATING",
+          "TERMINATED",
+        ]),
+        ...pagination,
+      },
+      ["compartmentId", "lifecycleState", "limit", "page"],
+    ),
+    outputSchema: listOutput("instances"),
+    followUpActions: ["oracle_cloud.get_instance", "oracle_cloud.list_vnic_attachments"],
+  }),
+  defineProviderAction(service, {
+    name: "get_instance",
+    description: "Get a compute instance by OCID.",
+    inputSchema: s.requiredObject("Instance lookup.", { instanceId }),
+    outputSchema: entityOutput("instance"),
+    followUpActions: ["oracle_cloud.instance_action", "oracle_cloud.list_vnic_attachments"],
+  }),
+  defineProviderAction(service, {
+    name: "launch_instance",
+    description: "Launch a compute instance from an image in a subnet.",
+    inputSchema: input(
+      "Instance launch details.",
+      {
+        compartmentId,
+        displayName: s.nonEmptyString("Instance display name."),
+        availabilityDomain: s.nonEmptyString("Availability domain name."),
+        subnetId: ocid("Primary VNIC subnet OCID."),
+        imageId: ocid("Boot image OCID."),
+        shape: s.nonEmptyString("Compute shape name."),
+        ocpus: s.positiveInteger("OCPU count for a flexible shape."),
+        memoryInGBs: s.number("Memory in GB for a flexible shape.", { minimum: 1 }),
+      },
+      ["compartmentId", "shape", "ocpus", "memoryInGBs"],
+    ),
+    outputSchema: entityOutput("instance"),
+    followUpActions: ["oracle_cloud.get_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "terminate_instance",
+    description: "Permanently terminate a compute instance. This destructive operation cannot be undone.",
+    inputSchema: s.requiredObject("Instance termination.", { instanceId }),
+    outputSchema: responseOutput("Instance termination response."),
+  }),
+  defineProviderAction(service, {
+    name: "update_instance",
+    description: "Update flexible shape resources for an instance; OCI may restart the instance.",
+    inputSchema: input(
+      "Instance shape update.",
+      {
+        instanceId,
+        ocpus: s.positiveInteger("New OCPU count."),
+        memoryInGBs: s.number("New memory in GB.", { minimum: 1 }),
+      },
+      ["ocpus", "memoryInGBs"],
+    ),
+    outputSchema: entityOutput("instance"),
+  }),
+  defineProviderAction(service, {
+    name: "list_images",
+    description: "List compute images, optionally filtered by operating system.",
+    inputSchema: input(
+      "Image filters.",
+      {
+        compartmentId,
+        operatingSystem: s.nonEmptyString("Operating system name."),
+        ...pagination,
+      },
+      ["compartmentId", "operatingSystem", "limit", "page"],
+    ),
+    outputSchema: listOutput("images"),
+    followUpActions: ["oracle_cloud.get_image", "oracle_cloud.launch_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "get_image",
+    description: "Get a compute image by OCID.",
+    inputSchema: s.requiredObject("Image lookup.", { imageId: ocid("Image OCID.") }),
+    outputSchema: entityOutput("image"),
+  }),
+  defineProviderAction(service, {
+    name: "instance_action",
+    description: "Perform one of the instance actions exposed by Oracle's official Compute MCP server.",
+    inputSchema: s.requiredObject("Instance action.", {
+      instanceId,
+      action: s.stringEnum("Action to perform.", oracleInstanceActions),
+    }),
+    outputSchema: entityOutput("instance"),
+    followUpActions: ["oracle_cloud.get_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_vnic_attachments",
+    description: "List VNIC attachments in a compartment, optionally for one instance.",
+    inputSchema: input("VNIC attachment filters.", { compartmentId, instanceId, ...pagination }, [
+      "compartmentId",
+      "instanceId",
+      "limit",
+      "page",
+    ]),
+    outputSchema: listOutput("vnicAttachments"),
+    followUpActions: ["oracle_cloud.get_vnic_attachment", "oracle_cloud.get_vnic"],
+  }),
+  defineProviderAction(service, {
+    name: "get_vnic_attachment",
+    description: "Get a VNIC attachment by OCID.",
+    inputSchema: s.requiredObject("VNIC attachment lookup.", {
+      vnicAttachmentId: ocid("VNIC attachment OCID."),
+    }),
+    outputSchema: entityOutput("vnicAttachment"),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_vcns",
+    description: "List virtual cloud networks in a compartment.",
+    inputSchema: input("VCN filters.", { compartmentId, ...pagination }, ["compartmentId", "limit", "page"]),
+    outputSchema: listOutput("vcns"),
+    followUpActions: ["oracle_cloud.get_vcn", "oracle_cloud.list_subnets"],
+  }),
+  defineProviderAction(service, {
+    name: "get_vcn",
+    description: "Get a virtual cloud network by OCID.",
+    inputSchema: s.requiredObject("VCN lookup.", { vcnId: ocid("VCN OCID.") }),
+    outputSchema: entityOutput("vcn"),
+  }),
+  defineProviderAction(service, {
+    name: "delete_vcn",
+    description: "Permanently delete an empty VCN. This is destructive.",
+    inputSchema: s.requiredObject("VCN deletion.", { vcnId: ocid("VCN OCID.") }),
+    outputSchema: responseOutput("VCN deletion response."),
+  }),
+  defineProviderAction(service, {
+    name: "create_vcn",
+    description: "Create a virtual cloud network.",
+    inputSchema: input("VCN creation.", {
+      compartmentId,
+      cidrBlock: s.nonEmptyString("IPv4 CIDR block."),
+      displayName: s.nonEmptyString("VCN display name."),
+    }),
+    outputSchema: entityOutput("vcn"),
+  }),
+  defineProviderAction(service, {
+    name: "list_subnets",
+    description: "List subnets in a compartment, optionally filtered by VCN.",
+    inputSchema: input("Subnet filters.", { compartmentId, vcnId: ocid("VCN OCID."), ...pagination }, [
+      "compartmentId",
+      "vcnId",
+      "limit",
+      "page",
+    ]),
+    outputSchema: listOutput("subnets"),
+  }),
+  defineProviderAction(service, {
+    name: "get_subnet",
+    description: "Get a subnet by OCID.",
+    inputSchema: s.requiredObject("Subnet lookup.", { subnetId: ocid("Subnet OCID.") }),
+    outputSchema: entityOutput("subnet"),
+  }),
+  defineProviderAction(service, {
+    name: "create_subnet",
+    description: "Create a subnet in a VCN.",
+    inputSchema: input("Subnet creation.", {
+      vcnId: ocid("VCN OCID."),
+      compartmentId,
+      cidrBlock: s.nonEmptyString("Subnet IPv4 CIDR block."),
+      displayName: s.nonEmptyString("Subnet display name."),
+    }),
+    outputSchema: entityOutput("subnet"),
+  }),
+  defineProviderAction(service, {
+    name: "list_security_lists",
+    description: "List security lists in a compartment, optionally filtered by VCN.",
+    inputSchema: input("Security list filters.", { compartmentId, vcnId: ocid("VCN OCID."), ...pagination }, [
+      "compartmentId",
+      "vcnId",
+      "limit",
+      "page",
+    ]),
+    outputSchema: listOutput("securityLists"),
+  }),
+  defineProviderAction(service, {
+    name: "get_security_list",
+    description: "Get a security list by OCID.",
+    inputSchema: s.requiredObject("Security list lookup.", {
+      securityListId: ocid("Security list OCID."),
+    }),
+    outputSchema: entityOutput("securityList"),
+  }),
+  defineProviderAction(service, {
+    name: "list_network_security_groups",
+    description: "List network security groups, optionally filtered by VCN or VLAN.",
+    inputSchema: input(
+      "Network security group filters.",
+      {
+        compartmentId,
+        vcnId: ocid("VCN OCID."),
+        vlanId: ocid("VLAN OCID."),
+        ...pagination,
+      },
+      ["compartmentId", "vcnId", "vlanId", "limit", "page"],
+    ),
+    outputSchema: listOutput("networkSecurityGroups"),
+  }),
+  defineProviderAction(service, {
+    name: "get_network_security_group",
+    description: "Get a network security group by OCID.",
+    inputSchema: s.requiredObject("Network security group lookup.", {
+      networkSecurityGroupId: ocid("Network security group OCID."),
+    }),
+    outputSchema: entityOutput("networkSecurityGroup"),
+  }),
+  defineProviderAction(service, {
+    name: "get_vnic",
+    description: "Get a VNIC and its assigned IP addresses by OCID.",
+    inputSchema: s.requiredObject("VNIC lookup.", { vnicId: ocid("VNIC OCID.") }),
+    outputSchema: entityOutput("vnic"),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_alarms",
+    description: "List Monitoring alarms in a compartment.",
+    inputSchema: input("Alarm filters.", { compartmentId, ...pagination }, ["compartmentId", "limit", "page"]),
+    outputSchema: listOutput("alarms"),
+  }),
+  defineProviderAction(service, {
+    name: "list_metric_definitions",
+    description: "List available OCI Monitoring metric definitions.",
+    inputSchema: input(
+      "Metric definition filters.",
+      {
+        compartmentId,
+        groupBy: s.array("Fields to group by.", s.stringEnum(["namespace", "name", "resourceGroup"])),
+        metricName: s.nonEmptyString("Metric name."),
+        namespace: s.nonEmptyString("Metric namespace."),
+        resourceGroup: s.nonEmptyString("Metric resource group."),
+        compartmentIdInSubtree: s.boolean("Search subcompartments."),
+        ...pagination,
+      },
+      [
+        "compartmentId",
+        "groupBy",
+        "metricName",
+        "namespace",
+        "resourceGroup",
+        "compartmentIdInSubtree",
+        "limit",
+        "page",
+      ],
+    ),
+    outputSchema: listOutput("metrics"),
+  }),
+  defineProviderAction(service, {
+    name: "get_metrics_data",
+    description: "Retrieve aggregated OCI Monitoring metric data using an MQL expression.",
+    inputSchema: input(
+      "Metric query.",
+      {
+        compartmentId,
+        query: s.nonEmptyString("Monitoring Query Language expression."),
+        namespace: s.nonEmptyString("Metric namespace."),
+        startTime: s.dateTime("Inclusive RFC3339 start time; defaults to three hours ago."),
+        endTime: s.dateTime("Exclusive RFC3339 end time; defaults to now."),
+        resourceGroup: s.nonEmptyString("Metric resource group."),
+        resolution: s.nonEmptyString("Aggregation resolution, such as 1m or 1h."),
+        compartmentIdInSubtree: s.boolean("Search subcompartments."),
+      },
+      ["compartmentId", "startTime", "endTime", "resourceGroup", "resolution", "compartmentIdInSubtree"],
+    ),
+    outputSchema: listOutput("metricData"),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_compartments",
+    description: "List child compartments, optionally traversing the tenancy subtree.",
+    inputSchema: input(
+      "Compartment filters.",
+      {
+        compartmentId,
+        compartmentIdInSubtree: s.boolean("Traverse the entire tenancy subtree."),
+        accessLevel: s.stringEnum("Permission filtering mode.", ["ANY", "ACCESSIBLE"]),
+        includeRoot: s.boolean("Include the tenancy root compartment."),
+        ...pagination,
+      },
+      ["compartmentId", "compartmentIdInSubtree", "accessLevel", "includeRoot", "limit", "page"],
+    ),
+    outputSchema: listOutput("compartments"),
+  }),
+  defineProviderAction(service, {
+    name: "get_tenancy",
+    description: "Get a tenancy by OCID.",
+    inputSchema: s.requiredObject("Tenancy lookup.", { tenancyId: ocid("Tenancy OCID.") }),
+    outputSchema: entityOutput("tenancy"),
+  }),
+  defineProviderAction(service, {
+    name: "list_availability_domains",
+    description: "List availability domains accessible from a compartment or tenancy.",
+    inputSchema: input("Availability domain lookup.", { compartmentId }, ["compartmentId"]),
+    outputSchema: listOutput("availabilityDomains"),
+  }),
+  defineProviderAction(service, {
+    name: "get_current_tenancy",
+    description: "Get the tenancy configured on this connection.",
+    inputSchema: s.object("No input.", {}),
+    outputSchema: entityOutput("tenancy"),
+  }),
+  defineProviderAction(service, {
+    name: "get_current_user",
+    description: "Get the IAM user configured on this connection.",
+    inputSchema: s.object("No input.", {}),
+    outputSchema: entityOutput("user"),
+  }),
+  defineProviderAction(service, {
+    name: "get_compartment_by_name",
+    description: "Find a direct child compartment by exact name.",
+    inputSchema: s.requiredObject("Compartment name lookup.", {
+      name: s.nonEmptyString("Exact compartment name."),
+      parentCompartmentId: compartmentId,
+    }),
+    outputSchema: s.requiredObject("Compartment lookup response.", {
+      compartment: s.nullable(resource),
+      ...requestMetadata,
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_subscribed_regions",
+    description: "List regions to which a tenancy is subscribed.",
+    inputSchema: input("Region subscription lookup.", { tenancyId: ocid("Tenancy OCID.") }, ["tenancyId"]),
+    outputSchema: listOutput("regions"),
+  }),
+
+  defineProviderAction(service, {
+    name: "run_instance_agent_command",
+    description:
+      "Run a shell or batch script through Oracle Cloud Agent. The script executes on the target host with the agent service account's privileges.",
+    inputSchema: input(
+      "Agent command.",
+      {
+        compartmentId,
+        instanceId,
+        displayName: s.nonEmptyString("Command display name."),
+        script: s.nonEmptyString("Plain-text script to execute."),
+        executionTimeoutInSeconds: s.positiveInteger("On-host command timeout in seconds."),
+      },
+      ["compartmentId", "executionTimeoutInSeconds"],
+    ),
+    outputSchema: entityOutput("commandExecution"),
+    followUpActions: ["oracle_cloud.list_instance_agent_command_executions"],
+  }),
+  defineProviderAction(service, {
+    name: "list_instance_agent_command_executions",
+    description: "List Oracle Cloud Agent command executions for a compute instance.",
+    inputSchema: input("Agent command execution filters.", { compartmentId, instanceId, ...pagination }, [
+      "compartmentId",
+      "limit",
+      "page",
+    ]),
+    outputSchema: listOutput("commandExecutions"),
+  }),
+];

--- a/src/providers/oracle_cloud/actions.ts
+++ b/src/providers/oracle_cloud/actions.ts
@@ -15,6 +15,7 @@ export const oracleInstanceActions: string[] = [
   "DIAGNOSTICREBOOT",
   "REBOOTMIGRATE",
 ];
+export const oracleInstanceAgentMaxWaitSeconds = 240;
 
 const ocid = (description: string): JsonSchema => s.nonEmptyString(description);
 const compartmentId = ocid("Compartment or tenancy OCID. Defaults to the connection's default compartment.");
@@ -347,7 +348,10 @@ export const oracleCloudActions: ActionDefinition[] = [
         compartmentId,
         compartmentIdInSubtree: s.boolean("Traverse the entire tenancy subtree."),
         accessLevel: s.stringEnum("Permission filtering mode.", ["ANY", "ACCESSIBLE"]),
-        includeRoot: s.boolean("Include the tenancy root compartment."),
+        includeRoot: s.boolean({
+          description: "Include the tenancy root compartment on the first page.",
+          default: true,
+        }),
         ...pagination,
       },
       ["compartmentId", "compartmentIdInSubtree", "accessLevel", "includeRoot", "limit", "page"],
@@ -408,7 +412,10 @@ export const oracleCloudActions: ActionDefinition[] = [
         instanceId,
         displayName: s.nonEmptyString("Command display name."),
         script: s.nonEmptyString("Plain-text script to execute."),
-        executionTimeoutInSeconds: s.positiveInteger("On-host command timeout in seconds."),
+        executionTimeoutInSeconds: s.positiveInteger(
+          "On-host command timeout in seconds. OpenConnector waits at most four minutes for completion.",
+          { maximum: oracleInstanceAgentMaxWaitSeconds },
+        ),
       },
       ["compartmentId", "executionTimeoutInSeconds"],
     ),

--- a/src/providers/oracle_cloud/definition.ts
+++ b/src/providers/oracle_cloud/definition.ts
@@ -1,0 +1,100 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { oracleCloudActions } from "./actions.ts";
+
+const service = "oracle_cloud";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Oracle Cloud Infrastructure",
+  description:
+    "Manage OCI compute hosts, networking, monitoring, identity discovery, and Oracle Cloud Agent commands through signed official REST APIs.",
+  categories: ["Developer Tools", "Infrastructure"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "tenancyId",
+          label: "Tenancy OCID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "ocid1.tenancy.oc1..example",
+          description:
+            "The tenancy OCID from the OCI API key configuration. See https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm.",
+        },
+        {
+          key: "userId",
+          label: "User OCID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "ocid1.user.oc1..example",
+          description: "The OCI IAM user OCID associated with the API signing key.",
+        },
+        {
+          key: "fingerprint",
+          label: "API Key Fingerprint",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "12:34:56:78:90:ab:cd:ef:...",
+          description: "The colon-separated fingerprint shown for the OCI IAM user's API signing key.",
+        },
+        {
+          key: "privateKey",
+          label: "API Signing Private Key",
+          inputType: "textarea",
+          required: true,
+          secret: true,
+          placeholder: "-----BEGIN PRIVATE KEY-----",
+          description:
+            "The PEM-encoded RSA private key paired with the configured OCI API key. OpenConnector treats this as a secret; configure OOMOL_CONNECT_ENCRYPTION_KEY to encrypt stored credentials at rest.",
+        },
+        {
+          key: "privateKeyPassphrase",
+          label: "Private Key Passphrase",
+          inputType: "password",
+          required: false,
+          secret: true,
+          placeholder: "Optional PEM passphrase",
+          description: "Optional passphrase when the PEM private key is encrypted.",
+        },
+        {
+          key: "region",
+          label: "OCI Region",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "us-ashburn-1",
+          description:
+            "The OCI region identifier used for Compute, Networking, Monitoring, Identity, and Instance Agent API requests.",
+        },
+        {
+          key: "realm",
+          label: "OCI Realm",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "oc1",
+          description:
+            "Optional OCI realm identifier used to resolve the API domain. Defaults to oc1 for commercial regions.",
+        },
+        {
+          key: "defaultCompartmentId",
+          label: "Default Compartment OCID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "ocid1.compartment.oc1..example",
+          description:
+            "The default compartment searched by list actions. The tenancy OCID may be used when resources live in the root compartment.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.oracle.com/cloud/",
+  actions: oracleCloudActions,
+};

--- a/src/providers/oracle_cloud/executors.ts
+++ b/src/providers/oracle_cloud/executors.ts
@@ -1,0 +1,28 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { OracleCloudContext } from "./runtime.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createOracleCloudContext, oracleCloudActionHandlers, validateOracleCloudCredential } from "./runtime.ts";
+
+const service = "oracle_cloud";
+
+export const executors: ProviderExecutors = defineProviderExecutors<OracleCloudContext>({
+  service,
+  handlers: oracleCloudActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<OracleCloudContext> {
+    const credential = await requireCustomCredential(context, service);
+    return createOracleCloudContext(credential.values, fetcher, context.signal);
+  },
+  fallbackMessage: "Oracle Cloud Infrastructure request failed",
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateOracleCloudCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/oracle_cloud/request-signer.test.ts
+++ b/src/providers/oracle_cloud/request-signer.test.ts
@@ -1,0 +1,86 @@
+import { Buffer } from "node:buffer";
+import { createHash, createVerify, generateKeyPairSync } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { buildOracleApiSigningString, parseOracleApiPrivateKey, signOracleApiRequest } from "./request-signer.ts";
+
+const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const privateKeyPem = keyPair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+const identity = {
+  tenancyId: "ocid1.tenancy.oc1..tenancy",
+  userId: "ocid1.user.oc1..user",
+  fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
+  privateKey: parseOracleApiPrivateKey(privateKeyPem),
+};
+
+describe("OCI API request signing", () => {
+  it("signs a GET request target, host, and date with RSA-SHA256", () => {
+    const url = new URL(
+      "https://iaas.us-ashburn-1.oraclecloud.com/20160918/instances?compartmentId=ocid1.compartment.oc1..demo&limit=1",
+    );
+    const headers = signOracleApiRequest(identity, {
+      method: "GET",
+      url,
+      now: new Date("2026-07-18T12:00:00Z"),
+    });
+
+    expect(headers.get("x-date")).toBe("Sat, 18 Jul 2026 12:00:00 GMT");
+    expect(headers.get("authorization")).toContain(
+      'keyId="ocid1.tenancy.oc1..tenancy/ocid1.user.oc1..user/00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"',
+    );
+    expect(headers.get("authorization")).toContain('headers="(request-target) host x-date"');
+    expect(buildOracleApiSigningString("GET", url, headers, ["(request-target)"]).split("\n")[0]).toBe(
+      "(request-target): get /20160918/instances?compartmentId=ocid1.compartment.oc1..demo&limit=1",
+    );
+    expectSignatureToVerify(url, "GET", headers);
+  });
+
+  it.each(["POST", "PUT"])("adds and signs the required body headers for %s requests", (method) => {
+    const url = new URL(
+      "https://iaas.us-ashburn-1.oraclecloud.com/20160918/instances/ocid1.instance.oc1..demo?action=SOFTRESET",
+    );
+    const body = "{}";
+    const headers = signOracleApiRequest(identity, {
+      method,
+      url,
+      body,
+      now: new Date("2026-07-18T12:00:00Z"),
+    });
+
+    expect(headers.get("content-length")).toBe("2");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-content-sha256")).toBe(createHash("sha256").update(body).digest("base64"));
+    expect(headers.get("authorization")).toContain(
+      'headers="(request-target) host x-date content-type content-length x-content-sha256"',
+    );
+    expectSignatureToVerify(url, method, headers);
+  });
+
+  it("signs DELETE requests without body headers", () => {
+    const url = new URL("https://iaas.us-ashburn-1.oraclecloud.com/20160918/instances/ocid1.instance.oc1..demo");
+    const headers = signOracleApiRequest(identity, {
+      method: "DELETE",
+      url,
+      now: new Date("2026-07-18T12:00:00Z"),
+    });
+
+    expect(headers.get("x-content-sha256")).toBeNull();
+    expect(headers.get("authorization")).toContain('headers="(request-target) host x-date"');
+    expectSignatureToVerify(url, "DELETE", headers);
+  });
+
+  it("rejects a non-RSA private key", () => {
+    const ecKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" }).privateKey;
+    const pem = ecKey.export({ type: "pkcs8", format: "pem" }).toString();
+    expect(() => parseOracleApiPrivateKey(pem)).toThrow("privateKey must be a valid RSA private key");
+  });
+});
+
+function expectSignatureToVerify(url: URL, method: string, headers: Headers): void {
+  const authorization = headers.get("authorization") ?? "";
+  const signedNames = /headers="([^"]+)"/u.exec(authorization)?.[1]?.split(" ") ?? [];
+  const signature = /signature="([^"]+)"/u.exec(authorization)?.[1] ?? "";
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(buildOracleApiSigningString(method, url, headers, signedNames));
+  verifier.end();
+  expect(verifier.verify(keyPair.publicKey, Buffer.from(signature, "base64"))).toBe(true);
+}

--- a/src/providers/oracle_cloud/request-signer.ts
+++ b/src/providers/oracle_cloud/request-signer.ts
@@ -1,0 +1,97 @@
+import type { KeyObject } from "node:crypto";
+
+import { Buffer } from "node:buffer";
+import { createHash, createPrivateKey, createSign } from "node:crypto";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+const bodySigningMethods = new Set(["POST", "PUT", "PATCH"]);
+
+export interface OracleApiSigningIdentity {
+  tenancyId: string;
+  userId: string;
+  fingerprint: string;
+  privateKey: KeyObject;
+}
+
+export interface OracleApiSigningInput {
+  method: string;
+  url: URL;
+  body?: string;
+  now?: Date;
+}
+
+/** Parse and validate an OCI RSA API signing key. */
+export function parseOracleApiPrivateKey(pem: string, passphrase?: string): KeyObject {
+  try {
+    const key = createPrivateKey({
+      key: pem,
+      format: "pem",
+      passphrase: passphrase || undefined,
+    });
+    if (key.asymmetricKeyType !== "rsa") {
+      throw new Error("key is not RSA");
+    }
+    return key;
+  } catch {
+    throw new ProviderRequestError(
+      400,
+      "privateKey must be a valid RSA private key in PEM format and privateKeyPassphrase must decrypt it",
+    );
+  }
+}
+
+/** Build the OCI Signature Authorization header and every header covered by it. */
+export function signOracleApiRequest(identity: OracleApiSigningIdentity, input: OracleApiSigningInput): Headers {
+  const method = input.method.toUpperCase();
+  const headers = new Headers({
+    accept: "application/json",
+    host: input.url.host,
+    "x-date": (input.now ?? new Date()).toUTCString(),
+  });
+  const signedHeaderNames = ["(request-target)", "host", "x-date"];
+
+  if (bodySigningMethods.has(method)) {
+    const body = input.body ?? "";
+    headers.set("content-type", "application/json");
+    headers.set("content-length", String(Buffer.byteLength(body, "utf8")));
+    headers.set("x-content-sha256", createHash("sha256").update(body).digest("base64"));
+    signedHeaderNames.push("content-type", "content-length", "x-content-sha256");
+  }
+
+  const signingString = buildOracleApiSigningString(method, input.url, headers, signedHeaderNames);
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingString);
+  signer.end();
+  const signature = signer.sign(identity.privateKey).toString("base64");
+  const keyId = `${identity.tenancyId}/${identity.userId}/${identity.fingerprint}`;
+  headers.set(
+    "authorization",
+    [
+      'Signature version="1"',
+      `keyId="${keyId}"`,
+      'algorithm="rsa-sha256"',
+      `headers="${signedHeaderNames.join(" ")}"`,
+      `signature="${signature}"`,
+    ].join(","),
+  );
+  return headers;
+}
+
+export function buildOracleApiSigningString(
+  method: string,
+  url: URL,
+  headers: Headers,
+  signedHeaderNames: readonly string[],
+): string {
+  const requestTarget = `${method.toLowerCase()} ${url.pathname}${url.search}`;
+  return signedHeaderNames
+    .map((name) => {
+      if (name === "(request-target)") return `(request-target): ${requestTarget}`;
+      const value = headers.get(name);
+      if (value == null) {
+        throw new ProviderRequestError(500, `OCI signing header ${name} is missing`);
+      }
+      return `${name}: ${value}`;
+    })
+    .join("\n");
+}

--- a/src/providers/oracle_cloud/runtime.test.ts
+++ b/src/providers/oracle_cloud/runtime.test.ts
@@ -1,0 +1,293 @@
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { oracleCloudActions } from "./actions.ts";
+import {
+  buildOracleApiBaseUrl,
+  createOracleCloudContext,
+  oracleCloudActionHandlers,
+  validateOracleCloudCredential,
+} from "./runtime.ts";
+
+const privateKey = generateKeyPairSync("rsa", { modulusLength: 2048 })
+  .privateKey.export({ type: "pkcs8", format: "pem" })
+  .toString();
+const values = {
+  tenancyId: "ocid1.tenancy.oc1..tenancy",
+  userId: "ocid1.user.oc1..user",
+  fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
+  privateKey,
+  region: "us-ashburn-1",
+  realm: "oc1",
+  defaultCompartmentId: "ocid1.compartment.oc1..default",
+};
+
+describe("Oracle Cloud provider contract", () => {
+  it("defines one runtime handler for every catalog action", () => {
+    expect(oracleCloudActions).toHaveLength(34);
+    expect(oracleCloudActions.map((action) => action.name).sort()).toEqual(
+      [
+        "create_subnet",
+        "create_vcn",
+        "delete_vcn",
+        "get_compartment_by_name",
+        "get_current_tenancy",
+        "get_current_user",
+        "get_image",
+        "get_instance",
+        "get_metrics_data",
+        "get_network_security_group",
+        "get_security_list",
+        "get_subnet",
+        "get_tenancy",
+        "get_vcn",
+        "get_vnic",
+        "get_vnic_attachment",
+        "instance_action",
+        "launch_instance",
+        "list_alarms",
+        "list_availability_domains",
+        "list_compartments",
+        "list_images",
+        "list_instance_agent_command_executions",
+        "list_instances",
+        "list_metric_definitions",
+        "list_network_security_groups",
+        "list_security_lists",
+        "list_subnets",
+        "list_subscribed_regions",
+        "list_vcns",
+        "list_vnic_attachments",
+        "run_instance_agent_command",
+        "terminate_instance",
+        "update_instance",
+      ].sort(),
+    );
+    expect(Object.keys(oracleCloudActionHandlers).sort()).toEqual(
+      oracleCloudActions.map((action) => action.name).sort(),
+    );
+  });
+
+  it("validates credentials with a signed instance-list request", async () => {
+    const fetchMock = vi.fn(async (input: URL | RequestInfo, _init?: RequestInit) => {
+      const url = new URL(input.toString());
+      expect(url.origin).toBe("https://iaas.us-ashburn-1.oraclecloud.com");
+      expect(url.pathname).toBe("/20160918/instances");
+      expect(url.searchParams.get("compartmentId")).toBe(values.defaultCompartmentId);
+      expect(url.searchParams.get("limit")).toBe("1");
+      return jsonResponse([], { "opc-request-id": "request-1" });
+    });
+    const fetcher = fetchMock as unknown as typeof fetch;
+
+    await expect(validateOracleCloudCredential(values, fetcher)).resolves.toMatchObject({
+      profile: { accountId: values.userId, displayName: "OCI us-ashburn-1" },
+      metadata: {
+        region: "us-ashburn-1",
+        realm: "oc1",
+        defaultCompartmentId: values.defaultCompartmentId,
+      },
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("authorization")).toMatch(/^Signature version="1"/u);
+  });
+
+  it("lists instances with filters and preserves OCI pagination metadata", async () => {
+    const fetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      expect(url.searchParams.get("compartmentId")).toBe(values.defaultCompartmentId);
+      expect(url.searchParams.get("lifecycleState")).toBe("RUNNING");
+      expect(url.searchParams.get("limit")).toBe("25");
+      return jsonResponse([{ id: "ocid1.instance.oc1..instance", compartmentId: values.defaultCompartmentId }], {
+        "opc-next-page": "next-token",
+        "opc-request-id": "request-2",
+      });
+    }) as unknown as typeof fetch;
+    const context = createOracleCloudContext(values, fetcher);
+
+    await expect(
+      oracleCloudActionHandlers.list_instances({ lifecycleState: "RUNNING", limit: 25 }, context),
+    ).resolves.toEqual({
+      instances: [{ id: "ocid1.instance.oc1..instance", compartmentId: values.defaultCompartmentId }],
+      nextPage: "next-token",
+      opcRequestId: "request-2",
+    });
+  });
+
+  it("retrieves VNIC IP data by OCID", async () => {
+    const vnicId = "ocid1.vnic.oc1..vnic";
+    const fetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe(`/20160918/vnics/${vnicId}`);
+      return jsonResponse({ id: vnicId, subnetId: "ocid1.subnet.oc1..subnet", privateIp: "10.0.0.2" });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.get_vnic({ vnicId }, createOracleCloudContext(values, fetcher)),
+    ).resolves.toMatchObject({ vnic: { id: vnicId, privateIp: "10.0.0.2" } });
+  });
+
+  it("sends curated lifecycle actions as signed POST requests", async () => {
+    const instanceId = "ocid1.instance.oc1..instance";
+    const fetcher = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe(`/20160918/instances/${instanceId}`);
+      expect(url.searchParams.get("action")).toBe("SOFTRESET");
+      expect(init?.method).toBe("POST");
+      expect(init?.body).toBe("{}");
+      expect(new Headers(init?.headers).get("x-content-sha256")).toBeTruthy();
+      return jsonResponse({ id: instanceId, compartmentId: values.defaultCompartmentId, lifecycleState: "STOPPING" });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.instance_action(
+        { instanceId, action: "SOFTRESET" },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).resolves.toMatchObject({ instance: { id: instanceId, lifecycleState: "STOPPING" } });
+  });
+
+  it("launches, updates, and terminates instances with official request shapes", async () => {
+    const instanceId = "ocid1.instance.oc1..instance";
+    const fetcher = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input.toString());
+      if (init?.method === "POST") {
+        expect(url.pathname).toBe("/20160918/instances");
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          displayName: "web-1",
+          shape: "VM.Standard.E5.Flex",
+          sourceDetails: { sourceType: "image", imageId: "ocid1.image.oc1..image" },
+          createVnicDetails: { subnetId: "ocid1.subnet.oc1..subnet" },
+        });
+        return jsonResponse({ id: instanceId });
+      }
+      if (init?.method === "PUT") {
+        expect(JSON.parse(String(init.body))).toEqual({ shapeConfig: { ocpus: 2, memoryInGBs: 16 } });
+        return jsonResponse({ id: instanceId });
+      }
+      expect(init?.method).toBe("DELETE");
+      return new Response(null, { status: 204, headers: { "opc-request-id": "deleted" } });
+    }) as unknown as typeof fetch;
+    const context = createOracleCloudContext(values, fetcher);
+
+    await oracleCloudActionHandlers.launch_instance(
+      {
+        displayName: "web-1",
+        availabilityDomain: "aBCD:US-ASHBURN-AD-1",
+        subnetId: "ocid1.subnet.oc1..subnet",
+        imageId: "ocid1.image.oc1..image",
+      },
+      context,
+    );
+    await oracleCloudActionHandlers.update_instance({ instanceId, ocpus: 2, memoryInGBs: 16 }, context);
+    await expect(oracleCloudActionHandlers.terminate_instance({ instanceId }, context)).resolves.toEqual({
+      status: 204,
+      opcRequestId: "deleted",
+    });
+  });
+
+  it("uses Monitoring POST actions and preserves pagination", async () => {
+    const fetcher = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input.toString());
+      expect(url.origin).toBe("https://telemetry.us-ashburn-1.oraclecloud.com");
+      expect(url.pathname).toBe("/20180401/metrics/actions/listMetrics");
+      expect(url.searchParams.get("compartmentId")).toBe(values.defaultCompartmentId);
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({ groupBy: ["namespace"], namespace: "oci_computeagent" });
+      return jsonResponse([{ namespace: "oci_computeagent", name: "CpuUtilization" }], {
+        "opc-next-page": "metrics-next",
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_metric_definitions(
+        { groupBy: ["namespace"], namespace: "oci_computeagent" },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).resolves.toMatchObject({ metrics: [{ name: "CpuUtilization" }], nextPage: "metrics-next" });
+  });
+
+  it("resolves current identity through the Identity service endpoint", async () => {
+    const fetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      expect(url.origin).toBe("https://identity.us-ashburn-1.oci.oraclecloud.com");
+      expect(url.pathname).toBe(`/20160918/users/${values.userId}`);
+      return jsonResponse({ id: values.userId, name: "api-user" });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.get_current_user({}, createOracleCloudContext(values, fetcher)),
+    ).resolves.toMatchObject({ user: { name: "api-user" } });
+  });
+
+  it("creates and reads an Instance Agent command through the 20180530 API", async () => {
+    const commandId = "ocid1.instanceagentcommand.oc1..command";
+    const instanceId = "ocid1.instance.oc1..instance";
+    const fetcher = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input.toString());
+      expect(url.pathname.startsWith("/20180530/")).toBe(true);
+      if (init?.method === "POST") {
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          target: { instanceId },
+          content: { source: { sourceType: "TEXT", text: "uptime" }, output: { outputType: "TEXT" } },
+          executionTimeOutInSeconds: 30,
+        });
+        return jsonResponse({ id: commandId });
+      }
+      expect(url.pathname).toBe(`/20180530/instanceAgentCommands/${commandId}/status`);
+      expect(url.searchParams.get("instanceId")).toBe(instanceId);
+      return jsonResponse({ lifecycleState: "SUCCEEDED", exitCode: 0 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.run_instance_agent_command(
+        { instanceId, displayName: "uptime", script: "uptime" },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).resolves.toMatchObject({ commandExecution: { lifecycleState: "SUCCEEDED", exitCode: 0 } });
+  });
+
+  it("maps OCI authorization failures during credential validation to invalid credentials", async () => {
+    const fetcher = vi.fn(async () =>
+      jsonResponse({ code: "NotAuthenticated", message: "The required information was not supplied." }, {}, 401),
+    ) as unknown as typeof fetch;
+
+    await expect(validateOracleCloudCredential(values, fetcher)).rejects.toMatchObject({
+      status: 400,
+      message: expect.stringContaining("NotAuthenticated"),
+    });
+  });
+
+  it("rejects unsupported realms and unsafe region values before making a request", () => {
+    const fetcher = vi.fn() as unknown as typeof fetch;
+    expect(() => createOracleCloudContext({ ...values, realm: "unknown" }, fetcher)).toThrow("realm must be one of");
+    expect(() => createOracleCloudContext({ ...values, realm: "toString" }, fetcher)).toThrow("realm must be one of");
+    expect(() => createOracleCloudContext({ ...values, region: "example.com/path" }, fetcher)).toThrow(
+      "region must be a valid OCI region identifier",
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("OCI endpoint resolution", () => {
+  it("uses the official second-level domain for each supported realm", () => {
+    expect(buildOracleApiBaseUrl("us-ashburn-1", "oc1")).toBe("https://iaas.us-ashburn-1.oraclecloud.com/20160918");
+    expect(buildOracleApiBaseUrl("us-langley-1", "oc2")).toBe("https://iaas.us-langley-1.oraclegovcloud.com/20160918");
+    expect(buildOracleApiBaseUrl("eu-frankfurt-2", "oc19")).toBe("https://iaas.eu-frankfurt-2.oraclecloud.eu/20160918");
+    expect(buildOracleApiBaseUrl("us-ashburn-1", "oc1", "monitoring")).toBe(
+      "https://telemetry.us-ashburn-1.oraclecloud.com/20180401",
+    );
+    expect(buildOracleApiBaseUrl("us-ashburn-1", "oc1", "identity")).toBe(
+      "https://identity.us-ashburn-1.oci.oraclecloud.com/20160918",
+    );
+    expect(buildOracleApiBaseUrl("us-ashburn-1", "oc1", "instanceAgent")).toBe(
+      "https://iaas.us-ashburn-1.oraclecloud.com/20180530",
+    );
+  });
+});
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}

--- a/src/providers/oracle_cloud/runtime.test.ts
+++ b/src/providers/oracle_cloud/runtime.test.ts
@@ -246,6 +246,84 @@ describe("Oracle Cloud provider contract", () => {
     ).resolves.toMatchObject({ commandExecution: { lifecycleState: "SUCCEEDED", exitCode: 0 } });
   });
 
+  it("rejects Instance Agent command timeouts beyond the four-minute polling contract", async () => {
+    const fetcher = vi.fn() as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.run_instance_agent_command(
+        {
+          instanceId: "ocid1.instance.oc1..instance",
+          displayName: "long-command",
+          script: "sleep 300",
+          executionTimeoutInSeconds: 300,
+        },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "executionTimeoutInSeconds must be between 1 and 240",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("includes the tenancy root only on the first compartment page", async () => {
+    const firstPageFetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      if (url.pathname === "/20160918/compartments") {
+        return jsonResponse([{ id: "ocid1.compartment.oc1..child" }], { "opc-next-page": "page-2" });
+      }
+      expect(url.pathname).toBe(`/20160918/compartments/${values.tenancyId}`);
+      return jsonResponse({ id: values.tenancyId, name: "root" });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_compartments({}, createOracleCloudContext(values, firstPageFetcher)),
+    ).resolves.toMatchObject({
+      compartments: [{ id: "ocid1.compartment.oc1..child" }, { id: values.tenancyId, name: "root" }],
+      nextPage: "page-2",
+    });
+    expect(firstPageFetcher).toHaveBeenCalledTimes(2);
+
+    const nextPageFetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe("/20160918/compartments");
+      expect(url.searchParams.get("page")).toBe("page-2");
+      return jsonResponse([{ id: "ocid1.compartment.oc1..next-child" }]);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_compartments(
+        { page: "page-2" },
+        createOracleCloudContext(values, nextPageFetcher),
+      ),
+    ).resolves.toMatchObject({ compartments: [{ id: "ocid1.compartment.oc1..next-child" }] });
+    expect(nextPageFetcher).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes response body read failures while the request timeout is active", async () => {
+    const fetcher = vi.fn(async () => {
+      return {
+        text: async () => {
+          throw new TypeError("response stream failed");
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_instances({}, createOracleCloudContext(values, fetcher)),
+    ).rejects.toMatchObject({ status: 502, message: "OCI request failed: response stream failed" });
+  });
+
+  it("accepts a signed 403 response as valid credentials with insufficient Compute permissions", async () => {
+    const fetcher = vi.fn(async () =>
+      jsonResponse({ code: "NotAuthorized", message: "The principal lacks INSTANCE_READ." }, {}, 403),
+    ) as unknown as typeof fetch;
+
+    await expect(validateOracleCloudCredential(values, fetcher)).resolves.toMatchObject({
+      profile: { accountId: values.userId, displayName: "OCI us-ashburn-1" },
+    });
+  });
+
   it("maps OCI authorization failures during credential validation to invalid credentials", async () => {
     const fetcher = vi.fn(async () =>
       jsonResponse({ code: "NotAuthenticated", message: "The required information was not supplied." }, {}, 401),

--- a/src/providers/oracle_cloud/runtime.test.ts
+++ b/src/providers/oracle_cloud/runtime.test.ts
@@ -246,6 +246,24 @@ describe("Oracle Cloud provider contract", () => {
     ).resolves.toMatchObject({ commandExecution: { lifecycleState: "SUCCEEDED", exitCode: 0 } });
   });
 
+  it("returns the execution as soon as it reaches a terminal state such as TIMED_OUT", async () => {
+    const commandId = "ocid1.instanceagentcommand.oc1..command";
+    const fetcher = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      if (init?.method === "POST") return jsonResponse({ id: commandId });
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe(`/20180530/instanceAgentCommands/${commandId}/status`);
+      return jsonResponse({ lifecycleState: "TIMED_OUT", exitCode: 124 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.run_instance_agent_command(
+        { instanceId: "ocid1.instance.oc1..instance", displayName: "sleep", script: "sleep 300" },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).resolves.toMatchObject({ commandExecution: { lifecycleState: "TIMED_OUT", exitCode: 124 } });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects Instance Agent command timeouts beyond the four-minute polling contract", async () => {
     const fetcher = vi.fn() as unknown as typeof fetch;
 
@@ -266,7 +284,7 @@ describe("Oracle Cloud provider contract", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
-  it("includes the tenancy root only on the first compartment page", async () => {
+  it("includes the tenancy root only on the first page of a tenancy listing", async () => {
     const firstPageFetcher = vi.fn(async (input: URL | RequestInfo) => {
       const url = new URL(input.toString());
       if (url.pathname === "/20160918/compartments") {
@@ -277,7 +295,10 @@ describe("Oracle Cloud provider contract", () => {
     }) as unknown as typeof fetch;
 
     await expect(
-      oracleCloudActionHandlers.list_compartments({}, createOracleCloudContext(values, firstPageFetcher)),
+      oracleCloudActionHandlers.list_compartments(
+        { compartmentId: values.tenancyId },
+        createOracleCloudContext(values, firstPageFetcher),
+      ),
     ).resolves.toMatchObject({
       compartments: [{ id: "ocid1.compartment.oc1..child" }, { id: values.tenancyId, name: "root" }],
       nextPage: "page-2",
@@ -293,11 +314,43 @@ describe("Oracle Cloud provider contract", () => {
 
     await expect(
       oracleCloudActionHandlers.list_compartments(
-        { page: "page-2" },
+        { compartmentId: values.tenancyId, page: "page-2" },
         createOracleCloudContext(values, nextPageFetcher),
       ),
     ).resolves.toMatchObject({ compartments: [{ id: "ocid1.compartment.oc1..next-child" }] });
     expect(nextPageFetcher).toHaveBeenCalledOnce();
+  });
+
+  it("omits the tenancy root when listing a child compartment", async () => {
+    const fetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe("/20160918/compartments");
+      expect(url.searchParams.get("compartmentId")).toBe(values.defaultCompartmentId);
+      return jsonResponse([{ id: "ocid1.compartment.oc1..grandchild" }]);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_compartments({}, createOracleCloudContext(values, fetcher)),
+    ).resolves.toMatchObject({ compartments: [{ id: "ocid1.compartment.oc1..grandchild" }] });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a tenancy listing usable when the root compartment is not readable", async () => {
+    const fetcher = vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(input.toString());
+      if (url.pathname === "/20160918/compartments") {
+        return jsonResponse([{ id: "ocid1.compartment.oc1..child" }]);
+      }
+      return jsonResponse({ code: "NotAuthorizedOrNotFound", message: "Authorization failed." }, {}, 404);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      oracleCloudActionHandlers.list_compartments(
+        { compartmentId: values.tenancyId },
+        createOracleCloudContext(values, fetcher),
+      ),
+    ).resolves.toMatchObject({ compartments: [{ id: "ocid1.compartment.oc1..child" }] });
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
   it("normalizes response body read failures while the request timeout is active", async () => {

--- a/src/providers/oracle_cloud/runtime.ts
+++ b/src/providers/oracle_cloud/runtime.ts
@@ -1,0 +1,716 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { KeyObject } from "node:crypto";
+
+import {
+  compactObject,
+  optionalBoolean,
+  optionalIntegerLike,
+  optionalNumber,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
+import { oracleInstanceActions } from "./actions.ts";
+import { parseOracleApiPrivateKey, signOracleApiRequest } from "./request-signer.ts";
+
+const requestTimeoutMs = 30_000;
+const commandWaitMs = 240_000;
+const defaultRealm = "oc1";
+
+export const oracleRealmDomains = {
+  oc1: "oraclecloud.com",
+  oc2: "oraclegovcloud.com",
+  oc3: "oraclegovcloud.com",
+  oc4: "oraclegovcloud.uk",
+  oc8: "oraclecloud8.com",
+  oc9: "oraclecloud9.com",
+  oc10: "oraclecloud10.com",
+  oc14: "oraclecloud14.com",
+  oc15: "oraclecloud15.com",
+  oc19: "oraclecloud.eu",
+  oc20: "oraclecloud20.com",
+  oc21: "oraclecloud21.com",
+  oc23: "oraclecloud23.com",
+  oc24: "oraclecloud24.com",
+  oc26: "oraclecloud26.com",
+  oc29: "oraclecloud29.com",
+  oc35: "oraclecloud35.com",
+  oc42: "oraclecloud42.com",
+  oc51: "oraclecloud51.com",
+  oc52: "oraclecloud52.com",
+} as const;
+
+type OracleRealm = keyof typeof oracleRealmDomains;
+type OracleService = "core" | "identity" | "monitoring" | "instanceAgent";
+type RequestPhase = "validate" | "execute";
+type OracleMethod = "GET" | "POST" | "PUT" | "DELETE";
+type OracleCloudActionHandler = (input: Record<string, unknown>, context: OracleCloudContext) => Promise<unknown>;
+
+interface OracleRequestInput {
+  context: OracleCloudContext;
+  path: string;
+  phase: RequestPhase;
+  service?: OracleService;
+  method?: OracleMethod;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: Record<string, unknown>;
+}
+
+interface OracleResponse {
+  payload: unknown;
+  status: number;
+  nextPage: string | null;
+  opcRequestId: string | null;
+  etag: string | null;
+  workRequestId: string | null;
+}
+
+export interface OracleCloudContext {
+  tenancyId: string;
+  userId: string;
+  fingerprint: string;
+  privateKey: KeyObject;
+  region: string;
+  realm: OracleRealm;
+  defaultCompartmentId: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export const oracleCloudActionHandlers: Record<string, OracleCloudActionHandler> = {
+  list_instances: (input, context) =>
+    listResources(input, context, "instances", "/instances", {
+      compartmentId: compartment(input, context),
+      lifecycleState: optionalString(input.lifecycleState),
+      limit: readLimit(input.limit),
+      page: optionalString(input.page),
+    }),
+  get_instance: (input, context) => getEntity(context, "instance", "/instances", input.instanceId, ["instance"]),
+  launch_instance: launchInstance,
+  terminate_instance: (input, context) => deleteEntity(context, "/instances", input.instanceId, ["instance"]),
+  update_instance: updateInstance,
+  list_images: (input, context) =>
+    listResources(input, context, "images", "/images", {
+      compartmentId: compartment(input, context),
+      operatingSystem: optionalString(input.operatingSystem),
+      limit: readLimit(input.limit),
+      page: optionalString(input.page),
+    }),
+  get_image: (input, context) => getEntity(context, "image", "/images", input.imageId, ["image"]),
+  instance_action: instanceAction,
+  list_vnic_attachments: (input, context) =>
+    listResources(input, context, "vnicAttachments", "/vnicAttachments", {
+      compartmentId: compartment(input, context),
+      instanceId: optionalOcid(input.instanceId, "instanceId", ["instance"]),
+      limit: readLimit(input.limit),
+      page: optionalString(input.page),
+    }),
+  get_vnic_attachment: (input, context) =>
+    getEntity(context, "vnicAttachment", "/vnicAttachments", input.vnicAttachmentId, ["vnicattachment"]),
+
+  list_vcns: (input, context) => listResources(input, context, "vcns", "/vcns", listQuery(input, context)),
+  get_vcn: (input, context) => getEntity(context, "vcn", "/vcns", input.vcnId, ["vcn"]),
+  delete_vcn: (input, context) => deleteEntity(context, "/vcns", input.vcnId, ["vcn"]),
+  create_vcn: (input, context) =>
+    createEntity(context, "vcn", "/vcns", {
+      compartmentId: compartment(input, context),
+      cidrBlock: requiredString(input.cidrBlock, "cidrBlock", inputError),
+      displayName: requiredString(input.displayName, "displayName", inputError),
+    }),
+  list_subnets: (input, context) =>
+    listResources(input, context, "subnets", "/subnets", {
+      ...listQuery(input, context),
+      vcnId: optionalOcid(input.vcnId, "vcnId", ["vcn"]),
+    }),
+  get_subnet: (input, context) => getEntity(context, "subnet", "/subnets", input.subnetId, ["subnet"]),
+  create_subnet: (input, context) =>
+    createEntity(context, "subnet", "/subnets", {
+      compartmentId: compartment(input, context),
+      vcnId: requireOcid(input.vcnId, "vcnId", ["vcn"]),
+      cidrBlock: requiredString(input.cidrBlock, "cidrBlock", inputError),
+      displayName: requiredString(input.displayName, "displayName", inputError),
+    }),
+  list_security_lists: (input, context) =>
+    listResources(input, context, "securityLists", "/securityLists", {
+      ...listQuery(input, context),
+      vcnId: optionalOcid(input.vcnId, "vcnId", ["vcn"]),
+    }),
+  get_security_list: (input, context) =>
+    getEntity(context, "securityList", "/securityLists", input.securityListId, ["securitylist"]),
+  list_network_security_groups: (input, context) =>
+    listResources(input, context, "networkSecurityGroups", "/networkSecurityGroups", {
+      ...listQuery(input, context),
+      vcnId: optionalOcid(input.vcnId, "vcnId", ["vcn"]),
+      vlanId: optionalOcid(input.vlanId, "vlanId", ["vlan"]),
+    }),
+  get_network_security_group: (input, context) =>
+    getEntity(context, "networkSecurityGroup", "/networkSecurityGroups", input.networkSecurityGroupId, [
+      "networksecuritygroup",
+    ]),
+  get_vnic: (input, context) => getEntity(context, "vnic", "/vnics", input.vnicId, ["vnic"]),
+
+  list_alarms: (input, context) =>
+    listResources(input, context, "alarms", "/alarms", listQuery(input, context), "monitoring"),
+  list_metric_definitions: listMetricDefinitions,
+  get_metrics_data: getMetricsData,
+
+  list_compartments: listCompartments,
+  get_tenancy: (input, context) =>
+    getEntity(context, "tenancy", "/tenancies", input.tenancyId, ["tenancy"], "identity"),
+  list_availability_domains: (input, context) =>
+    listResources(
+      input,
+      context,
+      "availabilityDomains",
+      "/availabilityDomains",
+      { compartmentId: compartment(input, context) },
+      "identity",
+    ),
+  get_current_tenancy: (_input, context) =>
+    getEntity(context, "tenancy", "/tenancies", context.tenancyId, ["tenancy"], "identity"),
+  get_current_user: (_input, context) => getEntity(context, "user", "/users", context.userId, ["user"], "identity"),
+  get_compartment_by_name: getCompartmentByName,
+  list_subscribed_regions: (input, context) =>
+    listResources(
+      input,
+      context,
+      "regions",
+      `/tenancies/${encodeURIComponent(optionalOcid(input.tenancyId, "tenancyId", ["tenancy"]) ?? context.tenancyId)}/regionSubscriptions`,
+      {},
+      "identity",
+    ),
+
+  run_instance_agent_command: runInstanceAgentCommand,
+  list_instance_agent_command_executions: (input, context) =>
+    listResources(
+      input,
+      context,
+      "commandExecutions",
+      "/instanceAgentCommandExecutions",
+      {
+        compartmentId: compartment(input, context),
+        instanceId: requireOcid(input.instanceId, "instanceId", ["instance"]),
+        limit: readLimit(input.limit),
+        page: optionalString(input.page),
+      },
+      "instanceAgent",
+    ),
+};
+
+export function createOracleCloudContext(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): OracleCloudContext {
+  return {
+    tenancyId: requireOcid(values.tenancyId, "tenancyId", ["tenancy"], credentialError),
+    userId: requireOcid(values.userId, "userId", ["user"], credentialError),
+    fingerprint: requireFingerprint(values.fingerprint),
+    privateKey: parseOracleApiPrivateKey(
+      requiredString(values.privateKey, "privateKey", credentialError),
+      optionalString(values.privateKeyPassphrase),
+    ),
+    region: requireRegion(values.region),
+    realm: requireRealm(values.realm),
+    defaultCompartmentId: requireOcid(
+      values.defaultCompartmentId,
+      "defaultCompartmentId",
+      ["compartment", "tenancy"],
+      credentialError,
+    ),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateOracleCloudCredential(
+  values: Record<string, string>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createOracleCloudContext(values, fetcher, signal);
+  await requestOracle({
+    context,
+    path: "/instances",
+    phase: "validate",
+    query: { compartmentId: context.defaultCompartmentId, limit: 1 },
+  });
+  return {
+    profile: { accountId: context.userId, displayName: `OCI ${context.region}` },
+    grantedScopes: [],
+    metadata: {
+      tenancyId: context.tenancyId,
+      region: context.region,
+      realm: context.realm,
+      defaultCompartmentId: context.defaultCompartmentId,
+      apiBaseUrl: buildOracleApiBaseUrl(context.region, context.realm, "core"),
+      validationEndpoint: "/20160918/instances",
+    },
+  };
+}
+
+export function buildOracleApiBaseUrl(region: string, realm: OracleRealm, service: OracleService = "core"): string {
+  const domain = oracleRealmDomains[realm];
+  if (service === "monitoring") return `https://telemetry.${region}.${domain}/20180401`;
+  if (service === "identity") return `https://identity.${region}.oci.${domain}/20160918`;
+  const version = service === "instanceAgent" ? "20180530" : "20160918";
+  return `https://iaas.${region}.${domain}/${version}`;
+}
+
+async function launchInstance(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const body = compactObject({
+    compartmentId: compartment(input, context),
+    displayName: requiredString(input.displayName, "displayName", inputError),
+    availabilityDomain: requiredString(input.availabilityDomain, "availabilityDomain", inputError),
+    shape: optionalString(input.shape) ?? "VM.Standard.E5.Flex",
+    sourceDetails: {
+      sourceType: "image",
+      imageId: requireOcid(input.imageId, "imageId", ["image"]),
+    },
+    createVnicDetails: { subnetId: requireOcid(input.subnetId, "subnetId", ["subnet"]) },
+    shapeConfig: compactObject({
+      ocpus: optionalIntegerLike(input.ocpus, "ocpus", inputError),
+      memoryInGBs: optionalNumber(input.memoryInGBs),
+    }),
+  });
+  return createEntity(context, "instance", "/instances", body);
+}
+
+async function updateInstance(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const shapeConfig = compactObject({
+    ocpus: optionalIntegerLike(input.ocpus, "ocpus", inputError),
+    memoryInGBs: optionalNumber(input.memoryInGBs),
+  });
+  if (Object.keys(shapeConfig).length === 0) throw inputError("ocpus or memoryInGBs is required");
+  const id = requireOcid(input.instanceId, "instanceId", ["instance"]);
+  const response = await requestOracle({
+    context,
+    path: `/instances/${encodeURIComponent(id)}`,
+    phase: "execute",
+    method: "PUT",
+    body: { shapeConfig },
+  });
+  return entityResult("instance", response);
+}
+
+async function instanceAction(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const id = requireOcid(input.instanceId, "instanceId", ["instance"]);
+  const action = requiredString(input.action, "action", inputError);
+  if (!oracleInstanceActions.includes(action)) {
+    throw inputError(`action must be one of ${oracleInstanceActions.join(", ")}`);
+  }
+  const response = await requestOracle({
+    context,
+    path: `/instances/${encodeURIComponent(id)}`,
+    phase: "execute",
+    method: "POST",
+    query: { action },
+    body: {},
+  });
+  return entityResult("instance", response);
+}
+
+async function listMetricDefinitions(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const groupBy = Array.isArray(input.groupBy)
+    ? input.groupBy.map((value) => requiredString(value, "groupBy", inputError))
+    : undefined;
+  const response = await requestOracle({
+    context,
+    service: "monitoring",
+    path: "/metrics/actions/listMetrics",
+    phase: "execute",
+    method: "POST",
+    query: compactObject({
+      compartmentId: compartment(input, context),
+      compartmentIdInSubtree: optionalBoolean(input.compartmentIdInSubtree),
+      limit: readLimit(input.limit),
+      page: optionalString(input.page),
+    }),
+    body: compactObject({
+      groupBy,
+      name: optionalString(input.metricName),
+      namespace: optionalString(input.namespace),
+      resourceGroup: optionalString(input.resourceGroup),
+    }),
+  });
+  return listResult("metrics", response);
+}
+
+async function getMetricsData(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const endTime = optionalString(input.endTime) ?? new Date().toISOString();
+  const startTime = optionalString(input.startTime) ?? new Date(Date.now() - 3 * 60 * 60 * 1_000).toISOString();
+  const response = await requestOracle({
+    context,
+    service: "monitoring",
+    path: "/metrics/actions/summarizeMetricsData",
+    phase: "execute",
+    method: "POST",
+    query: compactObject({
+      compartmentId: compartment(input, context),
+      compartmentIdInSubtree: optionalBoolean(input.compartmentIdInSubtree),
+    }),
+    body: compactObject({
+      query: requiredString(input.query, "query", inputError),
+      namespace: requiredString(input.namespace, "namespace", inputError),
+      startTime,
+      endTime,
+      resourceGroup: optionalString(input.resourceGroup),
+      resolution: optionalString(input.resolution) ?? "1m",
+    }),
+  });
+  return listResult("metricData", response);
+}
+
+async function listCompartments(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const response = await requestOracle({
+    context,
+    service: "identity",
+    path: "/compartments",
+    phase: "execute",
+    query: compactObject({
+      compartmentId: compartment(input, context),
+      compartmentIdInSubtree: optionalBoolean(input.compartmentIdInSubtree) ?? false,
+      accessLevel: optionalString(input.accessLevel) ?? "ANY",
+      limit: readLimit(input.limit),
+      page: optionalString(input.page),
+    }),
+  });
+  const result = listResult("compartments", response);
+  if (optionalBoolean(input.includeRoot) !== false) {
+    const root = await requestOracle({
+      context,
+      service: "identity",
+      path: `/compartments/${encodeURIComponent(context.tenancyId)}`,
+      phase: "execute",
+    });
+    (result.compartments as Array<unknown>).push(requiredRecord(root.payload, "OCI root compartment", responseError));
+  }
+  return result;
+}
+
+async function getCompartmentByName(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const name = requiredString(input.name, "name", inputError);
+  const response = await requestOracle({
+    context,
+    service: "identity",
+    path: "/compartments",
+    phase: "execute",
+    query: {
+      compartmentId: requireOcid(input.parentCompartmentId, "parentCompartmentId", ["compartment", "tenancy"]),
+      name,
+      accessLevel: "ACCESSIBLE",
+      lifecycleState: "ACTIVE",
+    },
+  });
+  const compartments = requireArray(response.payload);
+  const found = compartments.find((item) => optionalString(optionalRecord(item)?.name) === name) ?? null;
+  return { compartment: found, opcRequestId: response.opcRequestId };
+}
+
+async function runInstanceAgentCommand(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Promise<Record<string, unknown>> {
+  const instanceId = requireOcid(input.instanceId, "instanceId", ["instance"]);
+  const createResponse = await requestOracle({
+    context,
+    service: "instanceAgent",
+    path: "/instanceAgentCommands",
+    phase: "execute",
+    method: "POST",
+    body: {
+      compartmentId: compartment(input, context),
+      displayName: requiredString(input.displayName, "displayName", inputError),
+      target: { instanceId },
+      content: {
+        source: { sourceType: "TEXT", text: requiredString(input.script, "script", inputError) },
+        output: { outputType: "TEXT" },
+      },
+      executionTimeOutInSeconds:
+        optionalIntegerLike(input.executionTimeoutInSeconds, "executionTimeoutInSeconds", inputError) ?? 30,
+    },
+  });
+  const command = requiredRecord(createResponse.payload, "OCI instance agent command", responseError);
+  const commandId = requireOcid(command.id, "command.id", ["instanceagentcommand"], responseError);
+  const deadline = Date.now() + commandWaitMs;
+  while (Date.now() < deadline) {
+    const execution = await requestOracle({
+      context,
+      service: "instanceAgent",
+      path: `/instanceAgentCommands/${encodeURIComponent(commandId)}/status`,
+      phase: "execute",
+      query: { instanceId },
+    });
+    const lifecycleState = optionalString(optionalRecord(execution.payload)?.lifecycleState);
+    if (lifecycleState === "SUCCEEDED" || lifecycleState === "FAILED" || lifecycleState === "CANCELED") {
+      return entityResult("commandExecution", execution);
+    }
+    await waitForPoll(context.signal);
+  }
+  throw new ProviderRequestError(504, "OCI instance agent command timed out");
+}
+
+async function waitForPoll(signal?: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timeout);
+      reject(new ProviderRequestError(504, "OCI request was aborted"));
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, 5_000);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function listQuery(
+  input: Record<string, unknown>,
+  context: OracleCloudContext,
+): Record<string, string | number | undefined> {
+  return {
+    compartmentId: compartment(input, context),
+    limit: readLimit(input.limit),
+    page: optionalString(input.page),
+  };
+}
+
+async function listResources(
+  _input: Record<string, unknown>,
+  context: OracleCloudContext,
+  resultName: string,
+  path: string,
+  query: OracleRequestInput["query"],
+  service: OracleService = "core",
+): Promise<Record<string, unknown>> {
+  const response = await requestOracle({ context, service, path, phase: "execute", query });
+  return listResult(resultName, response);
+}
+
+async function getEntity(
+  context: OracleCloudContext,
+  resultName: string,
+  path: string,
+  idValue: unknown,
+  resourceTypes: string[],
+  service: OracleService = "core",
+): Promise<Record<string, unknown>> {
+  const id = requireOcid(idValue, `${resultName}Id`, resourceTypes);
+  const response = await requestOracle({
+    context,
+    service,
+    path: `${path}/${encodeURIComponent(id)}`,
+    phase: "execute",
+  });
+  return entityResult(resultName, response);
+}
+
+async function createEntity(
+  context: OracleCloudContext,
+  resultName: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await requestOracle({ context, path, phase: "execute", method: "POST", body });
+  return entityResult(resultName, response);
+}
+
+async function deleteEntity(
+  context: OracleCloudContext,
+  path: string,
+  idValue: unknown,
+  resourceTypes: string[],
+): Promise<Record<string, unknown>> {
+  const id = requireOcid(idValue, "resourceId", resourceTypes);
+  const response = await requestOracle({
+    context,
+    path: `${path}/${encodeURIComponent(id)}`,
+    phase: "execute",
+    method: "DELETE",
+  });
+  return { status: response.status, opcRequestId: response.opcRequestId };
+}
+
+function listResult(resultName: string, response: OracleResponse): Record<string, unknown> {
+  return {
+    [resultName]: requireArray(response.payload),
+    nextPage: response.nextPage,
+    opcRequestId: response.opcRequestId,
+  };
+}
+
+function entityResult(resultName: string, response: OracleResponse): Record<string, unknown> {
+  return {
+    [resultName]: requiredRecord(response.payload, `OCI ${resultName}`, responseError),
+    opcRequestId: response.opcRequestId,
+  };
+}
+
+export async function requestOracle(input: OracleRequestInput): Promise<OracleResponse> {
+  const service = input.service ?? "core";
+  const baseUrl = buildOracleApiBaseUrl(input.context.region, input.context.realm, service);
+  const url = new URL(`${baseUrl}${input.path}`);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, String(value));
+  }
+  const method = input.method ?? "GET";
+  const body = input.body === undefined ? undefined : JSON.stringify(input.body);
+  const headers = signOracleApiRequest(input.context, { method, url, body });
+  headers.set("user-agent", providerUserAgent);
+  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+
+  let response: Response;
+  try {
+    response = await input.context.fetcher(url, { method, headers, body, signal: timeout.signal });
+  } catch (error) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) throw new ProviderRequestError(504, "OCI request timed out");
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `OCI request failed: ${error.message}` : "OCI request failed",
+    );
+  } finally {
+    timeout.cleanup();
+  }
+
+  const text = await response.text();
+  const payload = parsePayload(text, response.ok);
+  if (!response.ok) throw createApiError(response, payload, input.phase);
+  return {
+    payload,
+    status: response.status,
+    nextPage: response.headers.get("opc-next-page"),
+    opcRequestId: response.headers.get("opc-request-id"),
+    etag: response.headers.get("etag"),
+    workRequestId: response.headers.get("opc-work-request-id"),
+  };
+}
+
+function parsePayload(text: string, successful: boolean): unknown {
+  if (!text) return successful ? null : {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    if (successful) throw new ProviderRequestError(502, "OCI returned invalid JSON");
+    return { message: text };
+  }
+}
+
+function createApiError(response: Response, payload: unknown, phase: RequestPhase): ProviderRequestError {
+  const record = optionalRecord(payload);
+  const code = optionalString(record?.code);
+  const message = optionalString(record?.message) ?? response.statusText ?? `HTTP ${response.status}`;
+  const detail = code ? `${code}: ${message}` : message;
+  if (response.status === 401 || response.status === 403) {
+    return new ProviderRequestError(
+      phase === "validate" ? 400 : response.status,
+      `OCI authorization failed: ${detail}`,
+    );
+  }
+  if ([400, 404, 409, 412, 429].includes(response.status)) {
+    return new ProviderRequestError(response.status, `OCI request failed: ${detail}`, payload);
+  }
+  return new ProviderRequestError(
+    response.status >= 500 ? 502 : response.status || 500,
+    `OCI request failed: ${detail}`,
+  );
+}
+
+function requireArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw responseError("OCI list response must be an array");
+  return value.map((item) => requiredRecord(item, "OCI list item", responseError));
+}
+
+function compartment(input: Record<string, unknown>, context: OracleCloudContext): string {
+  return input.compartmentId == null || input.compartmentId === ""
+    ? context.defaultCompartmentId
+    : requireOcid(input.compartmentId, "compartmentId", ["compartment", "tenancy"]);
+}
+
+function requireOcid(
+  value: unknown,
+  fieldName: string,
+  resourceTypes: readonly string[],
+  errorFactory: (message: string) => ProviderRequestError = inputError,
+): string {
+  const resolved = requiredString(value, fieldName, errorFactory);
+  if (!resourceTypes.some((type) => resolved.startsWith(`ocid1.${type}.`))) {
+    throw errorFactory(`${fieldName} must be an OCI ${resourceTypes.join(" or ")} OCID`);
+  }
+  return resolved;
+}
+
+function optionalOcid(value: unknown, fieldName: string, resourceTypes: readonly string[]): string | undefined {
+  const resolved = optionalString(value);
+  return resolved === undefined ? undefined : requireOcid(resolved, fieldName, resourceTypes);
+}
+
+function readLimit(value: unknown): number | undefined {
+  const resolved = optionalIntegerLike(value, "limit", inputError);
+  if (resolved !== undefined && (resolved < 1 || resolved > 1_000))
+    throw inputError("limit must be between 1 and 1000");
+  return resolved;
+}
+
+function requireFingerprint(value: unknown): string {
+  const resolved = requiredString(value, "fingerprint", credentialError).toLowerCase();
+  if (!/^(?:[0-9a-f]{2}:){15}[0-9a-f]{2}$/u.test(resolved)) {
+    throw credentialError("fingerprint must be a colon-separated hexadecimal OCI API key fingerprint");
+  }
+  return resolved;
+}
+
+function requireRegion(value: unknown): string {
+  const resolved = requiredString(value, "region", credentialError).toLowerCase();
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)+$/u.test(resolved)) {
+    throw credentialError("region must be a valid OCI region identifier such as us-ashburn-1");
+  }
+  return resolved;
+}
+
+function requireRealm(value: unknown): OracleRealm {
+  const resolved = optionalString(value)?.toLowerCase() || defaultRealm;
+  if (!Object.hasOwn(oracleRealmDomains, resolved)) {
+    throw credentialError(`realm must be one of ${Object.keys(oracleRealmDomains).join(", ")}`);
+  }
+  return resolved as OracleRealm;
+}
+
+function credentialError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function inputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function responseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/oracle_cloud/runtime.ts
+++ b/src/providers/oracle_cloud/runtime.ts
@@ -24,6 +24,12 @@ const requestTimeoutMs = 30_000;
 const commandWaitMs = oracleInstanceAgentMaxWaitSeconds * 1_000;
 const defaultRealm = "oc1";
 
+/**
+ * Non-terminal `InstanceAgentCommandExecution.lifecycleState` values. Every other state
+ * (SUCCEEDED, FAILED, TIMED_OUT, CANCELED, or one OCI adds later) ends the polling loop.
+ */
+const oracleInstanceAgentPendingStates = new Set(["ACCEPTED", "IN_PROGRESS"]);
+
 export const oracleRealmDomains = {
   oc1: "oraclecloud.com",
   oc2: "oraclegovcloud.com",
@@ -391,13 +397,14 @@ async function listCompartments(
   input: Record<string, unknown>,
   context: OracleCloudContext,
 ): Promise<Record<string, unknown>> {
+  const parentId = compartment(input, context);
   const response = await requestOracle({
     context,
     service: "identity",
     path: "/compartments",
     phase: "execute",
     query: compactObject({
-      compartmentId: compartment(input, context),
+      compartmentId: parentId,
       compartmentIdInSubtree: optionalBoolean(input.compartmentIdInSubtree) ?? false,
       accessLevel: optionalString(input.accessLevel) ?? "ANY",
       limit: readLimit(input.limit),
@@ -405,16 +412,34 @@ async function listCompartments(
     }),
   });
   const result = listResult("compartments", response);
-  if (optionalBoolean(input.includeRoot) !== false && optionalString(input.page) === undefined) {
+  const includeRoot =
+    optionalBoolean(input.includeRoot) !== false &&
+    optionalString(input.page) === undefined &&
+    parentId === context.tenancyId;
+  if (includeRoot) {
+    const root = await readRootCompartment(context);
+    if (root) (result.compartments as Array<unknown>).push(root);
+  }
+  return result;
+}
+
+/**
+ * Read the tenancy root compartment. It is supplementary data appended to a listing that already
+ * succeeded, so a tenancy the caller cannot inspect omits the root instead of failing the action.
+ */
+async function readRootCompartment(context: OracleCloudContext): Promise<Record<string, unknown> | null> {
+  try {
     const root = await requestOracle({
       context,
       service: "identity",
       path: `/compartments/${encodeURIComponent(context.tenancyId)}`,
       phase: "execute",
     });
-    (result.compartments as Array<unknown>).push(requiredRecord(root.payload, "OCI root compartment", responseError));
+    return requiredRecord(root.payload, "OCI root compartment", responseError);
+  } catch (error) {
+    if (error instanceof ProviderRequestError && error.status < 500) return null;
+    throw error;
   }
-  return result;
 }
 
 async function getCompartmentByName(
@@ -474,7 +499,7 @@ async function runInstanceAgentCommand(
       query: { instanceId },
     });
     const lifecycleState = optionalString(optionalRecord(execution.payload)?.lifecycleState);
-    if (lifecycleState === "SUCCEEDED" || lifecycleState === "FAILED" || lifecycleState === "CANCELED") {
+    if (lifecycleState !== undefined && !oracleInstanceAgentPendingStates.has(lifecycleState)) {
       return entityResult("commandExecution", execution);
     }
     await waitForPoll(context.signal);

--- a/src/providers/oracle_cloud/runtime.ts
+++ b/src/providers/oracle_cloud/runtime.ts
@@ -17,11 +17,11 @@ import {
   providerUserAgent,
   ProviderRequestError,
 } from "../provider-runtime.ts";
-import { oracleInstanceActions } from "./actions.ts";
+import { oracleInstanceActions, oracleInstanceAgentMaxWaitSeconds } from "./actions.ts";
 import { parseOracleApiPrivateKey, signOracleApiRequest } from "./request-signer.ts";
 
 const requestTimeoutMs = 30_000;
-const commandWaitMs = 240_000;
+const commandWaitMs = oracleInstanceAgentMaxWaitSeconds * 1_000;
 const defaultRealm = "oc1";
 
 export const oracleRealmDomains = {
@@ -236,12 +236,16 @@ export async function validateOracleCloudCredential(
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const context = createOracleCloudContext(values, fetcher, signal);
-  await requestOracle({
-    context,
-    path: "/instances",
-    phase: "validate",
-    query: { compartmentId: context.defaultCompartmentId, limit: 1 },
-  });
+  try {
+    await requestOracle({
+      context,
+      path: "/instances",
+      phase: "validate",
+      query: { compartmentId: context.defaultCompartmentId, limit: 1 },
+    });
+  } catch (error) {
+    if (!(error instanceof ProviderRequestError) || error.status !== 403) throw error;
+  }
   return {
     profile: { accountId: context.userId, displayName: `OCI ${context.region}` },
     grantedScopes: [],
@@ -401,7 +405,7 @@ async function listCompartments(
     }),
   });
   const result = listResult("compartments", response);
-  if (optionalBoolean(input.includeRoot) !== false) {
+  if (optionalBoolean(input.includeRoot) !== false && optionalString(input.page) === undefined) {
     const root = await requestOracle({
       context,
       service: "identity",
@@ -440,6 +444,7 @@ async function runInstanceAgentCommand(
   context: OracleCloudContext,
 ): Promise<Record<string, unknown>> {
   const instanceId = requireOcid(input.instanceId, "instanceId", ["instance"]);
+  const executionTimeoutInSeconds = readCommandTimeout(input.executionTimeoutInSeconds);
   const createResponse = await requestOracle({
     context,
     service: "instanceAgent",
@@ -454,8 +459,7 @@ async function runInstanceAgentCommand(
         source: { sourceType: "TEXT", text: requiredString(input.script, "script", inputError) },
         output: { outputType: "TEXT" },
       },
-      executionTimeOutInSeconds:
-        optionalIntegerLike(input.executionTimeoutInSeconds, "executionTimeoutInSeconds", inputError) ?? 30,
+      executionTimeOutInSeconds: executionTimeoutInSeconds,
     },
   });
   const command = requiredRecord(createResponse.payload, "OCI instance agent command", responseError);
@@ -588,8 +592,10 @@ export async function requestOracle(input: OracleRequestInput): Promise<OracleRe
   const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
 
   let response: Response;
+  let text: string;
   try {
     response = await input.context.fetcher(url, { method, headers, body, signal: timeout.signal });
+    text = await response.text();
   } catch (error) {
     if (timeout.didTimeout() || isAbortLikeError(error)) throw new ProviderRequestError(504, "OCI request timed out");
     throw new ProviderRequestError(
@@ -600,7 +606,6 @@ export async function requestOracle(input: OracleRequestInput): Promise<OracleRe
     timeout.cleanup();
   }
 
-  const text = await response.text();
   const payload = parsePayload(text, response.ok);
   if (!response.ok) throw createApiError(response, payload, input.phase);
   return {
@@ -628,11 +633,11 @@ function createApiError(response: Response, payload: unknown, phase: RequestPhas
   const code = optionalString(record?.code);
   const message = optionalString(record?.message) ?? response.statusText ?? `HTTP ${response.status}`;
   const detail = code ? `${code}: ${message}` : message;
-  if (response.status === 401 || response.status === 403) {
-    return new ProviderRequestError(
-      phase === "validate" ? 400 : response.status,
-      `OCI authorization failed: ${detail}`,
-    );
+  if (response.status === 401) {
+    return new ProviderRequestError(phase === "validate" ? 400 : 401, `OCI authorization failed: ${detail}`);
+  }
+  if (response.status === 403) {
+    return new ProviderRequestError(403, `OCI authorization failed: ${detail}`);
   }
   if ([400, 404, 409, 412, 429].includes(response.status)) {
     return new ProviderRequestError(response.status, `OCI request failed: ${detail}`, payload);
@@ -676,6 +681,14 @@ function readLimit(value: unknown): number | undefined {
   const resolved = optionalIntegerLike(value, "limit", inputError);
   if (resolved !== undefined && (resolved < 1 || resolved > 1_000))
     throw inputError("limit must be between 1 and 1000");
+  return resolved;
+}
+
+function readCommandTimeout(value: unknown): number {
+  const resolved = optionalIntegerLike(value, "executionTimeoutInSeconds", inputError) ?? 30;
+  if (resolved < 1 || resolved > oracleInstanceAgentMaxWaitSeconds) {
+    throw inputError(`executionTimeoutInSeconds must be between 1 and ${oracleInstanceAgentMaxWaitSeconds}`);
+  }
   return resolved;
 }
 


### PR DESCRIPTION
## Summary

- add an Oracle Cloud Infrastructure provider backed directly by OCI's signed REST APIs
- expose 34 static actions matching the current host-related tools in Oracle's official Compute, Networking, Monitoring, Identity, and Compute Instance Agent MCP servers
- support commercial and sovereign OCI realms without exposing a generic API proxy

## Actions

| Area | Count | Coverage |
| --- | ---: | --- |
| Compute | 10 | instances, images, lifecycle actions, and VNIC attachments |
| Networking | 12 | VCNs, subnets, security lists, NSGs, and VNICs |
| Monitoring | 3 | alarms, metric definitions, and MQL metric data |
| Identity | 7 | compartments, tenancy, user, availability domains, and subscribed regions |
| Compute Instance Agent | 2 | run commands and list command executions |

## Implementation

- signs OCI API requests with RSA-SHA256, including body hashes for POST and PUT requests
- routes all egress through the shared SSRF-guarded provider fetcher
- resolves the official service endpoint and API version for Compute/Networking, Monitoring, Identity, and Instance Agent
- preserves OCI pagination and request metadata and handles empty `204` responses
- keeps destructive and remote-execution operations as explicit, schema-validated actions

`launch_instance` requires an explicit image OCID instead of copying the official MCP server's Ashburn-specific default image, which would not be valid across regions.

## Validation

- `npm run fix-check`
- `npm run generate:catalog` — 1091 apps / 11170 actions
- `npm test` — 72 test files / 630 tests passed

The signing implementation is covered with real RSA cryptographic verification and mocked OCI HTTP contracts. Live OCI validation was not run because no OCI credentials were used during development.

