### PR TITLE
fix(netlify): remove unsupported granular scopes from oauth2 configuration

### DIFF
--- a/src/providers/netlify/actions.ts
+++ b/src/providers/netlify/actions.ts
@@ -561,9 +561,4 @@ export const netlifyActions: ActionDefinition[] = actionSources.map((action) =>
   }),
 );
 
-export const netlifyConnectorScopes: readonly string[] = [
-  netlifyReadScope,
-  netlifySiteWriteScope,
-  netlifyDeployWriteScope,
-  netlifyFormWriteScope,
-];
+export const netlifyConnectorScopes: readonly string[] = [];


### PR DESCRIPTION
Netlify's own OAuth 2.0 API does not support or document any granular/custom authorization scopes (unlike providers like GitHub or GitLab).

As confirmed by Netlify Support Staff (e.g. [Netlify Support Forums Thread](https://answers.netlify.com/t/netlify-oauth-scopes/112113/2)):
> **"There’s only public scope at the moment."**

Because Netlify does not recognize or support custom scopes, passing custom scope strings (such as `netlify.read`, etc.) in the OAuth authorization URL results in an immediate failure on Netlify's side with:
```
error=invalid_scope
error_description=The requested scope is invalid, unknown, or malformed.
```

By setting `netlifyConnectorScopes` to an empty array (`[]`), we avoid passing the `scope` query parameter entirely, allowing the Netlify OAuth authorization flow to succeed using the default implicit permissions of the authenticated user. This matches modern Netlify OAuth templates like [netlify-labs/oauth-example (auth-start.js:L22)](https://github.com/netlify-labs/oauth-example/blob/master/functions/auth-start.js#L22).