### PR TITLE
feat(providers): add Lovable provider support

### DIFF
--- a/src/providers/lovable/actions.ts
+++ b/src/providers/lovable/actions.ts
@@ -1,0 +1,235 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "lovable";
+
+export type LovableActionName =
+  | "get_me"
+  | "list_workspaces"
+  | "get_workspace"
+  | "create_project"
+  | "list_projects"
+  | "get_project"
+  | "deploy_project"
+  | "send_message"
+  | "get_message"
+  | "list_messages"
+  | "get_diff"
+  | "list_files"
+  | "read_file"
+  | "get_database_status"
+  | "enable_database"
+  | "query_database";
+
+export const lovableActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_me",
+    description: "Get authenticated user profile and workspaces.",
+    inputSchema: s.object("Input payload for get_me", {}),
+    outputSchema: s.looseObject("User profile and workspaces"),
+  }),
+  defineProviderAction(service, {
+    name: "list_workspaces",
+    description: "List all workspaces. Paginate with cursors.",
+    inputSchema: s.object(
+      "Input payload for list_workspaces",
+      {
+        limit: s.integer({ description: "Limit number of workspaces returned." }),
+        offset: s.integer({ description: "Offset for pagination." }),
+        cursor: s.string({ description: "Cursor for pagination." }),
+      },
+      { optional: ["limit", "offset", "cursor"] },
+    ),
+    outputSchema: s.looseObject("A page of workspaces"),
+  }),
+  defineProviderAction(service, {
+    name: "get_workspace",
+    description: "Get workspace details, credits, and settings.",
+    inputSchema: s.object("Input payload for get_workspace", {
+      workspace_id: s.nonEmptyString("The workspace identifier."),
+    }),
+    outputSchema: s.looseObject("Workspace details"),
+  }),
+  defineProviderAction(service, {
+    name: "create_project",
+    description: "Create a new project using Lovable's default backend stack.",
+    inputSchema: s.object(
+      "Input payload for create_project",
+      {
+        workspace_id: s.string({
+          description: "The workspace identifier. Required if account has multiple workspaces.",
+        }),
+        initial_message: s.nonEmptyString("The initial instructions for the project builder agent."),
+        files: s.array(
+          "Optional files to attach to the project (e.g. design assets, specs).",
+          s.looseObject("File attachment details"),
+        ),
+        template_project_id: s.string({ description: "Optional template project ID to fork from." }),
+        design_systems: s.array("Optional design systems to initialize with.", s.string()),
+        wait: s.boolean({ description: "Wait for the builder to finish writing initial code. Defaults to true." }),
+        timeout_seconds: s.integer({ description: "Custom timeout in seconds if wait is true." }),
+      },
+      { optional: ["workspace_id", "files", "template_project_id", "design_systems", "wait", "timeout_seconds"] },
+    ),
+    outputSchema: s.looseObject("Created project details"),
+  }),
+  defineProviderAction(service, {
+    name: "list_projects",
+    description: "Search and list projects inside a workspace.",
+    inputSchema: s.object(
+      "Input payload for list_projects",
+      {
+        workspace_id: s.nonEmptyString("The workspace identifier."),
+        query: s.string({ description: "Optional query to search by name." }),
+        visibility: s.stringEnum("Optional visibility filter.", ["draft", "private", "public"]),
+        publish_status: s.string({ description: "Optional publish status filter." }),
+        folder_id: s.string({ description: "Optional folder ID filter." }),
+        user_id: s.string({ description: "Optional user ID filter." }),
+        viewed_by_me: s.boolean({ description: "Optional filter for viewed projects." }),
+        limit: s.integer({ description: "Limit number of projects returned." }),
+        cursor: s.string({ description: "Cursor for pagination." }),
+      },
+      {
+        optional: ["query", "visibility", "publish_status", "folder_id", "user_id", "viewed_by_me", "limit", "cursor"],
+      },
+    ),
+    outputSchema: s.looseObject("A page of projects"),
+  }),
+  defineProviderAction(service, {
+    name: "get_project",
+    description: "Get project details and current build status.",
+    inputSchema: s.object("Input payload for get_project", {
+      project_id: s.nonEmptyString("The project identifier."),
+    }),
+    outputSchema: s.looseObject("Project details"),
+  }),
+  defineProviderAction(service, {
+    name: "deploy_project",
+    description: "Publish the project to a live URL on lovable.app.",
+    inputSchema: s.object(
+      "Input payload for deploy_project",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        name: s.string({ description: "Optional name of the deployment target." }),
+      },
+      { optional: ["name"] },
+    ),
+    outputSchema: s.looseObject("Deployment details"),
+  }),
+  defineProviderAction(service, {
+    name: "send_message",
+    description: "Send instructions or prompts to a project's AI builder agent.",
+    inputSchema: s.object(
+      "Input payload for send_message",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        message: s.nonEmptyString("The instruction prompt for the agent (1-100k chars)."),
+        variant_id: s.string({ description: "Optional variant ID to send the message to." }),
+        wait: s.boolean({ description: "Wait for the builder to finish writing code. Defaults to true." }),
+        timeout_seconds: s.integer({ description: "Custom timeout in seconds." }),
+        plan_mode: s.boolean({ description: "If true, discuss architecture without writing code." }),
+        files: s.array(
+          "Optional file IDs to attach (from get_file_upload_url).",
+          s.looseObject("File attachment details"),
+        ),
+      },
+      { optional: ["variant_id", "wait", "timeout_seconds", "plan_mode", "files"] },
+    ),
+    outputSchema: s.looseObject("Message send response"),
+  }),
+  defineProviderAction(service, {
+    name: "get_message",
+    description: "Retrieve a message's progress or build status.",
+    inputSchema: s.object(
+      "Input payload for get_message",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        message_id: s.nonEmptyString("The message identifier."),
+        thread_id: s.string({ description: "Optional thread identifier." }),
+      },
+      { optional: ["thread_id"] },
+    ),
+    outputSchema: s.looseObject("Message details"),
+  }),
+  defineProviderAction(service, {
+    name: "list_messages",
+    description: "List recent messages newest-first in a project.",
+    inputSchema: s.object(
+      "Input payload for list_messages",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        limit: s.integer({ description: "Limit number of messages returned." }),
+        cursor: s.string({ description: "Cursor for pagination." }),
+      },
+      { optional: ["limit", "cursor"] },
+    ),
+    outputSchema: s.looseObject("A page of messages"),
+  }),
+  defineProviderAction(service, {
+    name: "get_diff",
+    description: "Get unified diff from a message or between commits.",
+    inputSchema: s.object(
+      "Input payload for get_diff",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        message_id: s.string({ description: "Optional message ID to see its changes." }),
+        sha: s.string({ description: "Optional commit SHA." }),
+        base_sha: s.string({ description: "Optional base commit SHA." }),
+      },
+      { optional: ["message_id", "sha", "base_sha"] },
+    ),
+    outputSchema: s.looseObject("The unified diff"),
+  }),
+  defineProviderAction(service, {
+    name: "list_files",
+    description: "List files at a given git ref (sha/branch).",
+    inputSchema: s.object(
+      "Input payload for list_files",
+      {
+        project_id: s.nonEmptyString("The project identifier."),
+        ref: s.string({ description: "Optional git reference (commit SHA or branch name)." }),
+        limit: s.integer({ description: "Limit number of files returned." }),
+        cursor: s.string({ description: "Cursor for pagination." }),
+      },
+      { optional: ["ref", "limit", "cursor"] },
+    ),
+    outputSchema: s.looseObject("A page of files"),
+  }),
+  defineProviderAction(service, {
+    name: "read_file",
+    description: "Read a single file's contents at a git ref.",
+    inputSchema: s.object("Input payload for read_file", {
+      project_id: s.nonEmptyString("The project identifier."),
+      path: s.nonEmptyString("The relative file path inside the project."),
+      ref: s.nonEmptyString("The git reference (commit SHA or branch name)."),
+    }),
+    outputSchema: s.looseObject("File contents"),
+  }),
+  defineProviderAction(service, {
+    name: "get_database_status",
+    description: "Check if a project database is provisioned.",
+    inputSchema: s.object("Input payload for get_database_status", {
+      project_id: s.nonEmptyString("The project identifier."),
+    }),
+    outputSchema: s.looseObject("Database status details"),
+  }),
+  defineProviderAction(service, {
+    name: "enable_database",
+    description: "Provision a cloud PostgreSQL database for the project.",
+    inputSchema: s.object("Input payload for enable_database", {
+      project_id: s.nonEmptyString("The project identifier."),
+    }),
+    outputSchema: s.looseObject("Database provision details"),
+  }),
+  defineProviderAction(service, {
+    name: "query_database",
+    description: "Execute SQL query directly against the project database.",
+    inputSchema: s.object("Input payload for query_database", {
+      project_id: s.nonEmptyString("The project identifier."),
+      sql: s.nonEmptyString("The SQL query to execute."),
+    }),
+    outputSchema: s.looseObject("Query execution result"),
+  }),
+];

