### PR TITLE
feat(jira): add Jira Data Center PAT support

### DIFF
--- a/src/providers/jira/actions.ts
+++ b/src/providers/jira/actions.ts
@@ -65,10 +65,16 @@ const issue = s.object(
   },
   { additionalProperties: true, description: "Jira issue." },
 );
+const commentBody = s.union(
+  [adfDocument, s.string({ description: "Plain text comment body (Jira Server/Data Center)." })],
+  {
+    description: "Jira comment body: an ADF document (Cloud) or plain text (Server/Data Center).",
+  },
+);
 const comment = s.object(
   {
     id: s.string({ description: "Jira comment ID." }),
-    body: adfDocument,
+    body: commentBody,
     raw: objectSchema,
   },
   { additionalProperties: true, description: "Jira comment." },

--- a/src/providers/jira/definition.ts
+++ b/src/providers/jira/definition.ts
@@ -6,13 +6,13 @@ import { jiraOAuthScopes } from "./scopes.ts";
 const service = "jira";
 
 /**
- * Jira provider backed by Atlassian OAuth 2.0 and Jira Cloud REST API v3.
+ * Jira provider backed by Jira Cloud OAuth 2.0 and Jira Data Center personal access tokens.
  */
 export const provider: ProviderDefinition = {
   service,
   displayName: "Jira",
   categories: ["Productivity", "Developer Tools"],
-  authTypes: ["oauth2"],
+  authTypes: ["oauth2", "custom_credential"],
   auth: [
     {
       type: "oauth2",
@@ -25,6 +25,30 @@ export const provider: ProviderDefinition = {
         audience: "api.atlassian.com",
         prompt: "consent",
       },
+    },
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "baseUrl",
+          label: "Instance URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://jira.example.com",
+          description:
+            "Jira Data Center or Server instance root URL. A deployment context path is supported. Private-network instances require OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK.",
+        },
+        {
+          key: "personalAccessToken",
+          label: "Personal access token",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "JIRA_PAT",
+          description: "Jira Data Center or Server personal access token.",
+        },
+      ],
     },
   ],
   homepageUrl: "https://www.atlassian.com/software/jira",

--- a/src/providers/jira/definition.ts
+++ b/src/providers/jira/definition.ts
@@ -37,7 +37,7 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "https://jira.example.com",
           description:
