### PR TITLE
fix(feishu): correct document copy OAuth scope

### DIFF
--- a/src/providers/feishu/definition.test.ts
+++ b/src/providers/feishu/definition.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+describe("Feishu OAuth scopes", () => {
+  it("uses the current document copy permission", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth?.scopes).toContain("docs:document:copy");
+    expect(oauth?.scopes).not.toContain("space:document:copy");
+  });
+});

--- a/src/providers/feishu/shared/drive-actions.ts
+++ b/src/providers/feishu/shared/drive-actions.ts
@@ -6,7 +6,7 @@ export const feishuDriveProviderScopes = {
   metadataRead: "drive:drive.metadata:readonly",
   search: "search:docs:read",
   folderCreate: "space:folder:create",
-  copy: "space:document:copy",
+  copy: "docs:document:copy",
   move: "space:document:move",
   delete: "space:document:delete",
   commentRead: "docs:document.comment:read",


### PR DESCRIPTION
## Summary

- replace the invalid Feishu document copy scope `space:document:copy` with the currently documented `docs:document:copy`
- add a regression test that keeps the valid scope in the generated OAuth scope list and rejects the legacy value

## Problem

The Feishu provider builds its authorization request from the union of all action permissions. Because `copy_drive_file` declared `space:document:copy`, every Feishu OAuth flow was rejected before consent with error `20043` (invalid scope), even when the caller did not use the copy action.

Feishu's Copy File API documents `docs:document:copy` as the required granular permission:
https://open.feishu.cn/document/server-docs/docs/drive-v1/file/copy

## Verification

- `npm run fix-check`
- `npm run generate:catalog`
- `npm test` — 56 test files, 511 tests passed
- manually verified the generated authorization URL contains `docs:document:copy` and no longer contains `space:document:copy`
