### PR TITLE
fix(runtime): include execution status in action metadata

### DIFF
--- a/src/server/api/runtime-api.test.ts
+++ b/src/server/api/runtime-api.test.ts
@@ -4,10 +4,43 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import {
   parseRuntimeActionHttpResult,
+  serializeRuntimeAction,
   serializeRuntimeActionResult,
   serializeRuntimeFailure,
   writeRuntimeActionHttpResult,
 } from "./runtime-api.ts";
+
+describe("runtime action metadata", () => {
+  it("includes the execution status advertised by the runtime catalog", () => {
+    expect(
+      serializeRuntimeAction({
+        id: "example.echo",
+        service: "example",
+        name: "echo",
+        description: "Echo the provided value.",
+        requiredScopes: [],
+        providerPermissions: [],
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+        execution: {
+          locallyExecutable: true,
+          catalogOnly: false,
+          requiredAuthTypes: ["api_key"],
+          noAuthRunnable: false,
+          needsCredential: true,
+        },
+      }),
+    ).toMatchObject({
+      execution: {
+        locallyExecutable: true,
+        catalogOnly: false,
+        requiredAuthTypes: ["api_key"],
+        noAuthRunnable: false,
+        needsCredential: true,
+      },
+    });
+  });
+});
 
 describe("runtime action HTTP results", () => {
   it("serializes a successful execution without changing its wire shape", () => {

--- a/src/server/api/runtime-api.ts
+++ b/src/server/api/runtime-api.ts
@@ -57,6 +57,7 @@ export interface RuntimeActionMetadata {
   outputSchema: RuntimeActionDefinition["outputSchema"];
   followUpActions: RuntimeActionFollowUp[];
   asyncLifecycle: RuntimeActionDefinition["asyncLifecycle"] | null;
+  execution: RuntimeActionDefinition["execution"];
 }
 
 export interface RuntimeConnectedApp {
@@ -121,6 +122,7 @@ export function serializeRuntimeAction(action: RuntimeActionDefinition): Runtime
     outputSchema: action.outputSchema,
     followUpActions: (action.followUpActions ?? []).map((actionId) => ({ actionId })),
     asyncLifecycle: action.asyncLifecycle ?? null,
+    execution: action.execution,
   };
 
   return metadata;


### PR DESCRIPTION
## What changed

- include `execution` in runtime Action metadata
- return it from the shared `/v1` Action serializer
- add a regression test for the wire shape

## Why

The runtime catalog already knows whether an Action is locally executable or catalog-only, but the HTTP serializer drops that information.

For example, a client listing Gmail Actions currently receives `gmail.search_messages` without knowing whether this self-hosted runtime can actually execute it. The client must either expose a tool that may fail later or reject the incomplete catalog.

After this change, the response includes the existing status:

```json
{
  "execution": {
    "locallyExecutable": true,
    "catalogOnly": false,
    "requiredAuthTypes": ["oauth2"],
    "noAuthRunnable": false,
    "needsCredential": true
  }
}
```

This keeps HTTP discovery aligned with the runtime catalog contract.

## Validation

- `npm run fix-check`
- `npm test` — 70 files, 610 tests passed