--- a/src/providers/lovable/definition.ts
+++ b/src/providers/lovable/definition.ts
@@ -1,0 +1,30 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { lovableActions } from "./actions.ts";
+
+const service = "lovable";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Lovable",
+  categories: ["AI", "Developer Tools"],
+  authTypes: ["oauth2", "api_key"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://lovable.dev/oauth/authorize",
+      tokenUrl: "https://lovable.dev/oauth/token",
+      scopes: ["offline", "projects:read", "projects:write", "projects:create", "workspaces:read", "workspaces:write"],
+      tokenEndpointAuthMethod: "client_secret_post",
+    },
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "lov_...",
+      description:
+        "Lovable API key used with the Lovable-API-Key header. You can generate an API key in your Lovable settings.",
+    },
+  ],
+  homepageUrl: "https://lovable.dev",
+  actions: lovableActions,
+};

--- a/src/providers/lovable/executors.test.ts
+++ b/src/providers/lovable/executors.test.ts
@@ -1,0 +1,169 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+
+import { describe, expect, it } from "vitest";
+import { lovableActionHandlers, credentialValidators } from "./executors.ts";
+
+describe("Lovable executors", () => {
+  it("validates API key credentials successfully", async () => {
+    const mockUserResponse = {
+      user: {
+        id: "usr_123",
+        email: "user@example.com",
+        name: "Test User",
+      },
+    };
+
+    const fetcher = (async (url: any, init?: any): Promise<Response> => {
+      expect(String(url)).toBe("https://mcp.lovable.dev/");
+      expect(init?.method).toBe("POST");
+
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Lovable-API-Key"]).toBe("lov_key123");
+      expect(headers["Mcp-Protocol-Version"]).toBe("2024-11-05");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.method).toBe("tools/call");
+      expect(body.params.name).toBe("get_me");
+
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(mockUserResponse),
+            },
+          ],
+        },
+      });
+    }) as typeof fetch;
+
+    const result = (await credentialValidators.apiKey!(
+      { apiKey: "lov_key123", values: {} },
+      { fetcher },
+    )) as CredentialValidationResult;
+
+    expect(result.profile?.accountId).toBe("usr_123");
+    expect(result.profile?.displayName).toBe("Test User");
+    expect(result.metadata?.user).toEqual(mockUserResponse);
+  });
+
+  it("validates OAuth2 credentials successfully", async () => {
+    const mockUserResponse = {
+      user: {
+        id: "usr_oauth",
+        email: "oauth@example.com",
+        name: "OAuth User",
+      },
+    };
+
+    const fetcher = (async (url: any, init?: any): Promise<Response> => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer oauth_token_123");
+
+      const body = JSON.parse(init?.body as string);
+
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(mockUserResponse),
+            },
+          ],
+        },
+      });
+    }) as typeof fetch;
+
+    const result = (await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "oauth_token_123",
+        tokenType: "Bearer",
+        profile: { accountId: "usr_oauth", displayName: "OAuth User", grantedScopes: [] },
+        metadata: {},
+      },
+      { fetcher },
+    )) as CredentialValidationResult;
+
+    expect(result.profile?.accountId).toBe("usr_oauth");
+    expect(result.profile?.displayName).toBe("OAuth User");
+  });
+
+  it("executes an action successfully", async () => {
+    const mockWorkspaceResponse = {
+      workspaces: [{ id: "ws_1", name: "Workspace 1" }],
+    };
+
+    const fetcher = (async (url: any, init?: any): Promise<Response> => {
+      const body = JSON.parse(init?.body as string);
+      expect(body.params.name).toBe("list_workspaces");
+      expect(body.params.arguments).toEqual({ limit: 10 });
+
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(mockWorkspaceResponse),
+            },
+          ],
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await lovableActionHandlers.list_workspaces({ limit: 10 }, { accessToken: "lov_key123", fetcher });
+
+    expect(result).toEqual(mockWorkspaceResponse);
+  });
+
+  it("handles errors from the MCP server correctly", async () => {
+    const fetcher = (async (url: any, init?: any): Promise<Response> => {
+      const body = JSON.parse(init?.body as string);
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        error: {
+          code: -32601,
+          message: "Method not found",
+        },
+      });
+    }) as typeof fetch;
+
+    await expect(lovableActionHandlers.get_me({}, { accessToken: "lov_key123", fetcher })).rejects.toMatchObject({
+      status: 400,
+      message: "Method not found",
+    });
+  });
+
+  it("handles tool execution errors correctly", async () => {
+    const fetcher = (async (url: any, init?: any): Promise<Response> => {
+      const body = JSON.parse(init?.body as string);
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Workspace not found",
+            },
+          ],
+        },
+      });
+    }) as typeof fetch;
+
+    await expect(
+      lovableActionHandlers.get_workspace({ workspace_id: "ws_invalid" }, { accessToken: "lov_key123", fetcher }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Workspace not found",
+    });
+  });
+});

