### PR TITLE
feat(web): add multi-connection management

### DIFF
--- a/web/src/actions-page.test.ts
+++ b/web/src/actions-page.test.ts
@@ -1,0 +1,44 @@
+import type { ConnectionRecord } from "./model";
+
+import { describe, expect, it } from "vitest";
+import { actionRequestBody, initialActionConnectionName, reconcileActionConnectionName } from "./actions-page";
+
+function connection(connectionName: string, defaultConnection = false): ConnectionRecord {
+  return {
+    id: `connection-${connectionName}`,
+    service: "github",
+    connectionName,
+    authType: "api_key",
+    configured: true,
+    default: defaultConnection,
+    metadata: {},
+  };
+}
+
+describe("action connection selection", () => {
+  it("automatically selects the only usable connection", () => {
+    expect(initialActionConnectionName([connection("work")])).toBe("work");
+  });
+
+  it("prefers the reserved default connection when several exist", () => {
+    expect(initialActionConnectionName([connection("work"), connection("default", true)])).toBe("default");
+  });
+
+  it("requires an explicit choice when several connections exist without default", () => {
+    expect(initialActionConnectionName([connection("personal"), connection("work")])).toBeUndefined();
+  });
+
+  it("reconciles selection when refreshed connections remove or narrow the choices", () => {
+    expect(reconcileActionConnectionName("work", [connection("personal"), connection("work")])).toBe("work");
+    expect(reconcileActionConnectionName("removed", [connection("work")])).toBe("work");
+    expect(reconcileActionConnectionName(undefined, [connection("work")])).toBe("work");
+  });
+
+  it("includes an explicitly selected connection in the action request", () => {
+    expect(actionRequestBody({ repository: "open-connector" }, "work")).toEqual({
+      input: { repository: "open-connector" },
+      connectionName: "work",
+    });
+    expect(actionRequestBody({}, undefined)).toEqual({ input: {} });
+  });
+});

--- a/web/src/actions-page.tsx
+++ b/web/src/actions-page.tsx
@@ -1,4 +1,11 @@
-import type { ActionDefinition, AppData, ExecutionResult, JsonSchema, RuntimeActionResponse } from "./model";
+import type {
+  ActionDefinition,
+  AppData,
+  ConnectionRecord,
+  ExecutionResult,
+  JsonSchema,
+  RuntimeActionResponse,
+} from "./model";
 import type { ReactNode } from "react";
 
 import { useTranslate } from "@embra/i18n/react";
