### PR TITLE
feat(edenai): add Eden AI provider

### DIFF
--- a/src/providers/edenai/actions.ts
+++ b/src/providers/edenai/actions.ts
@@ -1,0 +1,169 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "edenai";
+
+const noInputSchema = s.actionInput({}, [], "No input parameters are required for this action.");
+const jsonValueSchema = s.unknown("Any JSON value accepted by the upstream API.");
+const jsonObjectSchema = s.record("A JSON object with arbitrary upstream fields.", jsonValueSchema);
+
+const edenaiModelSchema = s.looseRequiredObject(
+  "An Eden AI model record.",
+  {
+    id: s.string("The model identifier, formatted as `<vendor>/<model>` (for example `openai/gpt-4o-mini`)."),
+    object: s.string("The object type returned by the API."),
+    created: s.integer("The Unix timestamp when the model was created."),
+    owned_by: s.string("The upstream vendor that owns the model."),
+  },
+  { optional: ["created", "owned_by"] },
+);
+
+const listModelsOutputSchema = s.looseRequiredObject("The response payload for listing Eden AI models.", {
+  object: s.string("The top-level object type."),
+  data: s.array("The list of available Eden AI models.", edenaiModelSchema),
+});
+
+const chatMessageContentSchema = s.anyOf("The message content sent to the model.", [
+  s.string("Plain text message content."),
+  s.array("Structured message content blocks.", jsonObjectSchema),
+  s.nullable(s.string("Null content for assistant tool call messages.")),
+]);
+
+const chatMessageSchema = s.looseRequiredObject(
+  "A message in the OpenAI-compatible chat completion request.",
+  {
+    role: s.stringEnum("The role of the message author.", ["system", "user", "assistant", "tool"]),
+    content: chatMessageContentSchema,
+    name: s.string("The optional participant name for the message."),
+    tool_call_id: s.string("The identifier of the tool call that this tool message responds to."),
+    tool_calls: s.array("Tool calls emitted by the assistant.", jsonObjectSchema),
+  },
+  { optional: ["content", "name", "tool_call_id", "tool_calls"] },
+);
+
+const responseFormatSchema = s.looseRequiredObject(
+  "Response format configuration.",
+  {
+    type: s.stringEnum("The requested response format type.", ["text", "json_object", "json_schema"]),
+    json_schema: jsonObjectSchema,
+  },
+  { optional: ["json_schema"] },
+);
+
+const toolChoiceSchema = s.anyOf("Tool selection strategy for the request.", [
+  s.stringEnum("A predefined tool selection mode.", ["none", "auto", "required"]),
+  jsonObjectSchema,
+]);
+
+const chatCompletionInputSchema: JsonSchema = {
+  ...s.looseRequiredObject(
+    "The input payload for creating a non-streaming Eden AI chat completion.",
+    {
+      model: s.string("The Eden AI model identifier, formatted as `<vendor>/<model>`.", { minLength: 1 }),
+      messages: s.array("The ordered conversation history sent to the model.", chatMessageSchema, { minItems: 1 }),
+      frequency_penalty: s.number("The frequency penalty applied to repeated tokens.", { minimum: -2, maximum: 2 }),
+      logit_bias: jsonObjectSchema,
+      logprobs: s.boolean("Whether to include token-level log probabilities."),
+      max_completion_tokens: s.integer("The maximum number of completion tokens to generate.", { minimum: 1 }),
+      max_tokens: s.integer("The deprecated maximum token field accepted by compatible clients.", { minimum: 1 }),
+      n: s.integer("The number of chat completions to generate.", { minimum: 1 }),
+      presence_penalty: s.number("The presence penalty applied to newly introduced tokens.", {
+        minimum: -2,
+        maximum: 2,
+      }),
+      response_format: responseFormatSchema,
+      seed: s.integer("A seed for deterministic sampling."),
+      stop: s.anyOf("One or more sequences where generation should stop.", [
+        s.string("A single stop sequence."),
+        s.array("A list of stop sequences.", s.string("A stop sequence.")),
+      ]),
+      stream: s.boolean(
+        "Whether to request a streaming response. This connector only accepts false or an omitted value.",
+      ),
+      temperature: s.number("The sampling temperature.", { minimum: 0, maximum: 2 }),
+      tool_choice: toolChoiceSchema,
+      tools: s.array("Tools available to the model.", jsonObjectSchema),
+      top_logprobs: s.integer("The number of top token log probabilities to include.", { minimum: 0 }),
+      top_p: s.number("The nucleus sampling threshold.", { minimum: 0, maximum: 1 }),
+      user: s.string("An end-user identifier for monitoring or abuse detection."),
+    },
+    {
+      optional: [
+        "frequency_penalty",
+        "logit_bias",
+        "logprobs",
+        "max_completion_tokens",
+        "max_tokens",
+        "n",
+        "presence_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "stream",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "user",
+      ],
+    },
+  ),
+  not: {
+    type: "object",
+    properties: {
+      stream: { const: true },
+    },
+    required: ["stream"],
+  },
+};
+
+const chatCompletionChoiceSchema = s.looseRequiredObject(
+  "A chat completion choice.",
+  {
+    index: s.integer("The choice index."),
+    message: chatMessageSchema,
+    finish_reason: s.nullableString("The reason generation finished for this choice."),
+    logprobs: s.nullable(jsonObjectSchema),
+  },
+  { optional: ["finish_reason", "logprobs"] },
+);
+
+const usageSchema = s.looseObject("Token usage information.", {
+  prompt_tokens: s.integer("The number of prompt tokens consumed."),
+  completion_tokens: s.integer("The number of completion tokens generated."),
+  total_tokens: s.integer("The total number of tokens consumed."),
+});
+
+const chatCompletionOutputSchema = s.looseRequiredObject(
+  "The response payload for an Eden AI chat completion.",
+  {
+    id: s.string("The chat completion identifier."),
+    object: s.string("The object type returned by the API."),
+    created: s.integer("The Unix timestamp when the completion was created."),
+    model: s.string("The model used to generate the completion."),
+    choices: s.array("The generated completion choices.", chatCompletionChoiceSchema),
+    usage: usageSchema,
+    cost: s.number("The Eden AI billed cost for the request, when returned."),
+  },
+  { optional: ["usage", "cost"] },
+);
+
+export type EdenAiActionName = "list_models" | "create_chat_completion";
+
+export const edenaiActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_models",
+    description: "List the Eden AI models available to the current API key.",
+    inputSchema: noInputSchema,
+    outputSchema: listModelsOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "create_chat_completion",
+    description: "Create a non-streaming Eden AI OpenAI-compatible chat completion.",
+    inputSchema: chatCompletionInputSchema,
+    outputSchema: chatCompletionOutputSchema,
+  }),
+];