--- a/src/providers/lovable/executors.ts
+++ b/src/providers/lovable/executors.ts
@@ -1,0 +1,201 @@
+import type { CredentialValidators, CredentialValidationResult, ProviderExecutors } from "../../core/types.ts";
+import type { BearerProviderContext } from "../provider-runtime.ts";
+import type { LovableActionName } from "./actions.ts";
+
+import { defineBearerProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
+
+const service = "lovable";
+export const lovableMcpBaseUrl = "https://mcp.lovable.dev/";
+
+async function requestLovableMcp(
+  toolName: string,
+  argumentsData: Record<string, unknown>,
+  context: BearerProviderContext,
+): Promise<unknown> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Mcp-Protocol-Version": "2024-11-05",
+  };
+
+  if (context.accessToken.startsWith("lov_")) {
+    headers["Lovable-API-Key"] = context.accessToken;
+  } else {
+    const tokenType = context.tokenType || "Bearer";
+    headers["Authorization"] = `${tokenType} ${context.accessToken}`;
+  }
+
+  context.signal?.throwIfAborted();
+
+  const response = await context.fetcher(lovableMcpBaseUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: toolName,
+        arguments: argumentsData,
+      },
+    }),
+    signal: context.signal,
+  });
+
+  if (!response.ok) {
+    throw new ProviderRequestError(response.status, `Lovable MCP server request failed with status ${response.status}`);
+  }
+
+  const json = (await response.json()) as any;
+  if (json.error) {
+    throw new ProviderRequestError(400, json.error.message || "Lovable MCP tool call returned an error", json.error);
+  }
+
+  const result = json.result;
+  if (result?.isError) {
+    const errorText = result.content?.[0]?.text || "Unknown Lovable MCP error";
+    throw new ProviderRequestError(400, errorText);
+  }
+
+  const textContent = result?.content?.[0]?.text;
+  if (typeof textContent === "string") {
+    try {
+      return JSON.parse(textContent);
+    } catch {
+      return textContent;
+    }
+  }
+
+  return result;
+}
+
+export const lovableActionHandlers: Record<
+  LovableActionName,
+  (input: Record<string, unknown>, context: BearerProviderContext) => Promise<unknown>
+> = {
+  get_me(input, context) {
+    return requestLovableMcp("get_me", input, context);
+  },
+  list_workspaces(input, context) {
+    return requestLovableMcp("list_workspaces", input, context);
+  },
+  get_workspace(input, context) {
+    return requestLovableMcp("get_workspace", input, context);
+  },
+  create_project(input, context) {
+    return requestLovableMcp("create_project", input, context);
+  },
+  list_projects(input, context) {
+    return requestLovableMcp("list_projects", input, context);
+  },
+  get_project(input, context) {
+    return requestLovableMcp("get_project", input, context);
+  },
+  deploy_project(input, context) {
+    return requestLovableMcp("deploy_project", input, context);
+  },
+  send_message(input, context) {
+    return requestLovableMcp("send_message", input, context);
+  },
+  get_message(input, context) {
+    return requestLovableMcp("get_message", input, context);
+  },
+  list_messages(input, context) {
+    return requestLovableMcp("list_messages", input, context);
+  },
+  get_diff(input, context) {
+    return requestLovableMcp("get_diff", input, context);
+  },
+  list_files(input, context) {
+    return requestLovableMcp("list_files", input, context);
+  },
+  read_file(input, context) {
+    return requestLovableMcp("read_file", input, context);
+  },
+  get_database_status(input, context) {
+    return requestLovableMcp("get_database_status", input, context);
+  },
+  enable_database(input, context) {
+    return requestLovableMcp("enable_database", input, context);
+  },
+  query_database(input, context) {
+    return requestLovableMcp("query_database", input, context);
+  },
+};
+
+export const executors: ProviderExecutors = defineBearerProviderExecutors(service, lovableActionHandlers);
+
+async function validateLovableCredential(
+  auth: { apiKey?: string; accessToken?: string; tokenType?: string },
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Mcp-Protocol-Version": "2024-11-05",
+  };
+  if (auth.apiKey) {
+    headers["Lovable-API-Key"] = auth.apiKey;
+  } else if (auth.accessToken) {
+    const tokenType = auth.tokenType || "Bearer";
+    headers["Authorization"] = `${tokenType} ${auth.accessToken}`;
+  }
+
+  const response = await fetcher(lovableMcpBaseUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "validate",
+      method: "tools/call",
+      params: {
+        name: "get_me",
+        arguments: {},
+      },
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new ProviderRequestError(response.status, `Lovable API returned status ${response.status}`);
+  }
+
+  const json = (await response.json()) as any;
+  if (json.error) {
+    throw new ProviderRequestError(401, json.error.message || "Invalid credentials", json.error);
+  }
+
+  const result = json.result;
+  if (result?.isError) {
+    throw new ProviderRequestError(401, result.content?.[0]?.text || "Invalid credentials");
+  }
+
+  const textContent = result?.content?.[0]?.text;
+  let user: any = null;
+  if (typeof textContent === "string") {
+    try {
+      user = JSON.parse(textContent);
+    } catch {
+      user = { rawText: textContent };
+    }
+  }
+
+  return {
+    profile: {
+      accountId: user?.user?.id || user?.id || "lovable-user",
+      displayName: user?.user?.name || user?.name || user?.user?.email || user?.email || "Lovable User",
+    },
+    grantedScopes: [],
+    metadata: {
+      user,
+    },
+  };
+}
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    return validateLovableCredential({ apiKey: input.apiKey }, fetcher, signal);
+  },
+  async oauth2(input, { fetcher, signal }) {
+    return validateLovableCredential({ accessToken: input.accessToken, tokenType: input.tokenType }, fetcher, signal);
+  },
+};


### PR DESCRIPTION
This PR adds Lovable to the Open Connector setup, enabling OAuth2 and API Key credentials authentication to interface with Lovable's MCP server at https://mcp.lovable.dev.