### PR TITLE
feat(latchshot): add Latchshot provider

### DIFF
--- a/src/providers/latchshot/actions.ts
+++ b/src/providers/latchshot/actions.ts
@@ -1,0 +1,169 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "latchshot";
+
+const planSchema = s.stringEnum("The current Latchshot plan identifier.", ["trial", "launch", "build", "scale"]);
+
+const transitFileSchema = s.requiredObject("The rendered artifact stored in local transit storage.", {
+  fileId: s.nonEmptyString("The local transit file identifier."),
+  downloadUrl: s.url("The local URL used to download the rendered artifact."),
+  sizeBytes: s.nonNegativeInteger("The artifact size in bytes."),
+  name: s.nonEmptyString("The artifact filename."),
+  mimeType: s.stringEnum("The artifact MIME type.", ["image/png", "image/jpeg", "application/pdf"]),
+});
+
+const diagnosticsSchema = s.object(
+  "Bounded render diagnostics returned in Latchshot response headers.",
+  {
+    renderMs: s.nonNegativeInteger("The server-side render duration in milliseconds."),
+    navigation: s.stringEnum("Whether browser navigation completed before capture.", ["complete", "timed-out"]),
+    fonts: s.stringEnum("Whether the page used its original fonts or a fallback state.", ["original", "fallback"]),
+    scripts: s.stringEnum("Whether page scripts stayed active or were paused by the fallback path.", [
+      "active",
+      "paused",
+    ]),
+  },
+  { optional: ["renderMs", "navigation", "fonts", "scripts"] },
+);
+
+const quotaSchema = s.object(
+  "The successful-render quota snapshot returned with the artifact.",
+  {
+    limit: s.positiveInteger("The successful-render allowance for the current UTC calendar month."),
+    remaining: s.nonNegativeInteger("The successful renders remaining in the current month."),
+    resetAt: s.dateTime("The start of the next UTC calendar month."),
+  },
+  { optional: ["limit", "remaining", "resetAt"] },
+);
+
+const captureInputSchema = s.object(
+  "Input parameters for one bounded public-page screenshot or PDF render.",
+  {
+    url: s.url(
+      "The public HTTP or HTTPS page URL. Private, loopback, link-local, credential-bearing, and non-web-port targets are rejected.",
+    ),
+    kind: s.stringEnum(["screenshot", "pdf"], {
+      default: "screenshot",
+      description: "The artifact family to render.",
+    }),
+    format: s.stringEnum(["png", "jpeg"], {
+      default: "png",
+      description: "The image format for screenshots. PDF renders always return PDF.",
+    }),
+    width: s.integer({
+      minimum: 320,
+      maximum: 2560,
+      default: 1440,
+      description: "The browser viewport width in CSS pixels.",
+    }),
+    height: s.integer({
+      minimum: 240,
+      maximum: 1440,
+      default: 900,
+      description: "The browser viewport height in CSS pixels.",
+    }),
+    scale: s.integer({
+      minimum: 1,
+      maximum: 2,
+      default: 1,
+      description: "The device scale factor for screenshot output.",
+    }),
+    fullPage: s.boolean({
+      default: false,
+      description: "Whether a screenshot should include the bounded full document height.",
+    }),
+    waitUntil: s.stringEnum(["load", "domcontentloaded", "networkidle"], {
+      default: "domcontentloaded",
+      description: "The browser lifecycle event awaited before the optional delay.",
+    }),
+    delay: s.integer({
+      minimum: 0,
+      maximum: 3000,
+      default: 0,
+      description: "Additional wait in milliseconds after the lifecycle event.",
+    }),
+    timeout: s.integer({
+      minimum: 3000,
+      maximum: 30000,
+      default: 15000,
+      description: "The browser navigation timeout in milliseconds.",
+    }),
+    darkMode: s.boolean({ default: false, description: "Whether to emulate a dark color-scheme preference." }),
+    reducedMotion: s.boolean({
+      default: true,
+      description: "Whether to emulate reduced motion for a more stable capture.",
+    }),
+    paper: s.stringEnum(["A4", "Letter", "Legal"], {
+      default: "A4",
+      description: "The paper size for PDF rendering.",
+    }),
+    landscape: s.boolean({ default: false, description: "Whether PDF output should use landscape orientation." }),
+  },
+  { required: ["url"] },
+);
+
+const captureOutputSchema = s.object(
+  "A rendered artifact in local transit storage with render and quota diagnostics.",
+  {
+    file: transitFileSchema,
+    diagnostics: diagnosticsSchema,
+    quota: quotaSchema,
+  },
+  { required: ["file"], optional: ["diagnostics", "quota"] },
+);
+
+const usageSchema = s.requiredObject("Current successful-render usage for the UTC calendar month.", {
+  period: s.string({ pattern: "^[0-9]{4}-[0-9]{2}$", description: "The current UTC calendar month." }),
+  plan: planSchema,
+  limit: s.positiveInteger("The successful-render allowance for the current month."),
+  remaining: s.nonNegativeInteger("The successful renders remaining in the current month."),
+  resetAt: s.dateTime("The start of the next UTC calendar month."),
+  successful: s.nonNegativeInteger("The successful renders completed in the current month."),
+  failed: s.nonNegativeInteger("The failed reserved renders, which do not consume successful-render quota."),
+  reserved: s.nonNegativeInteger("The render slots currently reserved for in-flight work."),
+  outputBytes: s.nonNegativeInteger("The total successful output bytes in the current month."),
+  renderMs: s.nonNegativeInteger("The aggregate successful render duration in the current month."),
+  updatedAt: s.nullable(s.dateTime("The last usage update time, or null before the first render.")),
+});
+
+const upgradeRequestSchema = s.object(
+  "The latest paid-plan request attached to the key.",
+  {
+    id: s.positiveInteger("The request identifier."),
+    keyId: s.positiveInteger("The API key record identifier."),
+    requestedPlan: s.stringEnum("The requested paid plan.", ["launch", "build", "scale"]),
+    note: s.nullable(s.string("The optional request note.")),
+    status: s.stringEnum("The request review status.", ["new", "contacted", "fulfilled", "declined"]),
+    createdAt: s.dateTime("When the request was created."),
+    updatedAt: s.dateTime("When the request was last updated."),
+  },
+  { required: ["id", "keyId", "requestedPlan", "note", "status", "createdAt", "updatedAt"] },
+);
+
+const usageOutputSchema = s.requiredObject("The current Latchshot plan and quota snapshot.", {
+  customer: s.requiredObject("The display identity attached to the API key.", {
+    name: s.nonEmptyString("The display name attached to the API key."),
+    plan: planSchema,
+  }),
+  usage: usageSchema,
+  upgradeRequest: s.nullable(upgradeRequestSchema),
+});
+
+export const latchshotActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "capture_page",
+    description:
+      "Render a public web page as a PNG, JPEG, or PDF and store the bounded artifact in local transit storage.",
+    inputSchema: captureInputSchema,
+    outputSchema: captureOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_usage",
+    description: "Read the current Latchshot plan, successful-render quota, reset time, and upgrade-request status.",
+    inputSchema: s.object("No input is required to read usage for the configured API key.", {}),
+    outputSchema: usageOutputSchema,
+  }),
+];