--- a/src/providers/edenai/definition.ts
+++ b/src/providers/edenai/definition.ts
@@ -1,0 +1,22 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { edenaiActions } from "./actions.ts";
+
+const service = "edenai";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Eden AI",
+  categories: ["AI", "Developer Tools"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      description:
+        "Eden AI API key used with the Authorization Bearer header. Create or manage keys in your Eden AI account at https://app.edenai.run/v2/settings/api.",
+    },
+  ],
+  homepageUrl: "https://www.edenai.co",
+  actions: edenaiActions,
+};

--- a/src/providers/edenai/executors.ts
+++ b/src/providers/edenai/executors.ts
@@ -1,0 +1,149 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { EdenAiActionName } from "./actions.ts";
+
+import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
+import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+const service = "edenai";
+const edenaiApiBaseUrl = "https://api.edenai.run/v3";
+
+type EdenAiActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
+
+export const edenaiActionHandlers: Record<EdenAiActionName, EdenAiActionHandler> = {
+  list_models(_input, context) {
+    return edenaiRequest(context, { path: "/models", mode: "execute" });
+  },
+  create_chat_completion(input, context) {
+    assertStreamingDisabled(input);
+    return edenaiRequest(context, {
+      method: "POST",
+      path: "/chat/completions",
+      body: compactObject(input),
+      mode: "execute",
+    });
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, edenaiActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    const payload = await edenaiRequest(
+      {
+        apiKey: input.apiKey,
+        fetcher,
+        signal,
+      },
+      {
+        path: "/models",
+        mode: "validate",
+      },
+    );
+    const record = requireObject(payload, "Eden AI models response");
+    const data = Array.isArray(record.data) ? record.data : [];
+    return {
+      profile: {
+        accountId: "edenai-api-key",
+        displayName: "Eden AI API Key",
+      },
+      grantedScopes: [],
+      metadata: {
+        validationEndpoint: "/v3/models",
+        availableModels: data
+          .map((model) => optionalString(optionalRecord(model)?.id))
+          .filter((model): model is string => Boolean(model)),
+      },
+    };
+  },
+};
+
+async function edenaiRequest(
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
+  request: {
+    method?: "GET" | "POST";
+    path: string;
+    body?: Record<string, unknown>;
+    mode: "validate" | "execute";
+  },
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await context.fetcher(`${edenaiApiBaseUrl}${request.path}`, {
+      method: request.method ?? "GET",
+      headers: edenaiHeaders(context.apiKey),
+      body: request.body ? JSON.stringify(request.body) : undefined,
+      signal: context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `edenai request failed: ${error.message}` : "edenai request failed",
+    );
+  }
+
+  if (!response.ok) {
+    throw await buildEdenAiError(response, request.mode);
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new ProviderRequestError(502, "edenai returned malformed JSON");
+  }
+}
+
+function edenaiHeaders(apiKey: string): Headers {
+  return new Headers({
+    authorization: `Bearer ${apiKey}`,
+    "content-type": "application/json",
+    "user-agent": providerUserAgent,
+  });
+}
+
+function assertStreamingDisabled(input: Record<string, unknown>): void {
+  if (input.stream === true) {
+    throw new ProviderRequestError(400, "stream=true is not supported by connector actions");
+  }
+}
+
+async function buildEdenAiError(response: Response, mode: "validate" | "execute"): Promise<ProviderRequestError> {
+  const error = await readEdenAiError(response);
+  if (mode === "validate" && (response.status === 401 || response.status === 403)) {
+    return new ProviderRequestError(400, error.message, error);
+  }
+  return new ProviderRequestError(response.status, error.message, error);
+}
+
+async function readEdenAiError(response: Response): Promise<{ type: string; code?: string; message: string }> {
+  const raw = await response.text().catch(() => "");
+  try {
+    const payload = JSON.parse(raw) as {
+      error?: unknown;
+      message?: unknown;
+      detail?: unknown;
+    };
+    const nestedError = optionalRecord(payload.error) ?? {};
+    return {
+      type: optionalString(nestedError.type) ?? "provider_error",
+      code: optionalString(nestedError.code),
+      message:
+        optionalString(nestedError.message) ??
+        optionalString(payload.message) ??
+        optionalString(payload.detail) ??
+        `edenai request failed with ${response.status}`,
+    };
+  } catch {
+    return {
+      type: "provider_error",
+      message: raw || `edenai request failed with ${response.status}`,
+    };
+  }
+}
+
+function requireObject(value: unknown, label: string): Record<string, unknown> {
+  const record = optionalRecord(value);
+  if (!record) {
+    throw new ProviderRequestError(502, `${label} must be an object`);
+  }
+  return record;
+}


