### PR TITLE
feat(cloudflare): add Email Routing provider

### DIFF
--- a/src/providers/cloudflare_email_routing/actions.ts
+++ b/src/providers/cloudflare_email_routing/actions.ts
@@ -1,0 +1,152 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "cloudflare_email_routing";
+const rulesRead = "Email Routing Rules Read";
+const rulesWrite = "Email Routing Rules Write";
+const addressesRead = "Email Routing Addresses Read";
+
+const ruleId = s.nonEmptyString("The Cloudflare routing rule ID.");
+const zoneId = s.nonEmptyString("The Cloudflare zone ID.");
+const accountId = s.nonEmptyString("The Cloudflare account ID.");
+const actionSchema = s.object(
+  "An action applied to a matching email.",
+  {
+    type: s.stringEnum(["drop", "forward", "worker"], { description: "The action type." }),
+    value: s.stringArray("Destination email addresses or Worker names.", { minItems: 1 }),
+  },
+  { required: ["type"], optional: ["value"] },
+);
+const matcherSchema = s.object(
+  "A condition matching an incoming email.",
+  {
+    type: s.stringEnum(["all", "literal"], { description: "The matcher type." }),
+    field: s.stringEnum(["to"], { description: "The email field to match." }),
+    value: s.string({ description: "The literal email address to match.", maxLength: 90 }),
+  },
+  { required: ["type"], optional: ["field", "value"] },
+);
+const ruleSchema = s.object(
+  "A Cloudflare Email Routing rule.",
+  {
+    id: s.string("The routing rule ID."),
+    actions: s.array("Actions applied to matching email.", actionSchema),
+    enabled: s.boolean("Whether the rule is enabled."),
+    matchers: s.array("Conditions matching incoming email.", matcherSchema),
+    name: s.string("The rule name."),
+    priority: s.nonNegativeInteger("The rule priority."),
+    source: s.stringEnum(["api", "wrangler"], { description: "Who manages the rule." }),
+    zone: s.looseObject("Zone information returned for account rule listings."),
+  },
+  { required: ["id"], optional: ["actions", "enabled", "matchers", "name", "priority", "source", "zone"] },
+);
+const addressSchema = s.object(
+  "A Cloudflare Email Routing destination address. Verified addresses may be used by forward actions.",
+  {
+    id: s.string("The destination address ID."),
+    email: s.email("The destination email address."),
+    created: s.dateTime("When the address was created."),
+    modified: s.dateTime("When the address was last modified."),
+    verified: s.nullableString("When the address was verified; null means not verified."),
+  },
+  { required: ["id", "email"], optional: ["created", "modified", "verified"] },
+);
+const resultInfoSchema = s.looseObject("Cloudflare pagination metadata.");
+const paginationFields = {
+  page: s.positiveInteger("The result page number."),
+  perPage: s.positiveInteger("The page size."),
+};
+const ruleFields = {
+  actions: s.array("Actions applied to matching email.", actionSchema, { minItems: 1 }),
+  matchers: s.array("Conditions matching incoming email.", matcherSchema, { minItems: 1 }),
+  enabled: s.boolean("Whether the rule is enabled."),
+  name: s.string({ description: "The rule name.", maxLength: 256 }),
+  priority: s.nonNegativeInteger("The rule priority."),
+  source: s.stringEnum(["api", "wrangler"], { description: "Who manages the rule." }),
+};
+
+const createInput = s.object(
+  "The input payload for this action.",
+  { zoneId, ...ruleFields },
+  { required: ["actions", "matchers"], optional: ["zoneId", "enabled", "name", "priority", "source"] },
+);
+const updateInput = s.object(
+  "The input payload for this action.",
+  { zoneId, ruleId, ...ruleFields },
+  { required: ["ruleId"], optional: ["zoneId", "actions", "matchers", "enabled", "name", "priority", "source"] },
+);
+updateInput.anyOf = Object.keys(ruleFields).map((field) => ({ required: [field] }));
+const listRulesInput = s.object(
+  "The input payload for this action.",
+  { zoneId, accountId, ...paginationFields },
+  { optional: ["zoneId", "accountId", "page", "perPage"] },
+);
+
+export const cloudflareEmailRoutingActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_routing_rules",
+    description: "List Cloudflare Email Routing rules for a zone or account.",
+    requiredScopes: [rulesRead],
+    providerPermissions: [rulesRead],
+    inputSchema: listRulesInput,
+    outputSchema: s.object(
+      "The output payload for this action.",
+      { rules: s.array("Routing rules.", ruleSchema), resultInfo: resultInfoSchema },
+      { optional: ["resultInfo"] },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_routing_rule",
+    description:
+      "Create a Cloudflare Email Routing rule in a zone. Forward actions require verified destination addresses.",
+    requiredScopes: [rulesWrite],
+    providerPermissions: [rulesWrite],
+    inputSchema: createInput,
+    outputSchema: s.object("The output payload for this action.", { rule: ruleSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "update_routing_rule",
+    description: "Replace a Cloudflare Email Routing rule in a zone.",
+    requiredScopes: [rulesWrite],
+    providerPermissions: [rulesWrite],
+    inputSchema: updateInput,
+    outputSchema: s.object("The output payload for this action.", { rule: ruleSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "delete_routing_rule",
+    description: "Delete a Cloudflare Email Routing rule from a zone.",
+    requiredScopes: [rulesWrite],
+    providerPermissions: [rulesWrite],
+    inputSchema: s.object(
+      "The input payload for this action.",
+      { zoneId, ruleId },
+      { required: ["ruleId"], optional: ["zoneId"] },
+    ),
+    outputSchema: s.object("The output payload for this action.", {
+      id: ruleId,
+      deleted: s.boolean("Whether deletion completed."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_destination_addresses",
+    description:
+      "List Cloudflare Email Routing destination addresses. Use addresses with a non-null verified timestamp for forward actions.",
+    requiredScopes: [addressesRead],
+    providerPermissions: [addressesRead],
+    inputSchema: s.object(
+      "The input payload for this action.",
+      { accountId, ...paginationFields },
+      { optional: ["accountId", "page", "perPage"] },
+    ),
+    outputSchema: s.object(
+      "The output payload for this action.",
+      {
+        addresses: s.array("Destination addresses, including verification status.", addressSchema),
+        resultInfo: resultInfoSchema,
+      },
+      { optional: ["resultInfo"] },
+    ),
+  }),
+];

--- a/src/providers/cloudflare_email_routing/actions.ts
+++ b/src/providers/cloudflare_email_routing/actions.ts
@@ -75,9 +75,8 @@ const createInput = s.object(
 const updateInput = s.object(
   "The input payload for this action.",
   { zoneId, ruleId, ...ruleFields },
-  { required: ["ruleId"], optional: ["zoneId", "actions", "matchers", "enabled", "name", "priority", "source"] },
+  { required: ["ruleId", "actions", "matchers"], optional: ["zoneId", "enabled", "name", "priority", "source"] },
 );
-updateInput.anyOf = Object.keys(ruleFields).map((field) => ({ required: [field] }));
 const listRulesInput = s.object(
   "The input payload for this action.",
   { zoneId, accountId, ...paginationFields },

--- a/src/providers/cloudflare_email_routing/definition.ts
+++ b/src/providers/cloudflare_email_routing/definition.ts
@@ -1,0 +1,58 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { cloudflareEmailRoutingActions } from "./actions.ts";
+
+export const provider: ProviderDefinition = {
+  service: "cloudflare_email_routing",
+  displayName: "Cloudflare Email Routing",
+  categories: ["Communication", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "email",
+          label: "Cloudflare Account Email",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "you@example.com",
+          description:
+            "Email address for legacy Global API Key authentication. Leave blank when using a cfut_ User API Token with Email Routing permissions.",
+        },
+        {
+          key: "apiKey",
+          label: "Cloudflare API Credential",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "cloudflare_global_api_key",
+          description:
+            "Use a cfut_ User API Token with Email Routing Rules/Addresses permissions, or a Global API Key (cfk_ or legacy format) with the account email. Cloudflare cfat_ Account API Tokens are not accepted by the Email Routing API: https://developers.cloudflare.com/fundamentals/api/reference/permissions/.",
+        },
+        {
+          key: "accountId",
+          label: "Cloudflare Account ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "32-character Cloudflare account ID",
+          description:
+            "Default account ID for destination addresses and account rule listings. Action inputs may override it.",
+        },
+        {
+          key: "zoneId",
+          label: "Cloudflare Zone ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "32-character Cloudflare zone ID",
+          description: "Default zone ID for routing rule actions. Action inputs may override it.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.cloudflare.com",
+  actions: cloudflareEmailRoutingActions,
+};

--- a/src/providers/cloudflare_email_routing/executors.ts
+++ b/src/providers/cloudflare_email_routing/executors.ts
@@ -1,0 +1,39 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+import type { CloudflareEmailRoutingContext } from "./runtime.ts";
+
+import { createProviderFetch, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { cloudflareEmailRoutingActionHandlers, validateCloudflareEmailRoutingCredential } from "./runtime.ts";
+
+const service = "cloudflare_email_routing";
+
+export const executors: ProviderExecutors = defineProviderExecutors<CloudflareEmailRoutingContext>({
+  service,
+  handlers: cloudflareEmailRoutingActionHandlers,
+  skipDnsValidation: true,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<CloudflareEmailRoutingContext> {
+    const credential = await requireCustomCredential(context, service);
+    return {
+      email: credential.values.email,
+      apiKey: credential.values.apiKey ?? "",
+      accountId: credential.values.accountId ?? "",
+      zoneId: credential.values.zoneId ?? "",
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateCloudflareEmailRoutingCredential(
+      input.values,
+      createProviderFetch({ fetch: fetcher, skipDnsValidation: true }),
+      signal,
+    );
+  },
+};

--- a/src/providers/cloudflare_email_routing/runtime.ts
+++ b/src/providers/cloudflare_email_routing/runtime.ts
@@ -57,7 +57,7 @@ export async function validateCloudflareEmailRoutingCredential(
   fetcher: ProviderFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
-  const apiKey = requireCredentialValue(values.apiKey, "apiKey");
+  const apiKey = requireInputString(values.apiKey, "apiKey");
   if (apiKey.startsWith("cfat_") || apiKey.startsWith("cfpat_")) {
     throw new ProviderRequestError(
       400,
@@ -73,7 +73,7 @@ export async function validateCloudflareEmailRoutingCredential(
       metadata: { validationEndpoint: "/user/tokens/verify", tokenStatus: optionalString(verification.status) },
     };
   }
-  const email = requireCredentialValue(values.email, "email");
+  const email = requireInputString(values.email, "email");
   const envelope = await requestCloudflare({ email, apiKey, fetcher, signal }, { path: "/user" }, "validate");
   const user = readObject(envelope.result, "cloudflare user");
   return {
@@ -107,7 +107,7 @@ async function listRoutingRules(
     "execute",
   );
   return {
-    rules: normalizeList(envelope.result, "cloudflare routing rules"),
+    rules: normalizeRuleList(envelope.result, "cloudflare routing rules"),
     resultInfo: normalizeResultInfo(envelope.result_info),
   };
 }
@@ -136,7 +136,7 @@ async function mutateRoutingRule(
     },
     "execute",
   );
-  return { rule: normalizeObject(envelope.result, "cloudflare routing rule") };
+  return { rule: normalizeRule(envelope.result, "cloudflare routing rule") };
 }
 
 async function deleteRoutingRule(
@@ -167,7 +167,7 @@ async function listDestinationAddresses(
     "execute",
   );
   return {
-    addresses: normalizeList(envelope.result, "cloudflare destination addresses"),
+    addresses: normalizeAddressList(envelope.result, "cloudflare destination addresses"),
     resultInfo: normalizeResultInfo(envelope.result_info),
   };
 }
@@ -217,7 +217,7 @@ function buildHeaders(context: { email?: string; apiKey: string }, hasBody: bool
   }
   return {
     accept: "application/json",
-    "x-auth-email": requireCredentialValue(context.email, "email"),
+    "x-auth-email": requireInputString(context.email, "email"),
     "x-auth-key": context.apiKey,
     "user-agent": providerUserAgent,
     ...(hasBody ? { "content-type": "application/json" } : {}),
@@ -269,12 +269,17 @@ function readErrorMessage(envelope: CloudflareEnvelope): string | undefined {
   return undefined;
 }
 
-function normalizeList(value: unknown, label: string): Array<Record<string, unknown>> {
+function normalizeRuleList(value: unknown, label: string): Array<Record<string, unknown>> {
   if (!Array.isArray(value)) throw new ProviderRequestError(502, `malformed ${label} response`);
-  return value.map((item) => normalizeObject(item, label));
+  return value.map((item) => normalizeRule(item, label));
 }
 
-function normalizeObject(value: unknown, label: string): Record<string, unknown> {
+function normalizeAddressList(value: unknown, label: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw new ProviderRequestError(502, `malformed ${label} response`);
+  return value.map((item) => normalizeAddress(item, label));
+}
+
+function normalizeRule(value: unknown, label: string): Record<string, unknown> {
   const object = readObject(value, label);
   return compactObject({
     id: optionalString(object.id),
@@ -285,6 +290,13 @@ function normalizeObject(value: unknown, label: string): Record<string, unknown>
     priority: optionalInteger(object.priority),
     source: optionalString(object.source),
     zone: optionalRecord(object.zone),
+  });
+}
+
+function normalizeAddress(value: unknown, label: string): Record<string, unknown> {
+  const object = readObject(value, label);
+  return compactObject({
+    id: optionalString(object.id),
     email: optionalString(object.email),
     created: optionalString(object.created),
     modified: optionalString(object.modified),
@@ -318,10 +330,6 @@ function readObject(value: unknown, label: string): Record<string, unknown> {
   const object = optionalRecord(value);
   if (!object) throw new ProviderRequestError(502, `malformed ${label} response`);
   return object;
-}
-
-function requireCredentialValue(value: unknown, field: string): string {
-  return requireInputString(value, field);
 }
 
 function requireInputString(value: unknown, field: string): string {

--- a/src/providers/cloudflare_email_routing/runtime.ts
+++ b/src/providers/cloudflare_email_routing/runtime.ts
@@ -90,11 +90,14 @@ async function listRoutingRules(
   input: Record<string, unknown>,
   context: CloudflareEmailRoutingContext,
 ): Promise<unknown> {
-  const zone = optionalString(input.zoneId) ?? context.zoneId;
-  const account = optionalString(input.accountId) ?? context.accountId;
-  const scope = zone
-    ? `zones/${encodeURIComponent(zone)}`
-    : `accounts/${encodeURIComponent(requireInputString(account, "accountId"))}`;
+  const explicitAccount = optionalString(input.accountId);
+  const zone = explicitAccount ? undefined : (optionalString(input.zoneId) ?? context.zoneId);
+  const account = explicitAccount ?? context.accountId;
+  const scope = explicitAccount
+    ? `accounts/${encodeURIComponent(explicitAccount)}`
+    : zone
+      ? `zones/${encodeURIComponent(zone)}`
+      : `accounts/${encodeURIComponent(requireInputString(account, "accountId"))}`;
   const envelope = await requestCloudflare(
     context,
     {
@@ -116,12 +119,20 @@ async function mutateRoutingRule(
 ): Promise<unknown> {
   const zone = encodeURIComponent(optionalString(input.zoneId) ?? requireInputString(context.zoneId, "zoneId"));
   const suffix = method === "PUT" ? `/${encodeURIComponent(requireInputString(input.ruleId, "ruleId"))}` : "";
+  const bodyInput =
+    method === "PUT"
+      ? {
+          ...input,
+          actions: requireInputArray(input.actions, "actions"),
+          matchers: requireInputArray(input.matchers, "matchers"),
+        }
+      : input;
   const envelope = await requestCloudflare(
     context,
     {
       method,
       path: `/zones/${zone}/email/routing/rules${suffix}`,
-      body: buildRuleBody(input),
+      body: buildRuleBody(bodyInput),
     },
     "execute",
   );
@@ -170,6 +181,11 @@ function buildRuleBody(input: Record<string, unknown>): Record<string, unknown> 
     priority: optionalInteger(input.priority),
     source: optionalString(input.source),
   });
+}
+
+function requireInputArray(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value) || value.length === 0) throw new ProviderRequestError(400, `${field} is required`);
+  return value;
 }
 
 async function requestCloudflare(

--- a/src/providers/cloudflare_email_routing/runtime.ts
+++ b/src/providers/cloudflare_email_routing/runtime.ts
@@ -1,0 +1,315 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { queryParams } from "../../core/request.ts";
+import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+interface CloudflareEnvelope {
+  success?: unknown;
+  result?: unknown;
+  errors?: unknown;
+  messages?: unknown;
+  result_info?: unknown;
+}
+
+export interface CloudflareEmailRoutingContext {
+  email?: string;
+  apiKey: string;
+  accountId: string;
+  zoneId: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+interface CloudflareRequest {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: Record<string, unknown>;
+}
+
+const apiBaseUrl = "https://api.cloudflare.com/client/v4";
+
+export const cloudflareEmailRoutingActionHandlers: Record<
+  string,
+  ProviderRuntimeHandler<CloudflareEmailRoutingContext>
+> = {
+  list_routing_rules(input, context) {
+    return listRoutingRules(input, context);
+  },
+  create_routing_rule(input, context) {
+    return mutateRoutingRule("POST", input, context);
+  },
+  update_routing_rule(input, context) {
+    return mutateRoutingRule("PUT", input, context);
+  },
+  delete_routing_rule(input, context) {
+    return deleteRoutingRule(input, context);
+  },
+  list_destination_addresses(input, context) {
+    return listDestinationAddresses(input, context);
+  },
+};
+
+export async function validateCloudflareEmailRoutingCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const apiKey = requireCredentialValue(values.apiKey, "apiKey");
+  if (apiKey.startsWith("cfat_") || apiKey.startsWith("cfpat_")) {
+    throw new ProviderRequestError(
+      400,
+      "Cloudflare Email Routing does not accept cfat_ Account API Tokens; use a cfut_ User API Token with Email Routing permissions, or a Global API Key with the account email.",
+    );
+  }
+  if (apiKey.startsWith("cfut_")) {
+    const envelope = await requestCloudflare({ apiKey, fetcher, signal }, { path: "/user/tokens/verify" }, "validate");
+    const verification = readObject(envelope.result, "cloudflare token verification");
+    return {
+      profile: { accountId: optionalString(verification.id), displayName: "Cloudflare Email Routing User API Token" },
+      grantedScopes: [],
+      metadata: { validationEndpoint: "/user/tokens/verify", tokenStatus: optionalString(verification.status) },
+    };
+  }
+  const email = requireCredentialValue(values.email, "email");
+  const envelope = await requestCloudflare({ email, apiKey, fetcher, signal }, { path: "/user" }, "validate");
+  const user = readObject(envelope.result, "cloudflare user");
+  return {
+    profile: {
+      accountId: optionalString(user.id) ?? email,
+      displayName: optionalString(user.email) ?? email,
+    },
+    grantedScopes: [],
+    metadata: compactObject({ validationEndpoint: "/user", email: optionalString(user.email) }),
+  };
+}
+
+async function listRoutingRules(
+  input: Record<string, unknown>,
+  context: CloudflareEmailRoutingContext,
+): Promise<unknown> {
+  const zone = optionalString(input.zoneId) ?? context.zoneId;
+  const account = optionalString(input.accountId) ?? context.accountId;
+  const scope = zone
+    ? `zones/${encodeURIComponent(zone)}`
+    : `accounts/${encodeURIComponent(requireInputString(account, "accountId"))}`;
+  const envelope = await requestCloudflare(
+    context,
+    {
+      path: `/${scope}/email/routing/rules`,
+      query: { page: optionalInteger(input.page), per_page: optionalInteger(input.perPage) },
+    },
+    "execute",
+  );
+  return {
+    rules: normalizeList(envelope.result, "cloudflare routing rules"),
+    resultInfo: normalizeResultInfo(envelope.result_info),
+  };
+}
+
+async function mutateRoutingRule(
+  method: "POST" | "PUT",
+  input: Record<string, unknown>,
+  context: CloudflareEmailRoutingContext,
+): Promise<unknown> {
+  const zone = encodeURIComponent(optionalString(input.zoneId) ?? requireInputString(context.zoneId, "zoneId"));
+  const suffix = method === "PUT" ? `/${encodeURIComponent(requireInputString(input.ruleId, "ruleId"))}` : "";
+  const envelope = await requestCloudflare(
+    context,
+    {
+      method,
+      path: `/zones/${zone}/email/routing/rules${suffix}`,
+      body: buildRuleBody(input),
+    },
+    "execute",
+  );
+  return { rule: normalizeObject(envelope.result, "cloudflare routing rule") };
+}
+
+async function deleteRoutingRule(
+  input: Record<string, unknown>,
+  context: CloudflareEmailRoutingContext,
+): Promise<unknown> {
+  const zoneId = optionalString(input.zoneId) ?? requireInputString(context.zoneId, "zoneId");
+  const id = requireInputString(input.ruleId, "ruleId");
+  await requestCloudflare(
+    context,
+    { method: "DELETE", path: `/zones/${encodeURIComponent(zoneId)}/email/routing/rules/${encodeURIComponent(id)}` },
+    "execute",
+  );
+  return { id, deleted: true };
+}
+
+async function listDestinationAddresses(
+  input: Record<string, unknown>,
+  context: CloudflareEmailRoutingContext,
+): Promise<unknown> {
+  const accountId = optionalString(input.accountId) ?? requireInputString(context.accountId, "accountId");
+  const envelope = await requestCloudflare(
+    context,
+    {
+      path: `/accounts/${encodeURIComponent(accountId)}/email/routing/addresses`,
+      query: { page: optionalInteger(input.page), per_page: optionalInteger(input.perPage) },
+    },
+    "execute",
+  );
+  return {
+    addresses: normalizeList(envelope.result, "cloudflare destination addresses"),
+    resultInfo: normalizeResultInfo(envelope.result_info),
+  };
+}
+
+function buildRuleBody(input: Record<string, unknown>): Record<string, unknown> {
+  return compactObject({
+    actions: normalizeRecords(input.actions),
+    matchers: normalizeRecords(input.matchers),
+    enabled: optionalBoolean(input.enabled),
+    name: optionalString(input.name),
+    priority: optionalInteger(input.priority),
+    source: optionalString(input.source),
+  });
+}
+
+async function requestCloudflare(
+  context: { email?: string; apiKey: string; fetcher: ProviderFetch; signal?: AbortSignal },
+  request: CloudflareRequest,
+  phase: "validate" | "execute",
+): Promise<CloudflareEnvelope> {
+  const response = await context.fetcher(buildUrl(request.path, request.query), {
+    method: request.method ?? "GET",
+    headers: buildHeaders(context, request.body !== undefined),
+    body: request.body ? JSON.stringify(request.body) : undefined,
+    signal: context.signal,
+  });
+  const envelope = await readEnvelope(response);
+  if (!response.ok || envelope.success === false) {
+    throw normalizeError(response, envelope, phase);
+  }
+  return envelope;
+}
+
+function buildHeaders(context: { email?: string; apiKey: string }, hasBody: boolean): Record<string, string> {
+  if (context.apiKey.startsWith("cfut_")) {
+    return {
+      accept: "application/json",
+      authorization: `Bearer ${context.apiKey}`,
+      "user-agent": providerUserAgent,
+      ...(hasBody ? { "content-type": "application/json" } : {}),
+    };
+  }
+  return {
+    accept: "application/json",
+    "x-auth-email": requireCredentialValue(context.email, "email"),
+    "x-auth-key": context.apiKey,
+    "user-agent": providerUserAgent,
+    ...(hasBody ? { "content-type": "application/json" } : {}),
+  };
+}
+
+function buildUrl(path: string, query?: Record<string, string | number | boolean | undefined>): string {
+  const url = new URL(`${apiBaseUrl}${path}`);
+  for (const [key, value] of Object.entries(queryParams(query ?? {}))) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+async function readEnvelope(response: Response): Promise<CloudflareEnvelope> {
+  const text = await response.text().catch(() => "");
+  if (!text.trim())
+    return { success: false, errors: [{ message: `cloudflare request failed with ${response.status}` }] };
+  try {
+    return JSON.parse(text) as CloudflareEnvelope;
+  } catch {
+    return { success: false, errors: [{ message: text }] };
+  }
+}
+
+function normalizeError(
+  response: Response,
+  envelope: CloudflareEnvelope,
+  phase: "validate" | "execute",
+): ProviderRequestError {
+  const message = readErrorMessage(envelope) ?? `cloudflare request failed with ${response.status}`;
+  if (response.status === 429) return new ProviderRequestError(429, message);
+  if (phase === "validate" && [400, 401, 403, 404].includes(response.status))
+    return new ProviderRequestError(400, message);
+  return new ProviderRequestError(response.status >= 500 ? 502 : response.status, message);
+}
+
+function readErrorMessage(envelope: CloudflareEnvelope): string | undefined {
+  for (const item of [
+    ...(Array.isArray(envelope.errors) ? envelope.errors : []),
+    ...(Array.isArray(envelope.messages) ? envelope.messages : []),
+  ]) {
+    const record = optionalRecord(item);
+    const message = optionalString(record?.message);
+    if (message) return message;
+    for (const chainItem of Array.isArray(record?.error_chain) ? record.error_chain : []) {
+      const chainMessage = optionalString(optionalRecord(chainItem)?.message);
+      if (chainMessage) return chainMessage;
+    }
+  }
+  return undefined;
+}
+
+function normalizeList(value: unknown, label: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw new ProviderRequestError(502, `malformed ${label} response`);
+  return value.map((item) => normalizeObject(item, label));
+}
+
+function normalizeObject(value: unknown, label: string): Record<string, unknown> {
+  const object = readObject(value, label);
+  return compactObject({
+    id: optionalString(object.id),
+    actions: normalizeRecords(object.actions),
+    enabled: optionalBoolean(object.enabled),
+    matchers: normalizeRecords(object.matchers),
+    name: optionalString(object.name),
+    priority: optionalInteger(object.priority),
+    source: optionalString(object.source),
+    zone: optionalRecord(object.zone),
+    email: optionalString(object.email),
+    created: optionalString(object.created),
+    modified: optionalString(object.modified),
+    verified: optionalString(object.verified) ?? (object.verified === null ? null : undefined),
+  });
+}
+
+function normalizeRecords(value: unknown): Array<Record<string, unknown>> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map((item) => {
+    const record = optionalRecord(item);
+    if (!record) throw new ProviderRequestError(502, "malformed cloudflare nested object");
+    return compactObject(record);
+  });
+}
+
+function normalizeResultInfo(value: unknown): Record<string, unknown> | undefined {
+  const info = optionalRecord(value);
+  return info
+    ? compactObject({
+        page: optionalInteger(info.page),
+        perPage: optionalInteger(info.per_page),
+        count: optionalInteger(info.count),
+        totalCount: optionalInteger(info.total_count),
+        totalPages: optionalInteger(info.total_pages),
+      })
+    : undefined;
+}
+
+function readObject(value: unknown, label: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (!object) throw new ProviderRequestError(502, `malformed ${label} response`);
+  return object;
+}
+
+function requireCredentialValue(value: unknown, field: string): string {
+  return requireInputString(value, field);
+}
+
+function requireInputString(value: unknown, field: string): string {
+  const text = optionalString(value);
+  if (!text) throw new ProviderRequestError(400, `${field} is required`);
+  return text;
+}


### PR DESCRIPTION
## Summary

Adds Cloudflare Email Routing as a runnable custom-credential provider.

- Supports Cloudflare `cfut_` User API Tokens.
- Supports legacy Global API Keys with account email.
- Rejects `cfat_` Account API Tokens because Cloudflare Email Routing endpoints do not accept them.
- Requires Account ID and Zone ID in dashboard credentials, with per-action overrides.

## Actions

- `list_routing_rules`
- `create_routing_rule`
- `update_routing_rule`
- `delete_routing_rule`
- `list_destination_addresses`

Routing rules support drop, forward, and Worker actions plus all/literal matchers. Destination output includes verification status for forward-action selection.

## Changes

- Add provider definition, action schemas, executors, and Cloudflare API runtime.
- Use SSRF-guarded provider fetch.
- Normalize Cloudflare envelopes, rules, addresses, pagination, and errors.
- Keep credentials out of source, examples, catalog output, and PR content.

## Testing

- `npm run fix-check`
- `npm run typecheck`
- `npm test` — 515 tests passed
- Live validation through `cadence-connector` MCP for two Cloudflare connections:
  - destination address listing: passed; 2 verified addresses returned
  - routing rule listing: passed
  - disabled dummy rule create, update, delete: passed; dummy rules removed