--- a/src/providers/latchshot/actions.ts
+++ b/src/providers/latchshot/actions.ts
@@ -5,7 +5,9 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 
 const service = "latchshot";
 
-const planSchema = s.stringEnum("The current Latchshot plan identifier.", ["trial", "launch", "build", "scale"]);
+const planSchema = s.nonEmptyString(
+  "The current Latchshot plan identifier. Known values are trial, launch, build, and scale; newer tiers are passed through unchanged.",
+);
 
 const transitFileSchema = s.requiredObject("The rendered artifact stored in local transit storage.", {
   fileId: s.nonEmptyString("The local transit file identifier."),
@@ -32,7 +34,7 @@ const diagnosticsSchema = s.object(
 const quotaSchema = s.object(
   "The successful-render quota snapshot returned with the artifact.",
   {
-    limit: s.positiveInteger("The successful-render allowance for the current UTC calendar month."),
+    limit: s.nonNegativeInteger("The successful-render allowance for the current UTC calendar month."),
     remaining: s.nonNegativeInteger("The successful renders remaining in the current month."),
     resetAt: s.dateTime("The start of the next UTC calendar month."),
   },
@@ -118,7 +120,7 @@ const captureOutputSchema = s.object(
 const usageSchema = s.requiredObject("Current successful-render usage for the UTC calendar month.", {
   period: s.string({ pattern: "^[0-9]{4}-[0-9]{2}$", description: "The current UTC calendar month." }),
   plan: planSchema,
-  limit: s.positiveInteger("The successful-render allowance for the current month."),
+  limit: s.nonNegativeInteger("The successful-render allowance for the current month."),
   remaining: s.nonNegativeInteger("The successful renders remaining in the current month."),
   resetAt: s.dateTime("The start of the next UTC calendar month."),
   successful: s.nonNegativeInteger("The successful renders completed in the current month."),
@@ -134,9 +136,13 @@ const upgradeRequestSchema = s.object(
   {
     id: s.positiveInteger("The request identifier."),
     keyId: s.positiveInteger("The API key record identifier."),
-    requestedPlan: s.stringEnum("The requested paid plan.", ["launch", "build", "scale"]),
+    requestedPlan: s.nonEmptyString(
+      "The requested paid plan. Known values are launch, build, and scale; newer tiers are passed through unchanged.",
+    ),
     note: s.nullable(s.string("The optional request note.")),
-    status: s.stringEnum("The request review status.", ["new", "contacted", "fulfilled", "declined"]),
+    status: s.nonEmptyString(
+      "The request review status. Known values are new, contacted, fulfilled, and declined; newer statuses are passed through unchanged.",
+    ),
     createdAt: s.dateTime("When the request was created."),
     updatedAt: s.dateTime("When the request was last updated."),
   },

--- a/src/providers/latchshot/definition.ts
+++ b/src/providers/latchshot/definition.ts
@@ -1,0 +1,24 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { latchshotActions } from "./actions.ts";
+
+const service = "latchshot";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Latchshot",
+  description: "Render guarded screenshots and PDFs of public web pages without running a browser locally.",
+  categories: ["Developer Tools", "Design & Media"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "ls_live_...",
+      description:
+        "Latchshot API key sent as a Bearer token. Get a recurring Free-plan key from https://latchshot.fly.dev/#trial.",
+    },
+  ],
+  homepageUrl: "https://latchshot.fly.dev",
+  actions: latchshotActions,
+};

--- a/src/providers/latchshot/definition.ts
+++ b/src/providers/latchshot/definition.ts
@@ -16,7 +16,7 @@ export const provider: ProviderDefinition = {
       label: "API Key",
       placeholder: "ls_live_...",
       description:
-        "Latchshot API key sent as a Bearer token. Get a recurring Free-plan key from https://latchshot.fly.dev/#trial.",
+        "Latchshot API key sent as a Bearer token. Get a recurring Free-plan key from https://latchshot.fly.dev/?intent=openconnector#trial.",
     },
   ],
   homepageUrl: "https://latchshot.fly.dev",

--- a/src/providers/latchshot/executors.test.ts
+++ b/src/providers/latchshot/executors.test.ts
@@ -1,0 +1,185 @@
+import type { TransitFileStore } from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { credentialValidators, latchshotActionHandlers } from "./executors.ts";
+
+const pngBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+interface RecordedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+describe("Latchshot provider", () => {
+  it("renders a bounded artifact into local transit storage", async () => {
+    const requests: RecordedRequest[] = [];
+    const context = createContext(
+      requests,
+      new Response(pngBytes, {
+        headers: {
+          "content-type": "image/png",
+          "content-length": String(pngBytes.byteLength),
+          "x-latchshot-render-ms": "412",
+          "x-latchshot-navigation": "complete",
+          "x-latchshot-fonts": "original",
+          "x-latchshot-scripts": "active",
+          "x-quota-limit": "100",
+          "x-quota-remaining": "99",
+          "x-quota-reset": "2026-08-01T00:00:00.000Z",
+        },
+      }),
+    );
+
+    await expect(
+      latchshotActionHandlers.capture_page!(
+        {
+          url: "https://example.com",
+          width: 1200,
+          height: 630,
+          format: "png",
+          delay: 250,
+          darkMode: false,
+        },
+        context,
+      ),
+    ).resolves.toEqual({
+      file: {
+        fileId: "output-1",
+        downloadUrl: "/api/files/output-1",
+        sizeBytes: pngBytes.byteLength,
+        name: "latchshot-capture.png",
+        mimeType: "image/png",
+      },
+      diagnostics: {
+        renderMs: 412,
+        navigation: "complete",
+        fonts: "original",
+        scripts: "active",
+      },
+      quota: {
+        limit: 100,
+        remaining: 99,
+        resetAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+
+    expect(requests[0]?.url).toBe("https://latchshot.fly.dev/v1/render");
+    expect(requests[0]?.init?.method).toBe("POST");
+    expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe("Bearer test-api-key");
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
+      url: "https://example.com",
+      kind: "screenshot",
+      format: "png",
+      width: 1200,
+      height: 630,
+      delay: 250,
+      darkMode: false,
+    });
+  });
+
+  it("fails before consuming quota when transit storage is unavailable", async () => {
+    const fetcher = vi.fn(async () => new Response(pngBytes)) as unknown as typeof fetch;
+
+    await expect(
+      latchshotActionHandlers.capture_page!({ url: "https://example.com" }, { apiKey: "test-api-key", fetcher }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Latchshot capture requires local transit file storage.",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("validates credentials through the non-billable usage endpoint", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ url: String(input), init });
+      return Response.json(usagePayload());
+    }) as unknown as typeof fetch;
+
+    await expect(credentialValidators.apiKey!({ apiKey: "test-api-key", values: {} }, { fetcher })).resolves.toEqual({
+      profile: {
+        accountId: "latchshot-api-key",
+        displayName: "Open Connector QA (Free)",
+        grantedScopes: [],
+      },
+      metadata: {
+        apiBaseUrl: "https://latchshot.fly.dev",
+        plan: "trial",
+        quotaLimit: 100,
+        quotaRemaining: 100,
+        quotaResetAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+
+    expect(requests[0]?.url).toBe("https://latchshot.fly.dev/v1/usage");
+    expect(requests[0]?.init?.method).toBeUndefined();
+    expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe("Bearer test-api-key");
+  });
+
+  it("preserves a safe provider error without storing an artifact", async () => {
+    const context = createContext(
+      [],
+      Response.json({ error: { code: "unsafe_target", message: "target is not public" } }, { status: 400 }),
+    );
+
+    await expect(latchshotActionHandlers.capture_page!({ url: "http://127.0.0.1" }, context)).rejects.toMatchObject({
+      status: 400,
+      message: "target is not public",
+    });
+  });
+});
+
+function createContext(requests: RecordedRequest[], response: Response): ApiKeyProviderContext {
+  return {
+    apiKey: "test-api-key",
+    fetcher: vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: input instanceof Request ? input.url : String(input), init });
+      return response;
+    }) as unknown as typeof fetch,
+    transitFiles: createTransitFileStore(),
+  };
+}
+
+function createTransitFileStore(): TransitFileStore {
+  let outputCount = 0;
+  return {
+    maxBytes: 1024 * 1024,
+    async read(fileId) {
+      throw new Error(`Unknown test file: ${fileId}`);
+    },
+    async create(file) {
+      outputCount += 1;
+      return {
+        fileId: `output-${outputCount}`,
+        downloadUrl: `/api/files/output-${outputCount}`,
+        sizeBytes: file.size,
+        name: file.name,
+        mimeType: file.type,
+      };
+    },
+    async delete() {
+      return true;
+    },
+  };
+}
+
+function usagePayload(): Record<string, unknown> {
+  return {
+    customer: { name: "Open Connector QA", plan: "trial" },
+    usage: {
+      period: "2026-07",
+      plan: "trial",
+      limit: 100,
+      remaining: 100,
+      resetAt: "2026-08-01T00:00:00.000Z",
+      successful: 0,
+      failed: 0,
+      reserved: 0,
+      outputBytes: 0,
+      renderMs: 0,
+      updatedAt: null,
+    },
+    upgradeRequest: null,
+  };
+}

--- a/src/providers/latchshot/executors.test.ts
+++ b/src/providers/latchshot/executors.test.ts
@@ -90,6 +90,64 @@ describe("Latchshot provider", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      kind: "screenshot",
+      format: "jpeg",
+      contentType: "image/jpeg",
+      extension: "jpg",
+    },
+    {
+      kind: "pdf",
+      format: undefined,
+      contentType: "application/pdf",
+      extension: "pdf",
+    },
+  ])("stores $format $kind output with matching artifact metadata", async (sample) => {
+    const requests: RecordedRequest[] = [];
+    const context = createContext(
+      requests,
+      new Response(Uint8Array.from([1, 2, 3, 4]), {
+        headers: { "content-type": sample.contentType },
+      }),
+    );
+
+    const input = {
+      url: "https://example.com",
+      kind: sample.kind,
+      ...(sample.format ? { format: sample.format } : {}),
+    };
+    const result = await latchshotActionHandlers.capture_page!(input, context);
+
+    expect(result).toMatchObject({
+      file: {
+        name: `latchshot-capture.${sample.extension}`,
+        mimeType: sample.contentType,
+        sizeBytes: 4,
+      },
+    });
+    expect(JSON.parse(String(requests[0]?.init?.body))).toMatchObject({
+      kind: sample.kind,
+      format: sample.kind === "pdf" ? "pdf" : sample.format,
+    });
+  });
+
+  it("consumes a mismatched artifact response without storing it", async () => {
+    const response = new Response(pngBytes, { headers: { "content-type": "image/jpeg" } });
+    const context = createContext([], response);
+    const createFile = vi.spyOn(context.transitFiles!, "create");
+
+    await expect(
+      latchshotActionHandlers.capture_page!({ url: "https://example.com", format: "png" }, context),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Latchshot artifact type did not match the requested format.",
+    });
+
+    expect(response.bodyUsed).toBe(true);
+    expect(createFile).not.toHaveBeenCalled();
+  });
+
   it("validates credentials through the non-billable usage endpoint", async () => {
     const requests: RecordedRequest[] = [];
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/src/providers/latchshot/executors.test.ts
+++ b/src/providers/latchshot/executors.test.ts
@@ -175,6 +175,45 @@ describe("Latchshot provider", () => {
     expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe("Bearer test-api-key");
   });
 
+  it("reads usage without rejecting newer plan tiers, a spent allowance, or a blank note", async () => {
+    const context = createContext([], Response.json(forwardCompatibleUsagePayload()));
+
+    await expect(latchshotActionHandlers.get_usage!({}, context)).resolves.toEqual({
+      customer: { name: "Open Connector QA", plan: "enterprise" },
+      usage: {
+        period: "2026-07",
+        plan: "enterprise",
+        limit: 0,
+        remaining: 0,
+        resetAt: "2026-08-01T00:00:00.000Z",
+        successful: 12,
+        failed: 0,
+        reserved: 0,
+        outputBytes: 4096,
+        renderMs: 512,
+        updatedAt: "2026-07-19T00:00:00.000Z",
+      },
+      upgradeRequest: {
+        id: 7,
+        keyId: 3,
+        requestedPlan: "enterprise",
+        note: "",
+        status: "escalated",
+        createdAt: "2026-07-18T00:00:00.000Z",
+        updatedAt: "2026-07-19T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("rejects a usage response whose fields have the wrong type", async () => {
+    const context = createContext([], Response.json({ customer: { name: "QA", plan: 7 }, usage: {} }));
+
+    await expect(latchshotActionHandlers.get_usage!({}, context)).rejects.toMatchObject({
+      status: 502,
+      message: "customer.plan is required.",
+    });
+  });
+
   it("preserves a safe provider error without storing an artifact", async () => {
     const context = createContext(
       [],
@@ -239,5 +278,34 @@ function usagePayload(): Record<string, unknown> {
       updatedAt: null,
     },
     upgradeRequest: null,
+  };
+}
+
+/** A payload from a future Latchshot release: unknown plan and status values, a spent allowance, and a blank note. */
+function forwardCompatibleUsagePayload(): Record<string, unknown> {
+  return {
+    customer: { name: "Open Connector QA", plan: "enterprise" },
+    usage: {
+      period: "2026-07",
+      plan: "enterprise",
+      limit: 0,
+      remaining: 0,
+      resetAt: "2026-08-01T00:00:00.000Z",
+      successful: 12,
+      failed: 0,
+      reserved: 0,
+      outputBytes: 4096,
+      renderMs: 512,
+      updatedAt: "2026-07-19T00:00:00.000Z",
+    },
+    upgradeRequest: {
+      id: 7,
+      keyId: 3,
+      requestedPlan: "enterprise",
+      note: "",
+      status: "escalated",
+      createdAt: "2026-07-18T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+    },
   };
 }

--- a/src/providers/latchshot/executors.ts
+++ b/src/providers/latchshot/executors.ts
@@ -22,7 +22,7 @@ const service = "latchshot";
 const latchshotApiBaseUrl = "https://latchshot.fly.dev";
 const latchshotRenderPath = "/v1/render";
 const latchshotUsagePath = "/v1/usage";
-const latchshotErrorMaxBytes = 64 * 1024;
+const latchshotJsonMaxBytes = 64 * 1024;
 const planValues = new Set(["trial", "launch", "build", "scale"]);
 const upgradePlanValues = new Set(["launch", "build", "scale"]);
 const upgradeStatusValues = new Set(["new", "contacted", "fulfilled", "declined"]);
@@ -101,7 +101,6 @@ async function captureLatchshotPage(
     throw await createLatchshotError(response, "execute");
   }
 
-  const artifact = resolveArtifact(response.headers.get("content-type"), format);
   const bytes = await readBoundedResponseBytes(response, {
     maxBytes: context.transitFiles.maxBytes,
     fieldName: "Latchshot artifact",
@@ -111,6 +110,7 @@ async function captureLatchshotPage(
     throw new ProviderRequestError(502, "Latchshot returned an empty artifact.");
   }
 
+  const artifact = resolveArtifact(response.headers.get("content-type"), format);
   const stored = await context.transitFiles.create(
     new File([Uint8Array.from(bytes)], `latchshot-capture.${artifact.extension}`, { type: artifact.mimeType }),
   );
@@ -153,7 +153,7 @@ async function requestLatchshotUsage(
     throw await createLatchshotError(response, phase);
   }
 
-  const text = await readProviderTextBody(response, "Latchshot usage response", latchshotErrorMaxBytes);
+  const text = await readProviderTextBody(response, "Latchshot usage response", latchshotJsonMaxBytes);
   let payload: unknown;
   try {
     payload = JSON.parse(text) as unknown;
@@ -188,7 +188,7 @@ async function fetchLatchshot(
 }
 
 async function createLatchshotError(response: Response, phase: LatchshotRequestPhase): Promise<ProviderRequestError> {
-  const text = await readProviderTextBody(response, "Latchshot error response", latchshotErrorMaxBytes);
+  const text = await readProviderTextBody(response, "Latchshot error response", latchshotJsonMaxBytes);
   const message = extractLatchshotErrorMessage(text) ?? `Latchshot request failed with HTTP ${response.status}.`;
 
   if (phase === "validate" && (response.status === 401 || response.status === 403)) {

--- a/src/providers/latchshot/executors.ts
+++ b/src/providers/latchshot/executors.ts
@@ -5,6 +5,7 @@ import {
   compactObject,
   optionalBoolean,
   optionalInteger,
+  optionalRawString,
   optionalRecord,
   optionalString,
   requiredString,
@@ -23,9 +24,6 @@ const latchshotApiBaseUrl = "https://latchshot.fly.dev";
 const latchshotRenderPath = "/v1/render";
 const latchshotUsagePath = "/v1/usage";
 const latchshotJsonMaxBytes = 64 * 1024;
-const planValues = new Set(["trial", "launch", "build", "scale"]);
-const upgradePlanValues = new Set(["launch", "build", "scale"]);
-const upgradeStatusValues = new Set(["new", "contacted", "fulfilled", "declined"]);
 
 type LatchshotActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 type LatchshotRequestPhase = "validate" | "execute";
@@ -242,18 +240,16 @@ function normalizeUsagePayload(payload: unknown): {
   const record = requireObject(payload, "Latchshot usage response must be an object.");
   const customer = requireObject(record.customer, "Latchshot usage response is missing customer data.");
   const usage = requireObject(record.usage, "Latchshot usage response is missing usage data.");
-  const customerPlan = requireEnum(customer.plan, "customer.plan", planValues);
-  const usagePlan = requireEnum(usage.plan, "usage.plan", planValues);
 
   return {
     customer: {
       name: requiredString(customer.name, "customer.name", invalidResponseError),
-      plan: customerPlan,
+      plan: requiredString(customer.plan, "customer.plan", invalidResponseError),
     },
     usage: {
       period: requiredString(usage.period, "usage.period", invalidResponseError),
-      plan: usagePlan,
-      limit: requireNonNegativeInteger(usage.limit, "usage.limit", true),
+      plan: requiredString(usage.plan, "usage.plan", invalidResponseError),
+      limit: requireNonNegativeInteger(usage.limit, "usage.limit"),
       remaining: requireNonNegativeInteger(usage.remaining, "usage.remaining"),
       resetAt: requiredString(usage.resetAt, "usage.resetAt", invalidResponseError),
       successful: requireNonNegativeInteger(usage.successful, "usage.successful"),
@@ -276,9 +272,9 @@ function normalizeUpgradeRequest(value: unknown): Record<string, unknown> | null
   return {
     id: requireNonNegativeInteger(request.id, "upgradeRequest.id", true),
     keyId: requireNonNegativeInteger(request.keyId, "upgradeRequest.keyId", true),
-    requestedPlan: requireEnum(request.requestedPlan, "upgradeRequest.requestedPlan", upgradePlanValues),
-    note: request.note === null ? null : requiredString(request.note, "upgradeRequest.note", invalidResponseError),
-    status: requireEnum(request.status, "upgradeRequest.status", upgradeStatusValues),
+    requestedPlan: requiredString(request.requestedPlan, "upgradeRequest.requestedPlan", invalidResponseError),
+    note: optionalRawString(request.note) ?? null,
+    status: requiredString(request.status, "upgradeRequest.status", invalidResponseError),
     createdAt: requiredString(request.createdAt, "upgradeRequest.createdAt", invalidResponseError),
     updatedAt: requiredString(request.updatedAt, "upgradeRequest.updatedAt", invalidResponseError),
   };
@@ -290,14 +286,6 @@ function requireObject(value: unknown, message: string): Record<string, unknown>
     return record;
   }
   throw new ProviderRequestError(502, message);
-}
-
-function requireEnum(value: unknown, fieldName: string, allowed: Set<string>): string {
-  const text = optionalString(value);
-  if (text && allowed.has(text)) {
-    return text;
-  }
-  throw invalidResponseError(`${fieldName} is invalid.`);
 }
 
 function requireNonNegativeInteger(value: unknown, fieldName: string, positive = false): number {

--- a/src/providers/latchshot/executors.ts
+++ b/src/providers/latchshot/executors.ts
@@ -1,0 +1,330 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderTransitFile } from "../provider-runtime.ts";
+
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import {
+  createProviderFetch,
+  defineApiKeyProviderExecutors,
+  providerUserAgent,
+  ProviderRequestError,
+  readProviderTextBody,
+} from "../provider-runtime.ts";
+
+const service = "latchshot";
+const latchshotApiBaseUrl = "https://latchshot.fly.dev";
+const latchshotRenderPath = "/v1/render";
+const latchshotUsagePath = "/v1/usage";
+const latchshotErrorMaxBytes = 64 * 1024;
+const planValues = new Set(["trial", "launch", "build", "scale"]);
+const upgradePlanValues = new Set(["launch", "build", "scale"]);
+const upgradeStatusValues = new Set(["new", "contacted", "fulfilled", "declined"]);
+
+type LatchshotActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+type LatchshotRequestPhase = "validate" | "execute";
+
+export const latchshotActionHandlers: Record<string, LatchshotActionHandler> = {
+  capture_page(input, context) {
+    return captureLatchshotPage(input, context);
+  },
+  get_usage(_input, context) {
+    return getLatchshotUsage(context);
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, latchshotActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    const credentialFetch = createProviderFetch({ fetch: fetcher, skipDnsValidation: true });
+    const result = await requestLatchshotUsage(input.apiKey, credentialFetch, signal, "validate");
+    return {
+      profile: {
+        accountId: "latchshot-api-key",
+        displayName: `${result.customer.name} (${displayPlan(result.customer.plan)})`,
+        grantedScopes: [],
+      },
+      metadata: {
+        apiBaseUrl: latchshotApiBaseUrl,
+        plan: result.usage.plan,
+        quotaLimit: result.usage.limit,
+        quotaRemaining: result.usage.remaining,
+        quotaResetAt: result.usage.resetAt,
+      },
+    };
+  },
+};
+
+async function captureLatchshotPage(
+  input: Record<string, unknown>,
+  context: ApiKeyProviderContext,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "Latchshot capture requires local transit file storage.");
+  }
+
+  const kind = optionalString(input.kind) ?? "screenshot";
+  const format = kind === "pdf" ? "pdf" : (optionalString(input.format) ?? "png");
+  const response = await fetchLatchshot(latchshotRenderPath, context.apiKey, context.fetcher, context.signal, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(
+      compactObject({
+        url: requiredString(input.url, "url", providerInputError),
+        kind,
+        format,
+        width: optionalInteger(input.width),
+        height: optionalInteger(input.height),
+        scale: optionalInteger(input.scale),
+        fullPage: optionalBoolean(input.fullPage),
+        waitUntil: optionalString(input.waitUntil),
+        delay: optionalInteger(input.delay),
+        timeout: optionalInteger(input.timeout),
+        darkMode: optionalBoolean(input.darkMode),
+        reducedMotion: optionalBoolean(input.reducedMotion),
+        paper: optionalString(input.paper),
+        landscape: optionalBoolean(input.landscape),
+      }),
+    ),
+  });
+
+  if (!response.ok) {
+    throw await createLatchshotError(response, "execute");
+  }
+
+  const artifact = resolveArtifact(response.headers.get("content-type"), format);
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Latchshot artifact",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  if (bytes.byteLength === 0) {
+    throw new ProviderRequestError(502, "Latchshot returned an empty artifact.");
+  }
+
+  const stored = await context.transitFiles.create(
+    new File([Uint8Array.from(bytes)], `latchshot-capture.${artifact.extension}`, { type: artifact.mimeType }),
+  );
+  const file: ProviderTransitFile = {
+    fileId: stored.fileId,
+    downloadUrl: stored.downloadUrl,
+    sizeBytes: stored.sizeBytes,
+    name: stored.name,
+    mimeType: stored.mimeType,
+  };
+
+  return compactObject({
+    file,
+    diagnostics: compactObject({
+      renderMs: readIntegerHeader(response.headers, "x-latchshot-render-ms"),
+      navigation: optionalString(response.headers.get("x-latchshot-navigation")),
+      fonts: optionalString(response.headers.get("x-latchshot-fonts")),
+      scripts: optionalString(response.headers.get("x-latchshot-scripts")),
+    }),
+    quota: compactObject({
+      limit: readIntegerHeader(response.headers, "x-quota-limit"),
+      remaining: readIntegerHeader(response.headers, "x-quota-remaining"),
+      resetAt: optionalString(response.headers.get("x-quota-reset")),
+    }),
+  });
+}
+
+async function getLatchshotUsage(context: ApiKeyProviderContext): Promise<Record<string, unknown>> {
+  return requestLatchshotUsage(context.apiKey, context.fetcher, context.signal, "execute");
+}
+
+async function requestLatchshotUsage(
+  apiKey: string,
+  fetcher: typeof fetch,
+  signal: AbortSignal | undefined,
+  phase: LatchshotRequestPhase,
+): Promise<ReturnType<typeof normalizeUsagePayload>> {
+  const response = await fetchLatchshot(latchshotUsagePath, apiKey, fetcher, signal);
+  if (!response.ok) {
+    throw await createLatchshotError(response, phase);
+  }
+
+  const text = await readProviderTextBody(response, "Latchshot usage response", latchshotErrorMaxBytes);
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text) as unknown;
+  } catch {
+    throw new ProviderRequestError(502, "Latchshot returned an invalid usage response.");
+  }
+  return normalizeUsagePayload(payload);
+}
+
+async function fetchLatchshot(
+  path: string,
+  apiKey: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("accept", path === latchshotUsagePath ? "application/json" : "*/*");
+  headers.set("authorization", `Bearer ${apiKey}`);
+  headers.set("user-agent", providerUserAgent);
+  try {
+    return await fetcher(new URL(path, latchshotApiBaseUrl), { ...init, headers, signal });
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Latchshot request failed: ${error.message}` : "Latchshot request failed.",
+    );
+  }
+}
+
+async function createLatchshotError(response: Response, phase: LatchshotRequestPhase): Promise<ProviderRequestError> {
+  const text = await readProviderTextBody(response, "Latchshot error response", latchshotErrorMaxBytes);
+  const message = extractLatchshotErrorMessage(text) ?? `Latchshot request failed with HTTP ${response.status}.`;
+
+  if (phase === "validate" && (response.status === 401 || response.status === 403)) {
+    return new ProviderRequestError(400, message);
+  }
+  if ([400, 401, 403, 413, 429].includes(response.status)) {
+    return new ProviderRequestError(response.status, message);
+  }
+  return new ProviderRequestError(response.status >= 500 ? response.status : 502, message);
+}
+
+function extractLatchshotErrorMessage(text: string): string | undefined {
+  if (!text.trim()) {
+    return undefined;
+  }
+  try {
+    const record = optionalRecord(JSON.parse(text) as unknown);
+    return optionalString(optionalRecord(record?.error)?.message) ?? optionalString(record?.message);
+  } catch {
+    return text.trim().slice(0, 500);
+  }
+}
+
+function resolveArtifact(contentType: string | null, format: string): { mimeType: string; extension: string } {
+  const mimeType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+  const supported: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "application/pdf": "pdf",
+  };
+  const extension = mimeType ? supported[mimeType] : undefined;
+  if (!mimeType || !extension) {
+    throw new ProviderRequestError(502, "Latchshot returned an unsupported artifact type.", { contentType });
+  }
+
+  const expectedMimeType = format === "pdf" ? "application/pdf" : format === "jpeg" ? "image/jpeg" : "image/png";
+  if (mimeType !== expectedMimeType) {
+    throw new ProviderRequestError(502, "Latchshot artifact type did not match the requested format.", {
+      expectedMimeType,
+      contentType: mimeType,
+    });
+  }
+  return { mimeType, extension };
+}
+
+function normalizeUsagePayload(payload: unknown): {
+  customer: { name: string; plan: string };
+  usage: Record<string, unknown>;
+  upgradeRequest: Record<string, unknown> | null;
+} {
+  const record = requireObject(payload, "Latchshot usage response must be an object.");
+  const customer = requireObject(record.customer, "Latchshot usage response is missing customer data.");
+  const usage = requireObject(record.usage, "Latchshot usage response is missing usage data.");
+  const customerPlan = requireEnum(customer.plan, "customer.plan", planValues);
+  const usagePlan = requireEnum(usage.plan, "usage.plan", planValues);
+
+  return {
+    customer: {
+      name: requiredString(customer.name, "customer.name", invalidResponseError),
+      plan: customerPlan,
+    },
+    usage: {
+      period: requiredString(usage.period, "usage.period", invalidResponseError),
+      plan: usagePlan,
+      limit: requireNonNegativeInteger(usage.limit, "usage.limit", true),
+      remaining: requireNonNegativeInteger(usage.remaining, "usage.remaining"),
+      resetAt: requiredString(usage.resetAt, "usage.resetAt", invalidResponseError),
+      successful: requireNonNegativeInteger(usage.successful, "usage.successful"),
+      failed: requireNonNegativeInteger(usage.failed, "usage.failed"),
+      reserved: requireNonNegativeInteger(usage.reserved, "usage.reserved"),
+      outputBytes: requireNonNegativeInteger(usage.outputBytes, "usage.outputBytes"),
+      renderMs: requireNonNegativeInteger(usage.renderMs, "usage.renderMs"),
+      updatedAt:
+        usage.updatedAt === null ? null : requiredString(usage.updatedAt, "usage.updatedAt", invalidResponseError),
+    },
+    upgradeRequest: normalizeUpgradeRequest(record.upgradeRequest),
+  };
+}
+
+function normalizeUpgradeRequest(value: unknown): Record<string, unknown> | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const request = requireObject(value, "Latchshot upgrade request must be an object.");
+  return {
+    id: requireNonNegativeInteger(request.id, "upgradeRequest.id", true),
+    keyId: requireNonNegativeInteger(request.keyId, "upgradeRequest.keyId", true),
+    requestedPlan: requireEnum(request.requestedPlan, "upgradeRequest.requestedPlan", upgradePlanValues),
+    note: request.note === null ? null : requiredString(request.note, "upgradeRequest.note", invalidResponseError),
+    status: requireEnum(request.status, "upgradeRequest.status", upgradeStatusValues),
+    createdAt: requiredString(request.createdAt, "upgradeRequest.createdAt", invalidResponseError),
+    updatedAt: requiredString(request.updatedAt, "upgradeRequest.updatedAt", invalidResponseError),
+  };
+}
+
+function requireObject(value: unknown, message: string): Record<string, unknown> {
+  const record = optionalRecord(value);
+  if (record) {
+    return record;
+  }
+  throw new ProviderRequestError(502, message);
+}
+
+function requireEnum(value: unknown, fieldName: string, allowed: Set<string>): string {
+  const text = optionalString(value);
+  if (text && allowed.has(text)) {
+    return text;
+  }
+  throw invalidResponseError(`${fieldName} is invalid.`);
+}
+
+function requireNonNegativeInteger(value: unknown, fieldName: string, positive = false): number {
+  const resolved = optionalInteger(value);
+  if (resolved !== undefined && (positive ? resolved > 0 : resolved >= 0)) {
+    return resolved;
+  }
+  throw invalidResponseError(`${fieldName} is invalid.`);
+}
+
+function readIntegerHeader(headers: Headers, name: string): number | undefined {
+  const value = headers.get(name);
+  if (!value || !/^\d+$/u.test(value)) {
+    return undefined;
+  }
+  const resolved = Number(value);
+  return Number.isSafeInteger(resolved) ? resolved : undefined;
+}
+
+function displayPlan(plan: string): string {
+  return plan === "trial" ? "Free" : `${plan[0]!.toUpperCase()}${plan.slice(1)}`;
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function invalidResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}


### PR DESCRIPTION
## Summary

- add an API-key provider for the guarded Latchshot public-page renderer
- expose `latchshot.capture_page` with bounded PNG, JPEG, and PDF options plus local transit-file output
- expose non-billable `latchshot.get_usage` and use the same endpoint for credential validation
- preserve render diagnostics and successful-render quota headers
- fail before the upstream request when transit storage is unavailable, so a render is not charged without a usable artifact

I maintain Latchshot. The hosted API remains separate from this Apache-2.0 provider contribution; no logo, copied schema, generated catalog output, payment action, or upgrade action is included.

## Verification

- `npm run generate:catalog` — generated 1,091 providers and 11,138 actions
- `npm run fix-check` — lint, format, generated registries, and typecheck passed
- `npm test` — 71 files / 614 tests passed
- `npm run build` — CI-parity typecheck passed
- live production round trip with a bounded reserved-domain QA key:
  - usage read returned a 2-render allowance without consuming quota
  - `capture_page` stored a valid 16,323-byte 1200×630 PNG in transit storage
  - diagnostics reported complete navigation, original fonts, active scripts, and 462 ms render time
  - remaining quota moved from 2 to 1
  - the QA key was revoked immediately and now returns HTTP 401