### PR DESCRIPTION
## What

Adds Eden AI as a provider.

Eden AI is an EU-based, OpenAI-compatible LLM gateway (one API key, one endpoint, many upstream vendors). The provider mirrors the existing `x_ai` connector: an `api_key` auth type using the `Authorization: Bearer` header, a base URL of `https://api.edenai.run/v3`, and two actions that map to Eden AI's OpenAI-compatible endpoints.

Model ids are vendor-prefixed, e.g. `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`.

## Actions

- `list_models` -> `GET /models`
- `create_chat_completion` -> `POST /chat/completions` (non-streaming, same `stream !== true` guard as `x_ai`)

Eden AI's OpenAI-compatible surface does not expose a single-model lookup (`GET /models/{id}` returns 404) or the OpenRouter-specific endpoints, so only these two actions are defined. The chat completion output schema also surfaces the top-level `cost` field Eden AI returns.

## Changes

- `src/providers/edenai/definition.ts`, `actions.ts`, `executors.ts` (mirrors `src/providers/x_ai/`). The generated registry and catalog pick the provider up automatically.

## Testing

- `npm run typecheck` (includes `generate:registry`) passes; the provider is discovered (`catalog/apps/edenai.json` lists both actions).
- `oxlint` and `oxfmt --check` are clean on the new files.
- Live: verified against the real Eden AI API with a real key, calling the actual executor handlers. `list_models` returned the live catalog (775 models) and `create_chat_completion` returned completions for three upstream vendors (`openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`), each with a populated `cost`.
