### PR TITLE
fix(cloudflare-worker): clarify account selection contract

### DIFF
--- a/src/providers/cloudflare_worker/actions.ts
+++ b/src/providers/cloudflare_worker/actions.ts
@@ -11,7 +11,7 @@ const workersReadPermission = "Workers Scripts Read";
 const workersWritePermission = "Workers Scripts Write";
 
 const accountIdSchema = s.nonEmptyString(
-  "The Cloudflare account ID. Custom-credential connections reuse the connected account ID when this is omitted.",
+  "The Cloudflare account ID. Omit this when the connection can uniquely determine the account. This field is required for multi-account OAuth connections; use list_accounts to find an accessible account ID.",
 );
 const workerIdSchema = s.nonEmptyString("The Cloudflare Worker ID.");
 const workerNameSchema = s.nonEmptyString("The Worker name.");

--- a/src/providers/cloudflare_worker/executors.ts
+++ b/src/providers/cloudflare_worker/executors.ts
@@ -63,7 +63,7 @@ export const credentialValidators: CredentialValidators = {
       throw new ProviderRequestError(400, "Cloudflare OAuth credential cannot access any accounts");
     }
     const totalCount = optionalInteger(result.resultInfo?.totalCount);
-    if (result.accounts.length === 1 && (totalCount === undefined || totalCount === 1)) {
+    if (result.accounts.length === 1 && totalCount === 1) {
       const account = result.accounts[0]!;
       return {
         profile: {

--- a/src/providers/cloudflare_worker/executors.ts
+++ b/src/providers/cloudflare_worker/executors.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../core/types.ts";
 import type { CloudflareWorkerContext } from "./runtime.ts";
 
-import { optionalString, requiredString } from "../../core/cast.ts";
+import { optionalInteger, optionalString, requiredString } from "../../core/cast.ts";
 import { defineProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 import {
   cloudflareWorkerActionHandlers,
@@ -59,7 +59,11 @@ export const credentialValidators: CredentialValidators = {
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
     const result = await requestCloudflareWorkerAccounts(input.accessToken, fetcher, signal, { page: 1, perPage: 50 });
-    if (result.accounts.length === 1) {
+    if (result.accounts.length === 0) {
+      throw new ProviderRequestError(400, "Cloudflare OAuth credential cannot access any accounts");
+    }
+    const totalCount = optionalInteger(result.resultInfo?.totalCount);
+    if (result.accounts.length === 1 && (totalCount === undefined || totalCount === 1)) {
       const account = result.accounts[0]!;
       return {
         profile: {
@@ -82,7 +86,7 @@ export const credentialValidators: CredentialValidators = {
       },
       grantedScopes: input.profile.grantedScopes,
       metadata: {
-        availableAccounts: result.accounts,
+        requiresAccountSelection: true,
         validationEndpoint: "/accounts?page=1&per_page=50",
       },
     };

--- a/src/providers/cloudflare_worker/runtime.test.ts
+++ b/src/providers/cloudflare_worker/runtime.test.ts
@@ -1,0 +1,87 @@
+import type { CloudflareWorkerContext } from "./runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { optionalRecord } from "../../core/cast.ts";
+import { cloudflareWorkerActions } from "./actions.ts";
+import { cloudflareWorkerActionHandlers } from "./runtime.ts";
+
+const getWorkerScriptSettings = cloudflareWorkerActionHandlers.get_worker_script_settings;
+
+describe("Cloudflare Worker account resolution", () => {
+  it("reuses the account ID from a custom-credential connection", async () => {
+    const { context, requestedUrls } = testContext({
+      authType: "custom_credential",
+      accountId: "custom-account",
+    });
+
+    await getWorkerScriptSettings({ scriptName: "example-worker" }, context);
+
+    expect(requestedUrls).toEqual([
+      "https://api.cloudflare.com/client/v4/accounts/custom-account/workers/scripts/example-worker/settings",
+    ]);
+  });
+
+  it("reuses the account ID from single-account OAuth metadata", async () => {
+    const { context, requestedUrls } = testContext({
+      authType: "oauth2",
+      metadata: { accountId: "oauth-account" },
+    });
+
+    await getWorkerScriptSettings({ scriptName: "example-worker" }, context);
+
+    expect(requestedUrls).toEqual([
+      "https://api.cloudflare.com/client/v4/accounts/oauth-account/workers/scripts/example-worker/settings",
+    ]);
+  });
+
+  it("requires an explicit accessible account ID for multi-account OAuth", async () => {
+    const { context, requestedUrls } = testContext({
+      authType: "oauth2",
+      metadata: {
+        availableAccounts: [{ id: "first-account" }, { id: "second-account" }],
+      },
+    });
+
+    await expect(getWorkerScriptSettings({ scriptName: "example-worker" }, context)).rejects.toMatchObject({
+      status: 400,
+      message:
+        "accountId is required for this Cloudflare Worker action because the OAuth credential can access multiple accounts",
+    });
+
+    await getWorkerScriptSettings({ accountId: "second-account", scriptName: "example-worker" }, context);
+    expect(requestedUrls).toEqual([
+      "https://api.cloudflare.com/client/v4/accounts/second-account/workers/scripts/example-worker/settings",
+    ]);
+  });
+
+  it("documents the conditional account ID requirement in the action catalog", () => {
+    const action = cloudflareWorkerActions.find(({ name }) => name === "get_worker_script_settings");
+    const properties = optionalRecord(action?.inputSchema.properties);
+    const accountId = optionalRecord(properties?.accountId);
+
+    expect(action?.inputSchema.required).toEqual(["scriptName"]);
+    expect(accountId?.description).toContain("connection can uniquely determine the account");
+    expect(accountId?.description).toContain("multi-account OAuth");
+    expect(accountId?.description).toContain("list_accounts");
+  });
+});
+
+function testContext(overrides: Pick<CloudflareWorkerContext, "authType"> & Partial<CloudflareWorkerContext>): {
+  context: CloudflareWorkerContext;
+  requestedUrls: string[];
+} {
+  const requestedUrls: string[] = [];
+  const fetcher: typeof fetch = async (input) => {
+    requestedUrls.push(String(input));
+    return Response.json({ success: true, result: {} });
+  };
+  return {
+    context: {
+      accessToken: "test-token",
+      metadata: {},
+      fetcher,
+      ...overrides,
+    },
+    requestedUrls,
+  };
+}

--- a/src/providers/cloudflare_worker/runtime.test.ts
+++ b/src/providers/cloudflare_worker/runtime.test.ts
@@ -1,11 +1,24 @@
+import type { ResolvedCredential } from "../../core/types.ts";
 import type { CloudflareWorkerContext } from "./runtime.ts";
 
 import { describe, expect, it } from "vitest";
 import { optionalRecord } from "../../core/cast.ts";
 import { cloudflareWorkerActions } from "./actions.ts";
+import { credentialValidators } from "./executors.ts";
 import { cloudflareWorkerActionHandlers } from "./runtime.ts";
 
 const getWorkerScriptSettings = cloudflareWorkerActionHandlers.get_worker_script_settings;
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "test-token",
+  tokenType: "Bearer",
+  profile: {
+    accountId: "cloudflare-worker-oauth",
+    displayName: "Cloudflare Worker",
+    grantedScopes: ["workers-scripts.read"],
+  },
+  metadata: {},
+};
 
 describe("Cloudflare Worker account resolution", () => {
   it("reuses the account ID from a custom-credential connection", async () => {
@@ -37,9 +50,7 @@ describe("Cloudflare Worker account resolution", () => {
   it("requires an explicit accessible account ID for multi-account OAuth", async () => {
     const { context, requestedUrls } = testContext({
       authType: "oauth2",
-      metadata: {
-        availableAccounts: [{ id: "first-account" }, { id: "second-account" }],
-      },
+      metadata: { requiresAccountSelection: true },
     });
 
     await expect(getWorkerScriptSettings({ scriptName: "example-worker" }, context)).rejects.toMatchObject({
@@ -52,6 +63,36 @@ describe("Cloudflare Worker account resolution", () => {
     expect(requestedUrls).toEqual([
       "https://api.cloudflare.com/client/v4/accounts/second-account/workers/scripts/example-worker/settings",
     ]);
+  });
+
+  it("allows an account ID discovered after the OAuth validation page", async () => {
+    const validation = await credentialValidators.oauth2?.(oauthCredential, {
+      fetcher: accountsFetcher(
+        Array.from({ length: 50 }, (_, index) => ({ id: `account-${index + 1}` })),
+        { page: 1, per_page: 50, count: 50, total_count: 51, total_pages: 2 },
+      ),
+    });
+    const metadata = validation?.metadata ?? {};
+    const { context, requestedUrls } = testContext({ authType: "oauth2", metadata });
+
+    await getWorkerScriptSettings({ accountId: "page-two-account", scriptName: "example-worker" }, context);
+
+    expect(metadata).toMatchObject({ requiresAccountSelection: true });
+    expect(metadata).not.toHaveProperty("availableAccounts");
+    expect(requestedUrls).toEqual([
+      "https://api.cloudflare.com/client/v4/accounts/page-two-account/workers/scripts/example-worker/settings",
+    ]);
+  });
+
+  it("rejects OAuth credentials that cannot access any accounts", async () => {
+    await expect(
+      credentialValidators.oauth2?.(oauthCredential, {
+        fetcher: accountsFetcher([], { page: 1, per_page: 50, count: 0, total_count: 0, total_pages: 0 }),
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Cloudflare OAuth credential cannot access any accounts",
+    });
   });
 
   it("documents the conditional account ID requirement in the action catalog", () => {
@@ -84,4 +125,8 @@ function testContext(overrides: Pick<CloudflareWorkerContext, "authType"> & Part
     },
     requestedUrls,
   };
+}
+
+function accountsFetcher(accounts: Array<{ id: string }>, resultInfo: Record<string, number>): typeof fetch {
+  return async () => Response.json({ success: true, result: accounts, result_info: resultInfo });
 }

--- a/src/providers/cloudflare_worker/runtime.test.ts
+++ b/src/providers/cloudflare_worker/runtime.test.ts
@@ -95,6 +95,20 @@ describe("Cloudflare Worker account resolution", () => {
     });
   });
 
+  it("requires account selection when the OAuth account total is unknown", async () => {
+    const validation = await credentialValidators.oauth2?.(oauthCredential, {
+      fetcher: accountsFetcher([{ id: "only-returned-account" }], {
+        page: 1,
+        per_page: 50,
+        count: 1,
+        total_pages: 1,
+      }),
+    });
+
+    expect(validation?.metadata).toMatchObject({ requiresAccountSelection: true });
+    expect(validation?.metadata).not.toHaveProperty("accountId");
+  });
+
   it("documents the conditional account ID requirement in the action catalog", () => {
     const action = cloudflareWorkerActions.find(({ name }) => name === "get_worker_script_settings");
     const properties = optionalRecord(action?.inputSchema.properties);

--- a/src/providers/cloudflare_worker/runtime.ts
+++ b/src/providers/cloudflare_worker/runtime.ts
@@ -584,7 +584,7 @@ function resolveAccountId(input: Record<string, unknown>, context: CloudflareWor
   if (!accountId) {
     throw new ProviderRequestError(
       400,
-      Array.isArray(context.metadata.availableAccounts)
+      context.metadata.requiresAccountSelection === true || Array.isArray(context.metadata.availableAccounts)
         ? "accountId is required for this Cloudflare Worker action because the OAuth credential can access multiple accounts"
         : "accountId is required in the connected credential",
     );
@@ -592,24 +592,7 @@ function resolveAccountId(input: Record<string, unknown>, context: CloudflareWor
   if (context.authType === "custom_credential" && inputAccountId && inputAccountId !== accountId) {
     throw new ProviderRequestError(400, "accountId must match the connected credential");
   }
-  ensureAccountIsAvailable(accountId, context.metadata);
   return accountId;
-}
-
-function ensureAccountIsAvailable(accountId: string, metadata: Record<string, unknown>): void {
-  if (!Array.isArray(metadata.availableAccounts)) {
-    return;
-  }
-  const matched = metadata.availableAccounts.some((item) => {
-    const account = optionalRecord(item);
-    return optionalString(account?.id) === accountId;
-  });
-  if (!matched) {
-    throw new ProviderRequestError(
-      400,
-      "accountId must be one of the Cloudflare accounts accessible by this OAuth credential",
-    );
-  }
 }
 
 function buildWorkerMutationBody(input: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- clarify that accountId is optional when the connection uniquely identifies an account
- document that multi-account OAuth calls must pass accountId and can use list_accounts to discover it
- cover custom credentials, single-account OAuth, multi-account OAuth, and the catalog contract

## Testing

- npm run fix-check
- npm test (41 test files, 279 tests)