-            "Jira Data Center or Server instance root URL. A deployment context path is supported. Private-network instances require OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK.",
+            "Jira Data Center or Server instance root URL (a deployment context path is supported), without an API endpoint path. Public addresses work by default; private targets (RFC 1918, Tailscale, NetBird, private hostnames) require the self-hosted runtime to enable OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK. Unsafe local, reserved, and cloud-metadata targets always remain blocked.",
         },
         {
           key: "personalAccessToken",

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -25,6 +25,12 @@ describe("normalizeJiraServerApiBaseUrl", () => {
     expect(normalizeJiraServerApiBaseUrl("https://jira.example.com/rest/api/2?a=1#fragment")).toBe(
       "https://jira.example.com/rest/api/2",
     );
+    expect(normalizeJiraServerApiBaseUrl("https://jira.example.com/rest/api/3")).toBe(
+      "https://jira.example.com/rest/api/2",
+    );
+    expect(normalizeJiraServerApiBaseUrl("https://jira.example.com/jira/rest/api/latest")).toBe(
+      "https://jira.example.com/jira/rest/api/2",
+    );
   });
 
   it("rejects embedded credentials and private targets unless enabled", () => {
@@ -151,6 +157,128 @@ describe("Jira Data Center proxy", () => {
 
     expect(requests.map((request) => request.url)).toEqual(["https://example.com/jira/rest/api/2/myself"]);
     expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe(`Bearer ${personalAccessToken}`);
+  });
+});
+
+describe("Jira Data Center server payloads", () => {
+  const serverContext = (fetcher: typeof fetch) => ({
+    accessToken: personalAccessToken,
+    fetcher,
+    providerMetadata: { apiBaseUrl: "https://jira.example.com/rest/api/2" },
+    deployment: "server" as const,
+  });
+
+  it("sends expand as an array on POST /search", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json({ issues: [], total: 0 });
+    });
+
+    await jiraActionHandlers.search_issues(
+      { jql: "project = PROJ", expand: ["names", "schema"] },
+      serverContext(fetcher),
+    );
+
+    expect(readJsonBody(requests[0])).toMatchObject({ expand: ["names", "schema"] });
+  });
+
+  it("preserves mention text and rejects an empty comment body", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json({ id: "1" });
+    });
+    // A mention-only body used to convert to "" (mention text lives in attrs.text); assert it survives.
+    const mentionAdf = {
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [{ type: "mention", attrs: { text: "@alex" } }] }],
+    };
+
+    await jiraActionHandlers.add_comment({ issueIdOrKey: "PROJ-1", body: mentionAdf }, serverContext(fetcher));
+    expect(readJsonBody(requests[0])).toEqual({ body: "@alex" });
+
+    const emptyAdf = { type: "doc", version: 1, content: [{ type: "paragraph", content: [] }] };
+    await expect(
+      jiraActionHandlers.add_comment({ issueIdOrKey: "PROJ-1", body: emptyAdf }, serverContext(fetcher)),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe("Jira Cloud write payloads", () => {
+  const cloudContext = (fetcher: typeof fetch) => ({
+    accessToken: "cloud-token",
+    fetcher,
+    providerMetadata: { cloudId: "cloud-id" },
+    deployment: "cloud" as const,
+  });
+  const adf = {
+    type: "doc",
+    version: 1,
+    content: [{ type: "paragraph", content: [{ type: "text", text: "line" }] }],
+  };
+
+  it("keeps ADF description and accountId assignee for create_issue", async () => {
+    const requests: RecordedRequest[] = [];
+    const responses = [
+      { id: "10", key: "PROJ-9" },
+      { id: "10", key: "PROJ-9", fields: { summary: "Created" } },
+    ];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json(responses.shift());
+    });
+
+    await jiraActionHandlers.create_issue(
+      { projectKey: "PROJ", issueTypeName: "Task", summary: "Created", description: adf, assigneeAccountId: "acc-1" },
+      cloudContext(fetcher),
+    );
+
+    expect(requests[0]?.url).toBe("https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/issue");
+    expect(readJsonBody(requests[0])).toMatchObject({
+      fields: { description: adf, assignee: { accountId: "acc-1" } },
+    });
+  });
+
+  it("converts bodyText to an ADF document for add_comment", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json({ id: "1" });
+    });
+
+    await jiraActionHandlers.add_comment({ issueIdOrKey: "PROJ-1", bodyText: "hello" }, cloudContext(fetcher));
+
+    expect(readJsonBody(requests[0])).toMatchObject({
+      body: { type: "doc", version: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }] },
+    });
+  });
+});
+
+describe("Jira error mapping", () => {
+  const serverContext = (fetcher: typeof fetch) => ({
+    accessToken: personalAccessToken,
+    fetcher,
+    providerMetadata: { apiBaseUrl: "https://jira.example.com/rest/api/2" },
+    deployment: "server" as const,
+  });
+
+  it("maps a 404 on get_issue to invalid input (status 400)", async () => {
+    const fetcher = vi.fn(
+      async (): Promise<Response> => Response.json({ errorMessages: ["Issue does not exist"] }, { status: 404 }),
+    );
+
+    await expect(
+      jiraActionHandlers.get_issue({ issueIdOrKey: "PROJ-404" }, serverContext(fetcher)),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("maps a 5xx response to a provider error (status 502)", async () => {
+    const fetcher = vi.fn(async (): Promise<Response> => Response.json({ message: "boom" }, { status: 503 }));
+
+    await expect(jiraActionHandlers.list_projects({}, serverContext(fetcher))).rejects.toMatchObject({ status: 502 });
   });
 });
 

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -1,0 +1,183 @@
+import type { CredentialValidationResult, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { credentialValidators, jiraActionHandlers, normalizeJiraServerApiBaseUrl, proxy } from "./executors.ts";
+
+interface RecordedRequest {
+  url: string;
+  init?: RequestInit;
+}
+
+const personalAccessToken = "jira-pat-test";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setPrivateNetworkAccessAllowed(false);
+});
+
+describe("normalizeJiraServerApiBaseUrl", () => {
+  it("builds the REST API v2 base URL and preserves an instance context path", () => {
+    expect(normalizeJiraServerApiBaseUrl("https://jira.example.com")).toBe("https://jira.example.com/rest/api/2");
+    expect(normalizeJiraServerApiBaseUrl("https://jira.example.com/jira/")).toBe(
+      "https://jira.example.com/jira/rest/api/2",
+    );
+    expect(normalizeJiraServerApiBaseUrl("https://jira.example.com/rest/api/2?a=1#fragment")).toBe(
+      "https://jira.example.com/rest/api/2",
+    );
+  });
+
+  it("rejects embedded credentials and private targets unless enabled", () => {
+    expect(() => normalizeJiraServerApiBaseUrl("https://user:pass@jira.example.com")).toThrow();
+    expect(() => normalizeJiraServerApiBaseUrl("http://10.0.0.2")).toThrow();
+    setPrivateNetworkAccessAllowed(true);
+    expect(normalizeJiraServerApiBaseUrl("http://10.0.0.2")).toBe("http://10.0.0.2/rest/api/2");
+    expect(() => normalizeJiraServerApiBaseUrl("http://127.0.0.1")).toThrow();
+  });
+});
+
+describe("Jira Data Center credentials", () => {
+  it("validates a PAT against /myself and scopes the account to its instance", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json({ key: "alex", displayName: "Alex", emailAddress: "alex@example.com" });
+    });
+
+    const result = (await credentialValidators.customCredential!(
+      { values: { baseUrl: "https://example.com/jira", personalAccessToken } },
+      { fetcher },
+    )) as CredentialValidationResult;
+
+    expect(result).toMatchObject({
+      profile: { accountId: "jira:example.com:alex", displayName: "Alex" },
+      grantedScopes: [],
+      metadata: { apiBaseUrl: "https://example.com/jira/rest/api/2", validationEndpoint: "/myself" },
+    });
+    expect(requests.map((request) => request.url)).toEqual(["https://example.com/jira/rest/api/2/myself"]);
+    expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe(`Bearer ${personalAccessToken}`);
+  });
+});
+
+describe("Jira Data Center actions", () => {
+  it("uses v2 routes and Jira Server text field formats for every action", async () => {
+    const requests: RecordedRequest[] = [];
+    const responses = [
+      [{ id: "1", key: "PROJ", name: "Project" }],
+      { id: "1", key: "PROJ", name: "Project" },
+      { issues: [], total: 0 },
+      { id: "100", key: "PROJ-1", fields: { summary: "Issue" } },
+      { id: "101", key: "PROJ-2" },
+      { id: "101", key: "PROJ-2", fields: { summary: "Created" } },
+      { comments: [], total: 0 },
+      { id: "201", body: "comment" },
+    ];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json(responses.shift());
+    });
+    const context = {
+      accessToken: personalAccessToken,
+      fetcher,
+      providerMetadata: { apiBaseUrl: "https://jira.example.com/rest/api/2" },
+      deployment: "server" as const,
+    };
+    const adf = {
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [{ type: "text", text: "line" }] }],
+    };
+
+    await jiraActionHandlers.list_projects({ limit: 10 }, context);
+    await jiraActionHandlers.get_project({ projectIdOrKey: "PROJ" }, context);
+    await jiraActionHandlers.search_issues({ jql: "project = PROJ", limit: 10, cursor: "0" }, context);
+    await jiraActionHandlers.get_issue({ issueIdOrKey: "PROJ-1" }, context);
+    await jiraActionHandlers.create_issue(
+      { projectKey: "PROJ", issueTypeName: "Task", summary: "Created", description: adf, assigneeAccountId: "alex" },
+      context,
+    );
+    await jiraActionHandlers.list_issue_comments({ issueIdOrKey: "PROJ-1", limit: 10 }, context);
+    await jiraActionHandlers.add_comment({ issueIdOrKey: "PROJ-1", body: adf }, context);
+
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://jira.example.com/rest/api/2/project",
+      "https://jira.example.com/rest/api/2/project/PROJ",
+      "https://jira.example.com/rest/api/2/search",
+      "https://jira.example.com/rest/api/2/issue/PROJ-1?fields=summary%2Cdescription%2Cstatus%2Cissuetype%2Cproject%2Cassignee%2Creporter%2Cpriority%2Clabels%2Ccreated%2Cupdated%2Cduedate",
+      "https://jira.example.com/rest/api/2/issue",
+      "https://jira.example.com/rest/api/2/issue/PROJ-2?fields=summary%2Cdescription%2Cstatus%2Cissuetype%2Cproject%2Cassignee%2Creporter%2Cpriority%2Clabels%2Ccreated%2Cupdated%2Cduedate",
+      "https://jira.example.com/rest/api/2/issue/PROJ-1/comment?maxResults=10&startAt=0",
+      "https://jira.example.com/rest/api/2/issue/PROJ-1/comment",
+    ]);
+    expect(readJsonBody(requests[2])).toMatchObject({ jql: "project = PROJ", startAt: 0, maxResults: 10 });
+    expect(readJsonBody(requests[4])).toMatchObject({
+      fields: { description: "line", assignee: { name: "alex" } },
+    });
+    expect(readJsonBody(requests[7])).toEqual({ body: "line" });
+    for (const request of requests) {
+      expect(new Headers(request.init?.headers).get("authorization")).toBe(`Bearer ${personalAccessToken}`);
+    }
+  });
+});
+
+describe("Jira Cloud regression", () => {
+  it("keeps the Cloud enhanced JQL path and ADF payloads", async () => {
+    const requests: RecordedRequest[] = [];
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      requests.push({ url: String(input), init });
+      return Response.json({ issues: [], nextPageToken: "next" });
+    });
+
+    await jiraActionHandlers.search_issues(
+      { jql: "project = PROJ", limit: 10, cursor: "previous" },
+      { accessToken: "cloud-token", fetcher, providerMetadata: { cloudId: "cloud-id" }, deployment: "cloud" },
+    );
+
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/search/jql",
+    ]);
+    expect(readJsonBody(requests[0])).toMatchObject({ nextPageToken: "previous" });
+  });
+});
+
+describe("Jira Data Center proxy", () => {
+  it("uses the configured instance and PAT", async () => {
+    const requests = stubGlobalFetch([Response.json({ key: "alex" })]);
+
+    await expect(proxy({ method: "GET", endpoint: "/myself" }, serverExecutionContext())).resolves.toMatchObject({
+      ok: true,
+      response: { status: 200, data: { key: "alex" } },
+    });
+
+    expect(requests.map((request) => request.url)).toEqual(["https://example.com/jira/rest/api/2/myself"]);
+    expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe(`Bearer ${personalAccessToken}`);
+  });
+});
+
+function readJsonBody(request: RecordedRequest | undefined): unknown {
+  const body = request?.init?.body;
+  return typeof body === "string" ? JSON.parse(body) : body;
+}
+
+function serverExecutionContext(): { getCredential: () => Promise<ResolvedCredential> } {
+  const credential: ResolvedCredential = {
+    authType: "custom_credential",
+    values: { baseUrl: "https://example.com/jira", personalAccessToken },
+    profile: { accountId: "jira:example.com:alex", displayName: "Alex", grantedScopes: [] },
+    metadata: {},
+  };
+  return { getCredential: async () => credential };
+}
+
+function stubGlobalFetch(responses: Response[]): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    requests.push({ url: String(input), init });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected extra request");
+    }
+    return response;
+  });
+  return requests;
+}

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -205,6 +205,23 @@ describe("Jira Data Center server payloads", () => {
     ).rejects.toMatchObject({ status: 400 });
     expect(requests).toHaveLength(1);
   });