@@ -6,7 +13,13 @@ import { useClipboard } from "foxact/use-clipboard";
 import { Check, ChevronRight, Code2, Copy, ExternalLink, Loader2, Play, Search, TerminalSquare, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
-import { buildActionExamples, exampleInput, filterActions, parameterSummaries } from "./model";
+import {
+  buildActionExamples,
+  exampleInput,
+  filterActions,
+  parameterSummaries,
+  usableConnectionsForService,
+} from "./model";
 import { Badge, EmptyState, TagList } from "./shared-ui";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -24,6 +37,7 @@ interface ActionsPageProps {
 interface ActionDetailProps {
   action: ActionDefinition;
   providerName: string;
+  connections: ConnectionRecord[];
   onRefresh(): void;
 }
 
@@ -178,6 +192,7 @@ export function ActionsPage(props: ActionsPageProps): ReactNode {
             <ActionDetail
               action={selectedAction}
               providerName={providerNames.get(selectedAction.service) ?? selectedAction.service}
+              connections={usableConnectionsForService(props.data.connections, selectedAction.service)}
               onRefresh={props.onRefresh}
             />
           ) : (
@@ -243,7 +258,12 @@ function ActionDetail(props: ActionDetailProps): ReactNode {
       <ParameterList schema={props.action.inputSchema} />
       <ExampleTabs action={props.action} examples={examples} />
       {debugOpen ? (
-        <RunActionModal action={props.action} onRefresh={props.onRefresh} onClose={() => setDebugOpen(false)} />
+        <RunActionModal
+          action={props.action}
+          connections={props.connections}
+          onRefresh={props.onRefresh}
+          onClose={() => setDebugOpen(false)}
+        />
       ) : null}
     </>
   );
@@ -336,12 +356,23 @@ function ExampleTabs(props: ExampleTabsProps): ReactNode {
   );
 }
 
-function RunActionModal(props: { action: ActionDefinition; onRefresh(): void; onClose(): void }): ReactNode {
+interface RunActionModalProps {
+  action: ActionDefinition;
+  connections: ConnectionRecord[];
+  onRefresh(): void;
+  onClose(): void;
+}
+
+function RunActionModal(props: RunActionModalProps): ReactNode {
   const t = useTranslate();
   const [input, setInput] = useState(() => exampleInput(props.action.inputSchema));
   const [result, setResult] = useState<ExecutionResult | null>(null);
   const [running, setRunning] = useState(false);
   const [actionId, setActionId] = useState(props.action.id);
+  const initialConnectionName = initialActionConnectionName(props.connections);
+  const connectionSignature = props.connections.map((connection) => actionConnectionName(connection)).join("\0");
+  const [selectedConnectionName, setSelectedConnectionName] = useState(() => initialConnectionName);
+  const connectionSelectionRequired = props.connections.length > 1 && !selectedConnectionName;
 
   useEffect(() => {
     if (!shouldResetRunActionModal(actionId, props.action.id)) {
@@ -351,7 +382,12 @@ function RunActionModal(props: { action: ActionDefinition; onRefresh(): void; on
     setActionId(props.action.id);
     setInput(exampleInput(props.action.inputSchema));
     setResult(null);
-  }, [actionId, props.action.id, props.action.inputSchema]);
+    setSelectedConnectionName(initialConnectionName);
+  }, [actionId, initialConnectionName, props.action.id, props.action.inputSchema]);
+
+  useEffect(() => {
+    setSelectedConnectionName((current) => reconcileActionConnectionName(current, props.connections));
+  }, [connectionSignature]);
 
   async function run(): Promise<void> {
     setRunning(true);
@@ -362,7 +398,7 @@ function RunActionModal(props: { action: ActionDefinition; onRefresh(): void; on
         method: "POST",
         headers: new Headers({ "content-type": "application/json" }),
         credentials: "same-origin",
-        body: JSON.stringify({ input: parsed }),
+        body: JSON.stringify(actionRequestBody(parsed, selectedConnectionName)),
       });
       const payload = (await response.json()) as RuntimeActionResponse;
       setResult(
@@ -407,6 +443,32 @@ function RunActionModal(props: { action: ActionDefinition; onRefresh(): void; on
           </Button>
         </DialogHeader>
         <div className={result ? "run-action-dialog-body has-result" : "run-action-dialog-body"}>
+          {props.connections.length === 1 ? (
+            <div className="field">
+              <span>{t("actions.connection")}</span>
+              <div className="action-connection-value">{actionConnectionLabel(props.connections[0]!)}</div>
+            </div>
+          ) : props.connections.length > 1 ? (
+            <Label className="field">
+              <span>{t("actions.connection")}</span>
+              <Select value={selectedConnectionName} onValueChange={setSelectedConnectionName}>
+                <SelectTrigger aria-label={t("actions.connection")}>
+                  <SelectValue placeholder={t("actions.selectConnection")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {props.connections.map((connection) => {
+                    const connectionName = actionConnectionName(connection);
+                    return (
+                      <SelectItem key={connection.id ?? connectionName} value={connectionName}>
+                        {actionConnectionLabel(connection)}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              {connectionSelectionRequired ? <small>{t("actions.connectionRequired")}</small> : null}
+            </Label>
+          ) : null}
           <Label className="field">
             <span>{t("actions.input")}</span>
             <Textarea
@@ -417,7 +479,7 @@ function RunActionModal(props: { action: ActionDefinition; onRefresh(): void; on
             />
           </Label>
           <div className="button-row">
-            <Button type="button" onClick={() => void run()} disabled={running}>
+            <Button type="button" onClick={() => void run()} disabled={running || connectionSelectionRequired}>
               {running ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
               {running ? t("actions.running") : t("actions.run")}
             </Button>
@@ -452,6 +514,35 @@ function ResultPanel(props: { actionId: string; result: ExecutionResult }): Reac
 
 export function shouldResetRunActionModal(currentActionId: string, nextActionId: string): boolean {
   return currentActionId !== nextActionId;
+}
+
+export function initialActionConnectionName(connections: ConnectionRecord[]): string | undefined {
+  if (connections.length === 1) return actionConnectionName(connections[0]!);
+  return connections.find((connection) => actionConnectionName(connection) === "default") ? "default" : undefined;
+}
+
+export function reconcileActionConnectionName(
+  current: string | undefined,
+  connections: ConnectionRecord[],
+): string | undefined {
+  if (current && connections.some((connection) => actionConnectionName(connection) === current)) return current;
+  return initialActionConnectionName(connections);
+}
+
+export function actionRequestBody(input: unknown, connectionName: string | undefined): Record<string, unknown> {
+  return { input, ...(connectionName ? { connectionName } : {}) };
+}
+
+function actionConnectionName(connection: ConnectionRecord): string {
+  return connection.connectionName?.trim() || "default";
+}
+
+function actionConnectionLabel(connection: ConnectionRecord): string {
+  const connectionName = actionConnectionName(connection);
+  const displayName = connection.profile?.displayName;
+  return typeof displayName === "string" && displayName.trim() && displayName.trim() !== connectionName
+    ? `${connectionName} · ${displayName.trim()}`
+    : connectionName;
 }
 
 function buildAgentPrompt(action: ActionDefinition): { prompt: string } {

--- a/web/src/actions-page.tsx
+++ b/web/src/actions-page.tsx
@@ -371,6 +371,8 @@ function RunActionModal(props: RunActionModalProps): ReactNode {
   const [actionId, setActionId] = useState(props.action.id);
   const initialConnectionName = initialActionConnectionName(props.connections);
   const connectionSignature = props.connections.map((connection) => actionConnectionName(connection)).join("\0");
+  const connectionsRef = useRef(props.connections);
+  connectionsRef.current = props.connections;
   const [selectedConnectionName, setSelectedConnectionName] = useState(() => initialConnectionName);
   const connectionSelectionRequired = props.connections.length > 1 && !selectedConnectionName;
 
@@ -386,7 +388,7 @@ function RunActionModal(props: RunActionModalProps): ReactNode {
   }, [actionId, initialConnectionName, props.action.id, props.action.inputSchema]);
 
   useEffect(() => {
-    setSelectedConnectionName((current) => reconcileActionConnectionName(current, props.connections));
+    setSelectedConnectionName((current) => reconcileActionConnectionName(current, connectionsRef.current));
   }, [connectionSignature]);
 
   async function run(): Promise<void> {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -160,10 +160,23 @@
       "notUsed": "Not used"
     },
     "connection": "Connection",
+    "connectionCount": "{{count}} connections",
+    "savedConnections": "Saved connections",
+    "defaultConnection": "Default",
+    "connectionName": "Connection name",
+    "connectionNamePlaceholder": "for example, work",
+    "connectionNameDescription": "Use this name to select the account when running actions.",
+    "connectionNameErrors": {
+      "required": "Enter a connection name.",
+      "invalid": "Start with a letter or digit and use at most 64 letters, digits, underscores, or hyphens.",
+      "duplicate": "This name is already in use. Select that connection to update it."
+    },
     "connectionMethod": "Connection method",
     "connectionDescriptions": {
       "noSetup": "This provider can run without local credentials.",
+      "adding": "Configure a new named connection.",
       "connected": "Local credentials are configured with {{authType}}.",
+      "saved": "{{count}} saved connections. Select one to manage it or add another.",
       "oauthClientRequired": "{{name}} needs a local OAuth client before OAuth can start.",
       "notConnected": "Configure local credentials before running credentialed {{name}} actions.",
       "unavailable": "Connections cannot be configured in the current runtime."
@@ -202,6 +215,10 @@
       "configureOAuthClient": "Configure OAuth Client",
       "editOAuthClient": "Edit OAuth Client",
       "saveConnection": "Save Connection",
+      "addConnection": "Add Connection",
+      "cancel": "Cancel",
+      "clearSelection": "Clear selection",
+      "selected": "Selected",
       "connect": "Connect",
       "details": "Details",
       "manageConnection": "Manage",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "Connection",
+    "selectConnection": "Select a connection",
+    "connectionRequired": "Choose which connection should run this action.",
     "searchPlaceholder": "Search actions by name, id, or provider",
     "provider": "Provider",
     "allProviders": "All providers",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -176,7 +176,7 @@
       "noSetup": "This provider can run without local credentials.",
       "adding": "Configure a new named connection.",
       "connected": "Local credentials are configured with {{authType}}.",
-      "saved": "{{count}} saved connections. Select one to manage it or add another.",
+      "saved": "Saved connections: {{count}}. Select one to manage or add another.",
       "oauthClientRequired": "{{name}} needs a local OAuth client before OAuth can start.",
       "notConnected": "Configure local credentials before running credentialed {{name}} actions.",
       "unavailable": "Connections cannot be configured in the current runtime."

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -160,10 +160,23 @@
       "notUsed": "Non utilisé"
     },
     "connection": "Connexion",
+    "connectionCount": "{{count}} connexions",
+    "savedConnections": "Connexions enregistrées",
+    "defaultConnection": "Par défaut",
+    "connectionName": "Nom de la connexion",
+    "connectionNamePlaceholder": "par exemple, work",
+    "connectionNameDescription": "Utilisez ce nom pour sélectionner le compte lors de l’exécution d’actions.",
+    "connectionNameErrors": {
+      "required": "Saisissez un nom de connexion.",
+      "invalid": "Commencez par une lettre ou un chiffre et utilisez au plus 64 lettres, chiffres, tirets bas ou tirets.",
+      "duplicate": "Ce nom est déjà utilisé. Sélectionnez cette connexion pour la mettre à jour."
+    },
     "connectionMethod": "Méthode de connexion",
     "connectionDescriptions": {
       "noSetup": "Ce fournisseur peut s’exécuter sans identifiants locaux.",
+      "adding": "Configurez une nouvelle connexion nommée.",
       "connected": "Les identifiants locaux sont configurés avec {{authType}}.",
+      "saved": "{{count}} connexions enregistrées. Sélectionnez-en une à gérer ou ajoutez-en une autre.",
       "oauthClientRequired": "{{name}} nécessite un client OAuth local avant de lancer OAuth.",
       "notConnected": "Configurez des identifiants locaux avant d’exécuter les actions {{name}} qui en ont besoin.",
       "unavailable": "Les connexions ne peuvent pas être configurées dans l’environnement d’exécution actuel."
@@ -202,6 +215,10 @@
       "configureOAuthClient": "Configurer le client OAuth",
       "editOAuthClient": "Modifier le client OAuth",
       "saveConnection": "Enregistrer la connexion",
+      "addConnection": "Ajouter une connexion",
+      "cancel": "Annuler",
+      "clearSelection": "Annuler la sélection",
+      "selected": "Sélectionnée",
       "connect": "Connecter",
       "details": "Détails",
       "manageConnection": "Gérer",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "Connexion",
+    "selectConnection": "Sélectionner une connexion",
+    "connectionRequired": "Choisissez la connexion qui doit exécuter cette action.",
     "searchPlaceholder": "Rechercher des actions par nom, ID ou fournisseur",
     "provider": "Fournisseur",
     "allProviders": "Tous les fournisseurs",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -176,7 +176,7 @@
       "noSetup": "Ce fournisseur peut s’exécuter sans identifiants locaux.",
       "adding": "Configurez une nouvelle connexion nommée.",
       "connected": "Les identifiants locaux sont configurés avec {{authType}}.",
-      "saved": "{{count}} connexions enregistrées. Sélectionnez-en une à gérer ou ajoutez-en une autre.",
+      "saved": "Connexions enregistrées : {{count}}. Sélectionnez-en une à gérer ou ajoutez-en une autre.",
       "oauthClientRequired": "{{name}} nécessite un client OAuth local avant de lancer OAuth.",
       "notConnected": "Configurez des identifiants locaux avant d’exécuter les actions {{name}} qui en ont besoin.",
       "unavailable": "Les connexions ne peuvent pas être configurées dans l’environnement d’exécution actuel."

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -160,10 +160,23 @@
       "notUsed": "未使用"
     },
     "connection": "接続",
+    "connectionCount": "{{count}} 件の接続",
+    "savedConnections": "保存済みの接続",
+    "defaultConnection": "デフォルト",
+    "connectionName": "接続名",
+    "connectionNamePlaceholder": "例: work",
+    "connectionNameDescription": "アクションの実行時に、この名前でアカウントを選択します。",
+    "connectionNameErrors": {
+      "required": "接続名を入力してください。",
+      "invalid": "先頭は英数字とし、64文字以内の英数字、アンダースコア、ハイフンを使用してください。",
+      "duplicate": "この名前はすでに使用されています。既存の接続を選択して更新してください。"
+    },
     "connectionMethod": "接続方式",
     "connectionDescriptions": {
       "noSetup": "このプロバイダーはローカル認証情報なしで実行できます。",
+      "adding": "新しい名前付き接続を設定します。",
       "connected": "ローカル認証情報は {{authType}} で設定済みです。",
+      "saved": "保存済みの接続が {{count}} 件あります。管理する接続を選択するか、新しい接続を追加してください。",
       "oauthClientRequired": "{{name}} で OAuth を開始するには、ローカル OAuth client が必要です。",
       "notConnected": "認証情報が必要な {{name}} アクションを実行する前に、ローカル認証情報を設定してください。",
       "unavailable": "現在のランタイムでは接続を設定できません。"
@@ -202,6 +215,10 @@
       "configureOAuthClient": "OAuth Client を設定",
       "editOAuthClient": "OAuth Client を編集",
       "saveConnection": "接続を保存",
+      "addConnection": "接続を追加",
+      "cancel": "キャンセル",
+      "clearSelection": "選択を解除",
+      "selected": "選択中",
       "connect": "接続",
       "details": "詳細",
       "manageConnection": "管理",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "接続",
+    "selectConnection": "接続を選択",
+    "connectionRequired": "このアクションを実行する接続を選択してください。",
     "searchPlaceholder": "名前、ID、プロバイダーでアクションを検索",
     "provider": "プロバイダー",
     "allProviders": "すべてのプロバイダー",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -160,10 +160,23 @@
       "notUsed": "Не используется"
     },
     "connection": "Подключение",
+    "connectionCount": "Подключений: {{count}}",
+    "savedConnections": "Сохраненные подключения",
+    "defaultConnection": "По умолчанию",
+    "connectionName": "Имя подключения",
+    "connectionNamePlaceholder": "например, work",
+    "connectionNameDescription": "Используйте это имя для выбора аккаунта при запуске действий.",
+    "connectionNameErrors": {
+      "required": "Введите имя подключения.",
+      "invalid": "Начните с буквы или цифры и используйте не более 64 букв, цифр, знаков подчеркивания или дефисов.",
+      "duplicate": "Это имя уже используется. Выберите это подключение, чтобы обновить его."
+    },
     "connectionMethod": "Способ подключения",
     "connectionDescriptions": {
       "noSetup": "Этот провайдер может работать без локальных учетных данных.",
+      "adding": "Настройте новое именованное подключение.",
       "connected": "Локальные учетные данные настроены через {{authType}}.",
+      "saved": "Сохранено подключений: {{count}}. Выберите подключение для управления или добавьте новое.",
       "oauthClientRequired": "{{name}} требует локальный OAuth client перед запуском OAuth.",
       "notConnected": "Настройте локальные учетные данные перед запуском действий {{name}}, которым они нужны.",
       "unavailable": "Подключения нельзя настроить в текущей среде выполнения."
@@ -202,6 +215,10 @@
       "configureOAuthClient": "Настроить OAuth Client",
       "editOAuthClient": "Изменить OAuth Client",
       "saveConnection": "Сохранить подключение",
+      "addConnection": "Добавить подключение",
+      "cancel": "Отмена",
+      "clearSelection": "Снять выбор",
+      "selected": "Выбрано",
       "connect": "Подключить",
       "details": "Детали",
       "manageConnection": "Управлять",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "Подключение",
+    "selectConnection": "Выберите подключение",
+    "connectionRequired": "Выберите подключение для выполнения этого действия.",
     "searchPlaceholder": "Искать действия по имени, ID или провайдеру",
     "provider": "Провайдер",
     "allProviders": "Все провайдеры",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -160,10 +160,23 @@
       "notUsed": "未使用"
     },
     "connection": "连接",
+    "connectionCount": "{{count}} 个连接",
+    "savedConnections": "已保存的连接",
+    "defaultConnection": "默认",
+    "connectionName": "连接名称",
+    "connectionNamePlaceholder": "例如 work",
+    "connectionNameDescription": "运行操作时使用这个名称选择账号。",
+    "connectionNameErrors": {
+      "required": "请输入连接名称。",
+      "invalid": "请以字母或数字开头，并仅使用最多 64 个字母、数字、下划线或连字符。",
+      "duplicate": "这个名称已被使用，请选择已有连接进行更新。"
+    },
     "connectionMethod": "连接方式",
     "connectionDescriptions": {
       "noSetup": "这个提供商无需本地凭证即可运行。",
+      "adding": "配置一个新的命名连接。",
       "connected": "本地凭证已通过 {{authType}} 配置。",
+      "saved": "{{count}} 个已保存的连接。选择一个进行管理，或添加新连接。",
       "oauthClientRequired": "{{name}} 需要先配置本地 OAuth client 才能开始 OAuth。",
       "notConnected": "运行需要凭证的 {{name}} 操作前，请先配置本地凭证。",
       "unavailable": "当前运行时无法配置连接。"
@@ -202,6 +215,10 @@
       "configureOAuthClient": "配置 OAuth Client",
       "editOAuthClient": "编辑 OAuth Client",
       "saveConnection": "保存连接",
+      "addConnection": "添加连接",
+      "cancel": "取消",
+      "clearSelection": "取消选择",
+      "selected": "已选择",
       "connect": "连接",
       "details": "详情",
       "manageConnection": "管理",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "连接",
+    "selectConnection": "选择连接",
+    "connectionRequired": "请选择用于运行此操作的连接。",
     "searchPlaceholder": "按名称、ID 或提供商搜索操作",
     "provider": "提供商",
     "allProviders": "全部提供商",

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -160,10 +160,23 @@
       "notUsed": "未使用"
     },
     "connection": "連線",
+    "connectionCount": "{{count}} 個連線",
+    "savedConnections": "已儲存的連線",
+    "defaultConnection": "預設",
+    "connectionName": "連線名稱",
+    "connectionNamePlaceholder": "例如 work",
+    "connectionNameDescription": "執行操作時使用此名稱選擇帳號。",
+    "connectionNameErrors": {
+      "required": "請輸入連線名稱。",
+      "invalid": "請以字母或數字開頭，並僅使用最多 64 個字母、數字、底線或連字號。",
+      "duplicate": "此名稱已被使用，請選擇現有連線進行更新。"
+    },
     "connectionMethod": "連線方式",
     "connectionDescriptions": {
       "noSetup": "此服務提供者無須本機憑證即可執行。",
+      "adding": "設定新的命名連線。",
       "connected": "已透過 {{authType}} 設定本機憑證。",
+      "saved": "已有 {{count}} 個已儲存的連線。請選擇一個進行管理，或新增連線。",
       "oauthClientRequired": "{{name}} 需要本機 OAuth 用戶端才能啟動 OAuth。",
       "notConnected": "執行需要憑證的 {{name}} 動作前，請先設定本機憑證。",
       "unavailable": "目前的執行階段無法設定連線。"
@@ -202,6 +215,10 @@
       "configureOAuthClient": "設定 OAuth 用戶端",
       "editOAuthClient": "編輯 OAuth 用戶端",
       "saveConnection": "儲存連線",
+      "addConnection": "新增連線",
+      "cancel": "取消",
+      "clearSelection": "取消選取",
+      "selected": "已選取",
       "connect": "連線",
       "details": "詳細資料",
       "manageConnection": "管理",
@@ -232,6 +249,9 @@
     }
   },
   "actions": {
+    "connection": "連線",
+    "selectConnection": "選擇連線",
+    "connectionRequired": "請選擇用於執行此操作的連線。",
     "searchPlaceholder": "依名稱、ID 或服務提供者搜尋動作",
     "provider": "服務提供者",
     "allProviders": "所有服務提供者",

--- a/web/src/model.test.ts
+++ b/web/src/model.test.ts
@@ -179,7 +179,7 @@ describe("resolveProviderConnectionStatus", () => {
     expect(status.connection?.authType).toBe("oauth2");
   });
 
-  it("can show an OAuth client warning alongside another credential connection", () => {
+  it("does not show an OAuth client warning alongside a usable API-key connection", () => {
     const status = resolveProviderConnectionStatus(
       {
         ...oauthProvider("notion", "Notion"),
@@ -192,6 +192,15 @@ describe("resolveProviderConnectionStatus", () => {
 
     expect(status).toMatchObject({
       connected: true,
+      oauthClientRequired: false,
+    });
+  });
+
+  it("keeps the OAuth client warning for an unconfigured OAuth-only provider", () => {
+    const status = resolveProviderConnectionStatus(oauthProvider("gmail", "Gmail"), [], []);
+
+    expect(status).toMatchObject({
+      connected: false,
       oauthClientRequired: true,
     });
   });
@@ -207,6 +216,22 @@ describe("resolveProviderConnectionStatus", () => {
     );
 
     expect(status.connection?.authType).toBe("api_key");
+    expect(status.connections).toHaveLength(2);
+  });
+
+  it("excludes virtual, no-auth, and explicitly unconfigured records", () => {
+    const status = resolveProviderConnectionStatus(
+      oauthProvider("slack", "Slack"),
+      [
+        { service: "slack", connectionName: "work", authType: "oauth2", metadata: {} },
+        { service: "slack", connectionName: "virtual", authType: "oauth2", virtual: true, metadata: {} },
+        { service: "slack", connectionName: "disabled", authType: "oauth2", configured: false, metadata: {} },
+        { service: "slack", connectionName: "anonymous", authType: "no_auth", metadata: {} },
+      ],
+      [{ service: "slack", configured: true, clientId: "slack-client-id" }],
+    );
+
+    expect(status.connections.map((connection) => connection.connectionName)).toEqual(["work"]);
   });
 });
 

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -182,6 +182,7 @@ export interface ProviderConnectionStatus {
   noSetupRequired: boolean;
   connected: boolean;
   oauthClientRequired: boolean;
+  connections: ConnectionRecord[];
   connection?: ConnectionRecord;
 }
 
@@ -283,14 +284,20 @@ export function resolveProviderConnectionStatus(
   oauthConfigs: OAuthConfig[],
 ): ProviderConnectionStatus {
   const noSetupRequired = isNoAuthOnlyProvider(provider);
-  const serviceConnections = connections.filter((connection) => connection.service === provider.service);
-  const connection = noSetupRequired ? undefined : pickUsableCredentialConnection(serviceConnections);
+  const serviceConnections = noSetupRequired ? [] : usableConnectionsForService(connections, provider.service);
+  const connection = pickUsableCredentialConnection(serviceConnections);
   return {
     noSetupRequired,
     connected: connection != null,
-    oauthClientRequired: providerHasOAuth(provider) && !oauthClientConfigured(provider.service, oauthConfigs),
+    oauthClientRequired:
+      connection == null && providerRequiresOAuth(provider) && !oauthClientConfigured(provider.service, oauthConfigs),
+    connections: serviceConnections,
     connection,
   };
+}
+
+export function usableConnectionsForService(connections: ConnectionRecord[], service: string): ConnectionRecord[] {
+  return connections.filter((connection) => connection.service === service && isUsableCredentialConnection(connection));
 }
 
 export function isNoAuthOnlyProvider(provider: ProviderDefinition): boolean {
@@ -312,8 +319,9 @@ function isUsableCredentialConnection(connection: ConnectionRecord | undefined):
   );
 }
 
-function providerHasOAuth(provider: ProviderDefinition): boolean {
-  return provider.auth.some((auth) => auth.type === "oauth2") || provider.authTypes.includes("oauth2");
+function providerRequiresOAuth(provider: ProviderDefinition): boolean {
+  const authTypes = provider.auth.length > 0 ? provider.auth.map((auth) => auth.type) : provider.authTypes;
+  return authTypes.includes("oauth2") && authTypes.every((authType) => authType === "oauth2");
 }
 
 function oauthClientConfigured(service: string, oauthConfigs: OAuthConfig[]): boolean {

--- a/web/src/providers-page-hooks.test.ts
+++ b/web/src/providers-page-hooks.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 });
 
 describe("ProvidersPage OAuth polling effects", () => {
-  it("stops OAuth refresh polling when the refreshed connection record changes", () => {
+  it("does not mount the OAuth editor while saved connections are collapsed", () => {
     renderToStaticMarkup(
       createElement(
         I18nProvider,
@@ -45,7 +45,7 @@ describe("ProvidersPage OAuth polling effects", () => {
 
     expect(
       useEffectMock.mock.calls.some(([, deps]) => Array.isArray(deps) && deps.length === 1 && deps[0] === connection),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/web/src/providers-page.test.ts
+++ b/web/src/providers-page.test.ts
@@ -7,10 +7,15 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppI18n } from "./i18n";
 import {
+  configurableConnectionsForProvider,
+  connectionDeletePath,
+  connectionDisplayLabel,
   connectionSubmitLabel,
   createOAuthPopupFeatures,
+  credentialConnectionRequestBody,
   isProviderLocallyAvailable,
   oauthClientActionLabel,
+  oauthAuthorizationRequestBody,
   oauthConfigForProvider,
   providerBrowserResetKey,
   ProvidersPage,
@@ -20,6 +25,7 @@ import {
   shouldShowDisconnectAction,
   shouldShowOAuthClientForm,
   startOAuthRefreshPolling,
+  validateNewConnectionName,
 } from "./providers-page";
 
 afterEach(() => {
@@ -188,6 +194,130 @@ describe("ProvidersPage route shell", () => {
     expect(markup).toContain("Configure OAuth Client");
   });
 
+  it("does not show an OAuth warning when an API-key connection is already usable", () => {
+    const githubProvider: ProviderDefinition = {
+      ...oauthProvider,
+      service: "github",
+      displayName: "GitHub",
+      authTypes: ["oauth2", "api_key"],
+      auth: [{ type: "oauth2", scopes: [] }, { type: "api_key" }],
+    };
+    const markup = renderProvidersPage(
+      {
+        ...providerData,
+        providers: [githubProvider],
+        connections: [
+          {
+            id: "github-default",
+            service: "github",
+            connectionName: "default",
+            authType: "api_key",
+            configured: true,
+            metadata: {},
+          },
+        ],
+        oauthConfigs: [],
+      },
+      "/providers/github",
+    );
+
+    expect(markup).toContain("Configured");
+    expect(markup).not.toContain("OAuth client required");
+  });
+
+  it("shows every named connection and only safe account profile fields", () => {
+    const markup = renderProvidersPage(
+      {
+        ...providerData,
+        connections: [
+          {
+            id: "gmail-default",
+            service: "gmail",
+            connectionName: "default",
+            authType: "oauth2",
+            configured: true,
+            default: true,
+            profile: { displayName: "personal@example.com" },
+            metadata: { accessToken: "must-not-render" },
+          },
+          {
+            id: "gmail-work",
+            service: "gmail",
+            connectionName: "work",
+            authType: "oauth2",
+            configured: true,
+            profile: { displayName: "work@example.com" },
+            metadata: { refreshToken: "must-not-render-either" },
+          },
+        ],
+      },
+      "/providers/gmail",
+    );
+
+    expect(markup).toContain("default · personal@example.com");
+    expect(markup).toContain("work · work@example.com");
+    expect(markup).toContain("2 connections");
+    expect(markup).toContain("Add Connection");
+    expect(markup).not.toContain("Reconnect Gmail");
+    expect(markup).not.toContain("Clear selection");
+    expect(markup).not.toContain("must-not-render");
+  });
+
+  it("keeps the original connection form visible when no connection exists", () => {
+    const markup = renderProvidersPage(providerData, "/providers/gmail");
+
+    expect(markup).toContain('value="default"');
+    expect(markup).toContain("Connect Gmail");
+    expect(markup).toContain("OAuth Client");
+    expect(markup).not.toContain("Add Connection");
+  });
+
+  it("lists OAuth and API-key connections together before opening either editor", () => {
+    const githubProvider: ProviderDefinition = {
+      ...oauthProvider,
+      service: "github",
+      displayName: "GitHub",
+      authTypes: ["oauth2", "api_key"],
+      auth: [
+        { type: "oauth2", scopes: [] },
+        { type: "api_key", label: "Personal access token" },
+      ],
+    };
+    const markup = renderProvidersPage(
+      {
+        ...providerData,
+        providers: [githubProvider],
+        connections: [
+          {
+            id: "github-personal",
+            service: "github",
+            connectionName: "personal",
+            authType: "oauth2",
+            configured: true,
+            profile: { displayName: "octocat" },
+            metadata: {},
+          },
+          {
+            id: "github-work",
+            service: "github",
+            connectionName: "work",
+            authType: "api_key",
+            configured: true,
+            profile: { displayName: "work account" },
+            metadata: {},
+          },
+        ],
+      },
+      "/providers/github",
+    );
+
+    expect(markup).toContain("personal · octocat");
+    expect(markup).toContain("work · work account");
+    expect(markup).toContain("Add Connection");
+    expect(markup).not.toContain("Connection name");
+    expect(markup).not.toContain("Personal access token");
+  });
+
   it("shows catalog-only providers as unavailable without connection controls", () => {
     const data = { ...providerData, providers: [catalogOnlyProvider], oauthConfigs: [] };
     const browserMarkup = renderProvidersPage(data, "/providers");
@@ -204,7 +334,7 @@ describe("ProvidersPage route shell", () => {
     expect(detailMarkup).not.toContain("Host");
   });
 
-  it("allows stale catalog-only connections to be removed", () => {
+  it("keeps stale catalog-only connections available to manage", () => {
     const markup = renderProvidersPage(
       {
         ...providerData,
@@ -215,7 +345,8 @@ describe("ProvidersPage route shell", () => {
       "/providers/catalog-only",
     );
 
-    expect(markup).toContain("Disconnect");
+    expect(markup).toContain("Manage");
+    expect(markup).not.toContain("Disconnect");
     expect(markup).not.toContain("Save Connection");
   });
 
@@ -241,6 +372,59 @@ describe("ProvidersPage route shell", () => {
     expect(markup).toContain("Show more");
     expect(markup).toContain("Clock 47");
     expect(markup).not.toContain("Clock 48");
+  });
+});
+
+describe("named provider connections", () => {
+  const connections: AppData["connections"] = [
+    {
+      service: "gmail",
+      connectionName: "default",
+      authType: "oauth2",
+      profile: { displayName: "personal@example.com" },
+      metadata: {},
+    },
+    { service: "gmail", connectionName: "work", authType: "oauth2", metadata: {} },
+  ];
+
+  it("filters configurable records and formats safe labels", () => {
+    expect(
+      configurableConnectionsForProvider(
+        [
+          ...connections,
+          { service: "gmail", connectionName: "virtual", authType: "oauth2", virtual: true, metadata: {} },
+          { service: "slack", connectionName: "work", authType: "oauth2", metadata: {} },
+        ],
+        "gmail",
+      ).map((connection) => connection.connectionName),
+    ).toEqual(["default", "work"]);
+    expect(connectionDisplayLabel(connections[0]!)).toBe("default · personal@example.com");
+    expect(connectionDisplayLabel(connections[1]!)).toBe("work");
+  });
+
+  it("validates names before sending credentials", () => {
+    expect(validateNewConnectionName("", connections)).toBe("required");
+    expect(validateNewConnectionName("bad name", connections)).toBe("invalid");
+    expect(validateNewConnectionName("work", connections)).toBe("duplicate");
+    expect(validateNewConnectionName("team-2", connections)).toBeUndefined();
+  });
+
+  it("targets one encoded connection when disconnecting", () => {
+    expect(connectionDeletePath("google/mail", "work team")).toBe(
+      "/api/connections/google%2Fmail?connectionName=work%20team",
+    );
+  });
+
+  it("includes the named connection in credential and OAuth requests", () => {
+    expect(credentialConnectionRequestBody("api_key", "work", { apiKey: "secret" })).toEqual({
+      authType: "api_key",
+      connectionName: "work",
+      values: { apiKey: "secret" },
+    });
+    expect(oauthAuthorizationRequestBody("gmail", "personal")).toEqual({
+      service: "gmail",
+      connectionName: "personal",
+    });
   });
 });
 

--- a/web/src/providers-page.test.ts
+++ b/web/src/providers-page.test.ts
@@ -222,6 +222,7 @@ describe("ProvidersPage route shell", () => {
     );
 
     expect(markup).toContain("Configured");
+    expect(markup).toContain("Saved connections: 1. Select one to manage or add another.");
     expect(markup).not.toContain("OAuth client required");
   });
 

--- a/web/src/providers-page.tsx
+++ b/web/src/providers-page.tsx
@@ -1,6 +1,7 @@
 import type {
   AppData,
   AuthDefinition,
+  ConnectionRecord,
   CredentialField,
   OAuthConfig,
   ProviderConnectionStatus,
@@ -18,6 +19,7 @@ import {
   CircleSlash2,
   ExternalLink,
   KeyRound,
+  Plus,
   Search,
   Settings,
   Trash2,
@@ -26,7 +28,13 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
 import { apiDelete, apiPost, apiPut } from "./api";
-import { credentialFieldsFor, filterProviders, resolveProviderConnectionStatus, sortProviders } from "./model";
+import {
+  credentialFieldsFor,
+  filterProviders,
+  resolveProviderConnectionStatus,
+  sortProviders,
+  usableConnectionsForService,
+} from "./model";
 import { Badge, EmptyState, FormStatus, ProviderIcon, TagList } from "./shared-ui";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -42,7 +50,7 @@ interface ProvidersPageProps {
 
 interface ProviderDetailProps {
   provider: ProviderDefinition;
-  connection?: AppData["connections"][number];
+  connections: ConnectionRecord[];
   connectionStatus: ProviderConnectionStatus;
   oauthConfig?: OAuthConfig;
   onRefresh(): void;
@@ -60,10 +68,27 @@ interface ProviderCardProps {
 interface ConnectionFormProps {
   provider: ProviderDefinition;
   auth: AuthDefinition;
+  connectionName: string;
+  connectionNameValid: boolean;
   connection?: AppData["connections"][number];
   oauthConfig?: OAuthConfig;
   onRefresh(): void;
   onConfigureOAuthClient(): void;
+  onConnectionPendingChange?(connectionName?: string): void;
+}
+
+interface ConnectionManagerProps {
+  connections: ConnectionRecord[];
+  selectedConnectionName?: string;
+  creating: boolean;
+  newConnectionName: string;
+  newConnectionNameError?: "required" | "invalid" | "duplicate";
+  canAdd: boolean;
+  onSelect(connectionName: string): void;
+  onAdd(): void;
+  onCancel(): void;
+  onClearSelection(): void;
+  onNewConnectionNameChange(connectionName: string): void;
 }
 
 interface OAuthConfigFormProps {
@@ -75,6 +100,8 @@ interface OAuthConfigFormProps {
 type ProviderStatusFilter = "all" | "connected" | "not_connected" | "oauth_needs_config";
 
 const providerPageSize = 48;
+const defaultConnectionName = "default";
+const connectionNamePattern = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 const oauthRefreshPollingIntervalMs = 1_000;
 const oauthRefreshPollingMaxAttempts = 30;
 const compactNumberFormatter = Intl.NumberFormat(undefined, {
@@ -108,8 +135,9 @@ export function ProvidersPage(props: ProvidersPageProps): ReactNode {
 
   return (
     <ProviderDetail
+      key={routeProvider.service}
       provider={routeProvider}
-      connection={connectionStatus.connection}
+      connections={configurableConnectionsForProvider(props.data.connections, routeProvider.service)}
       connectionStatus={connectionStatus}
       oauthConfig={oauthConfigForProvider(props.data.oauthConfigs, routeProvider.service)}
       onRefresh={props.onRefresh}
@@ -406,6 +434,13 @@ function ProviderStatusBadges(props: {
         {t("providers.configuredBadge")}
       </Badge>,
     );
+    if (props.status.connections.length > 1) {
+      badges.push(
+        <Badge key="connection-count">
+          {t("providers.connectionCount", { count: props.status.connections.length })}
+        </Badge>,
+      );
+    }
   } else if (props.status.noSetupRequired) {
     badges.push(
       <Badge key="no-setup">
@@ -449,29 +484,114 @@ function ProviderNotFound(props: { service: string }): ReactNode {
 
 function ProviderDetail(props: ProviderDetailProps): ReactNode {
   const t = useTranslate();
-  const [selectedAuthType, setSelectedAuthType] = useState(() => initialAuthType(props.provider, props.connection));
+  const [selectedConnectionName, setSelectedConnectionName] = useState<string>();
+  const [creatingConnection, setCreatingConnection] = useState(props.connections.length === 0);
+  const [newConnectionName, setNewConnectionName] = useState(
+    props.connections.length === 0 ? defaultConnectionName : "",
+  );
+  const [pendingConnectionName, setPendingConnectionName] = useState<string>();
+  const selectedConnection =
+    !creatingConnection && selectedConnectionName
+      ? connectionByName(props.connections, selectedConnectionName)
+      : undefined;
+  const [selectedAuthType, setSelectedAuthType] = useState(() => initialAuthType(props.provider, selectedConnection));
   const [oauthClientExpanded, setOAuthClientExpanded] = useState(false);
   const selectedAuth = props.provider.auth.find((auth) => auth.type === selectedAuthType) ?? props.provider.auth[0];
   const oauthAuth = props.provider.auth.find((auth) => auth.type === "oauth2");
   const hasMultipleAuthMethods = props.provider.auth.length > 1;
   const locallyAvailable = isProviderLocallyAvailable(props.provider);
+  const supportsCredentialConnections = props.provider.auth.some((auth) => shouldShowConnectionActions(auth));
+  const connectionEditorOpen = !supportsCredentialConnections || creatingConnection || selectedConnection != null;
+  const formConnectionName = creatingConnection ? newConnectionName.trim() : (selectedConnectionName ?? "");
+  const newConnectionNameError = creatingConnection
+    ? validateNewConnectionName(newConnectionName, props.connections)
+    : undefined;
   const connectionDescription = !locallyAvailable
     ? t("providers.connectionDescriptions.unavailable")
     : props.connectionStatus.noSetupRequired
       ? t("providers.connectionDescriptions.noSetup")
-      : props.connectionStatus.connected
-        ? t("providers.connectionDescriptions.connected", { authType: props.connection?.authType ?? "" })
-        : props.connectionStatus.oauthClientRequired
-          ? t("providers.connectionDescriptions.oauthClientRequired", { name: props.provider.displayName })
-          : t("providers.connectionDescriptions.notConnected", { name: props.provider.displayName });
+      : creatingConnection
+        ? t("providers.connectionDescriptions.adding")
+        : selectedConnection
+          ? t("providers.connectionDescriptions.connected", {
+              authType: selectedConnection.authType,
+            })
+          : props.connectionStatus.connected
+            ? t("providers.connectionDescriptions.saved", { count: props.connections.length })
+            : props.connectionStatus.oauthClientRequired
+              ? t("providers.connectionDescriptions.oauthClientRequired", { name: props.provider.displayName })
+              : t("providers.connectionDescriptions.notConnected", { name: props.provider.displayName });
 
   useEffect(() => {
-    setSelectedAuthType(initialAuthType(props.provider, props.connection));
-  }, [props.provider.service, props.connection?.authType]);
+    if (creatingConnection && pendingConnectionName) {
+      const createdConnection = connectionByName(props.connections, pendingConnectionName);
+      if (createdConnection) {
+        setSelectedConnectionName(pendingConnectionName);
+        setCreatingConnection(false);
+        setNewConnectionName("");
+        setPendingConnectionName(undefined);
+        setSelectedAuthType(initialAuthType(props.provider, createdConnection));
+      }
+      return;
+    }
+
+    if (!creatingConnection && selectedConnectionName && !connectionByName(props.connections, selectedConnectionName)) {
+      if (props.connections.length === 0) {
+        setSelectedConnectionName(undefined);
+        setCreatingConnection(true);
+        setNewConnectionName(defaultConnectionName);
+      } else {
+        setSelectedConnectionName(undefined);
+        setSelectedAuthType(initialAuthType(props.provider, undefined));
+      }
+      return;
+    }
+
+    if (!creatingConnection && !selectedConnectionName && props.connections.length === 0) {
+      setCreatingConnection(true);
+      setNewConnectionName(defaultConnectionName);
+    }
+  }, [creatingConnection, pendingConnectionName, props.connections, props.provider, selectedConnectionName]);
+
+  useEffect(() => {
+    setSelectedAuthType(initialAuthType(props.provider, selectedConnection));
+  }, [props.provider.service, selectedConnection?.authType]);
 
   useEffect(() => {
     setOAuthClientExpanded(false);
   }, [props.provider.service, props.oauthConfig?.clientId]);
+
+  function selectConnection(connectionName: string): void {
+    const connection = connectionByName(props.connections, connectionName);
+    setSelectedConnectionName(connectionName);
+    setCreatingConnection(false);
+    setNewConnectionName("");
+    setSelectedAuthType(initialAuthType(props.provider, connection));
+  }
+
+  function startNewConnection(): void {
+    setSelectedConnectionName(undefined);
+    setCreatingConnection(true);
+    setNewConnectionName("");
+    setPendingConnectionName(undefined);
+    setSelectedAuthType(initialAuthType(props.provider, undefined));
+    setOAuthClientExpanded(false);
+  }
+
+  function cancelNewConnection(): void {
+    setCreatingConnection(false);
+    setNewConnectionName("");
+    setPendingConnectionName(undefined);
+  }
+
+  function clearConnectionSelection(): void {
+    setSelectedConnectionName(undefined);
+    setCreatingConnection(false);
+    setNewConnectionName("");
+    setPendingConnectionName(undefined);
+    setSelectedAuthType(initialAuthType(props.provider, undefined));
+    setOAuthClientExpanded(false);
+  }
 
   return (
     <div className="provider-detail-page">
@@ -523,7 +643,22 @@ function ProviderDetail(props: ProviderDetailProps): ReactNode {
               <p>{connectionDescription}</p>
             </div>
           </div>
-          {locallyAvailable && hasMultipleAuthMethods ? (
+          {supportsCredentialConnections && (locallyAvailable || props.connections.length > 0) ? (
+            <ConnectionManager
+              connections={props.connections}
+              selectedConnectionName={selectedConnectionName}
+              creating={creatingConnection}
+              newConnectionName={newConnectionName}
+              newConnectionNameError={newConnectionNameError}
+              canAdd={locallyAvailable}
+              onSelect={selectConnection}
+              onAdd={startNewConnection}
+              onCancel={cancelNewConnection}
+              onClearSelection={clearConnectionSelection}
+              onNewConnectionNameChange={setNewConnectionName}
+            />
+          ) : null}
+          {connectionEditorOpen && locallyAvailable && hasMultipleAuthMethods ? (
             <ToggleGroup
               className="auth-method-control bg-muted p-[3px]"
               type="single"
@@ -543,21 +678,25 @@ function ProviderDetail(props: ProviderDetailProps): ReactNode {
               ))}
             </ToggleGroup>
           ) : null}
-          {!locallyAvailable ? (
+          {!connectionEditorOpen ? null : !locallyAvailable ? (
             <UnavailableProviderConnection
               provider={props.provider}
-              connection={props.connection}
+              connection={selectedConnection}
+              connectionName={formConnectionName}
               onRefresh={props.onRefresh}
             />
           ) : selectedAuth ? (
             <ConnectionForm
-              key={selectedAuth.type}
+              key={`${selectedAuth.type}:${creatingConnection ? "new" : selectedConnectionName}`}
               provider={props.provider}
               auth={selectedAuth}
-              connection={props.connection}
+              connection={selectedConnection}
+              connectionName={formConnectionName}
+              connectionNameValid={!newConnectionNameError}
               oauthConfig={props.oauthConfig}
               onRefresh={props.onRefresh}
               onConfigureOAuthClient={() => setOAuthClientExpanded(true)}
+              onConnectionPendingChange={creatingConnection ? setPendingConnectionName : undefined}
             />
           ) : (
             <EmptyState
@@ -565,7 +704,7 @@ function ProviderDetail(props: ProviderDetailProps): ReactNode {
               description={t("providers.noConnectionMethodDescription")}
             />
           )}
-          {locallyAvailable && oauthAuth && selectedAuth?.type === "oauth2" ? (
+          {connectionEditorOpen && locallyAvailable && oauthAuth && selectedAuth?.type === "oauth2" ? (
             <div className="provider-inline-oauth-settings">
               <h3>{t("providers.oauthClient")}</h3>
               <OAuthClientSettings
@@ -725,9 +864,149 @@ function authTypeLabel(authType: string, t: (key: string) => string): string {
   return authType;
 }
 
+export function configurableConnectionsForProvider(
+  connections: ConnectionRecord[],
+  service: string,
+): ConnectionRecord[] {
+  return usableConnectionsForService(connections, service);
+}
+
+export function connectionDisplayLabel(connection: ConnectionRecord): string {
+  const connectionName = connectionNameOf(connection);
+  const profileLabel = [connection.profile?.displayName, connection.profile?.accountId].find(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  return profileLabel && profileLabel.trim() !== connectionName
+    ? `${connectionName} · ${profileLabel.trim()}`
+    : connectionName;
+}
+
+export function validateNewConnectionName(
+  connectionName: string,
+  connections: ConnectionRecord[],
+): "required" | "invalid" | "duplicate" | undefined {
+  const normalized = connectionName.trim();
+  if (!normalized) return "required";
+  if (!connectionNamePattern.test(normalized)) return "invalid";
+  if (connections.some((connection) => connectionNameOf(connection) === normalized)) return "duplicate";
+  return undefined;
+}
+
+function connectionNameOf(connection: ConnectionRecord): string {
+  return connection.connectionName?.trim() || defaultConnectionName;
+}
+
+function connectionByName(connections: ConnectionRecord[], connectionName: string): ConnectionRecord | undefined {
+  return connections.find((connection) => connectionNameOf(connection) === connectionName);
+}
+
+export function connectionDeletePath(service: string, connectionName: string): string {
+  return `/api/connections/${encodeURIComponent(service)}?connectionName=${encodeURIComponent(connectionName)}`;
+}
+
+export function credentialConnectionRequestBody(
+  authType: "no_auth" | "api_key" | "custom_credential",
+  connectionName: string,
+  values: Record<string, string>,
+): Record<string, unknown> {
+  return authType === "no_auth" ? { authType, connectionName } : { authType, connectionName, values };
+}
+
+export function oauthAuthorizationRequestBody(service: string, connectionName: string): Record<string, string> {
+  return { service, connectionName };
+}
+
+function ConnectionManager(props: ConnectionManagerProps): ReactNode {
+  const t = useTranslate();
+  const inputId = "provider-connection-name";
+  const errorId = `${inputId}-error`;
+
+  return (
+    <div className="connection-manager">
+      {props.connections.length > 0 ? (
+        <div className="connection-list" aria-label={t("providers.savedConnections")}>
+          {props.connections.map((connection) => {
+            const connectionName = connectionNameOf(connection);
+            const selected = !props.creating && connectionName === props.selectedConnectionName;
+            return (
+              <div key={connection.id ?? `${connection.service}:${connectionName}`} className="connection-list-item">
+                <div className="connection-list-copy">
+                  <div className="connection-list-title">
+                    <strong>{connectionDisplayLabel(connection)}</strong>
+                    {connectionName === defaultConnectionName ? (
+                      <Badge>{t("providers.defaultConnection")}</Badge>
+                    ) : null}
+                  </div>
+                  <small>{authTypeLabel(connection.authType, t)}</small>
+                </div>
+                <Button
+                  variant={selected ? "default" : "outline"}
+                  size="sm"
+                  type="button"
+                  aria-pressed={selected}
+                  disabled={selected}
+                  onClick={() => props.onSelect(connectionName)}
+                >
+                  {t(selected ? "providers.buttons.selected" : "providers.buttons.manageConnection")}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {props.creating ? (
+        <div className="connection-manager-new">
+          <Label className="field" htmlFor={inputId}>
+            <span>{t("providers.connectionName")}</span>
+            <Input
+              id={inputId}
+              maxLength={64}
+              placeholder={t("providers.connectionNamePlaceholder")}
+              required
+              aria-invalid={props.newConnectionNameError != null}
+              aria-describedby={errorId}
+              value={props.newConnectionName}
+              onChange={(event) => props.onNewConnectionNameChange(event.target.value)}
+            />
+            <small id={errorId} className={props.newConnectionNameError ? "field-error" : undefined}>
+              {t(
+                props.newConnectionNameError
+                  ? `providers.connectionNameErrors.${props.newConnectionNameError}`
+                  : "providers.connectionNameDescription",
+              )}
+            </small>
+          </Label>
+          {props.connections.length > 0 ? (
+            <Button variant="outline" type="button" onClick={props.onCancel}>
+              {t("providers.buttons.cancel")}
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="connection-manager-actions">
+          {props.canAdd ? (
+            <Button className="connection-add-button" variant="outline" type="button" onClick={props.onAdd}>
+              <Plus size={16} />
+              {t("providers.buttons.addConnection")}
+            </Button>
+          ) : null}
+          {props.selectedConnectionName ? (
+            <Button variant="ghost" type="button" onClick={props.onClearSelection}>
+              <X size={16} />
+              {t("providers.buttons.clearSelection")}
+            </Button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function UnavailableProviderConnection(props: {
   provider: ProviderDefinition;
   connection?: AppData["connections"][number];
+  connectionName: string;
   onRefresh(): void;
 }): ReactNode {
   const t = useTranslate();
@@ -736,7 +1015,7 @@ function UnavailableProviderConnection(props: {
   async function disconnect(): Promise<void> {
     setStatus(t("providers.connectionMessages.disconnecting"));
     try {
-      await apiDelete(`/api/connections/${props.provider.service}`);
+      await apiDelete(connectionDeletePath(props.provider.service, props.connectionName));
       setStatus(t("providers.connectionMessages.disconnected"));
       props.onRefresh();
     } catch (error) {
@@ -775,7 +1054,10 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
   const showActions = shouldShowConnectionActions(props.auth);
   const connected = props.connection != null;
   const needsOAuthClient = props.auth.type === "oauth2" && !props.oauthConfig;
-  const canSubmit = shouldEnableConnectionSubmit(props.auth, props.oauthConfig);
+  const canSubmit =
+    props.connectionName.length > 0 &&
+    props.connectionNameValid &&
+    shouldEnableConnectionSubmit(props.auth, props.oauthConfig);
   const submitLabel =
     props.auth.type === "oauth2"
       ? t(connected ? "providers.buttons.reconnectProvider" : "providers.buttons.connectProvider", {
@@ -799,26 +1081,41 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
 
   async function submit(event: FormEvent): Promise<void> {
     event.preventDefault();
+    if (!canSubmit) {
+      if (needsOAuthClient) {
+        setStatus(t("providers.connectionMessages.configureOAuthFirst"));
+      }
+      return;
+    }
+
+    const connectionName = props.connectionName.trim();
     setStatus(
       props.auth.type === "oauth2"
         ? t("providers.connectionMessages.openingOAuth")
         : t("providers.connectionMessages.saving"),
     );
+    props.onConnectionPendingChange?.(connectionName);
     try {
       if (props.auth.type === "no_auth") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "no_auth" });
+        await apiPut(
+          `/api/connections/${props.provider.service}`,
+          credentialConnectionRequestBody("no_auth", connectionName, values),
+        );
       } else if (props.auth.type === "api_key") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "api_key", values });
+        await apiPut(
+          `/api/connections/${props.provider.service}`,
+          credentialConnectionRequestBody("api_key", connectionName, values),
+        );
       } else if (props.auth.type === "custom_credential") {
-        await apiPut(`/api/connections/${props.provider.service}`, { authType: "custom_credential", values });
+        await apiPut(
+          `/api/connections/${props.provider.service}`,
+          credentialConnectionRequestBody("custom_credential", connectionName, values),
+        );
       } else {
-        if (!canSubmit) {
-          setStatus(t("providers.connectionMessages.configureOAuthFirst"));
-          return;
-        }
-        const result = await apiPost<{ authorizationUrl?: string }>(`/api/oauth/authorizations`, {
-          service: props.provider.service,
-        });
+        const result = await apiPost<{ authorizationUrl?: string }>(
+          `/api/oauth/authorizations`,
+          oauthAuthorizationRequestBody(props.provider.service, connectionName),
+        );
         if (result.authorizationUrl) {
           window.open(
             result.authorizationUrl,
@@ -839,6 +1136,7 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
       setStatus(t("providers.connectionMessages.updated"));
       props.onRefresh();
     } catch (error) {
+      props.onConnectionPendingChange?.(undefined);
       setStatus(error instanceof Error ? error.message : t("providers.connectionMessages.failed"));
     }
   }
@@ -846,7 +1144,7 @@ function ConnectionForm(props: ConnectionFormProps): ReactNode {
   async function disconnect(): Promise<void> {
     setStatus(t("providers.connectionMessages.disconnecting"));
     try {
-      await apiDelete(`/api/connections/${props.provider.service}`);
+      await apiDelete(connectionDeletePath(props.provider.service, props.connectionName));
       setStatus(t("providers.connectionMessages.disconnected"));
       props.onRefresh();
     } catch (error) {

--- a/web/src/styles/actions.css
+++ b/web/src/styles/actions.css
@@ -270,6 +270,15 @@
   resize: vertical;
 }
 
+.action-connection-value {
+  min-height: 36px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--muted);
+  font-size: 13px;
+}
+
 .run-action-dialog-body .button-row,
 .run-action-dialog-body .loading-panel {
   margin-top: 0;

--- a/web/src/styles/providers.css
+++ b/web/src/styles/providers.css
@@ -321,6 +321,7 @@
 }
 
 .provider-connection-card > .auth-method-control,
+.provider-connection-card > .connection-manager,
 .provider-connection-card > .connection-form,
 .provider-inline-oauth-settings,
 .provider-detail-card > .tag-list,
@@ -331,6 +332,78 @@
 
 .provider-connection-card > .auth-method-control {
   margin-bottom: 0;
+}
+
+.connection-manager {
+  display: grid;
+  gap: 12px;
+}
+
+.connection-list {
+  display: grid;
+  gap: 8px;
+}
+
+.connection-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--muted) 32%, transparent);
+}
+
+.connection-list-copy,
+.connection-list-title {
+  min-width: 0;
+}
+
+.connection-list-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.connection-list-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.connection-list-title strong {
+  overflow-wrap: anywhere;
+}
+
+.connection-list-copy small {
+  color: var(--muted-foreground);
+}
+
+.connection-manager-new {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+}
+
+.connection-manager-new .field {
+  flex: 1;
+}
+
+.connection-add-button {
+  justify-self: start;
+}
+
+.connection-manager-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.field-error {
+  color: var(--destructive) !important;
 }
 
 .provider-inline-oauth-settings {
@@ -531,6 +604,17 @@
 
   .oauth-client-actions {
     justify-content: flex-start;
+  }
+
+  .connection-list-item,
+  .connection-manager-new {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .connection-list-item [data-slot="button"],
+  .connection-manager-new [data-slot="button"] {
+    align-self: flex-start;
   }
 
   .provider-row,


### PR DESCRIPTION
## Summary

- show all configured, non-virtual connections on the provider detail page
- keep the original connection form when no connection exists, and otherwise open it only when adding or managing a connection
- allow users to add, select, update, reauthorize, disconnect, or clear the selection for a specific named connection
- pass `connectionName` through credential, OAuth, disconnect, and action-debug requests
- add connection selection to the action debug dialog
- scope OAuth client warnings to the OAuth setup flow
- add validation, responsive styles, tests, and translations for all supported Console languages

## Behavior

When a provider has no saved connections, the existing OAuth, API key, or custom credential form remains directly available and creates the reserved `default` connection unless another name is entered.

Once connections exist, the page first shows a unified list of OAuth and credential-based connections. Selecting **Manage** opens the existing update, reauthorization, and disconnect controls for that connection; **Add Connection** opens the new-connection form; **Clear selection** or **Cancel** returns to the list without changing credentials.

Action debugging follows the behavior agreed in #154:

- one usable connection is selected automatically
- `default` is selected initially when multiple connections exist
- when multiple connections exist without `default`, the user must choose one explicitly

`default` remains the compatibility connection used when `connectionName` is omitted. This PR does not add connection renaming or a separate mutable default setting.

Provider usability is based on whether at least one usable connection exists. A provider configured through an API key no longer shows a provider-level OAuth client warning; OAuth configuration is requested only when the OAuth method is selected.

## Implementation notes

This uses the existing local management APIs based on `service + connectionName`; no backend API redesign is required. Stable connection IDs are preserved, while connection names remain local management aliases rather than authorization boundaries.

This follows the earlier Web Console exploration in #122 and completes the scope agreed in #154.

## Validation

- `vitest run` — 82 test files, 757 tests passed
- Web TypeScript check
- Web production build
- full repository lint and formatting checks
- full repository typecheck

Closes #154