+
+  it("preserves Server user name/key when normalizing an issue", async () => {
+    const fetcher = vi.fn(
+      async (): Promise<Response> =>
+        Response.json({
+          id: "1",
+          key: "PROJ-1",
+          fields: { summary: "S", assignee: { name: "alex", key: "alex", displayName: "Alex" } },
+        }),
+    );
+
+    const result = (await jiraActionHandlers.get_issue({ issueIdOrKey: "PROJ-1" }, serverContext(fetcher))) as {
+      issue: { assignee?: { name?: string; key?: string; displayName?: string } };
+    };
+
+    expect(result.issue.assignee).toMatchObject({ name: "alex", key: "alex", displayName: "Alex" });
+  });
 });
 
 describe("Jira Cloud write payloads", () => {

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -13,12 +13,13 @@ import {
   optionalRecord as asOptionalObject,
   optionalString as asOptionalString,
 } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  createProviderFetch,
   ProviderRequestError,
   defineProviderExecutors,
   defineProviderProxy,
   providerUserAgent,
-  requireOAuthCredential,
 } from "../provider-runtime.ts";
 
 type JiraAccessibleResource = {
@@ -43,6 +44,7 @@ type JiraActionContext = {
   accessToken: string;
   fetcher: typeof fetch;
   providerMetadata?: Record<string, unknown>;
+  deployment: "cloud" | "server";
 };
 
 type JiraActionHandler = (input: Record<string, unknown>, context: JiraActionContext) => Promise<unknown>;
@@ -169,6 +171,51 @@ async function fetchJiraCurrentAccount(
   };
 }
 
+async function fetchJiraServerCurrentAccount(
+  accessToken: string,
+  apiBaseUrl: string,
+  fetcher: typeof fetch,
+): Promise<{
+  profile: {
+    accountId: string;
+    displayName: string;
+  };
+  grantedScopes: string[];
+  metadata: Record<string, unknown>;
+}> {
+  const currentUser = await jiraJsonRequest<JiraCurrentUserPayload>({
+    accessToken,
+    fetcher,
+    providerMetadata: { apiBaseUrl },
+    path: jiraCurrentUserPath,
+  });
+  const accountKey =
+    asOptionalString(currentUser.accountId) ??
+    asOptionalString((currentUser as Record<string, unknown>).key) ??
+    asOptionalString((currentUser as Record<string, unknown>).name);
+  if (!accountKey) {
+    throw new ProviderRequestError(502, "jira current user response is missing an account identifier");
+  }
+
+  const displayName =
+    asOptionalString(currentUser.displayName) ?? asOptionalString(currentUser.emailAddress) ?? accountKey;
+  return {
+    profile: {
+      accountId: `jira:${new URL(apiBaseUrl).host}:${accountKey}`,
+      displayName,
+    },
+    grantedScopes: [],
+    metadata: compactObject({
+      apiBaseUrl,
+      validationEndpoint: jiraCurrentUserPath,
+      accountId: accountKey,
+      displayName: asOptionalString(currentUser.displayName),
+      emailAddress: asOptionalString(currentUser.emailAddress),
+      timeZone: asOptionalString(currentUser.timeZone),
+    }),
+  };
+}
+
 function mapJiraGrantedScopes(providerScopes: string[]): string[] {
   const scopes: string[] = [];
 
@@ -188,29 +235,67 @@ export const executors: ProviderExecutors = defineProviderExecutors<JiraActionCo
   service: "jira",
   handlers: jiraActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<JiraActionContext> {
-    const credential = await requireOAuthCredential(context, "jira");
-    return {
-      accessToken: credential.accessToken,
-      fetcher,
-      providerMetadata: credential.metadata,
-    };
+    const credential = await context.getCredential("jira");
+    if (credential?.authType === "oauth2") {
+      return {
+        accessToken: credential.accessToken,
+        fetcher,
+        providerMetadata: credential.metadata,
+        deployment: "cloud",
+      };
+    }
+    if (credential?.authType === "custom_credential") {
+      return {
+        accessToken: requirePersonalAccessToken(credential.values),
+        fetcher,
+        providerMetadata: {
+          ...credential.metadata,
+          apiBaseUrl: resolveJiraServerApiBaseUrl(credential.values, credential.metadata),
+        },
+        deployment: "server",
+      };
+    }
+    throw new ProviderRequestError(401, "Configure Jira OAuth or Data Center personal access token credentials first.");
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service: "jira",
   baseUrl: async (context) => {
-    const credential = await requireOAuthCredential(context, "jira");
-    return resolveJiraApiBaseUrl(credential.metadata);
+    const credential = await context.getCredential("jira");
+    if (credential?.authType === "oauth2") {
+      return resolveJiraApiBaseUrl(credential.metadata);
+    }
+    if (credential?.authType === "custom_credential") {
+      return resolveJiraServerApiBaseUrl(credential.values, credential.metadata);
+    }
+    throw new ProviderRequestError(401, "Configure Jira OAuth or Data Center personal access token credentials first.");
   },
-  auth: {
-    type: "oauth_bearer",
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    const credential = await context.getCredential("jira");
+    if (credential?.authType === "oauth2") {
+      headers.set("authorization", `${credential.tokenType} ${credential.accessToken}`);
+      return;
+    }
+    if (credential?.authType === "custom_credential") {
+      headers.set("authorization", `Bearer ${requirePersonalAccessToken(credential.values)}`);
+      return;
+    }
+    throw new ProviderRequestError(401, "Configure Jira OAuth or Data Center personal access token credentials first.");
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
   async oauth2(input, { fetcher }) {
     return fetchJiraCurrentAccount(input.accessToken, fetcher);
+  },
+  async customCredential(input, { fetcher }) {
+    const apiBaseUrl = normalizeJiraServerApiBaseUrl(input.values.baseUrl);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return fetchJiraServerCurrentAccount(requirePersonalAccessToken(input.values), apiBaseUrl, guardedFetcher);
   },
 };
 
@@ -218,6 +303,24 @@ async function listProjects(input: Record<string, unknown>, context: JiraActionC
   const limit = asOptionalInteger(input.limit) ?? 50;
   const startAt = parseNumericCursor(input.cursor);
   const expand = joinOptionalList(readStringArray(input.expand));
+
+  if (context.deployment === "server") {
+    const payload = await jiraJsonValueRequest({
+      accessToken: context.accessToken,
+      fetcher: context.fetcher,
+      providerMetadata: context.providerMetadata,
+      path: "/project",
+      query: compactQuery({ expand }),
+    });
+    const projects = readRecordArray(payload).map((project) => normalizeProject(project));
+    const page = projects.slice(startAt, startAt + limit);
+    return {
+      projects: page,
+      pagination: {
+        nextCursor: startAt + page.length < projects.length ? String(startAt + page.length) : null,
+      },
+    };
+  }
 
   const payload = await jiraJsonRequest<Record<string, unknown>>({
     accessToken: context.accessToken,
@@ -237,7 +340,7 @@ async function listProjects(input: Record<string, unknown>, context: JiraActionC
   return {
     projects: values,
     pagination: {
-      nextCursor: resolveNumericNextCursor(startAt, values.length, total),
+      nextCursor: resolveNumericNextCursor(startAt, values.length, total, optionalBoolean(payload.isLast)),
     },
   };
 }
@@ -261,16 +364,17 @@ async function getProject(input: Record<string, unknown>, context: JiraActionCon
 }
 
 async function searchIssues(input: Record<string, unknown>, context: JiraActionContext) {
+  const isServer = context.deployment === "server";
   const payload = await jiraJsonRequest<Record<string, unknown>>({
     accessToken: context.accessToken,
     fetcher: context.fetcher,
     providerMetadata: context.providerMetadata,
-    path: "/search/jql",
+    path: isServer ? "/search" : "/search/jql",
     method: "POST",
     body: compactObject({
       jql: requireString(input.jql, "jql"),
       maxResults: asOptionalInteger(input.limit) ?? 50,
-      nextPageToken: asOptionalString(input.cursor),
+      ...(isServer ? { startAt: parseNumericCursor(input.cursor) } : { nextPageToken: asOptionalString(input.cursor) }),
       fields: mergeUniqueFieldIds(defaultIssueFieldIds, readStringArray(input.includeFields)),
       expand: joinOptionalList(readStringArray(input.expand)),
     }),
@@ -279,7 +383,13 @@ async function searchIssues(input: Record<string, unknown>, context: JiraActionC
   return {
     issues: readRecordArray(payload.issues).map((issue) => normalizeIssue(issue)),
     pagination: {
-      nextCursor: asOptionalString(payload.nextPageToken) ?? null,
+      nextCursor: isServer
+        ? resolveNumericNextCursor(
+            parseNumericCursor(input.cursor),
+            readRecordArray(payload.issues).length,
+            asOptionalInteger(payload.total),
+          )
+        : (asOptionalString(payload.nextPageToken) ?? null),
     },
   };
 }
@@ -312,7 +422,7 @@ async function createIssue(input: Record<string, unknown>, context: JiraActionCo
     path: "/issue",
     method: "POST",
     body: {
-      fields: buildCreateIssueFields(input),
+      fields: buildCreateIssueFields(input, context.deployment),
     },
   });
 
@@ -381,7 +491,14 @@ async function addComment(input: Record<string, unknown>, context: JiraActionCon
     path: `/issue/${encodeURIComponent(issueIdOrKey)}/comment`,
     method: "POST",
     body: {
-      body: rawBody !== undefined ? normalizeLooseRecord(rawBody, "body") : textToAdfDocument(textBody ?? ""),
+      body:
+        context.deployment === "server"
+          ? rawBody !== undefined
+            ? adfToPlainText(normalizeLooseRecord(rawBody, "body"))
+            : (textBody ?? "")
+          : rawBody !== undefined
+            ? normalizeLooseRecord(rawBody, "body")
+            : textToAdfDocument(textBody ?? ""),
     },
     notFoundAsInvalidInput: true,
   });
@@ -392,8 +509,12 @@ async function addComment(input: Record<string, unknown>, context: JiraActionCon
 }
 
 async function jiraJsonRequest<T>(input: JiraRequestInput) {
+  return readJsonObject<T>(await jiraJsonValueRequest(input), "jira response payload");
+}
+
+async function jiraJsonValueRequest(input: JiraRequestInput): Promise<unknown> {
   const response = await jiraRequest(input);
-  return readJsonObject<T>(await readJsonValue(response), "jira response payload");
+  return readJsonValue(response);
 }
 
 async function jiraRequest(input: JiraRequestInput) {
@@ -434,12 +555,12 @@ function buildJiraUrl(
   pathOrUrl: string,
   query?: Record<string, string | undefined>,
 ) {
-  const target = isAbsoluteUrl(pathOrUrl)
-    ? new URL(pathOrUrl)
-    : new URL(trimLeadingSlash(pathOrUrl), `${resolveJiraApiBaseUrl(providerMetadata)}/`);
+  const apiBaseUrl = resolveJiraApiBaseUrl(providerMetadata);
+  const target = isAbsoluteUrl(pathOrUrl) ? new URL(pathOrUrl) : new URL(trimLeadingSlash(pathOrUrl), `${apiBaseUrl}/`);
+  const apiBase = new URL(apiBaseUrl);
 
-  if (target.origin !== jiraApiOrigin) {
-    throw new ProviderRequestError(400, `jira requests must target ${jiraApiOrigin}`);
+  if (target.origin !== apiBase.origin || !target.pathname.startsWith(`${apiBase.pathname}/`)) {
+    throw new ProviderRequestError(400, `jira requests must target ${apiBaseUrl}`);
   }
 
   for (const [key, value] of Object.entries(query ?? {})) {
@@ -453,6 +574,10 @@ function buildJiraUrl(
 }
 
 function resolveJiraApiBaseUrl(providerMetadata: Record<string, unknown> | undefined) {
+  const apiBaseUrl = asOptionalString(providerMetadata?.apiBaseUrl);
+  if (apiBaseUrl) {
+    return apiBaseUrl;
+  }
   const cloudId = asOptionalString(providerMetadata?.cloudId);
   if (!cloudId) {
     throw new ProviderRequestError(502, "jira provider metadata is missing cloudId");
@@ -462,6 +587,42 @@ function resolveJiraApiBaseUrl(providerMetadata: Record<string, unknown> | undef
 
 function buildJiraApiBaseUrl(cloudId: string) {
   return `${jiraApiOrigin}/ex/jira/${encodeURIComponent(cloudId)}/rest/api/3`;
+}
+
+export function normalizeJiraServerApiBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
+  const instanceUrl = asOptionalString(value);
+  if (!instanceUrl) {
+    throw new ProviderRequestError(400, "baseUrl is required");
+  }
+  const url = assertPublicHttpUrl(instanceUrl, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password) {
+    throw new ProviderRequestError(400, "baseUrl must not include credentials");
+  }
+
+  url.hash = "";
+  url.search = "";
+  const path = url.pathname.replace(/\/+$/u, "");
+  url.pathname = path.endsWith("/rest/api/2") ? path : `${path}/rest/api/2`;
+  return url.toString().replace(/\/$/u, "");
+}
+
+function resolveJiraServerApiBaseUrl(values: Record<string, string>, metadata: Record<string, unknown>): string {
+  return asOptionalString(metadata.apiBaseUrl) ?? normalizeJiraServerApiBaseUrl(values.baseUrl);
+}
+
+function requirePersonalAccessToken(values: Record<string, string>): string {
+  const token = asOptionalString(values.personalAccessToken);
+  if (!token) {
+    throw new ProviderRequestError(400, "personalAccessToken is required");
+  }
+  return token;
 }
 
 function readAccessibleResources(payload: unknown) {
@@ -511,7 +672,7 @@ function pickPrimaryResource(resources: JiraAccessibleResource[]) {
   return candidates[0] ?? null;
 }
 
-function buildCreateIssueFields(input: Record<string, unknown>) {
+function buildCreateIssueFields(input: Record<string, unknown>, deployment: JiraActionContext["deployment"]) {
   const extraFields = asOptionalObject(input.extraFields) ?? {};
   const explicitFields = compactObject({
     project: buildProjectReference(input),
@@ -519,10 +680,10 @@ function buildCreateIssueFields(input: Record<string, unknown>) {
     summary: requireString(input.summary, "summary"),
     description:
       input.description !== undefined
-        ? normalizeLooseRecord(input.description, "description")
-        : buildOptionalTextDocument(input.descriptionText),
+        ? formatJiraDocument(normalizeLooseRecord(input.description, "description"), deployment)
+        : buildOptionalTextDocument(input.descriptionText, deployment),
     labels: readStringArray(input.labels),
-    assignee: buildOptionalAccountReference(input.assigneeAccountId),
+    assignee: buildOptionalAccountReference(input.assigneeAccountId, deployment),
     priority: buildOptionalIdReference(input.priorityId),
     duedate: asOptionalString(input.dueDate),
     parent: buildOptionalKeyReference(input.parentIssueKey),
@@ -562,9 +723,12 @@ function buildIssueTypeReference(input: Record<string, unknown>) {
   throw new ProviderRequestError(400, "issueTypeId or issueTypeName is required");
 }
 
-function buildOptionalAccountReference(value: unknown) {
+function buildOptionalAccountReference(value: unknown, deployment: JiraActionContext["deployment"]) {
   const accountId = asOptionalString(value);
-  return accountId ? { accountId } : undefined;
+  if (!accountId) {
+    return undefined;
+  }
+  return deployment === "server" ? { name: accountId } : { accountId };
 }
 
 function buildOptionalIdReference(value: unknown) {
@@ -577,9 +741,16 @@ function buildOptionalKeyReference(value: unknown) {
   return key ? { key } : undefined;
 }
 
-function buildOptionalTextDocument(value: unknown) {
+function buildOptionalTextDocument(value: unknown, deployment: JiraActionContext["deployment"]) {
   const text = asOptionalString(value);
-  return text ? textToAdfDocument(text) : undefined;
+  if (!text) {
+    return undefined;
+  }
+  return deployment === "server" ? text : textToAdfDocument(text);
+}
+
+function formatJiraDocument(value: Record<string, unknown>, deployment: JiraActionContext["deployment"]) {
+  return deployment === "server" ? adfToPlainText(value) : value;
 }
 
 function normalizeProject(record: Record<string, unknown>) {
@@ -715,6 +886,40 @@ function textToAdfDocument(text: string) {
             },
           ],
   };
+}
+
+function adfToPlainText(value: Record<string, unknown>): string {
+  const parts: string[] = [];
+  appendAdfText(value, parts);
+  return parts
+    .join("")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+function appendAdfText(value: unknown, parts: string[]): void {
+  const record = asOptionalObject(value);
+  if (!record) {
+    return;
+  }
+
+  const type = asOptionalString(record.type);
+  if (type === "text") {
+    const text = asOptionalString(record.text);
+    if (text) {
+      parts.push(text);
+    }
+  } else if (type === "hardBreak") {
+    parts.push("\n");
+  }
+
+  const content = Array.isArray(record.content) ? record.content : [];
+  for (const child of content) {
+    appendAdfText(child, parts);
+  }
+  if (content.length > 0 && ["paragraph", "heading", "listItem"].includes(type ?? "")) {
+    parts.push("\n");
+  }
 }
 
 function readScopeArray(value: unknown) {
@@ -859,8 +1064,11 @@ function parseNumericCursor(value: unknown) {
   return parsed;
 }
 
-function resolveNumericNextCursor(startAt: number, itemCount: number, total?: number) {
+function resolveNumericNextCursor(startAt: number, itemCount: number, total?: number, isLast?: boolean) {
   if (itemCount === 0) {
+    return null;
+  }
+  if (isLast) {
     return null;
   }
   if (typeof total === "number" && startAt + itemCount >= total) {

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -33,6 +33,9 @@ type JiraAccessibleResource = {
 type JiraCurrentUserPayload = {
   accountId?: unknown;
   accountType?: unknown;
+  // Jira Server/Data Center /myself returns key/name instead of a Cloud accountId.
+  key?: unknown;
+  name?: unknown;
   displayName?: unknown;
   emailAddress?: unknown;
   active?: unknown;
@@ -190,9 +193,7 @@ async function fetchJiraServerCurrentAccount(
     path: jiraCurrentUserPath,
   });
   const accountKey =
-    asOptionalString(currentUser.accountId) ??
-    asOptionalString((currentUser as Record<string, unknown>).key) ??
-    asOptionalString((currentUser as Record<string, unknown>).name);
+    asOptionalString(currentUser.accountId) ?? asOptionalString(currentUser.key) ?? asOptionalString(currentUser.name);
   if (!accountKey) {
     throw new ProviderRequestError(502, "jira current user response is missing an account identifier");
   }
@@ -305,6 +306,10 @@ async function listProjects(input: Record<string, unknown>, context: JiraActionC
   const expand = joinOptionalList(readStringArray(input.expand));
 
   if (context.deployment === "server") {
+    // Jira Data Center has no paginated /project/search, so we fetch the full /project list and
+    // page in memory. Each page re-fetches rather than caching: the stateless runtime exposes no
+    // per-context cache, and a credential-keyed module cache would trade this for staleness and
+    // unbounded per-instance memory — not worth it for typical DC project counts.
     const payload = await jiraJsonValueRequest({
       accessToken: context.accessToken,
       fetcher: context.fetcher,
@@ -596,6 +601,15 @@ function buildJiraApiBaseUrl(cloudId: string) {
   return `${jiraApiOrigin}/ex/jira/${encodeURIComponent(cloudId)}/rest/api/3`;
 }
 
+/**
+ * Normalize a user-supplied Jira Data Center / Server instance URL into its REST API v2 base.
+ *
+ * Enforces the provider's egress contract: the URL must be a public http(s) target
+ * ({@link assertPublicHttpUrl}; private networks only when `allowPrivateNetwork` is set, and
+ * loopback/reserved/cloud-metadata stay blocked), must not embed credentials, and has its query
+ * and fragment stripped. A trailing `/rest/api/{2,3,latest}` is normalized to the `/rest/api/2`
+ * suffix this provider speaks, so a pasted API URL is not double-appended.
+ */
 export function normalizeJiraServerApiBaseUrl(
   value: unknown,
   allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
@@ -832,6 +846,9 @@ function normalizeOptionalUser(value: unknown) {
   return compactObject({
     accountId: asOptionalString(record.accountId),
     accountType: asOptionalString(record.accountType),
+    // Jira Server/Data Center identifies users by name/key rather than a Cloud accountId.
+    name: asOptionalString(record.name),
+    key: asOptionalString(record.key),
     displayName: asOptionalString(record.displayName),
     emailAddress: asOptionalString(record.emailAddress),
     active: optionalBoolean(record.active),

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -374,9 +374,12 @@ async function searchIssues(input: Record<string, unknown>, context: JiraActionC
     body: compactObject({
       jql: requireString(input.jql, "jql"),
       maxResults: asOptionalInteger(input.limit) ?? 50,
-      ...(isServer ? { startAt: parseNumericCursor(input.cursor) } : { nextPageToken: asOptionalString(input.cursor) }),
       fields: mergeUniqueFieldIds(defaultIssueFieldIds, readStringArray(input.includeFields)),
-      expand: joinOptionalList(readStringArray(input.expand)),
+      // Jira Server/DC POST /rest/api/2/search binds a SearchRequestBean whose `expand` is a
+      // List<String>; the Cloud enhanced POST /rest/api/3/search/jql takes it as a comma string.
+      ...(isServer
+        ? { startAt: parseNumericCursor(input.cursor), expand: optionalStringList(readStringArray(input.expand)) }
+        : { nextPageToken: asOptionalString(input.cursor), expand: joinOptionalList(readStringArray(input.expand)) }),
     }),
   });
 
@@ -431,7 +434,7 @@ async function createIssue(input: Record<string, unknown>, context: JiraActionCo
     asOptionalString(createPayload.id) ??
     requireNonEmptyString(createPayload.self, "jira created issue self");
 
-  const issueLookupPath = createdIssueIdOrKey.startsWith("https://")
+  const issueLookupPath = isAbsoluteUrl(createdIssueIdOrKey)
     ? createdIssueIdOrKey
     : `/issue/${encodeURIComponent(createdIssueIdOrKey)}`;
 
@@ -491,14 +494,7 @@ async function addComment(input: Record<string, unknown>, context: JiraActionCon
     path: `/issue/${encodeURIComponent(issueIdOrKey)}/comment`,
     method: "POST",
     body: {
-      body:
-        context.deployment === "server"
-          ? rawBody !== undefined
-            ? adfToPlainText(normalizeLooseRecord(rawBody, "body"))
-            : (textBody ?? "")
-          : rawBody !== undefined
-            ? normalizeLooseRecord(rawBody, "body")
-            : textToAdfDocument(textBody ?? ""),
+      body: buildCommentBody(rawBody, textBody, context.deployment),
     },
     notFoundAsInvalidInput: true,
   });
@@ -506,6 +502,17 @@ async function addComment(input: Record<string, unknown>, context: JiraActionCon
   return {
     comment: normalizeComment(payload),
   };
+}
+
+function buildCommentBody(rawBody: unknown, textBody: string | undefined, deployment: JiraActionContext["deployment"]) {
+  if (deployment === "server") {
+    const text = rawBody !== undefined ? adfToPlainText(normalizeLooseRecord(rawBody, "body")) : (textBody ?? "");
+    if (!text) {
+      throw new ProviderRequestError(400, "comment body or bodyText is required");
+    }
+    return text;
+  }
+  return rawBody !== undefined ? normalizeLooseRecord(rawBody, "body") : textToAdfDocument(textBody ?? "");
 }
 
 async function jiraJsonRequest<T>(input: JiraRequestInput) {
@@ -608,8 +615,10 @@ export function normalizeJiraServerApiBaseUrl(
 
   url.hash = "";
   url.search = "";
-  const path = url.pathname.replace(/\/+$/u, "");
-  url.pathname = path.endsWith("/rest/api/2") ? path : `${path}/rest/api/2`;
+  // Strip a trailing REST API segment the user may have pasted (…/rest/api/2|3|latest) so we do
+  // not double-append and 404 every request, then pin to the v2 API this provider speaks.
+  const path = url.pathname.replace(/\/+$/u, "").replace(/\/rest\/api\/(?:2|3|latest)$/u, "");
+  url.pathname = `${path}/rest/api/2`;
   return url.toString().replace(/\/$/u, "");
 }
 
@@ -911,6 +920,19 @@ function appendAdfText(value: unknown, parts: string[]): void {
     }
   } else if (type === "hardBreak") {
     parts.push("\n");
+  } else if (type === "mention" || type === "emoji" || type === "date" || type === "status") {
+    // These inline nodes carry their visible text in attrs.text rather than a text child.
+    const attrs = asOptionalObject(record.attrs);
+    const text = asOptionalString(attrs?.text);
+    if (text) {
+      parts.push(text);
+    }
+  } else if (type === "inlineCard") {
+    const attrs = asOptionalObject(record.attrs);
+    const url = asOptionalString(attrs?.url);
+    if (url) {
+      parts.push(url);
+    }
   }
 
   const content = Array.isArray(record.content) ? record.content : [];
@@ -1048,6 +1070,10 @@ function mergeUniqueFieldIds(baseFields: string[], extraFields: string[]) {
 
 function joinOptionalList(values: string[]) {
   return values.length > 0 ? values.join(",") : undefined;
+}
+
+function optionalStringList(values: string[]) {
+  return values.length > 0 ? values : undefined;
 }
 
 function parseNumericCursor(value: unknown) {


### PR DESCRIPTION
## Summary

Adds Jira Data Center and Server support to the existing Jira provider through a user-configured instance URL and personal access token.

## Changes

- Keep Jira Cloud OAuth behavior unchanged.
- Add custom credentials for Jira Data Center/Server PAT authentication.
- Route private deployments through REST API v2, including private-network egress safeguards.
- Support project, issue, JQL, and comment actions with Server-compatible payloads and pagination.
- Add focused provider tests for PAT validation, URL policy, proxy requests, private action routing, and Cloud regression coverage.

## Validation

- `npx vitest run src/providers/jira/executors.test.ts`
- `npm run typecheck`
- `npm run generate:catalog`
- `npm run fix-check`
- Read-only validation against a Jira Data Center instance: current user, project listing, and JQL search.
