### PR TITLE
feat: add dynamic upstream MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ For npm-based local development, open `http://localhost:5173`; the Web Console d
 API requests to the runtime on `http://localhost:3000`. For Docker or a built Node runtime, the
 console is served from `http://localhost:3000`.
 
-The console supports provider browsing, API key and OAuth client configuration, runtime token
-creation, Action schema inspection, Action debugging, recent run review, and access to the
-generated OpenAPI and MCP metadata.
+The console supports provider browsing, upstream MCP server registration and tool review, API key
+and OAuth client configuration, runtime token creation, Action schema inspection, Action debugging,
+recent run review, and access to the generated OpenAPI and MCP metadata.
 
 ## Cloudflare Deployment
 
@@ -232,6 +232,7 @@ create, and sync across connected tools.
 - [Developer tools](docs/sdk-cli.md)
 - [Gmail OAuth and SDK tutorial](docs/gmail-oauth-sdk.md)
 - [Runtime API and MCP](docs/runtime-api.md)
+- [Upstream MCP servers](docs/upstream-mcp.md)
 - [Fly.io deployment](docs/fly-io.md)
 - [Cloudflare deployment](docs/cloudflare.md)
 - [Docker image (GHCR)](docs/docker-ghcr.md)

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -50,6 +50,11 @@ The MCP server exposes a small discovery-oriented tool set:
 - `get_action_guide`
 - `execute_action`
 
+Configured upstream MCP servers do not expand this fixed downstream tool set. Their reviewed tools
+appear as normal Actions and are discovered through `search_actions`, then invoked through
+`execute_action`. See [Upstream MCP Servers](upstream-mcp.md) for registration, synchronization,
+contract review, and security behavior.
+
 Use `list_connections` to discover configured accounts before selecting one. Both
 `get_action_guide` and `execute_action` accept an optional `connectionName`:
 

--- a/docs/upstream-mcp.md
+++ b/docs/upstream-mcp.md
@@ -1,0 +1,162 @@
+# Upstream MCP Servers
+
+OpenConnector can register remote MCP servers as runtime providers. Discovered MCP tools become
+OpenConnector Actions, so downstream clients keep using the stable discovery tools exposed by
+`POST /mcp` instead of importing every upstream tool into their own MCP session.
+
+## Supported Contract
+
+The first version supports:
+
+- MCP Streamable HTTP endpoints
+- no authentication
+- bearer tokens
+- one custom API key header
+- Node with SQLite and Cloudflare Workers with D1
+- named OpenConnector connections for the same MCP server
+
+OAuth discovery, DCR, CIMD, legacy SSE transports, and stdio upstreams are not supported.
+
+Every server receives a stable service id in the form `mcp_<slug>`. The upstream tool name is
+preserved for MCP calls, while OpenConnector assigns a route-safe Action name. The Web Console and
+admin API never return stored credential values.
+
+## Register A Server
+
+Create and synchronize a public unauthenticated server:
+
+```bash
+curl -s -X POST http://localhost:3000/api/mcp-servers \
+  -H 'content-type: application/json' \
+  -d '{
+    "slug": "example",
+    "displayName": "Example MCP",
+    "endpoint": "https://mcp.example.com/mcp",
+    "auth": {"type": "none"},
+    "sync": true
+  }'
+```
+
+For bearer authentication, use:
+
+```json
+{
+  "auth": { "type": "bearer" },
+  "credential": "<token>"
+}
+```
+
+For a custom API key header, use:
+
+```json
+{
+  "auth": {
+    "type": "api_key_header",
+    "headerName": "X-API-Key"
+  },
+  "credential": "<api-key>"
+}
+```
+
+The credential is stored as the server's `default` OpenConnector connection. Additional named
+connections use the existing connection endpoint:
+
+```bash
+curl -s -X PUT http://localhost:3000/api/connections/mcp_example \
+  -H 'content-type: application/json' \
+  -d '{
+    "authType": "api_key",
+    "connectionName": "secondary",
+    "values": {"apiKey": "<token>"}
+  }'
+```
+
+All named connections for one server must expose the same tool contract. Synchronization may use a
+named connection by passing `connectionName`; the resulting contract applies to the server, not
+only to that connection.
+
+## Review And Publish Tools
+
+New tools are discovered as disabled. If an enabled tool changes its title, description, input
+schema, output schema, or annotations, OpenConnector changes its status to `review_required` and
+disables it. Tools removed by the upstream server remain recorded as `removed` and are not
+executable.
+
+List the current contract and server revision:
+
+```bash
+curl -s http://localhost:3000/api/mcp-servers/mcp_example/tools
+```
+
+Publish an explicit reviewed set:
+
+```bash
+curl -s -X PUT http://localhost:3000/api/mcp-servers/mcp_example/tools \
+  -H 'content-type: application/json' \
+  -d '{
+    "expectedRevision": 2,
+    "enabledTools": ["search", "get_record"]
+  }'
+```
+
+`expectedRevision` provides optimistic locking. A stale revision returns `409` and does not replace
+the current selection.
+
+Synchronize manually:
+
+```bash
+curl -s -X POST http://localhost:3000/api/mcp-servers/mcp_example/sync \
+  -H 'content-type: application/json' \
+  -d '{}'
+```
+
+There is no periodic synchronization. Create and update operations synchronize by default, and the
+Web Console provides an explicit Sync action.
+
+## Downstream Agent Usage
+
+Enabled tools appear in the normal provider and Action catalog. A downstream MCP client still sees
+the stable OpenConnector tools:
+
+- `list_apps`
+- `list_connections`
+- `search_actions`
+- `get_action_guide`
+- `execute_action`
+
+For example, search for the dynamically published Action, read its guide, then execute it with
+`execute_action`. OpenConnector selects the named connection, applies policy and input validation,
+calls the original upstream MCP tool, and writes the normal run audit record.
+
+## Limits And Security
+
+Synchronization enforces these limits:
+
+- 20 `tools/list` pages
+- 500 tools
+- 256 KiB per tool contract
+- 5 MiB total tool contract data
+- 120 seconds per synchronization request
+
+All upstream requests use the shared SSRF-guarded provider fetch. URL literals, DNS answers, and
+redirect targets are validated. Credentials are removed when a redirect crosses origins, including
+runtime-configured custom API key headers.
+
+Private-network endpoints are disabled by default. Self-hosted deployments may opt in with
+`OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true`; loopback, link-local, reserved, and cloud metadata
+targets remain blocked.
+
+## Admin API
+
+| Method   | Path                              | Purpose                                  |
+| -------- | --------------------------------- | ---------------------------------------- |
+| `GET`    | `/api/mcp-servers`                | List configured servers                  |
+| `POST`   | `/api/mcp-servers`                | Create and optionally synchronize        |
+| `GET`    | `/api/mcp-servers/:service`       | Read one server and its tools            |
+| `PUT`    | `/api/mcp-servers/:service`       | Update and optionally synchronize        |
+| `DELETE` | `/api/mcp-servers/:service`       | Delete the server and stored connections |
+| `GET`    | `/api/mcp-servers/:service/tools` | Read tool contracts and current revision |
+| `PUT`    | `/api/mcp-servers/:service/tools` | Publish the reviewed tool selection      |
+| `POST`   | `/api/mcp-servers/:service/sync`  | Synchronize tool contracts               |
+
+These endpoints use the same admin authentication as the rest of `/api/*`.

--- a/migrations/0009_upstream_mcp.sql
+++ b/migrations/0009_upstream_mcp.sql
@@ -1,0 +1,46 @@
+create table mcp_servers (
+  service text primary key,
+  slug text not null unique,
+  display_name text not null,
+  description text,
+  endpoint text not null,
+  auth_type text not null,
+  header_name text,
+  enabled integer not null,
+  revision integer not null,
+  sync_status text not null,
+  last_sync_at text,
+  last_sync_error text,
+  mutation_token text not null default '',
+  created_at text not null,
+  updated_at text not null
+);
+
+create table mcp_server_tools (
+  service text not null,
+  upstream_name text not null,
+  action_name text not null,
+  title text,
+  description text,
+  input_schema text not null,
+  output_schema text,
+  annotations text,
+  contract_hash text not null,
+  enabled integer not null,
+  status text not null,
+  invalid_reason text,
+  first_seen_at text not null,
+  last_seen_at text not null,
+  primary key (service, upstream_name),
+  unique (service, action_name),
+  foreign key (service) references mcp_servers(service) on delete cascade
+);
+
+create table mcp_catalog_state (
+  id integer primary key check (id = 1),
+  revision integer not null,
+  updated_at text not null
+);
+
+insert into mcp_catalog_state (id, revision, updated_at)
+values (1, 0, '1970-01-01T00:00:00.000Z');

--- a/src/catalog-store.ts
+++ b/src/catalog-store.ts
@@ -45,23 +45,24 @@ export type ProviderSummaryDefinition = Omit<RuntimeProviderDefinition, "actions
  * scan every provider.
  */
 export type CatalogStore = {
+  /** Monotonic in-process revision used to invalidate derived search indexes. */
+  revision: number;
   providers: RuntimeProviderDefinition[];
   /**
-   * Schema-free view of `providers`, precomputed once because the catalog is
-   * immutable at runtime. Served by `/api/providers` so the dashboard does not
+   * Schema-free view of `providers`, recomputed when the runtime catalog
+   * revision changes. Served by `/api/providers` so the dashboard does not
    * download every action schema on load.
    */
   providerSummaries: ProviderSummaryDefinition[];
   /**
-   * `providerSummaries` pre-serialized to JSON. Served verbatim by
+   * `providerSummaries` pre-serialized for the current revision. Served verbatim by
    * `/api/providers` so the response is neither re-serialized per request nor
    * able to drift from {@link providerSummariesEtag}.
    */
   providerSummariesJson: string;
   /**
-   * Stable ETag for `providerSummariesJson`. The catalog is immutable at
-   * runtime, so this is computed once and lets `/api/providers` answer
-   * conditional requests with `304 Not Modified`.
+   * Content-derived ETag for the current provider summaries. It lets
+   * `/api/providers` answer conditional requests with `304 Not Modified`.
    */
   providerSummariesEtag: string;
   actions: RuntimeActionDefinition[];
@@ -73,9 +74,53 @@ export interface LoadCatalogOptions {
   executableActionIds?: Iterable<string>;
 }
 
+interface StaticCatalogState {
+  providers: ProviderDefinition[];
+  executableActionIds: Set<string>;
+}
+
+const staticCatalogStates = new WeakMap<CatalogStore, StaticCatalogState>();
+
 export function createCatalogStore(providers: ProviderDefinition[], options: LoadCatalogOptions = {}): CatalogStore {
+  const executableActionIds = new Set(options.executableActionIds ?? []);
+  const catalog = buildCatalogStore(providers, executableActionIds, 0);
+  staticCatalogStates.set(catalog, {
+    providers: [...providers],
+    executableActionIds,
+  });
+  return catalog;
+}
+
+/**
+ * Replace all runtime-defined providers while retaining the generated catalog.
+ *
+ * The store object is updated in place so long-lived services observe the same
+ * catalog revision without rebuilding their dependency graph.
+ */
+export function replaceDynamicProviders(
+  catalog: CatalogStore,
+  providers: ProviderDefinition[],
+  executableActionIds: Iterable<string>,
+): void {
+  const staticState = staticCatalogStates.get(catalog);
+  if (!staticState) {
+    throw new Error("Catalog store was not created by createCatalogStore.");
+  }
+  const nextExecutableActionIds = new Set([...staticState.executableActionIds, ...executableActionIds]);
+  const next = buildCatalogStore(
+    [...staticState.providers, ...providers],
+    nextExecutableActionIds,
+    catalog.revision + 1,
+  );
+  Object.assign(catalog, next);
+}
+
+function buildCatalogStore(
+  providers: ProviderDefinition[],
+  executableActions: Set<string>,
+  revision: number,
+): CatalogStore {
   const sortedProviders = sortProviders(providers);
-  const executableActions = new Set(options.executableActionIds ?? []);
   const runtimeProviders = sortedProviders.map((provider): RuntimeProviderDefinition => {
     const actions = provider.actions.map(
       (action): RuntimeActionDefinition => ({
@@ -99,6 +144,7 @@ export function createCatalogStore(providers: ProviderDefinition[], options: Loa
   const providerSummariesJson = JSON.stringify(providerSummaries);
 
   return {
+    revision,
     providers: runtimeProviders,
     providerSummaries,
     providerSummariesJson,
@@ -112,8 +158,8 @@ export function createCatalogStore(providers: ProviderDefinition[], options: Loa
 /**
  * Content-derived ETag using a pure-JS FNV-1a hash. Runtime-agnostic (no
  * `node:crypto`, so the Cloudflare Workers build shares this path) and computed
- * once per catalog. Emitted as a weak validator because the response body may
- * be gzip-transformed downstream.
+ * once per catalog revision. Emitted as a weak validator because the response
+ * body may be gzip-transformed downstream.
  */
 function weakEtag(content: string): string {
   let hash = 0x811c_9dc5;

--- a/src/core/action-search.ts
+++ b/src/core/action-search.ts
@@ -231,6 +231,33 @@ export function createActionSearchIndexProvider(actions: Iterable<ActionDefiniti
   };
 }
 
+/**
+ * Build an index lazily and rebuild it only when the catalog revision changes.
+ */
+export function createRevisionedActionSearchIndexProvider(input: {
+  getActions(): Iterable<ActionDefinition>;
+  getRevision(): number;
+}): ActionSearchIndexProvider {
+  let revision = -1;
+  let indexPromise: Promise<MiniSearch<ActionSearchDocument>> | undefined;
+  return {
+    get() {
+      const currentRevision = input.getRevision();
+      if (!indexPromise || currentRevision !== revision) {
+        revision = currentRevision;
+        const building = Promise.resolve().then(() => buildActionSearchIndex(input.getActions()));
+        building.catch(() => {
+          if (indexPromise === building) {
+            indexPromise = undefined;
+          }
+        });
+        indexPromise = building;
+      }
+      return indexPromise;
+    },
+  };
+}
+
 export function searchActions(
   index: MiniSearch<ActionSearchDocument>,
   query: string,

--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -235,6 +235,28 @@ describe("createGuardedFetch redirects", () => {
     expect(crossOriginHeaders.get("x-correlation-id")).toBe("cid");
   });
 
+  it("strips a runtime-configured credential header on cross-origin redirects", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://other.example.net/away"),
+      new Response("ok", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({
+      fetch: transport,
+      sensitiveHeaders: ["X-Custom-MCP-Key"],
+    });
+
+    await guarded("https://api.example.com/", {
+      headers: {
+        "x-custom-mcp-key": "secret",
+        "x-trace": "keep",
+      },
+    });
+
+    const redirectedHeaders = new Headers(calls[1]?.init?.headers);
+    expect(redirectedHeaders.has("x-custom-mcp-key")).toBe(false);
+    expect(redirectedHeaders.get("x-trace")).toBe("keep");
+  });
+
   it("passes through when the caller handles redirects manually", async () => {
     const { transport, calls } = createTransport([redirectTo("http://169.254.169.254/")]);
     const guarded = createGuardedFetch({ fetch: transport });

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -46,6 +46,11 @@ export interface GuardedFetchOptions {
   skipDnsValidation?: boolean;
   /** Transform errors thrown by the underlying transport before they escape the guarded fetch. */
   mapTransportError?: (error: unknown) => unknown;
+  /**
+   * Additional credential-bearing headers to strip when a redirect crosses
+   * origins. Use this for runtime-configured authentication header names.
+   */
+  sensitiveHeaders?: Iterable<string>;
 }
 
 // Match the platform default for `redirect: "follow"` (undici/browsers follow up
@@ -162,6 +167,10 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
   const baseFetch = unwrapGuardedFetch(options.fetch);
   const createError = options.createError ?? ((message: string) => new TypeError(message));
   const maxRedirects = options.maxRedirects ?? defaultMaxRedirects;
+  const sensitiveHeaders = new Set([
+    ...crossOriginCredentialHeaders,
+    ...Array.from(options.sensitiveHeaders ?? [], (name) => name.toLowerCase()),
+  ]);
   const guardedFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const transport = baseFetch ?? globalThis.fetch;
     const fetchTransport = async (
@@ -252,7 +261,7 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
       }
       if (guardedNext.origin !== url.origin) {
         for (const name of [...headers.keys()]) {
-          if (crossOriginCredentialHeaders.has(name)) {
+          if (sensitiveHeaders.has(name)) {
             headers.delete(name);
           }
         }

--- a/src/mcp-upstream/catalog.ts
+++ b/src/mcp-upstream/catalog.ts
@@ -1,0 +1,74 @@
+import type { CatalogStore } from "../catalog-store.ts";
+import type { ActionDefinition, ProviderDefinition, ProviderAuthDefinition } from "../core/types.ts";
+import type { IUpstreamMcpServerStore } from "./mcp-server-store.ts";
+import type { UpstreamMcpServer, UpstreamMcpServerWithTools } from "./types.ts";
+
+import { replaceDynamicProviders } from "../catalog-store.ts";
+
+const unconstrainedOutputSchema = {};
+
+/**
+ * Reload enabled upstream MCP servers into the runtime provider catalog.
+ */
+export async function refreshUpstreamMcpCatalog(catalog: CatalogStore, store: IUpstreamMcpServerStore): Promise<void> {
+  const servers = await store.listServers();
+  const upstreams = (
+    await Promise.all(
+      servers.map(async (server) => {
+        const upstream = await store.getServerWithTools(server.service);
+        return upstream
+          ? {
+              server,
+              tools: server.enabled ? upstream.tools.filter((tool) => tool.enabled && tool.status === "available") : [],
+            }
+          : undefined;
+      }),
+    )
+  ).filter((upstream): upstream is UpstreamMcpServerWithTools => upstream !== undefined);
+  const providers = upstreams.map(toProviderDefinition);
+  const executableActionIds = providers.flatMap((provider) => provider.actions.map((action) => action.id));
+  replaceDynamicProviders(catalog, providers, executableActionIds);
+}
+
+export function toProviderDefinition(input: UpstreamMcpServerWithTools): ProviderDefinition {
+  return {
+    service: input.server.service,
+    displayName: input.server.displayName,
+    description: input.server.description ?? `Tools provided by ${input.server.endpoint}.`,
+    categories: ["mcp"],
+    authTypes: [input.server.auth.type === "none" ? "no_auth" : "api_key"],
+    auth: [toAuthDefinition(input.server)],
+    actions: input.tools.map(
+      (tool): ActionDefinition => ({
+        id: `${input.server.service}.${tool.actionName}`,
+        service: input.server.service,
+        name: tool.actionName,
+        description: tool.description ?? tool.title ?? `Run upstream MCP tool ${tool.upstreamName}.`,
+        requiredScopes: [],
+        providerPermissions: [],
+        inputSchema: tool.inputSchema,
+        outputSchema: tool.outputSchema ?? unconstrainedOutputSchema,
+      }),
+    ),
+  };
+}
+
+function toAuthDefinition(server: UpstreamMcpServer): ProviderAuthDefinition {
+  if (server.auth.type === "none") {
+    return { type: "no_auth" };
+  }
+  if (server.auth.type === "bearer") {
+    return {
+      type: "api_key",
+      label: "Bearer token",
+      placeholder: "Enter bearer token",
+      description: `Bearer token sent to ${server.displayName}.`,
+    };
+  }
+  return {
+    type: "api_key",
+    label: server.auth.headerName,
+    placeholder: `Enter ${server.auth.headerName} value`,
+    description: `API key sent in the ${server.auth.headerName} header.`,
+  };
+}

--- a/src/mcp-upstream/contract.ts
+++ b/src/mcp-upstream/contract.ts
@@ -1,0 +1,32 @@
+import type { DiscoveredMcpTool } from "./types.ts";
+
+/**
+ * Hash all upstream fields that can change an Action's public or execution
+ * contract.
+ */
+export async function hashUpstreamMcpToolContract(tool: DiscoveredMcpTool): Promise<string> {
+  const value = canonicalJson({
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    outputSchema: tool.outputSchema,
+    annotations: tool.annotations,
+  });
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .filter(([, child]) => child !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}

--- a/src/mcp-upstream/mcp-client.test.ts
+++ b/src/mcp-upstream/mcp-client.test.ts
@@ -1,0 +1,108 @@
+import type { UpstreamMcpServer } from "./types.ts";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { setDefaultGuardedFetchDnsLookup } from "../core/guarded-fetch.ts";
+import { UpstreamMcpClient } from "./mcp-client.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  setDefaultGuardedFetchDnsLookup(undefined);
+});
+
+describe("UpstreamMcpClient", () => {
+  it("discovers and executes tools over Streamable HTTP with bearer authentication", async () => {
+    const authorizationHeaders: Array<string | null> = [];
+    const testCredential = ["test", "credential"].join("-");
+    setDefaultGuardedFetchDnsLookup(null);
+    globalThis.fetch = async (input, init) => {
+      const request = new Request(input, init);
+      authorizationHeaders.push(request.headers.get("authorization"));
+
+      const server = createTestServer();
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      await server.connect(transport);
+      try {
+        return await transport.handleRequest(request);
+      } finally {
+        await server.close();
+      }
+    };
+
+    const client = new UpstreamMcpClient();
+    const server = testServer();
+    const credential = {
+      authType: "api_key" as const,
+      apiKey: testCredential,
+      values: { apiKey: testCredential },
+      profile: {
+        accountId: server.service,
+        displayName: server.displayName,
+        grantedScopes: [],
+      },
+      metadata: {},
+    };
+
+    await expect(client.discoverTools(server, credential)).resolves.toMatchObject([
+      {
+        name: "lookup",
+        description: "Look up a record.",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      },
+    ]);
+    await expect(client.callTool(server, credential, "lookup", { query: "record-1" })).resolves.toEqual({
+      query: "record-1",
+      found: true,
+    });
+    expect(authorizationHeaders).not.toContain(null);
+    expect(new Set(authorizationHeaders)).toEqual(new Set([`Bearer ${testCredential}`]));
+  });
+});
+
+function createTestServer(): McpServer {
+  const server = new McpServer({
+    name: "upstream-mcp-client-test",
+    version: "1.0.0",
+  });
+  server.registerTool(
+    "lookup",
+    {
+      description: "Look up a record.",
+      inputSchema: { query: z.string() },
+    },
+    async ({ query }) => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ query, found: true }),
+        },
+      ],
+    }),
+  );
+  return server;
+}
+
+function testServer(): UpstreamMcpServer {
+  return {
+    service: "mcp_test",
+    slug: "test",
+    displayName: "Test MCP",
+    endpoint: "https://mcp.example.com/mcp",
+    auth: { type: "bearer" },
+    enabled: true,
+    revision: 1,
+    syncStatus: "never",
+    createdAt: "2026-07-25T00:00:00.000Z",
+    updatedAt: "2026-07-25T00:00:00.000Z",
+  };
+}

--- a/src/mcp-upstream/mcp-client.ts
+++ b/src/mcp-upstream/mcp-client.ts
@@ -1,0 +1,218 @@
+import type { ResolvedCredential } from "../core/types.ts";
+import type { DiscoveredMcpTool, UpstreamMcpServer } from "./types.ts";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { CallToolResultSchema, ListToolsResultSchema, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { isPrivateNetworkAccessAllowed } from "../core/request.ts";
+import { createProviderFetch, ProviderRequestError, providerUserAgent } from "../providers/provider-runtime.ts";
+
+const maxListPages = 20;
+const maxTools = 500;
+const maxToolBytes = 256 * 1024;
+const maxTotalToolBytes = 5 * 1024 * 1024;
+const requestTimeoutMs = 120_000;
+
+export interface IUpstreamMcpClient {
+  discoverTools(server: UpstreamMcpServer, credential?: ResolvedCredential): Promise<DiscoveredMcpTool[]>;
+  callTool(
+    server: UpstreamMcpServer,
+    credential: ResolvedCredential | undefined,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<unknown>;
+}
+
+/**
+ * Streamable HTTP MCP client with bounded discovery and SSRF-guarded egress.
+ */
+export class UpstreamMcpClient implements IUpstreamMcpClient {
+  async discoverTools(server: UpstreamMcpServer, credential?: ResolvedCredential): Promise<DiscoveredMcpTool[]> {
+    return await this.withClient(server, credential, async (client) => {
+      const tools: DiscoveredMcpTool[] = [];
+      let cursor: string | undefined;
+      let totalBytes = 0;
+      for (let page = 0; page < maxListPages; page++) {
+        const result = await client.request(
+          {
+            method: "tools/list",
+            params: cursor ? { cursor } : {},
+          },
+          ListToolsResultSchema,
+          { timeout: requestTimeoutMs },
+        );
+        for (const tool of result.tools) {
+          const bytes = jsonByteLength(tool);
+          if (bytes > maxToolBytes) {
+            throw new UpstreamMcpClientError(
+              "tool_contract_too_large",
+              `MCP tool ${tool.name} exceeds the ${maxToolBytes} byte contract limit.`,
+            );
+          }
+          totalBytes += bytes;
+          if (totalBytes > maxTotalToolBytes) {
+            throw new UpstreamMcpClientError(
+              "catalog_too_large",
+              `MCP tool catalog exceeds the ${maxTotalToolBytes} byte limit.`,
+            );
+          }
+          tools.push({
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            outputSchema: tool.outputSchema,
+            annotations: tool.annotations,
+          });
+          if (tools.length > maxTools) {
+            throw new UpstreamMcpClientError("too_many_tools", `MCP server exposes more than ${maxTools} tools.`);
+          }
+        }
+        cursor = result.nextCursor;
+        if (!cursor) {
+          return tools;
+        }
+      }
+      throw new UpstreamMcpClientError("too_many_pages", `MCP tools/list exceeded the ${maxListPages} page limit.`);
+    });
+  }
+
+  async callTool(
+    server: UpstreamMcpServer,
+    credential: ResolvedCredential | undefined,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<unknown> {
+    return await this.withClient(server, credential, async (client) => {
+      const result = await client.request(
+        {
+          method: "tools/call",
+          params: { name: toolName, arguments: input },
+        },
+        CallToolResultSchema,
+        { timeout: requestTimeoutMs },
+      );
+      return normalizeToolResult(server.displayName, toolName, result);
+    });
+  }
+
+  private async withClient<T>(
+    server: UpstreamMcpServer,
+    credential: ResolvedCredential | undefined,
+    run: (client: Client) => Promise<T>,
+  ): Promise<T> {
+    const headers = createHeaders(server, credential);
+    const sensitiveHeaders = server.auth.type === "api_key_header" ? [server.auth.headerName] : [];
+    const fetcher = createProviderFetch({
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+      sensitiveHeaders,
+    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    const transport = new StreamableHTTPClientTransport(new URL(server.endpoint), {
+      fetch: fetcher,
+      requestInit: { headers, signal: controller.signal },
+    });
+    const client = new Client({ name: "oomol-connect-upstream-mcp", version: "1.0.0" });
+
+    try {
+      await client.connect(transport, { timeout: requestTimeoutMs });
+      return await run(client);
+    } catch (error) {
+      throw mapClientError(server.displayName, error);
+    } finally {
+      clearTimeout(timeout);
+      await client.close().catch(() => undefined);
+    }
+  }
+}
+
+export class UpstreamMcpClientError extends Error {
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(code: string, message: string, details?: unknown) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function createHeaders(server: UpstreamMcpServer, credential: ResolvedCredential | undefined): Headers {
+  const headers = new Headers({ "user-agent": providerUserAgent });
+  if (server.auth.type === "none") {
+    return headers;
+  }
+  if (!credential || credential.authType !== "api_key" || !credential.apiKey) {
+    throw new UpstreamMcpClientError("connection_required", `${server.displayName} requires a configured credential.`);
+  }
+  if (server.auth.type === "bearer") {
+    headers.set("authorization", `Bearer ${credential.apiKey}`);
+  } else {
+    headers.set(server.auth.headerName, credential.apiKey);
+  }
+  return headers;
+}
+
+function normalizeToolResult(serverName: string, toolName: string, result: CallToolResult): unknown {
+  if (result.isError) {
+    throw new UpstreamMcpClientError(
+      "upstream_tool_error",
+      `${serverName} tool ${toolName} returned an error: ${formatTextContent(result)}`,
+      result,
+    );
+  }
+  if (result.structuredContent) {
+    return result.structuredContent;
+  }
+  const textContent = result.content.filter((item) => item.type === "text");
+  if (textContent.length === 1) {
+    try {
+      return JSON.parse(textContent[0]!.text);
+    } catch {
+      return textContent[0]!.text;
+    }
+  }
+  return result.content;
+}
+
+function formatTextContent(result: CallToolResult): string {
+  const message = result.content
+    .filter((item) => item.type === "text")
+    .map((item) => item.text)
+    .join("; ");
+  return message || "unknown upstream error";
+}
+
+function mapClientError(serverName: string, error: unknown): UpstreamMcpClientError {
+  if (error instanceof UpstreamMcpClientError) {
+    return error;
+  }
+  if (error instanceof UnauthorizedError) {
+    return new UpstreamMcpClientError("credential_rejected", `${serverName} MCP credential was rejected.`, error);
+  }
+  if (error instanceof StreamableHTTPError) {
+    return new UpstreamMcpClientError(
+      error.code === 401 || error.code === 403 ? "credential_rejected" : "upstream_http_error",
+      `${serverName} MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof ProviderRequestError) {
+    return new UpstreamMcpClientError("upstream_network_error", error.message, error.details);
+  }
+  if (error instanceof McpError) {
+    return new UpstreamMcpClientError("upstream_protocol_error", `${serverName} MCP request failed: ${error.message}`);
+  }
+  return new UpstreamMcpClientError(
+    "upstream_request_failed",
+    error instanceof Error ? `${serverName} MCP request failed: ${error.message}` : `${serverName} MCP request failed.`,
+    error,
+  );
+}
+
+function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}

--- a/src/mcp-upstream/mcp-server-service.test.ts
+++ b/src/mcp-upstream/mcp-server-service.test.ts
@@ -1,0 +1,274 @@
+import type { ResolvedCredential } from "../core/types.ts";
+import type { IUpstreamMcpClient } from "./mcp-client.ts";
+import type { DiscoveredMcpTool, UpstreamMcpServer } from "./types.ts";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createCatalogStore } from "../catalog-store.ts";
+import { ConnectionService } from "../connection-service.ts";
+import { ProviderLoader } from "../providers/provider-loader.ts";
+import { SqliteRuntimeDatabase } from "../server/storage/sqlite-runtime-store.ts";
+import { UpstreamMcpServerService, UpstreamMcpServerServiceError } from "./mcp-server-service.ts";
+import { UpstreamMcpProviderLoader } from "./provider-loader.ts";
+
+const databases: SqliteRuntimeDatabase[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) {
+    database.close();
+  }
+});
+
+describe("UpstreamMcpServerService", () => {
+  it("keeps new tools disabled, publishes approved tools, and pauses changed contracts", async () => {
+    const initialCredential = ["initial", "credential"].join("-");
+    const sameContractCredential = ["same", "contract"].join("-");
+    const differentContractCredential = ["different", "contract"].join("-");
+    const client = new TestMcpClient([
+      {
+        name: "search-records",
+        description: "Search records.",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      },
+    ]);
+    const { catalog, database, service } = createService(client);
+
+    const created = await service.createServer(
+      {
+        slug: "example",
+        displayName: "Example MCP",
+        endpoint: "https://mcp.example.com/mcp",
+        auth: { type: "bearer" },
+      },
+      { credential: initialCredential },
+    );
+
+    expect(created.server.revision).toBe(2);
+    expect(created.tools).toMatchObject([
+      {
+        upstreamName: "search-records",
+        enabled: false,
+        status: "available",
+      },
+    ]);
+    expect(catalog.actions).toEqual([]);
+
+    await service.setEnabledTools(created.server.service, {
+      expectedRevision: created.server.revision,
+      enabledTools: ["search-records"],
+    });
+    expect(catalog.actions.map((action) => action.id)).toEqual(["mcp_example.search_records"]);
+    const providerLoader = new UpstreamMcpProviderLoader({
+      base: new ProviderLoader({}),
+      client,
+      store: database.upstreamMcpServerStore,
+    });
+    const executor = await providerLoader.loadActionExecutor(created.server.service, "mcp_example.search_records");
+    await expect(
+      executor?.(
+        { query: "example" },
+        {
+          getCredential: async () => ({
+            authType: "api_key",
+            apiKey: initialCredential,
+            values: { apiKey: initialCredential },
+            profile: { accountId: "mcp_example", displayName: "Example MCP", grantedScopes: [] },
+            metadata: {},
+          }),
+        },
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      output: { toolName: "search-records", input: { query: "example" } },
+    });
+    const validators = await providerLoader.loadCredentialValidators(created.server.service);
+    await expect(
+      validators?.apiKey?.(
+        { apiKey: sameContractCredential, values: { apiKey: sameContractCredential } },
+        { fetcher: fetch },
+      ),
+    ).resolves.toMatchObject({
+      profile: { accountId: created.server.service },
+    });
+
+    const endpointUpdated = await service.updateServer(
+      created.server.service,
+      { endpoint: "https://mcp.example.com/v2/mcp" },
+      { sync: false },
+    );
+    expect(endpointUpdated.tools).toMatchObject([{ upstreamName: "search-records", enabled: false }]);
+    expect(catalog.actions).toEqual([]);
+    await expect(
+      executor?.(
+        { query: "stale" },
+        {
+          getCredential: async () => undefined,
+        },
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "action_unavailable" },
+    });
+    await service.setEnabledTools(created.server.service, {
+      expectedRevision: endpointUpdated.server.revision,
+      enabledTools: ["search-records"],
+    });
+
+    client.tools = [
+      {
+        name: "search-records",
+        description: "Search records with filters.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            limit: { type: "number" },
+          },
+        },
+      },
+    ];
+    await expect(
+      validators?.apiKey?.(
+        { apiKey: differentContractCredential, values: { apiKey: differentContractCredential } },
+        { fetcher: fetch },
+      ),
+    ).rejects.toMatchObject({
+      code: "tool_contract_mismatch",
+    });
+    await service.syncServer(created.server.service);
+    const changed = await service.getServer(created.server.service);
+
+    expect(changed.tools).toMatchObject([
+      {
+        upstreamName: "search-records",
+        enabled: false,
+        status: "review_required",
+      },
+    ]);
+    expect(catalog.actions).toEqual([]);
+  });
+
+  it("marks tools removed upstream and records duplicate-name sync failures", async () => {
+    const client = new TestMcpClient([
+      {
+        name: "first",
+        inputSchema: { type: "object" },
+      },
+      {
+        name: "second",
+        inputSchema: { type: "object" },
+      },
+    ]);
+    const { service } = createService(client);
+    const created = await service.createServer({
+      slug: "removal",
+      displayName: "Removal MCP",
+      endpoint: "https://mcp.example.com/mcp",
+      auth: { type: "none" },
+    });
+
+    client.tools = [{ name: "first", inputSchema: { type: "object" } }];
+    await service.syncServer(created.server.service);
+    const afterRemoval = await service.getServer(created.server.service);
+    expect(afterRemoval.tools.find((tool) => tool.upstreamName === "second")).toMatchObject({
+      enabled: false,
+      status: "removed",
+    });
+
+    client.tools = [
+      { name: "first", inputSchema: { type: "object" } },
+      { name: "first", inputSchema: { type: "object" } },
+    ];
+    await expect(service.syncServer(created.server.service)).rejects.toMatchObject({
+      code: "duplicate_tool_names",
+    });
+    await expect(service.getServer(created.server.service)).resolves.toMatchObject({
+      server: {
+        syncStatus: "error",
+        lastSyncError: expect.stringContaining("duplicate tool names"),
+      },
+    });
+  });
+
+  it("rejects unsafe endpoints and custom credential header names", async () => {
+    const { service } = createService(new TestMcpClient([]));
+
+    await expect(
+      service.createServer({
+        slug: "metadata",
+        displayName: "Metadata",
+        endpoint: "http://169.254.169.254/mcp",
+        auth: { type: "none" },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_endpoint" });
+
+    await expect(
+      service.createServer({
+        slug: "bad-header",
+        displayName: "Bad Header",
+        endpoint: "https://mcp.example.com/mcp",
+        auth: { type: "api_key_header", headerName: "Host" },
+      }),
+    ).rejects.toBeInstanceOf(UpstreamMcpServerServiceError);
+  });
+
+  it("rejects a dynamic service that conflicts with a static provider", async () => {
+    const catalog = createCatalogStore([
+      {
+        service: "mcp_example",
+        displayName: "Static MCP Example",
+        categories: ["Developer Tools"],
+        authTypes: ["no_auth"],
+        auth: [{ type: "no_auth" }],
+        actions: [],
+      },
+    ]);
+    const { service } = createService(new TestMcpClient([]), catalog);
+
+    await expect(
+      service.createServer({
+        slug: "example",
+        displayName: "Dynamic MCP Example",
+        endpoint: "https://mcp.example.com/mcp",
+        auth: { type: "none" },
+      }),
+    ).rejects.toMatchObject({ code: "mcp_server_conflict" });
+  });
+});
+
+function createService(client: IUpstreamMcpClient, catalog = createCatalogStore([])) {
+  const database = new SqliteRuntimeDatabase(":memory:");
+  databases.push(database);
+  const connections = new ConnectionService({
+    catalog,
+    providerLoader: new ProviderLoader({}),
+    store: database.connectionStore,
+  });
+  const service = new UpstreamMcpServerService({
+    catalog,
+    client,
+    connections,
+    store: database.upstreamMcpServerStore,
+  });
+  return { catalog, database, service };
+}
+
+class TestMcpClient implements IUpstreamMcpClient {
+  tools: DiscoveredMcpTool[];
+
+  constructor(tools: DiscoveredMcpTool[]) {
+    this.tools = tools;
+  }
+
+  async discoverTools(_server: UpstreamMcpServer, _credential?: ResolvedCredential): Promise<DiscoveredMcpTool[]> {
+    return structuredClone(this.tools);
+  }
+
+  async callTool(
+    _server: UpstreamMcpServer,
+    _credential: ResolvedCredential | undefined,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<unknown> {
+    return { toolName, input };
+  }
+}

--- a/src/mcp-upstream/mcp-server-service.ts
+++ b/src/mcp-upstream/mcp-server-service.ts
@@ -1,0 +1,486 @@
+import type { CatalogStore } from "../catalog-store.ts";
+import type { ConnectionService } from "../connection-service.ts";
+import type { IUpstreamMcpClient } from "./mcp-client.ts";
+import type { IUpstreamMcpServerStore } from "./mcp-server-store.ts";
+import type {
+  CreateUpstreamMcpServerInput,
+  DiscoveredMcpTool,
+  SetUpstreamMcpToolsInput,
+  UpdateUpstreamMcpServerInput,
+  UpstreamMcpAuth,
+  UpstreamMcpServer,
+  UpstreamMcpServerWithTools,
+  UpstreamMcpSyncResult,
+  UpstreamMcpTool,
+  UpstreamMcpToolSelectionResult,
+} from "./types.ts";
+
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../core/request.ts";
+import { refreshUpstreamMcpCatalog } from "./catalog.ts";
+import { hashUpstreamMcpToolContract } from "./contract.ts";
+
+const slugPattern = /^[a-z][a-z0-9-]{0,47}$/u;
+const headerNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/u;
+const blockedHeaderNames = new Set(["connection", "content-length", "host", "transfer-encoding"]);
+const maxToolNameLength = 128;
+
+export interface CreateMcpServerOptions {
+  credential?: string;
+  sync?: boolean;
+}
+
+export interface UpdateMcpServerOptions {
+  credential?: string;
+  sync?: boolean;
+}
+
+export interface SyncMcpServerOptions {
+  connectionName?: string;
+}
+
+/**
+ * Coordinates upstream MCP configuration, contract review state, and catalog
+ * publication.
+ */
+export class UpstreamMcpServerService {
+  private readonly catalog: CatalogStore;
+  private readonly client: IUpstreamMcpClient;
+  private readonly connections: ConnectionService;
+  private readonly store: IUpstreamMcpServerStore;
+
+  constructor(input: {
+    catalog: CatalogStore;
+    client: IUpstreamMcpClient;
+    connections: ConnectionService;
+    store: IUpstreamMcpServerStore;
+  }) {
+    this.catalog = input.catalog;
+    this.client = input.client;
+    this.connections = input.connections;
+    this.store = input.store;
+  }
+
+  async initialize(): Promise<void> {
+    await refreshUpstreamMcpCatalog(this.catalog, this.store);
+  }
+
+  async listServers(): Promise<UpstreamMcpServer[]> {
+    return await this.store.listServers();
+  }
+
+  async getServer(service: string): Promise<UpstreamMcpServerWithTools> {
+    const upstream = await this.store.getServerWithTools(service);
+    if (!upstream) {
+      throw new UpstreamMcpServerServiceError("mcp_server_not_found", `MCP server not found: ${service}.`, 404);
+    }
+    return upstream;
+  }
+
+  async createServer(
+    input: CreateUpstreamMcpServerInput,
+    options: CreateMcpServerOptions = {},
+  ): Promise<UpstreamMcpServerWithTools> {
+    const slug = normalizeSlug(input.slug);
+    const now = new Date().toISOString();
+    const service = `mcp_${slug.replaceAll("-", "_")}`;
+    if (this.catalog.providers.some((provider) => provider.service === service)) {
+      throw new UpstreamMcpServerServiceError(
+        "mcp_server_conflict",
+        `MCP server service conflicts with an existing provider: ${service}.`,
+        409,
+      );
+    }
+    const server: UpstreamMcpServer = {
+      service,
+      slug,
+      displayName: normalizeRequiredText(input.displayName, "displayName", 100),
+      description: normalizeOptionalText(input.description, "description", 500),
+      endpoint: normalizeEndpoint(input.endpoint),
+      auth: normalizeAuth(input.auth),
+      enabled: true,
+      revision: 1,
+      syncStatus: "never",
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (!(await this.store.createServer(server))) {
+      throw new UpstreamMcpServerServiceError(
+        "mcp_server_conflict",
+        `MCP server slug or service already exists: ${slug}.`,
+        409,
+      );
+    }
+    await refreshUpstreamMcpCatalog(this.catalog, this.store);
+
+    try {
+      await this.configureDefaultCredential(server, options.credential);
+    } catch (error) {
+      await this.store.deleteServer(server.service);
+      await refreshUpstreamMcpCatalog(this.catalog, this.store);
+      throw error;
+    }
+
+    if (options.sync !== false) {
+      await this.syncServer(server.service);
+    }
+    return await this.getServer(server.service);
+  }
+
+  async updateServer(
+    service: string,
+    input: UpdateUpstreamMcpServerInput,
+    options: UpdateMcpServerOptions = {},
+  ): Promise<UpstreamMcpServerWithTools> {
+    const current = (await this.getServer(service)).server;
+    const now = new Date().toISOString();
+    let server: UpstreamMcpServer = {
+      ...current,
+      displayName:
+        input.displayName === undefined
+          ? current.displayName
+          : normalizeRequiredText(input.displayName, "displayName", 100),
+      description:
+        input.description === undefined
+          ? current.description
+          : normalizeOptionalText(input.description, "description", 500),
+      endpoint: input.endpoint === undefined ? current.endpoint : normalizeEndpoint(input.endpoint),
+      auth: input.auth === undefined ? current.auth : normalizeAuth(input.auth),
+      enabled: input.enabled ?? current.enabled,
+      revision: current.revision + 1,
+      updatedAt: now,
+    };
+    if (!(await this.store.updateServer(server))) {
+      throw new UpstreamMcpServerServiceError("mcp_server_not_found", `MCP server not found: ${service}.`, 404);
+    }
+    if (server.endpoint !== current.endpoint || !sameAuth(server.auth, current.auth)) {
+      const paused = await this.store.setEnabledTools({
+        service,
+        expectedRevision: server.revision,
+        enabledTools: [],
+        updatedAt: now,
+      });
+      if (!paused) {
+        await refreshUpstreamMcpCatalog(this.catalog, this.store);
+        throw new UpstreamMcpServerServiceError(
+          "mcp_server_revision_conflict",
+          "MCP server changed while its endpoint or authentication was being updated.",
+          409,
+        );
+      }
+      server = { ...server, revision: paused.revision };
+    }
+    await refreshUpstreamMcpCatalog(this.catalog, this.store);
+    await this.configureDefaultCredential(server, options.credential);
+    if (options.sync !== false) {
+      await this.syncServer(service);
+    }
+    return await this.getServer(service);
+  }
+
+  async deleteServer(service: string): Promise<void> {
+    if (!(await this.store.deleteServer(service))) {
+      throw new UpstreamMcpServerServiceError("mcp_server_not_found", `MCP server not found: ${service}.`, 404);
+    }
+    await refreshUpstreamMcpCatalog(this.catalog, this.store);
+  }
+
+  async syncServer(service: string, options: SyncMcpServerOptions = {}): Promise<UpstreamMcpSyncResult> {
+    const current = await this.getServer(service);
+    const now = new Date().toISOString();
+    try {
+      const credential = await this.connections.getCredential(service, options.connectionName);
+      const discovered = await this.client.discoverTools(current.server, credential);
+      const sync = await buildSyncState(current, discovered, now);
+      const result = await this.store.applySync(sync);
+      if (!result) {
+        throw new UpstreamMcpServerServiceError(
+          "mcp_server_revision_conflict",
+          "MCP server changed while synchronization was in progress.",
+          409,
+        );
+      }
+      await refreshUpstreamMcpCatalog(this.catalog, this.store);
+      return result;
+    } catch (error) {
+      if (!(error instanceof UpstreamMcpServerServiceError && error.code === "mcp_server_revision_conflict")) {
+        await this.store.recordSyncError(service, current.server.revision, toErrorMessage(error), now);
+      }
+      throw error;
+    }
+  }
+
+  async setEnabledTools(service: string, input: SetUpstreamMcpToolsInput): Promise<UpstreamMcpToolSelectionResult> {
+    if (!Number.isInteger(input.expectedRevision) || input.expectedRevision < 1) {
+      throw new UpstreamMcpServerServiceError("invalid_revision", "expectedRevision must be a positive integer.", 400);
+    }
+    const enabledTools = normalizeToolSelection(input.enabledTools);
+    const result = await this.store.setEnabledTools({
+      service,
+      expectedRevision: input.expectedRevision,
+      enabledTools,
+      updatedAt: new Date().toISOString(),
+    });
+    if (!result) {
+      throw new UpstreamMcpServerServiceError(
+        "mcp_server_revision_conflict",
+        "MCP server revision changed or the tool selection contains an unknown tool.",
+        409,
+      );
+    }
+    await refreshUpstreamMcpCatalog(this.catalog, this.store);
+    return result;
+  }
+
+  private async configureDefaultCredential(server: UpstreamMcpServer, credential?: string): Promise<void> {
+    if (server.auth.type === "none") {
+      await this.connections.disconnect(server.service);
+      return;
+    }
+    if (credential === undefined) {
+      return;
+    }
+    await this.connections.connectWithApiKey(server.service, {
+      values: { apiKey: normalizeRequiredText(credential, "credential", 16_384) },
+    });
+  }
+}
+
+export class UpstreamMcpServerServiceError extends Error {
+  readonly code: string;
+  readonly status: 400 | 404 | 409;
+
+  constructor(code: string, message: string, status: 400 | 404 | 409) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+async function buildSyncState(current: UpstreamMcpServerWithTools, discovered: DiscoveredMcpTool[], syncedAt: string) {
+  const duplicates = findDuplicateToolNames(discovered);
+  if (duplicates.length > 0) {
+    throw new UpstreamMcpServerServiceError(
+      "duplicate_tool_names",
+      `MCP server returned duplicate tool names: ${duplicates.join(", ")}.`,
+      400,
+    );
+  }
+
+  const previousByName = new Map(current.tools.map((tool) => [tool.upstreamName, tool]));
+  const usedActionNames = new Set(current.tools.map((tool) => tool.actionName));
+  const tools: UpstreamMcpTool[] = [];
+  let added = 0;
+  let changed = 0;
+  let unchanged = 0;
+  let invalid = 0;
+
+  for (const tool of discovered) {
+    const previous = previousByName.get(tool.name);
+    const invalidReason = validateToolName(tool.name);
+    const contractHash = await hashUpstreamMcpToolContract(tool);
+    const actionName = previous?.actionName ?? createActionName(tool.name, usedActionNames);
+    usedActionNames.add(actionName);
+    let status: UpstreamMcpTool["status"];
+    let enabled = false;
+    if (invalidReason) {
+      status = "invalid";
+      invalid++;
+    } else if (!previous) {
+      status = "available";
+      added++;
+    } else if (previous.contractHash !== contractHash || previous.status === "removed") {
+      status = "review_required";
+      changed++;
+    } else {
+      status = previous.status;
+      enabled = previous.enabled && status === "available";
+      unchanged++;
+    }
+    tools.push({
+      service: current.server.service,
+      upstreamName: tool.name,
+      actionName,
+      title: tool.title,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      outputSchema: tool.outputSchema,
+      annotations: tool.annotations,
+      contractHash,
+      enabled,
+      status,
+      invalidReason,
+      firstSeenAt: previous?.firstSeenAt ?? syncedAt,
+      lastSeenAt: syncedAt,
+    });
+    previousByName.delete(tool.name);
+  }
+
+  const removed = previousByName.size;
+  for (const previous of previousByName.values()) {
+    tools.push({
+      ...previous,
+      enabled: false,
+      status: "removed",
+    });
+  }
+
+  return {
+    expectedRevision: current.server.revision,
+    server: {
+      ...current.server,
+      revision: current.server.revision + 1,
+      syncStatus: "ok" as const,
+      lastSyncAt: syncedAt,
+      lastSyncError: undefined,
+      updatedAt: syncedAt,
+    },
+    tools,
+    result: {
+      service: current.server.service,
+      discovered: discovered.length,
+      added,
+      changed,
+      unchanged,
+      removed,
+      invalid,
+      syncedAt,
+    },
+  };
+}
+
+function normalizeSlug(value: string): string {
+  const slug = value.trim().toLowerCase();
+  if (!slugPattern.test(slug)) {
+    throw new UpstreamMcpServerServiceError(
+      "invalid_slug",
+      "slug must start with a lowercase letter and contain only lowercase letters, digits, or hyphens.",
+      400,
+    );
+  }
+  return slug;
+}
+
+function normalizeEndpoint(value: string): string {
+  try {
+    const url = assertPublicHttpUrl(value.trim(), {
+      fieldName: "endpoint",
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed(),
+      createError: (message) => new UpstreamMcpServerServiceError("invalid_endpoint", message, 400),
+    });
+    if (url.username || url.password) {
+      throw new UpstreamMcpServerServiceError(
+        "invalid_endpoint",
+        "endpoint must not contain embedded credentials.",
+        400,
+      );
+    }
+    url.hash = "";
+    return url.toString();
+  } catch (error) {
+    if (error instanceof UpstreamMcpServerServiceError) {
+      throw error;
+    }
+    throw new UpstreamMcpServerServiceError("invalid_endpoint", "endpoint must be a valid HTTP URL.", 400);
+  }
+}
+
+function normalizeAuth(auth: UpstreamMcpAuth): UpstreamMcpAuth {
+  if (auth.type === "none" || auth.type === "bearer") {
+    return { type: auth.type };
+  }
+  const headerName = auth.headerName.trim();
+  if (!headerNamePattern.test(headerName) || blockedHeaderNames.has(headerName.toLowerCase())) {
+    throw new UpstreamMcpServerServiceError("invalid_header_name", "auth.headerName is not allowed.", 400);
+  }
+  return { type: "api_key_header", headerName };
+}
+
+function sameAuth(left: UpstreamMcpAuth, right: UpstreamMcpAuth): boolean {
+  return (
+    left.type === right.type &&
+    (left.type !== "api_key_header" ||
+      (right.type === "api_key_header" && left.headerName.toLowerCase() === right.headerName.toLowerCase()))
+  );
+}
+
+function normalizeRequiredText(value: string, fieldName: string, maxLength: number): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxLength) {
+    throw new UpstreamMcpServerServiceError(
+      "invalid_input",
+      `${fieldName} must contain between 1 and ${maxLength} characters.`,
+      400,
+    );
+  }
+  return normalized;
+}
+
+function normalizeOptionalText(value: string | undefined, fieldName: string, maxLength: number): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (normalized.length > maxLength) {
+    throw new UpstreamMcpServerServiceError(
+      "invalid_input",
+      `${fieldName} must not exceed ${maxLength} characters.`,
+      400,
+    );
+  }
+  return normalized || undefined;
+}
+
+function normalizeToolSelection(values: string[]): string[] {
+  if (!Array.isArray(values) || values.some((value) => typeof value !== "string" || !value)) {
+    throw new UpstreamMcpServerServiceError("invalid_tool_selection", "enabledTools must contain tool names.", 400);
+  }
+  return [...new Set(values)].sort();
+}
+
+function validateToolName(name: string): string | undefined {
+  if (!name) {
+    return "Tool name must not be empty.";
+  }
+  if (name.length > maxToolNameLength) {
+    return `Tool name exceeds ${maxToolNameLength} characters.`;
+  }
+  return undefined;
+}
+
+function createActionName(upstreamName: string, usedNames: Set<string>): string {
+  const normalized = upstreamName
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_]+/gu, "_")
+    .replaceAll(/^_+|_+$/gu, "")
+    .slice(0, 48);
+  const base = normalized && /^[a-z]/u.test(normalized) ? normalized : `tool_${stableHash(upstreamName)}`;
+  if (!usedNames.has(base)) {
+    return base;
+  }
+  return `${base.slice(0, 54)}_${stableHash(upstreamName)}`;
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c_9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x0100_0193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function findDuplicateToolNames(tools: DiscoveredMcpTool[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const tool of tools) {
+    if (seen.has(tool.name)) {
+      duplicates.add(tool.name);
+    }
+    seen.add(tool.name);
+  }
+  return [...duplicates].sort();
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 2_000) : "Unknown MCP synchronization error.";
+}

--- a/src/mcp-upstream/mcp-server-store.ts
+++ b/src/mcp-upstream/mcp-server-store.ts
@@ -1,0 +1,35 @@
+import type {
+  UpstreamMcpServer,
+  UpstreamMcpServerWithTools,
+  UpstreamMcpSyncResult,
+  UpstreamMcpTool,
+  UpstreamMcpToolSelectionResult,
+} from "./types.ts";
+
+export interface ApplyUpstreamMcpSyncInput {
+  expectedRevision: number;
+  server: UpstreamMcpServer;
+  tools: UpstreamMcpTool[];
+  result: Omit<UpstreamMcpSyncResult, "revision">;
+}
+
+export interface SetUpstreamMcpToolsStoreInput {
+  service: string;
+  expectedRevision: number;
+  enabledTools: string[];
+  updatedAt: string;
+}
+
+export interface IUpstreamMcpServerStore {
+  getCatalogRevision(): Promise<number>;
+  listServers(): Promise<UpstreamMcpServer[]>;
+  getServer(service: string): Promise<UpstreamMcpServer | undefined>;
+  getServerWithTools(service: string): Promise<UpstreamMcpServerWithTools | undefined>;
+  listEnabledServersWithTools(): Promise<UpstreamMcpServerWithTools[]>;
+  createServer(server: UpstreamMcpServer): Promise<boolean>;
+  updateServer(server: UpstreamMcpServer): Promise<boolean>;
+  deleteServer(service: string): Promise<boolean>;
+  applySync(input: ApplyUpstreamMcpSyncInput): Promise<UpstreamMcpSyncResult | undefined>;
+  recordSyncError(service: string, expectedRevision: number, message: string, updatedAt: string): Promise<boolean>;
+  setEnabledTools(input: SetUpstreamMcpToolsStoreInput): Promise<UpstreamMcpToolSelectionResult | undefined>;
+}

--- a/src/mcp-upstream/provider-loader.ts
+++ b/src/mcp-upstream/provider-loader.ts
@@ -1,0 +1,177 @@
+import type { ActionExecutor, CredentialValidators, ExecutionResult, ResolvedCredential } from "../core/types.ts";
+import type { ProviderProxyExecutor } from "../core/types.ts";
+import type { IProviderLoader } from "../providers/provider-loader.ts";
+import type { IUpstreamMcpClient } from "./mcp-client.ts";
+import type { IUpstreamMcpServerStore } from "./mcp-server-store.ts";
+import type { UpstreamMcpServer } from "./types.ts";
+
+import { hashUpstreamMcpToolContract } from "./contract.ts";
+import { UpstreamMcpClientError } from "./mcp-client.ts";
+
+/**
+ * Provider loader that delegates generated providers to the static registry and
+ * resolves configured MCP servers from runtime storage.
+ */
+export class UpstreamMcpProviderLoader implements IProviderLoader {
+  private readonly base: IProviderLoader;
+  private readonly client: IUpstreamMcpClient;
+  private readonly store: IUpstreamMcpServerStore;
+
+  constructor(input: { base: IProviderLoader; client: IUpstreamMcpClient; store: IUpstreamMcpServerStore }) {
+    this.base = input.base;
+    this.client = input.client;
+    this.store = input.store;
+  }
+
+  async loadActionExecutor(
+    service: string,
+    actionId: string,
+    providerDisplayName?: string,
+  ): Promise<ActionExecutor | undefined> {
+    const upstream = await this.store.getServerWithTools(service);
+    if (!upstream) {
+      return await this.base.loadActionExecutor(service, actionId, providerDisplayName);
+    }
+    const tool = upstream.server.enabled
+      ? upstream.tools.find(
+          (candidate) =>
+            candidate.enabled && candidate.status === "available" && `${service}.${candidate.actionName}` === actionId,
+        )
+      : undefined;
+    if (!tool) {
+      return undefined;
+    }
+    return async (input, context): Promise<ExecutionResult> => {
+      if (!isRecord(input)) {
+        return {
+          ok: false,
+          error: { code: "invalid_input", message: "Upstream MCP tool input must be an object." },
+        };
+      }
+      const current = await this.store.getServerWithTools(service);
+      const currentTool = current?.server.enabled
+        ? current.tools.find(
+            (candidate) =>
+              candidate.enabled &&
+              candidate.status === "available" &&
+              candidate.actionName === tool.actionName &&
+              candidate.contractHash === tool.contractHash,
+          )
+        : undefined;
+      if (!current || !currentTool) {
+        return {
+          ok: false,
+          error: {
+            code: "action_unavailable",
+            message: "The upstream MCP tool is disabled or its contract changed.",
+          },
+        };
+      }
+      try {
+        const credential = await context.getCredential(service);
+        return {
+          ok: true,
+          output: await this.client.callTool(current.server, credential, currentTool.upstreamName, input),
+        };
+      } catch (error) {
+        return toExecutionFailure(error);
+      }
+    };
+  }
+
+  async loadProxyExecutor(service: string, providerDisplayName?: string): Promise<ProviderProxyExecutor | undefined> {
+    return (await this.store.getServer(service))
+      ? undefined
+      : await this.base.loadProxyExecutor(service, providerDisplayName);
+  }
+
+  async loadCredentialValidators(service: string): Promise<CredentialValidators | undefined> {
+    const server = await this.store.getServer(service);
+    if (!server) {
+      return await this.base.loadCredentialValidators(service);
+    }
+    if (server.auth.type === "none") {
+      return undefined;
+    }
+    return {
+      apiKey: async (input) => {
+        const discovered = await this.client.discoverTools(
+          server,
+          createValidationCredential(server, input.apiKey, input.values),
+        );
+        await this.assertCompatibleContract(service, discovered);
+        return {
+          profile: {
+            accountId: server.service,
+            displayName: server.displayName,
+            grantedScopes: [],
+          },
+        };
+      },
+    };
+  }
+
+  private async assertCompatibleContract(
+    service: string,
+    discovered: Awaited<ReturnType<IUpstreamMcpClient["discoverTools"]>>,
+  ): Promise<void> {
+    const current = await this.store.getServerWithTools(service);
+    const expected = current?.tools.filter((tool) => tool.status !== "removed") ?? [];
+    if (expected.length === 0) {
+      return;
+    }
+    const actual = new Map(
+      await Promise.all(discovered.map(async (tool) => [tool.name, await hashUpstreamMcpToolContract(tool)] as const)),
+    );
+    const compatible =
+      actual.size === expected.length && expected.every((tool) => actual.get(tool.upstreamName) === tool.contractHash);
+    if (!compatible) {
+      throw new UpstreamMcpClientError(
+        "tool_contract_mismatch",
+        `${current?.server.displayName ?? service} connection exposes a different MCP tool contract.`,
+      );
+    }
+  }
+}
+
+function createValidationCredential(
+  server: UpstreamMcpServer,
+  apiKey: string,
+  values: Record<string, string>,
+): ResolvedCredential {
+  return {
+    authType: "api_key",
+    apiKey,
+    values,
+    profile: {
+      accountId: server.service,
+      displayName: server.displayName,
+      grantedScopes: [],
+    },
+    metadata: {},
+  };
+}
+
+function toExecutionFailure(error: unknown): ExecutionResult {
+  if (error instanceof UpstreamMcpClientError) {
+    return {
+      ok: false,
+      error: {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      },
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      code: "upstream_request_failed",
+      message: error instanceof Error ? error.message : "Upstream MCP request failed.",
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/mcp-upstream/storage-codec.ts
+++ b/src/mcp-upstream/storage-codec.ts
@@ -1,0 +1,154 @@
+import type { JsonSchema } from "../core/types.ts";
+import type { UpstreamMcpAuth, UpstreamMcpServer, UpstreamMcpTool } from "./types.ts";
+
+type SqlValue = string | number | null;
+
+export function readUpstreamMcpInteger(row: unknown, key: string): number {
+  const value = readRow(row)[key];
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`Expected upstream MCP storage column ${key} to be an integer.`);
+  }
+  return value;
+}
+
+export function readUpstreamMcpServerRow(row: unknown): UpstreamMcpServer {
+  const syncStatus = readString(row, "sync_status");
+  if (syncStatus !== "never" && syncStatus !== "ok" && syncStatus !== "error") {
+    throw new Error(`Unexpected upstream MCP sync status: ${syncStatus}.`);
+  }
+  return {
+    service: readString(row, "service"),
+    slug: readString(row, "slug"),
+    displayName: readString(row, "display_name"),
+    description: readOptionalString(row, "description"),
+    endpoint: readString(row, "endpoint"),
+    auth: readAuth(row),
+    enabled: readBoolean(row, "enabled"),
+    revision: readUpstreamMcpInteger(row, "revision"),
+    syncStatus,
+    lastSyncAt: readOptionalString(row, "last_sync_at"),
+    lastSyncError: readOptionalString(row, "last_sync_error"),
+    createdAt: readString(row, "created_at"),
+    updatedAt: readString(row, "updated_at"),
+  };
+}
+
+export function readUpstreamMcpToolRow(row: unknown): UpstreamMcpTool {
+  const status = readString(row, "status");
+  if (status !== "available" && status !== "review_required" && status !== "removed" && status !== "invalid") {
+    throw new Error(`Unexpected upstream MCP tool status: ${status}.`);
+  }
+  const outputSchema = readOptionalString(row, "output_schema");
+  const annotations = readOptionalString(row, "annotations");
+  return {
+    service: readString(row, "service"),
+    upstreamName: readString(row, "upstream_name"),
+    actionName: readString(row, "action_name"),
+    title: readOptionalString(row, "title"),
+    description: readOptionalString(row, "description"),
+    inputSchema: parseJsonObject(readString(row, "input_schema")),
+    outputSchema: outputSchema ? parseJsonObject(outputSchema) : undefined,
+    annotations: annotations ? parseJsonObject(annotations) : undefined,
+    contractHash: readString(row, "contract_hash"),
+    enabled: readBoolean(row, "enabled"),
+    status,
+    invalidReason: readOptionalString(row, "invalid_reason"),
+    firstSeenAt: readString(row, "first_seen_at"),
+    lastSeenAt: readString(row, "last_seen_at"),
+  };
+}
+
+export function upstreamMcpServerValues(server: UpstreamMcpServer): SqlValue[] {
+  return [
+    server.service,
+    server.slug,
+    server.displayName,
+    server.description ?? null,
+    server.endpoint,
+    server.auth.type,
+    server.auth.type === "api_key_header" ? server.auth.headerName : null,
+    server.enabled ? 1 : 0,
+    server.revision,
+    server.syncStatus,
+    server.lastSyncAt ?? null,
+    server.lastSyncError ?? null,
+    server.createdAt,
+    server.updatedAt,
+  ];
+}
+
+export function upstreamMcpToolValues(tool: UpstreamMcpTool): SqlValue[] {
+  return [
+    tool.service,
+    tool.upstreamName,
+    tool.actionName,
+    tool.title ?? null,
+    tool.description ?? null,
+    JSON.stringify(tool.inputSchema),
+    tool.outputSchema ? JSON.stringify(tool.outputSchema) : null,
+    tool.annotations ? JSON.stringify(tool.annotations) : null,
+    tool.contractHash,
+    tool.enabled ? 1 : 0,
+    tool.status,
+    tool.invalidReason ?? null,
+    tool.firstSeenAt,
+    tool.lastSeenAt,
+  ];
+}
+
+function readAuth(row: unknown): UpstreamMcpAuth {
+  const type = readString(row, "auth_type");
+  if (type === "none" || type === "bearer") {
+    return { type };
+  }
+  if (type === "api_key_header") {
+    const headerName = readOptionalString(row, "header_name");
+    if (!headerName) {
+      throw new Error("Expected upstream MCP storage column header_name for api_key_header.");
+    }
+    return { type, headerName };
+  }
+  throw new Error(`Unexpected upstream MCP auth type: ${type}.`);
+}
+
+function readBoolean(row: unknown, key: string): boolean {
+  const value = readUpstreamMcpInteger(row, key);
+  if (value !== 0 && value !== 1) {
+    throw new Error(`Expected upstream MCP storage column ${key} to be a boolean integer.`);
+  }
+  return value === 1;
+}
+
+function readString(row: unknown, key: string): string {
+  const value = readRow(row)[key];
+  if (typeof value !== "string") {
+    throw new Error(`Expected upstream MCP storage column ${key} to be a string.`);
+  }
+  return value;
+}
+
+function readOptionalString(row: unknown, key: string): string | undefined {
+  const value = readRow(row)[key];
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Expected upstream MCP storage column ${key} to be a string.`);
+  }
+  return value;
+}
+
+function readRow(row: unknown): Record<string, unknown> {
+  if (typeof row !== "object" || row === null || Array.isArray(row)) {
+    throw new Error("Expected an upstream MCP storage row.");
+  }
+  return row as Record<string, unknown>;
+}
+
+function parseJsonObject(value: string): JsonSchema {
+  const parsed: unknown = JSON.parse(value);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Expected an upstream MCP storage JSON object.");
+  }
+  return parsed as JsonSchema;
+}

--- a/src/mcp-upstream/types.ts
+++ b/src/mcp-upstream/types.ts
@@ -1,0 +1,93 @@
+import type { JsonSchema } from "../core/types.ts";
+
+export type UpstreamMcpAuth = { type: "none" } | { type: "bearer" } | { type: "api_key_header"; headerName: string };
+
+export type UpstreamMcpSyncStatus = "never" | "ok" | "error";
+
+export interface UpstreamMcpServer {
+  service: string;
+  slug: string;
+  displayName: string;
+  description?: string;
+  endpoint: string;
+  auth: UpstreamMcpAuth;
+  enabled: boolean;
+  revision: number;
+  syncStatus: UpstreamMcpSyncStatus;
+  lastSyncAt?: string;
+  lastSyncError?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type UpstreamMcpToolStatus = "available" | "review_required" | "removed" | "invalid";
+
+export interface UpstreamMcpTool {
+  service: string;
+  upstreamName: string;
+  actionName: string;
+  title?: string;
+  description?: string;
+  inputSchema: JsonSchema;
+  outputSchema?: JsonSchema;
+  annotations?: Record<string, unknown>;
+  contractHash: string;
+  enabled: boolean;
+  status: UpstreamMcpToolStatus;
+  invalidReason?: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface UpstreamMcpServerWithTools {
+  server: UpstreamMcpServer;
+  tools: UpstreamMcpTool[];
+}
+
+export interface DiscoveredMcpTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema: JsonSchema;
+  outputSchema?: JsonSchema;
+  annotations?: Record<string, unknown>;
+}
+
+export interface UpstreamMcpSyncResult {
+  service: string;
+  revision: number;
+  discovered: number;
+  added: number;
+  changed: number;
+  unchanged: number;
+  removed: number;
+  invalid: number;
+  syncedAt: string;
+}
+
+export interface UpstreamMcpToolSelectionResult {
+  service: string;
+  revision: number;
+  enabledTools: string[];
+}
+
+export interface CreateUpstreamMcpServerInput {
+  slug: string;
+  displayName: string;
+  description?: string;
+  endpoint: string;
+  auth: UpstreamMcpAuth;
+}
+
+export interface UpdateUpstreamMcpServerInput {
+  displayName?: string;
+  description?: string;
+  endpoint?: string;
+  auth?: UpstreamMcpAuth;
+  enabled?: boolean;
+}
+
+export interface SetUpstreamMcpToolsInput {
+  expectedRevision: number;
+  enabledTools: string[];
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -12,7 +12,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import { ConnectionError } from "./connection-service.ts";
 import { ActionPolicyService, emptyPolicyRules } from "./core/action-policy.ts";
-import { createActionSearchIndexProvider, searchActions as searchActionIndex } from "./core/action-search.ts";
+import { createRevisionedActionSearchIndexProvider, searchActions as searchActionIndex } from "./core/action-search.ts";
 import { renderActionMarkdown } from "./server/api/action-markdown.ts";
 
 /**
@@ -239,7 +239,12 @@ async function searchActions(
     return errorPayload("internal_error", "Runtime policy is unavailable.");
   }
   const query = input.query?.trim();
-  const actionSearch = options.actionSearch ?? createActionSearchIndexProvider(options.catalog.actions);
+  const actionSearch =
+    options.actionSearch ??
+    createRevisionedActionSearchIndexProvider({
+      getActions: () => options.catalog.actions,
+      getRevision: () => options.catalog.revision,
+    });
   const rankedActions = query
     ? searchActionIndex(await actionSearch.get(), query, { service: input.service, limit: input.limit })
         .map((result) => options.catalog.actionsById.get(result.id))

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -32,6 +32,8 @@ export interface ProviderFetchOptions {
    * derived from user/credential input. See {@link GuardedFetchOptions.skipDnsValidation}.
    */
   skipDnsValidation?: boolean;
+  /** Runtime-configured credential headers removed from cross-origin redirects. */
+  sensitiveHeaders?: Iterable<string>;
 }
 
 /**
@@ -45,6 +47,7 @@ export function createProviderFetch(options: ProviderFetchOptions = {}): Provide
     fetch: options.fetch,
     allowPrivateNetwork: options.allowPrivateNetwork,
     skipDnsValidation: options.skipDnsValidation,
+    sensitiveHeaders: options.sensitiveHeaders,
     mapTransportError: (error) =>
       error instanceof TypeError ? new ProviderRequestError(502, "provider network request failed") : error,
     createError: (message) => new ProviderRequestError(502, message),

--- a/src/server/api/http-utils.ts
+++ b/src/server/api/http-utils.ts
@@ -76,7 +76,7 @@ export async function readJsonBody(context: Context, maxBytes?: number): Promise
  */
 export function jsonError(
   context: Context,
-  status: 400 | 401 | 404 | 413 | 500,
+  status: 400 | 401 | 404 | 409 | 413 | 500 | 502,
   code: string,
   message: string,
 ): Response {

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -201,6 +201,10 @@ export function createOpenApiDocument(
       items: { $ref: "#/components/schemas/ConnectionSummary" },
     }),
     "/api/connections/{service}": createConnectionPath(),
+    "/api/mcp-servers": createUpstreamMcpServersPath(),
+    "/api/mcp-servers/{service}": createUpstreamMcpServerPath(),
+    "/api/mcp-servers/{service}/sync": createUpstreamMcpSyncPath(),
+    "/api/mcp-servers/{service}/tools": createUpstreamMcpToolsPath(),
     "/api/oauth/configs": getOperation("OAuth", "List local OAuth client configurations.", {
       type: "array",
       items: { $ref: "#/components/schemas/OAuthClientConfigSummary" },
@@ -236,6 +240,7 @@ export function createOpenApiDocument(
       { name: "System", description: "Runtime health and server-level status." },
       { name: "Catalog", description: "Provider and action metadata used by users and agents." },
       { name: "Connections", description: "Local provider credentials and connection state." },
+      { name: "MCP Upstreams", description: "Configured upstream MCP servers and reviewed tool contracts." },
       { name: "OAuth", description: "Local OAuth client configuration and authorization flow." },
       { name: "Access", description: "Runtime execution policy and bearer tokens for /v1 and MCP clients." },
       { name: "Files", description: "Local temporary file transit for provider actions." },
@@ -330,6 +335,37 @@ export function createOpenApiDocument(
         ),
         ErrorResponse: errorResponseSchema,
         ConnectionUpsertRequest: createConnectionUpsertRequestSchema(),
+        UpstreamMcpServer: jsonSchema.unknownObject(
+          "Configured upstream MCP server. Credential values are never returned.",
+        ),
+        UpstreamMcpServerWithTools: jsonSchema.unknownObject(
+          "Configured upstream MCP server and its discovered tool contracts.",
+        ),
+        UpstreamMcpServerRequest: jsonSchema.object(
+          {
+            slug: jsonSchema.string({ description: "Stable lowercase slug used to derive the service id." }),
+            displayName: jsonSchema.string({ description: "Human-readable server name." }),
+            description: jsonSchema.string({ description: "Optional server description." }),
+            endpoint: jsonSchema.string({ description: "Streamable HTTP MCP endpoint." }),
+            auth: jsonSchema.unknownObject("Authentication mode: none, bearer, or api_key_header."),
+            credential: jsonSchema.string({ description: "Optional credential stored as the default connection." }),
+            sync: jsonSchema.boolean({ description: "Synchronize tools after saving. Defaults to true." }),
+          },
+          {
+            required: ["slug", "displayName", "endpoint", "auth"],
+            description: "Create an upstream MCP server.",
+          },
+        ),
+        UpstreamMcpToolSelectionRequest: jsonSchema.object(
+          {
+            expectedRevision: { type: "integer", minimum: 1 },
+            enabledTools: { type: "array", items: { type: "string" } },
+          },
+          {
+            required: ["expectedRevision", "enabledTools"],
+            description: "Optimistic-locking tool publication selection.",
+          },
+        ),
         OAuthClientConfigSummary: jsonSchema.object(
           {
             service: jsonSchema.string({ description: "Provider service identifier." }),
@@ -990,6 +1026,123 @@ function createConnectionPath(): Record<string, unknown> {
           ],
         }),
         404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+  };
+}
+
+function createUpstreamMcpServersPath(): Record<string, unknown> {
+  return {
+    get: {
+      tags: ["MCP Upstreams"],
+      summary: "List configured upstream MCP servers.",
+      responses: {
+        200: jsonResponse({
+          type: "array",
+          items: { $ref: "#/components/schemas/UpstreamMcpServer" },
+        }),
+      },
+    },
+    post: {
+      tags: ["MCP Upstreams"],
+      summary: "Create and optionally synchronize an upstream MCP server.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/UpstreamMcpServerRequest" },
+          },
+        },
+      },
+      responses: {
+        201: jsonResponse({ $ref: "#/components/schemas/UpstreamMcpServerWithTools" }),
+        400: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        409: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        502: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+  };
+}
+
+function createUpstreamMcpServerPath(): Record<string, unknown> {
+  return {
+    get: {
+      tags: ["MCP Upstreams"],
+      summary: "Get one upstream MCP server and its discovered tools.",
+      responses: {
+        200: jsonResponse({ $ref: "#/components/schemas/UpstreamMcpServerWithTools" }),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+    put: {
+      tags: ["MCP Upstreams"],
+      summary: "Update and optionally synchronize an upstream MCP server.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: jsonSchema.unknownObject("Partial upstream MCP server update."),
+          },
+        },
+      },
+      responses: {
+        200: jsonResponse({ $ref: "#/components/schemas/UpstreamMcpServerWithTools" }),
+        400: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        502: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+    delete: {
+      tags: ["MCP Upstreams"],
+      summary: "Delete an upstream MCP server and its stored connections.",
+      responses: {
+        200: jsonResponse(jsonSchema.unknownObject("Upstream MCP server deletion result.")),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+  };
+}
+
+function createUpstreamMcpSyncPath(): Record<string, unknown> {
+  return {
+    post: {
+      tags: ["MCP Upstreams"],
+      summary: "Synchronize upstream tools and pause changed contracts for review.",
+      responses: {
+        200: jsonResponse(jsonSchema.unknownObject("Upstream MCP synchronization summary.")),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        502: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+  };
+}
+
+function createUpstreamMcpToolsPath(): Record<string, unknown> {
+  return {
+    get: {
+      tags: ["MCP Upstreams"],
+      summary: "List discovered tools for one upstream MCP server.",
+      responses: {
+        200: jsonResponse(jsonSchema.unknownObject("Discovered upstream MCP tools and current server revision.")),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+      },
+    },
+    put: {
+      tags: ["MCP Upstreams"],
+      summary: "Publish an explicit set of reviewed upstream MCP tools.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/UpstreamMcpToolSelectionRequest" },
+          },
+        },
+      },
+      responses: {
+        200: jsonResponse(jsonSchema.unknownObject("Updated tool publication selection.")),
+        400: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        404: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
+        409: jsonResponse({ $ref: "#/components/schemas/ErrorResponse" }),
       },
     },
   };

--- a/src/server/cloudflare.test.ts
+++ b/src/server/cloudflare.test.ts
@@ -166,7 +166,32 @@ function memoryAssets(files: Record<string, unknown>): AssetsBinding {
 
 class UnusedD1Database implements D1DatabaseBinding {
   prepare(query: string): D1PreparedStatementBinding {
+    if (query === "select * from mcp_servers order by display_name, service") {
+      return new EmptyD1PreparedStatement();
+    }
     throw new Error(`Unexpected D1 query: ${query}`);
+  }
+
+  async batch(): Promise<never> {
+    throw new Error("Unexpected D1 batch");
+  }
+}
+
+class EmptyD1PreparedStatement implements D1PreparedStatementBinding {
+  bind(): D1PreparedStatementBinding {
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    return null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: [] };
+  }
+
+  async run(): Promise<never> {
+    throw new Error("Unexpected D1 statement run");
   }
 }
 

--- a/src/server/cloudflare/cloudflare-bindings.ts
+++ b/src/server/cloudflare/cloudflare-bindings.ts
@@ -1,12 +1,18 @@
 export interface D1DatabaseBinding {
   prepare(query: string): D1PreparedStatementBinding;
+  batch(statements: D1PreparedStatementBinding[]): Promise<D1ResultBinding[]>;
 }
 
 export interface D1PreparedStatementBinding {
   bind(...values: unknown[]): D1PreparedStatementBinding;
   first<T = Record<string, unknown>>(): Promise<T | null>;
   all<T = Record<string, unknown>>(): Promise<{ results: T[] }>;
-  run(): Promise<{ success: boolean; meta: { changes?: number } }>;
+  run(): Promise<D1ResultBinding>;
+}
+
+export interface D1ResultBinding {
+  success: boolean;
+  meta: { changes?: number };
 }
 
 export interface R2BucketBinding {

--- a/src/server/connect-app.test.ts
+++ b/src/server/connect-app.test.ts
@@ -1,0 +1,154 @@
+import type { ResolvedCredential } from "../core/types.ts";
+import type { IUpstreamMcpClient } from "../mcp-upstream/mcp-client.ts";
+import type { DiscoveredMcpTool, UpstreamMcpServer } from "../mcp-upstream/types.ts";
+import type { ITransitFileService, TransitFileRead, TransitFileUpload } from "./files/transit-file-store.ts";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createCatalogStore } from "../catalog-store.ts";
+import { ProviderLoader } from "../providers/provider-loader.ts";
+import { createConnectApp } from "./connect-app.ts";
+import { PlainTextSecretCodec } from "./secrets/secret-codec-core.ts";
+import { SqliteRuntimeDatabase } from "./storage/sqlite-runtime-store.ts";
+
+const databases: SqliteRuntimeDatabase[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) {
+    database.close();
+  }
+});
+
+describe("createConnectApp upstream MCP integration", () => {
+  it("registers, reviews, publishes, and executes an upstream MCP tool", async () => {
+    const client = new TestMcpClient([
+      {
+        name: "lookup",
+        description: "Look up one record.",
+        inputSchema: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    ]);
+    const database = new SqliteRuntimeDatabase(":memory:");
+    databases.push(database);
+    const { app } = await createConnectApp({
+      catalog: createCatalogStore([]),
+      providerLoader: new ProviderLoader({}),
+      runtimeDatabase: database,
+      transitFiles: new UnusedTransitFileService(),
+      publicOrigin: "http://localhost:3000",
+      secretCodec: new PlainTextSecretCodec(),
+      upstreamMcpClient: client,
+    });
+
+    const createdResponse = await app.request("/api/mcp-servers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        slug: "example",
+        displayName: "Example MCP",
+        endpoint: "https://mcp.example.com/mcp",
+        auth: { type: "none" },
+      }),
+    });
+    expect(createdResponse.status).toBe(201);
+    await expect(createdResponse.json()).resolves.toMatchObject({
+      server: { service: "mcp_example", revision: 2, syncStatus: "ok" },
+      tools: [{ upstreamName: "lookup", enabled: false, status: "available" }],
+    });
+
+    const selectionResponse = await app.request("/api/mcp-servers/mcp_example/tools", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        expectedRevision: 2,
+        enabledTools: ["lookup"],
+      }),
+    });
+    expect(selectionResponse.status).toBe(200);
+
+    const actionResponse = await app.request("/v1/actions/mcp_example.lookup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: { id: "record-1" } }),
+    });
+    expect(actionResponse.status).toBe(200);
+    await expect(actionResponse.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        toolName: "lookup",
+        input: { id: "record-1" },
+      },
+    });
+    expect(client.calls).toEqual([{ service: "mcp_example", toolName: "lookup", input: { id: "record-1" } }]);
+
+    client.tools = [
+      {
+        name: "lookup",
+        description: "Look up one record with expanded fields.",
+        inputSchema: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    ];
+    const syncResponse = await app.request("/api/mcp-servers/mcp_example/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(syncResponse.status).toBe(200);
+    await expect(syncResponse.json()).resolves.toMatchObject({ changed: 1 });
+
+    const actionsAfterChange = await app.request("/api/actions");
+    await expect(actionsAfterChange.json()).resolves.toEqual([]);
+    const toolsAfterChange = await app.request("/api/mcp-servers/mcp_example/tools");
+    await expect(toolsAfterChange.json()).resolves.toMatchObject({
+      tools: [{ upstreamName: "lookup", enabled: false, status: "review_required" }],
+    });
+  });
+});
+
+class TestMcpClient implements IUpstreamMcpClient {
+  tools: DiscoveredMcpTool[];
+  readonly calls: Array<{ service: string; toolName: string; input: Record<string, unknown> }> = [];
+
+  constructor(tools: DiscoveredMcpTool[]) {
+    this.tools = tools;
+  }
+
+  async discoverTools(): Promise<DiscoveredMcpTool[]> {
+    return structuredClone(this.tools);
+  }
+
+  async callTool(
+    server: UpstreamMcpServer,
+    _credential: ResolvedCredential | undefined,
+    toolName: string,
+    input: Record<string, unknown>,
+  ): Promise<unknown> {
+    this.calls.push({ service: server.service, toolName, input });
+    return { toolName, input };
+  }
+}
+
+class UnusedTransitFileService implements ITransitFileService {
+  readonly maxBytes = 1024;
+
+  async create(_file: File): Promise<TransitFileUpload> {
+    throw new Error("Unexpected transit file create.");
+  }
+
+  async read(_fileId: string): Promise<TransitFileRead> {
+    throw new Error("Unexpected transit file read.");
+  }
+
+  async delete(_fileId: string): Promise<boolean> {
+    throw new Error("Unexpected transit file delete.");
+  }
+
+  async cleanupExpired(): Promise<void> {}
+}

--- a/src/server/connect-app.ts
+++ b/src/server/connect-app.ts
@@ -1,5 +1,6 @@
 import type { CatalogStore } from "../catalog-store.ts";
 import type { ActionPolicyService } from "../core/action-policy.ts";
+import type { IUpstreamMcpClient } from "../mcp-upstream/mcp-client.ts";
 import type { IProviderLoader } from "../providers/provider-loader.ts";
 import type { RuntimeJwtVerifier } from "./api/runtime-jwt.ts";
 import type { ITransitFileService } from "./files/transit-file-store.ts";
@@ -9,6 +10,9 @@ import type { RuntimeDatabase } from "./storage/runtime-database.ts";
 import type { Hono } from "hono";
 
 import { ConnectionService } from "../connection-service.ts";
+import { UpstreamMcpClient } from "../mcp-upstream/mcp-client.ts";
+import { UpstreamMcpServerService } from "../mcp-upstream/mcp-server-service.ts";
+import { UpstreamMcpProviderLoader } from "../mcp-upstream/provider-loader.ts";
 import { OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
 import { OAuthCredentialRefreshService } from "../oauth/oauth-credential-refresh-service.ts";
 import { OAuthFlowService } from "../oauth/oauth-flow-service.ts";
@@ -30,6 +34,7 @@ export interface ConnectAppOptions {
   registerStaticRoutes?: (app: Hono) => void;
   logger?: Logger;
   computeRuntimeAuthConfigured?: boolean;
+  upstreamMcpClient?: IUpstreamMcpClient;
 }
 
 export interface ConnectApp {
@@ -40,6 +45,12 @@ export interface ConnectApp {
 export async function createConnectApp(options: ConnectAppOptions): Promise<ConnectApp> {
   const runtimeTokens = new RuntimeTokenService(options.runtimeDatabase.runtimeTokenStore);
   const hasStoredRuntimeTokens = async (): Promise<boolean> => (await runtimeTokens.listTokens()).length > 0;
+  const upstreamMcpClient = options.upstreamMcpClient ?? new UpstreamMcpClient();
+  const providerLoader = new UpstreamMcpProviderLoader({
+    base: options.providerLoader,
+    client: upstreamMcpClient,
+    store: options.runtimeDatabase.upstreamMcpServerStore,
+  });
   const oauthClientConfigs = new OAuthClientConfigService({
     catalog: options.catalog,
     origin: options.publicOrigin,
@@ -48,13 +59,20 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
   const connections = new ConnectionService({
     catalog: options.catalog,
     oauthCredentials: new OAuthCredentialRefreshService(oauthClientConfigs),
-    providerLoader: options.providerLoader,
+    providerLoader,
     store: options.runtimeDatabase.connectionStore,
     logger: options.logger,
   });
+  const upstreamMcps = new UpstreamMcpServerService({
+    catalog: options.catalog,
+    client: upstreamMcpClient,
+    connections,
+    store: options.runtimeDatabase.upstreamMcpServerStore,
+  });
+  await upstreamMcps.initialize();
   const actions = new ActionRunner({
     catalog: options.catalog,
-    providerLoader: options.providerLoader,
+    providerLoader,
     connections,
     runs: options.runtimeDatabase.runLogStore,
     transitFiles: options.transitFiles,
@@ -65,7 +83,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
   return {
     app: new ConnectServer({
       catalog: options.catalog,
-      providerLoader: options.providerLoader,
+      providerLoader,
       connections,
       oauthClientConfigs,
       oauthFlow: new OAuthFlowService({
@@ -78,6 +96,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
       transitFiles: options.transitFiles,
       runtimeTokens,
       runtimePolicyStore: options.runtimeDatabase.runtimePolicyStore,
+      upstreamMcps,
       registerStaticRoutes: options.registerStaticRoutes,
       auth: {
         adminToken: options.adminToken,

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -2,6 +2,13 @@ import type { CatalogStore, RuntimeActionDefinition } from "../catalog-store.ts"
 import type { ConnectionService } from "../connection-service.ts";
 import type { ActionPolicySnapshot } from "../core/action-policy.ts";
 import type { ActionSearchIndexProvider, ActionSearchResult } from "../core/action-search.ts";
+import type { UpstreamMcpServerService } from "../mcp-upstream/mcp-server-service.ts";
+import type {
+  CreateUpstreamMcpServerInput,
+  SetUpstreamMcpToolsInput,
+  UpdateUpstreamMcpServerInput,
+  UpstreamMcpAuth,
+} from "../mcp-upstream/types.ts";
 import type { IProviderLoader } from "../providers/provider-loader.ts";
 import type { LocalAuthOptions } from "./api/auth.ts";
 import type { RuntimeActionHttpResult } from "./api/runtime-api.ts";
@@ -19,8 +26,21 @@ import { Hono } from "hono";
 import { compress } from "hono/compress";
 import { ConnectionError, defaultConnectionName } from "../connection-service.ts";
 import { ActionPolicyService, emptyPolicyRules } from "../core/action-policy.ts";
-import { DEFAULT_ACTION_SEARCH_LIMIT, createActionSearchIndexProvider, searchActions } from "../core/action-search.ts";
-import { optionalRecord, optionalString, requiredString } from "../core/cast.ts";
+import {
+  DEFAULT_ACTION_SEARCH_LIMIT,
+  createRevisionedActionSearchIndexProvider,
+  searchActions,
+} from "../core/action-search.ts";
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredString,
+  requiredStringArray,
+} from "../core/cast.ts";
+import { UpstreamMcpClientError } from "../mcp-upstream/mcp-client.ts";
+import { UpstreamMcpServerServiceError } from "../mcp-upstream/mcp-server-service.ts";
 import { createMcpServer, listMcpToolSummaries } from "../mcp.ts";
 import { OAuthClientConfigError, OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
 import { OAuthFlowError, OAuthFlowService } from "../oauth/oauth-flow-service.ts";
@@ -72,6 +92,7 @@ export interface IConnectServerOptions {
   auth?: LocalAuthOptions;
   actionPolicy?: ActionPolicyService;
   runtimePolicyStore: IRuntimePolicyStore;
+  upstreamMcps?: UpstreamMcpServerService;
   actionSearch?: ActionSearchIndexProvider;
   registerStaticRoutes?: (app: Hono) => void;
   logger?: Logger;
@@ -90,7 +111,12 @@ export class ConnectServer {
 
   constructor(options: IConnectServerOptions) {
     this.options = options;
-    this.actionSearch = options.actionSearch ?? createActionSearchIndexProvider(options.catalog.actions);
+    this.actionSearch =
+      options.actionSearch ??
+      createRevisionedActionSearchIndexProvider({
+        getActions: () => options.catalog.actions,
+        getRevision: () => options.catalog.revision,
+      });
     this.actionPolicy = options.actionPolicy ?? new ActionPolicyService();
     this.proxyRunner = new ProxyRunner({
       catalog: options.catalog,
@@ -163,9 +189,9 @@ export class ConnectServer {
     );
 
     // Schema-free listing. The action detail view loads full schemas on demand
-    // from /api/actions/:actionId. The catalog is immutable at runtime, so the
-    // body and its ETag are precomputed and reused, and unchanged reloads get a
-    // 304 instead of re-downloading the payload.
+    // from /api/actions/:actionId. The body and its ETag are precomputed for
+    // each catalog revision, and unchanged reloads get a 304 instead of
+    // re-downloading the payload.
     app.get("/api/providers", (context) => this.listProviderSummaries(context));
     app.get("/api/providers/:service", (context) => this.getProvider(context, context.req.param("service")));
 
@@ -201,6 +227,28 @@ export class ConnectServer {
     app.delete("/api/oauth/configs/:service", (context) =>
       this.deleteOAuthConfig(context, context.req.param("service")),
     );
+    if (this.options.upstreamMcps) {
+      app.get("/api/mcp-servers", (context) => this.listUpstreamMcpServers(context));
+      app.post("/api/mcp-servers", (context) => this.createUpstreamMcpServer(context));
+      app.get("/api/mcp-servers/:service", (context) =>
+        this.getUpstreamMcpServer(context, context.req.param("service")),
+      );
+      app.put("/api/mcp-servers/:service", (context) =>
+        this.updateUpstreamMcpServer(context, context.req.param("service")),
+      );
+      app.delete("/api/mcp-servers/:service", (context) =>
+        this.deleteUpstreamMcpServer(context, context.req.param("service")),
+      );
+      app.get("/api/mcp-servers/:service/tools", (context) =>
+        this.listUpstreamMcpTools(context, context.req.param("service")),
+      );
+      app.post("/api/mcp-servers/:service/sync", (context) =>
+        this.syncUpstreamMcpServer(context, context.req.param("service")),
+      );
+      app.put("/api/mcp-servers/:service/tools", (context) =>
+        this.setUpstreamMcpTools(context, context.req.param("service")),
+      );
+    }
     app.post("/api/oauth/authorizations", (context) => this.createOAuthAuthorization(context));
     app.get("/oauth/callback", (context) => this.completeOAuth(context));
     app.post("/mcp", (context) => this.handleMcp(context));
@@ -1017,6 +1065,103 @@ export class ConnectServer {
     }
   }
 
+  private async listUpstreamMcpServers(context: Context): Promise<Response> {
+    return await this.writeUpstreamMcpResult(context, this.requireUpstreamMcps().listServers());
+  }
+
+  private async getUpstreamMcpServer(context: Context, service: string): Promise<Response> {
+    return await this.writeUpstreamMcpResult(context, this.requireUpstreamMcps().getServer(service));
+  }
+
+  private async listUpstreamMcpTools(context: Context, service: string): Promise<Response> {
+    const operation = this.requireUpstreamMcps()
+      .getServer(service)
+      .then((upstream) => ({
+        service,
+        revision: upstream.server.revision,
+        tools: upstream.tools,
+      }));
+    return await this.writeUpstreamMcpResult(context, operation);
+  }
+
+  private async createUpstreamMcpServer(context: Context): Promise<Response> {
+    const body = await readJsonBody(context, 64 * 1024);
+    const input = readCreateUpstreamMcpServerInput(body);
+    return await this.writeUpstreamMcpResult(
+      context,
+      this.requireUpstreamMcps().createServer(input.server, input.options),
+      201,
+    );
+  }
+
+  private async updateUpstreamMcpServer(context: Context, service: string): Promise<Response> {
+    const body = await readJsonBody(context, 64 * 1024);
+    const input = readUpdateUpstreamMcpServerInput(body);
+    return await this.writeUpstreamMcpResult(
+      context,
+      this.requireUpstreamMcps().updateServer(service, input.server, input.options),
+    );
+  }
+
+  private async deleteUpstreamMcpServer(context: Context, service: string): Promise<Response> {
+    return await this.writeUpstreamMcpResult(
+      context,
+      this.requireUpstreamMcps()
+        .deleteServer(service)
+        .then(() => ({ service, deleted: true })),
+    );
+  }
+
+  private async syncUpstreamMcpServer(context: Context, service: string): Promise<Response> {
+    const body = await readJsonBody(context, 16 * 1024);
+    return await this.writeUpstreamMcpResult(
+      context,
+      this.requireUpstreamMcps().syncServer(service, {
+        connectionName: optionalString(body.connectionName),
+      }),
+    );
+  }
+
+  private async setUpstreamMcpTools(context: Context, service: string): Promise<Response> {
+    const body = await readJsonBody(context, 64 * 1024);
+    const input: SetUpstreamMcpToolsInput = {
+      expectedRevision: requiredInteger(body.expectedRevision, "expectedRevision"),
+      enabledTools: requiredStringArray(body.enabledTools, "enabledTools", invalidMcpInput),
+    };
+    return await this.writeUpstreamMcpResult(context, this.requireUpstreamMcps().setEnabledTools(service, input));
+  }
+
+  private requireUpstreamMcps(): UpstreamMcpServerService {
+    if (!this.options.upstreamMcps) {
+      throw new Error("Upstream MCP service is unavailable.");
+    }
+    return this.options.upstreamMcps;
+  }
+
+  private async writeUpstreamMcpResult(
+    context: Context,
+    operation: Promise<unknown>,
+    successStatus: 200 | 201 = 200,
+  ): Promise<Response> {
+    try {
+      return context.json(await operation, successStatus);
+    } catch (error) {
+      if (error instanceof UpstreamMcpServerServiceError) {
+        return jsonError(context, error.status, error.code, error.message);
+      }
+      if (error instanceof UpstreamMcpClientError) {
+        return jsonError(context, 502, error.code, error.message);
+      }
+      if (error instanceof ConnectionError) {
+        return jsonError(context, error.code === "unknown_service" ? 404 : 400, error.code, error.message);
+      }
+      if (error instanceof HttpRequestError) {
+        return jsonError(context, error.status, error.code, error.message);
+      }
+      throw error;
+    }
+  }
+
   private getPolicySnapshot(context: Context): Promise<ActionPolicySnapshot> {
     const request = context.req.raw;
     let snapshot = this.policySnapshots.get(request);
@@ -1054,6 +1199,110 @@ interface ConnectionLogContext {
   service: string;
   authType?: string;
   connectionName?: string;
+}
+
+interface CreateUpstreamMcpServerRequest {
+  server: CreateUpstreamMcpServerInput;
+  options: {
+    credential?: string;
+    sync?: boolean;
+  };
+}
+
+interface UpdateUpstreamMcpServerRequest {
+  server: UpdateUpstreamMcpServerInput;
+  options: {
+    credential?: string;
+    sync?: boolean;
+  };
+}
+
+function readCreateUpstreamMcpServerInput(body: Record<string, unknown>): CreateUpstreamMcpServerRequest {
+  return {
+    server: {
+      slug: requiredString(body.slug, "slug", invalidMcpInput),
+      displayName: requiredString(body.displayName, "displayName", invalidMcpInput),
+      description: readOptionalBodyString(body, "description"),
+      endpoint: requiredString(body.endpoint, "endpoint", invalidMcpInput),
+      auth: readUpstreamMcpAuth(body.auth, true)!,
+    },
+    options: {
+      credential: readOptionalBodyString(body, "credential"),
+      sync: readOptionalBodyBoolean(body, "sync"),
+    },
+  };
+}
+
+function readUpdateUpstreamMcpServerInput(body: Record<string, unknown>): UpdateUpstreamMcpServerRequest {
+  return {
+    server: {
+      displayName: readOptionalBodyString(body, "displayName"),
+      description: readOptionalBodyString(body, "description", true),
+      endpoint: readOptionalBodyString(body, "endpoint"),
+      auth: readUpstreamMcpAuth(body.auth, false),
+      enabled: readOptionalBodyBoolean(body, "enabled"),
+    },
+    options: {
+      credential: readOptionalBodyString(body, "credential"),
+      sync: readOptionalBodyBoolean(body, "sync"),
+    },
+  };
+}
+
+function readUpstreamMcpAuth(value: unknown, required: boolean): UpstreamMcpAuth | undefined {
+  if (value === undefined && !required) {
+    return undefined;
+  }
+  const auth = optionalRecord(value);
+  if (!auth) {
+    throw invalidMcpInput("auth must be an object.");
+  }
+  const type = requiredString(auth.type, "auth.type", invalidMcpInput);
+  if (type === "none" || type === "bearer") {
+    return { type };
+  }
+  if (type === "api_key_header") {
+    return {
+      type,
+      headerName: requiredString(auth.headerName, "auth.headerName", invalidMcpInput),
+    };
+  }
+  throw invalidMcpInput("auth.type must be none, bearer, or api_key_header.");
+}
+
+function readOptionalBodyString(body: Record<string, unknown>, key: string, preserveEmpty = false): string | undefined {
+  const value = body[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw invalidMcpInput(`${key} must be a string.`);
+  }
+  return preserveEmpty ? value : optionalString(value);
+}
+
+function readOptionalBodyBoolean(body: Record<string, unknown>, key: string): boolean | undefined {
+  const value = body[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  const boolean = optionalBoolean(value);
+  if (boolean === undefined) {
+    throw invalidMcpInput(`${key} must be a boolean.`);
+  }
+  return boolean;
+}
+
+function requiredInteger(value: unknown, fieldName: string): number {
+  const integer = optionalInteger(value);
+  if (integer === undefined) {
+    throw invalidMcpInput(`${fieldName} must be an integer.`);
+  }
+  return integer;
+}
+
+function invalidMcpInput(message: string): HttpRequestError {
+  return new HttpRequestError("invalid_input", message);
 }
 
 /**

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -400,6 +400,116 @@ describe("D1RuntimeDatabase", () => {
     });
     await expect(database.runLogStore.get("run-2")).resolves.toMatchObject({ id: "run-2" });
   });
+
+  it("stores upstream MCP contracts and applies optimistic tool publication", async () => {
+    const database = new D1RuntimeDatabase(new SqliteD1Database());
+    const server = {
+      service: "mcp_example",
+      slug: "example",
+      displayName: "Example MCP",
+      endpoint: "https://mcp.example.com/mcp",
+      auth: { type: "none" as const },
+      enabled: true,
+      revision: 1,
+      syncStatus: "never" as const,
+      createdAt: "2026-07-25T00:00:00.000Z",
+      updatedAt: "2026-07-25T00:00:00.000Z",
+    };
+
+    await expect(database.upstreamMcpServerStore.createServer(server)).resolves.toBe(true);
+    await expect(database.upstreamMcpServerStore.createServer(server)).resolves.toBe(false);
+    await expect(
+      database.upstreamMcpServerStore.applySync({
+        expectedRevision: 1,
+        server: {
+          ...server,
+          revision: 2,
+          syncStatus: "ok",
+          lastSyncAt: "2026-07-25T00:01:00.000Z",
+          updatedAt: "2026-07-25T00:01:00.000Z",
+        },
+        tools: [
+          {
+            service: server.service,
+            upstreamName: "search",
+            actionName: "search",
+            description: "Search records.",
+            inputSchema: { type: "object" },
+            contractHash: "hash-1",
+            enabled: false,
+            status: "available",
+            firstSeenAt: "2026-07-25T00:01:00.000Z",
+            lastSeenAt: "2026-07-25T00:01:00.000Z",
+          },
+        ],
+        result: {
+          service: server.service,
+          discovered: 1,
+          added: 1,
+          changed: 0,
+          unchanged: 0,
+          removed: 0,
+          invalid: 0,
+          syncedAt: "2026-07-25T00:01:00.000Z",
+        },
+      }),
+    ).resolves.toMatchObject({ revision: 2, added: 1 });
+
+    await expect(
+      database.upstreamMcpServerStore.applySync({
+        expectedRevision: 1,
+        server: {
+          ...server,
+          revision: 3,
+          syncStatus: "ok",
+          lastSyncAt: "2026-07-25T00:01:30.000Z",
+          updatedAt: "2026-07-25T00:01:30.000Z",
+        },
+        tools: [],
+        result: {
+          service: server.service,
+          discovered: 0,
+          added: 0,
+          changed: 0,
+          unchanged: 0,
+          removed: 1,
+          invalid: 0,
+          syncedAt: "2026-07-25T00:01:30.000Z",
+        },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(database.upstreamMcpServerStore.getServerWithTools(server.service)).resolves.toMatchObject({
+      server: { revision: 2 },
+      tools: [{ upstreamName: "search" }],
+    });
+
+    await expect(
+      database.upstreamMcpServerStore.setEnabledTools({
+        service: server.service,
+        expectedRevision: 2,
+        enabledTools: ["search"],
+        updatedAt: "2026-07-25T00:02:00.000Z",
+      }),
+    ).resolves.toEqual({
+      service: server.service,
+      revision: 3,
+      enabledTools: ["search"],
+    });
+    await expect(database.upstreamMcpServerStore.listEnabledServersWithTools()).resolves.toMatchObject([
+      {
+        server: { service: server.service, revision: 3 },
+        tools: [{ upstreamName: "search", enabled: true }],
+      },
+    ]);
+    await expect(
+      database.upstreamMcpServerStore.setEnabledTools({
+        service: server.service,
+        expectedRevision: 2,
+        enabledTools: [],
+        updatedAt: "2026-07-25T00:03:00.000Z",
+      }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 function createRun(id: string, startedAt: string, actionId = "hackernews.get_top_stories", service = "hackernews") {
@@ -445,10 +555,32 @@ class SqliteD1Database implements D1DatabaseBinding {
     this.database.exec(
       readFileSync(new URL("../../../migrations/0008_runtime_token_policy.sql", import.meta.url), "utf8"),
     );
+    this.database.exec(readFileSync(new URL("../../../migrations/0009_upstream_mcp.sql", import.meta.url), "utf8"));
   }
 
   prepare(query: string): D1PreparedStatementBinding {
     return new SqliteD1PreparedStatement(this.database, query);
+  }
+
+  async batch(
+    statements: D1PreparedStatementBinding[],
+  ): Promise<Array<{ success: boolean; meta: { changes?: number } }>> {
+    this.database.exec("begin");
+    try {
+      const results = await Promise.all(
+        statements.map(async (statement) => {
+          if (!(statement instanceof SqliteD1PreparedStatement)) {
+            throw new Error("Unsupported D1 statement implementation.");
+          }
+          return await statement.run();
+        }),
+      );
+      this.database.exec("commit");
+      return results;
+    } catch (error) {
+      this.database.exec("rollback");
+      throw error;
+    }
   }
 
   exec(sql: string): void {

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -1,6 +1,18 @@
 import type { IConnectionStore, StoredConnection } from "../../connection-service.ts";
 import type { TokenActionPolicy } from "../../core/action-policy.ts";
 import type { ResolvedCredential } from "../../core/types.ts";
+import type {
+  ApplyUpstreamMcpSyncInput,
+  IUpstreamMcpServerStore,
+  SetUpstreamMcpToolsStoreInput,
+} from "../../mcp-upstream/mcp-server-store.ts";
+import type {
+  UpstreamMcpServer,
+  UpstreamMcpServerWithTools,
+  UpstreamMcpSyncResult,
+  UpstreamMcpTool,
+  UpstreamMcpToolSelectionResult,
+} from "../../mcp-upstream/types.ts";
 import type { IOAuthClientConfigStore, OAuthClientConfig } from "../../oauth/oauth-client-config-service.ts";
 import type { IOAuthStateStore, OAuthAuthorizationState } from "../../oauth/oauth-flow-service.ts";
 import type { D1DatabaseBinding } from "../cloudflare/cloudflare-bindings.ts";
@@ -16,6 +28,13 @@ import type { IRuntimePolicyStore, RuntimePolicyRecord } from "./runtime-policy-
 import type { IRunLogStore, RunLog, RunLogListInput, RunLogPage, RunLogWriteResult } from "./runtime-store.ts";
 import type { IRuntimeTokenStore, RuntimeTokenRecord } from "./runtime-token-service.ts";
 
+import {
+  readUpstreamMcpInteger,
+  readUpstreamMcpServerRow,
+  readUpstreamMcpToolRow,
+  upstreamMcpServerValues,
+  upstreamMcpToolValues,
+} from "../../mcp-upstream/storage-codec.ts";
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
 import { DEFAULT_RUN_LIMIT, decodeRunLogCursor, encodeRunLogCursor } from "./runtime-store.ts";
@@ -36,6 +55,7 @@ export class D1RuntimeDatabase implements RuntimeDatabase {
   readonly runtimePolicyStore: D1RuntimePolicyStore;
   readonly runLogStore: D1RunLogStore;
   readonly idempotencyStore: D1IdempotencyStore;
+  readonly upstreamMcpServerStore: D1UpstreamMcpServerStore;
 
   constructor(database: D1DatabaseBinding, options: D1RuntimeDatabaseOptions = {}) {
     const secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
@@ -46,6 +66,312 @@ export class D1RuntimeDatabase implements RuntimeDatabase {
     this.runtimePolicyStore = new D1RuntimePolicyStore(database);
     this.runLogStore = new D1RunLogStore(database, options.runLimit ?? DEFAULT_RUN_LIMIT);
     this.idempotencyStore = new D1IdempotencyStore(database, secretCodec);
+    this.upstreamMcpServerStore = new D1UpstreamMcpServerStore(database);
+  }
+}
+
+export class D1UpstreamMcpServerStore implements IUpstreamMcpServerStore {
+  private readonly database: D1DatabaseBinding;
+
+  constructor(database: D1DatabaseBinding) {
+    this.database = database;
+  }
+
+  async getCatalogRevision(): Promise<number> {
+    const row = await this.database.prepare("select revision from mcp_catalog_state where id = 1").first<RuntimeRow>();
+    return readUpstreamMcpInteger(row, "revision");
+  }
+
+  async listServers(): Promise<UpstreamMcpServer[]> {
+    const { results } = await this.database
+      .prepare("select * from mcp_servers order by display_name, service")
+      .all<RuntimeRow>();
+    return results.map(readUpstreamMcpServerRow);
+  }
+
+  async getServer(service: string): Promise<UpstreamMcpServer | undefined> {
+    const row = await this.database
+      .prepare("select * from mcp_servers where service = ?")
+      .bind(service)
+      .first<RuntimeRow>();
+    return row ? readUpstreamMcpServerRow(row) : undefined;
+  }
+
+  async getServerWithTools(service: string): Promise<UpstreamMcpServerWithTools | undefined> {
+    const server = await this.getServer(service);
+    if (!server) {
+      return undefined;
+    }
+    return { server, tools: await this.listTools(service) };
+  }
+
+  async listEnabledServersWithTools(): Promise<UpstreamMcpServerWithTools[]> {
+    const { results } = await this.database
+      .prepare("select * from mcp_servers where enabled = 1 order by service")
+      .all<RuntimeRow>();
+    return await Promise.all(
+      results.map(async (row) => {
+        const server = readUpstreamMcpServerRow(row);
+        const tools = await this.listTools(server.service);
+        return {
+          server,
+          tools: tools.filter((tool) => tool.enabled && tool.status === "available"),
+        };
+      }),
+    );
+  }
+
+  async createServer(server: UpstreamMcpServer): Promise<boolean> {
+    try {
+      await this.database.batch([
+        this.bindServerInsert(server),
+        this.database
+          .prepare(
+            "update mcp_catalog_state set revision = revision + 1, updated_at = ? where id = 1 and changes() > 0",
+          )
+          .bind(server.updatedAt),
+      ]);
+      return true;
+    } catch (error) {
+      if (isD1ConstraintError(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async updateServer(server: UpstreamMcpServer): Promise<boolean> {
+    const results = await this.database.batch([
+      this.database
+        .prepare(
+          `
+          update mcp_servers
+          set display_name = ?, description = ?, endpoint = ?, auth_type = ?, header_name = ?,
+              enabled = ?, revision = ?, sync_status = ?, last_sync_at = ?, last_sync_error = ?,
+              updated_at = ?, mutation_token = ?
+          where service = ?
+        `,
+        )
+        .bind(
+          server.displayName,
+          server.description ?? null,
+          server.endpoint,
+          server.auth.type,
+          server.auth.type === "api_key_header" ? server.auth.headerName : null,
+          server.enabled ? 1 : 0,
+          server.revision,
+          server.syncStatus,
+          server.lastSyncAt ?? null,
+          server.lastSyncError ?? null,
+          server.updatedAt,
+          crypto.randomUUID(),
+          server.service,
+        ),
+      this.database
+        .prepare("update mcp_catalog_state set revision = revision + 1, updated_at = ? where id = 1 and changes() > 0")
+        .bind(server.updatedAt),
+    ]);
+    return (results[0]?.meta.changes ?? 0) > 0;
+  }
+
+  async deleteServer(service: string): Promise<boolean> {
+    const results = await this.database.batch([
+      this.database.prepare("delete from mcp_server_tools where service = ?").bind(service),
+      this.database.prepare("delete from connections where service = ?").bind(service),
+      this.database.prepare("delete from mcp_servers where service = ?").bind(service),
+      this.database
+        .prepare("update mcp_catalog_state set revision = revision + 1, updated_at = ? where id = 1 and changes() > 0")
+        .bind(new Date().toISOString()),
+    ]);
+    return (results[2]?.meta.changes ?? 0) > 0;
+  }
+
+  async applySync(input: ApplyUpstreamMcpSyncInput): Promise<UpstreamMcpSyncResult | undefined> {
+    const mutationToken = crypto.randomUUID();
+    const statements = [
+      this.bindServerSyncUpdate(input.server, input.expectedRevision, mutationToken),
+      this.database
+        .prepare(
+          `
+          delete from mcp_server_tools
+          where service = ?
+            and exists (select 1 from mcp_servers where service = ? and mutation_token = ?)
+        `,
+        )
+        .bind(input.server.service, input.server.service, mutationToken),
+      ...input.tools.map((tool) => this.bindConditionalToolInsert(tool, mutationToken)),
+      this.database
+        .prepare(
+          `
+          update mcp_catalog_state
+          set revision = revision + 1, updated_at = ?
+          where id = 1
+            and exists (select 1 from mcp_servers where service = ? and mutation_token = ?)
+        `,
+        )
+        .bind(input.result.syncedAt, input.server.service, mutationToken),
+    ];
+    const results = await this.database.batch(statements);
+    if ((results[0]?.meta.changes ?? 0) === 0) {
+      return undefined;
+    }
+    return { ...input.result, revision: input.server.revision };
+  }
+
+  async recordSyncError(
+    service: string,
+    expectedRevision: number,
+    message: string,
+    updatedAt: string,
+  ): Promise<boolean> {
+    const result = await this.database
+      .prepare(
+        `
+        update mcp_servers
+        set sync_status = 'error', last_sync_error = ?, updated_at = ?, mutation_token = ?
+        where service = ? and revision = ?
+      `,
+      )
+      .bind(message, updatedAt, crypto.randomUUID(), service, expectedRevision)
+      .run();
+    return (result.meta.changes ?? 0) > 0;
+  }
+
+  async setEnabledTools(input: SetUpstreamMcpToolsStoreInput): Promise<UpstreamMcpToolSelectionResult | undefined> {
+    const server = await this.getServer(input.service);
+    if (!server || server.revision !== input.expectedRevision) {
+      return undefined;
+    }
+    const tools = await this.listTools(input.service);
+    const available = new Set(tools.filter((tool) => tool.status !== "removed").map((tool) => tool.upstreamName));
+    if (input.enabledTools.some((toolName) => !available.has(toolName))) {
+      return undefined;
+    }
+
+    const nextRevision = input.expectedRevision + 1;
+    const mutationToken = crypto.randomUUID();
+    const statements = [
+      this.database
+        .prepare(
+          `
+          update mcp_servers
+          set revision = ?, updated_at = ?, mutation_token = ?
+          where service = ? and revision = ?
+        `,
+        )
+        .bind(nextRevision, input.updatedAt, mutationToken, input.service, input.expectedRevision),
+      this.database
+        .prepare(
+          `
+          update mcp_server_tools
+          set enabled = 0
+          where service = ?
+            and exists (
+              select 1 from mcp_servers where service = ? and mutation_token = ?
+            )
+        `,
+        )
+        .bind(input.service, input.service, mutationToken),
+      ...input.enabledTools.map((toolName) =>
+        this.database
+          .prepare(
+            `
+            update mcp_server_tools
+            set enabled = 1, status = 'available'
+            where service = ? and upstream_name = ?
+              and exists (
+                select 1 from mcp_servers where service = ? and mutation_token = ?
+              )
+          `,
+          )
+          .bind(input.service, toolName, input.service, mutationToken),
+      ),
+      this.database
+        .prepare(
+          `
+          update mcp_catalog_state
+          set revision = revision + 1, updated_at = ?
+          where id = 1 and exists (
+            select 1 from mcp_servers where service = ? and mutation_token = ?
+          )
+        `,
+        )
+        .bind(input.updatedAt, input.service, mutationToken),
+    ];
+    const results = await this.database.batch(statements);
+    if ((results[0]?.meta.changes ?? 0) === 0) {
+      return undefined;
+    }
+    return {
+      service: input.service,
+      revision: nextRevision,
+      enabledTools: [...input.enabledTools].sort(),
+    };
+  }
+
+  private async listTools(service: string): Promise<UpstreamMcpTool[]> {
+    const { results } = await this.database
+      .prepare("select * from mcp_server_tools where service = ? order by upstream_name")
+      .bind(service)
+      .all<RuntimeRow>();
+    return results.map(readUpstreamMcpToolRow);
+  }
+
+  private bindServerInsert(server: UpstreamMcpServer) {
+    return this.database
+      .prepare(
+        `
+        insert into mcp_servers (
+          service, slug, display_name, description, endpoint, auth_type, header_name, enabled, revision,
+          sync_status, last_sync_at, last_sync_error, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .bind(...upstreamMcpServerValues(server));
+  }
+
+  private bindServerSyncUpdate(server: UpstreamMcpServer, expectedRevision: number, mutationToken: string) {
+    return this.database
+      .prepare(
+        `
+        update mcp_servers
+        set display_name = ?, description = ?, endpoint = ?, auth_type = ?, header_name = ?,
+            enabled = ?, revision = ?, sync_status = ?, last_sync_at = ?, last_sync_error = ?,
+            updated_at = ?, mutation_token = ?
+        where service = ? and revision = ?
+      `,
+      )
+      .bind(
+        server.displayName,
+        server.description ?? null,
+        server.endpoint,
+        server.auth.type,
+        server.auth.type === "api_key_header" ? server.auth.headerName : null,
+        server.enabled ? 1 : 0,
+        server.revision,
+        server.syncStatus,
+        server.lastSyncAt ?? null,
+        server.lastSyncError ?? null,
+        server.updatedAt,
+        mutationToken,
+        server.service,
+        expectedRevision,
+      );
+  }
+
+  private bindConditionalToolInsert(tool: UpstreamMcpTool, mutationToken: string) {
+    return this.database
+      .prepare(
+        `
+        insert into mcp_server_tools (
+          service, upstream_name, action_name, title, description, input_schema, output_schema, annotations,
+          contract_hash, enabled, status, invalid_reason, first_seen_at, last_seen_at
+        )
+        select ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        where exists (select 1 from mcp_servers where service = ? and mutation_token = ?)
+      `,
+      )
+      .bind(...upstreamMcpToolValues(tool), tool.service, mutationToken);
   }
 }
 
@@ -549,6 +875,10 @@ function readOptionalString(row: RuntimeRow, key: string): string | undefined {
   }
 
   return value;
+}
+
+function isD1ConstraintError(error: unknown): boolean {
+  return error instanceof Error && /constraint|unique/i.test(error.message);
 }
 
 function parseJson<T>(value: string): T {

--- a/src/server/storage/runtime-database.ts
+++ b/src/server/storage/runtime-database.ts
@@ -1,4 +1,5 @@
 import type { IConnectionStore } from "../../connection-service.ts";
+import type { IUpstreamMcpServerStore } from "../../mcp-upstream/mcp-server-store.ts";
 import type { IOAuthClientConfigStore } from "../../oauth/oauth-client-config-service.ts";
 import type { IOAuthStateStore } from "../../oauth/oauth-flow-service.ts";
 import type { IIdempotencyStore } from "./idempotency-store.ts";
@@ -14,4 +15,5 @@ export interface RuntimeDatabase {
   runtimePolicyStore: IRuntimePolicyStore;
   runLogStore: IRunLogStore;
   idempotencyStore: IIdempotencyStore;
+  upstreamMcpServerStore: IUpstreamMcpServerStore;
 }

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -47,6 +47,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0006_connection_identity.sql",
       "0007_runtime_policy.sql",
       "0008_runtime_token_policy.sql",
+      "0009_upstream_mcp.sql",
     ];
     expect(entries.filter((entry) => entry.message === "sqlite migration started")).toEqual(
       migrations.map((migration) => ({ fields: { migration }, message: "sqlite migration started" })),

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -1,6 +1,18 @@
 import type { IConnectionStore, StoredConnection } from "../../connection-service.ts";
 import type { TokenActionPolicy } from "../../core/action-policy.ts";
 import type { ResolvedCredential, RuntimeLogger } from "../../core/types.ts";
+import type {
+  ApplyUpstreamMcpSyncInput,
+  IUpstreamMcpServerStore,
+  SetUpstreamMcpToolsStoreInput,
+} from "../../mcp-upstream/mcp-server-store.ts";
+import type {
+  UpstreamMcpServer,
+  UpstreamMcpServerWithTools,
+  UpstreamMcpSyncResult,
+  UpstreamMcpTool,
+  UpstreamMcpToolSelectionResult,
+} from "../../mcp-upstream/types.ts";
 import type { IOAuthClientConfigStore, OAuthClientConfig } from "../../oauth/oauth-client-config-service.ts";
 import type { IOAuthStateStore, OAuthAuthorizationState } from "../../oauth/oauth-flow-service.ts";
 import type { ISecretCodec } from "../secrets/secret-codec-core.ts";
@@ -17,6 +29,13 @@ import type { IRuntimeTokenStore, RuntimeTokenRecord } from "./runtime-token-ser
 
 import { readFileSync, readdirSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
+import {
+  readUpstreamMcpInteger,
+  readUpstreamMcpServerRow,
+  readUpstreamMcpToolRow,
+  upstreamMcpServerValues,
+  upstreamMcpToolValues,
+} from "../../mcp-upstream/storage-codec.ts";
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
 import { DEFAULT_RUN_LIMIT, decodeRunLogCursor, encodeRunLogCursor } from "./runtime-store.ts";
@@ -69,6 +88,7 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
   readonly runtimePolicyStore: SqliteRuntimePolicyStore;
   readonly runLogStore: SqliteRunLogStore;
   readonly idempotencyStore: SqliteIdempotencyStore;
+  readonly upstreamMcpServerStore: SqliteUpstreamMcpServerStore;
 
   private readonly database: DatabaseSync;
   private readonly secretCodec: ISecretCodec;
@@ -84,6 +104,7 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
     this.runtimePolicyStore = new SqliteRuntimePolicyStore(this.database);
     this.runLogStore = new SqliteRunLogStore(this.database, options.runLimit ?? DEFAULT_RUN_LIMIT);
     this.idempotencyStore = new SqliteIdempotencyStore(this.database, this.secretCodec);
+    this.upstreamMcpServerStore = new SqliteUpstreamMcpServerStore(this.database);
   }
 
   close(): void {
@@ -115,12 +136,249 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
       delete from runtime_policy;
       delete from runs;
       delete from idempotency_records;
+      delete from mcp_server_tools;
+      delete from mcp_servers;
+      update mcp_catalog_state set revision = 0, updated_at = '1970-01-01T00:00:00.000Z' where id = 1;
     `);
   }
 
   private initialize(logger?: RuntimeLogger): void {
     this.database.exec("pragma journal_mode = wal;");
     runSqliteMigrations(this.database, logger);
+  }
+}
+
+export class SqliteUpstreamMcpServerStore implements IUpstreamMcpServerStore {
+  private readonly database: DatabaseSync;
+
+  constructor(database: DatabaseSync) {
+    this.database = database;
+  }
+
+  async getCatalogRevision(): Promise<number> {
+    const row = this.database.prepare("select revision from mcp_catalog_state where id = 1").get();
+    return readUpstreamMcpInteger(row, "revision");
+  }
+
+  async listServers(): Promise<UpstreamMcpServer[]> {
+    return this.database
+      .prepare("select * from mcp_servers order by display_name, service")
+      .all()
+      .map(readUpstreamMcpServerRow);
+  }
+
+  async getServer(service: string): Promise<UpstreamMcpServer | undefined> {
+    const row = this.database.prepare("select * from mcp_servers where service = ?").get(service);
+    return row ? readUpstreamMcpServerRow(row) : undefined;
+  }
+
+  async getServerWithTools(service: string): Promise<UpstreamMcpServerWithTools | undefined> {
+    const server = await this.getServer(service);
+    if (!server) {
+      return undefined;
+    }
+    return {
+      server,
+      tools: this.listTools(service),
+    };
+  }
+
+  async listEnabledServersWithTools(): Promise<UpstreamMcpServerWithTools[]> {
+    const servers = this.database
+      .prepare("select * from mcp_servers where enabled = 1 order by service")
+      .all()
+      .map(readUpstreamMcpServerRow);
+    return servers.map((server) => ({
+      server,
+      tools: this.listTools(server.service).filter((tool) => tool.enabled && tool.status === "available"),
+    }));
+  }
+
+  async createServer(server: UpstreamMcpServer): Promise<boolean> {
+    try {
+      runInTransaction(this.database, () => {
+        this.insertServer(server);
+        incrementMcpCatalogRevision(this.database, server.updatedAt);
+      });
+      return true;
+    } catch (error) {
+      if (isSqliteConstraintError(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async updateServer(server: UpstreamMcpServer): Promise<boolean> {
+    return runInTransaction(this.database, () => {
+      const result = this.database
+        .prepare(
+          `
+          update mcp_servers
+          set display_name = ?, description = ?, endpoint = ?, auth_type = ?, header_name = ?,
+              enabled = ?, revision = ?, sync_status = ?, last_sync_at = ?, last_sync_error = ?,
+              updated_at = ?, mutation_token = ?
+          where service = ?
+        `,
+        )
+        .run(
+          server.displayName,
+          server.description ?? null,
+          server.endpoint,
+          server.auth.type,
+          server.auth.type === "api_key_header" ? server.auth.headerName : null,
+          server.enabled ? 1 : 0,
+          server.revision,
+          server.syncStatus,
+          server.lastSyncAt ?? null,
+          server.lastSyncError ?? null,
+          server.updatedAt,
+          crypto.randomUUID(),
+          server.service,
+        );
+      if (result.changes === 0) {
+        return false;
+      }
+      incrementMcpCatalogRevision(this.database, server.updatedAt);
+      return true;
+    });
+  }
+
+  async deleteServer(service: string): Promise<boolean> {
+    return runInTransaction(this.database, () => {
+      this.database.prepare("delete from mcp_server_tools where service = ?").run(service);
+      this.database.prepare("delete from connections where service = ?").run(service);
+      const result = this.database.prepare("delete from mcp_servers where service = ?").run(service);
+      if (result.changes === 0) {
+        return false;
+      }
+      incrementMcpCatalogRevision(this.database, new Date().toISOString());
+      return true;
+    });
+  }
+
+  async applySync(input: ApplyUpstreamMcpSyncInput): Promise<UpstreamMcpSyncResult | undefined> {
+    return runInTransaction(this.database, () => {
+      const serverRow = this.database
+        .prepare("select revision from mcp_servers where service = ?")
+        .get(input.server.service);
+      if (!serverRow || readUpstreamMcpInteger(serverRow, "revision") !== input.expectedRevision) {
+        return undefined;
+      }
+      this.database.prepare("delete from mcp_server_tools where service = ?").run(input.server.service);
+      const statement = this.database.prepare(
+        `
+        insert into mcp_server_tools (
+          service, upstream_name, action_name, title, description, input_schema, output_schema, annotations,
+          contract_hash, enabled, status, invalid_reason, first_seen_at, last_seen_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      );
+      for (const tool of input.tools) {
+        statement.run(...upstreamMcpToolValues(tool));
+      }
+      this.upsertServer(input.server);
+      incrementMcpCatalogRevision(this.database, input.result.syncedAt);
+      return { ...input.result, revision: input.server.revision };
+    });
+  }
+
+  async recordSyncError(
+    service: string,
+    expectedRevision: number,
+    message: string,
+    updatedAt: string,
+  ): Promise<boolean> {
+    const result = this.database
+      .prepare(
+        `
+        update mcp_servers
+        set sync_status = 'error', last_sync_error = ?, updated_at = ?
+        where service = ? and revision = ?
+      `,
+      )
+      .run(message, updatedAt, service, expectedRevision);
+    return result.changes > 0;
+  }
+
+  async setEnabledTools(input: SetUpstreamMcpToolsStoreInput): Promise<UpstreamMcpToolSelectionResult | undefined> {
+    return runInTransaction(this.database, () => {
+      const row = this.database.prepare("select revision from mcp_servers where service = ?").get(input.service);
+      if (!row || readUpstreamMcpInteger(row, "revision") !== input.expectedRevision) {
+        return undefined;
+      }
+      const available = new Set(
+        this.database
+          .prepare("select upstream_name from mcp_server_tools where service = ? and status != 'removed'")
+          .all(input.service)
+          .map((toolRow) => readString(toolRow, "upstream_name")),
+      );
+      if (input.enabledTools.some((toolName) => !available.has(toolName))) {
+        return undefined;
+      }
+      this.database.prepare("update mcp_server_tools set enabled = 0 where service = ?").run(input.service);
+      const enable = this.database.prepare(
+        "update mcp_server_tools set enabled = 1, status = 'available' where service = ? and upstream_name = ?",
+      );
+      for (const toolName of input.enabledTools) {
+        enable.run(input.service, toolName);
+      }
+      const nextServerRevision = input.expectedRevision + 1;
+      this.database
+        .prepare("update mcp_servers set revision = ?, updated_at = ? where service = ?")
+        .run(nextServerRevision, input.updatedAt, input.service);
+      incrementMcpCatalogRevision(this.database, input.updatedAt);
+      return {
+        service: input.service,
+        revision: nextServerRevision,
+        enabledTools: [...input.enabledTools].sort(),
+      };
+    });
+  }
+
+  private listTools(service: string): UpstreamMcpTool[] {
+    return this.database
+      .prepare("select * from mcp_server_tools where service = ? order by upstream_name")
+      .all(service)
+      .map(readUpstreamMcpToolRow);
+  }
+
+  private insertServer(server: UpstreamMcpServer): void {
+    this.database
+      .prepare(
+        `
+        insert into mcp_servers (
+          service, slug, display_name, description, endpoint, auth_type, header_name, enabled, revision,
+          sync_status, last_sync_at, last_sync_error, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(...upstreamMcpServerValues(server));
+  }
+
+  private upsertServer(server: UpstreamMcpServer): void {
+    this.database
+      .prepare(
+        `
+        insert into mcp_servers (
+          service, slug, display_name, description, endpoint, auth_type, header_name, enabled, revision,
+          sync_status, last_sync_at, last_sync_error, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        on conflict(service) do update set
+          display_name = excluded.display_name,
+          description = excluded.description,
+          endpoint = excluded.endpoint,
+          auth_type = excluded.auth_type,
+          header_name = excluded.header_name,
+          enabled = excluded.enabled,
+          revision = excluded.revision,
+          sync_status = excluded.sync_status,
+          last_sync_at = excluded.last_sync_at,
+          last_sync_error = excluded.last_sync_error,
+          updated_at = excluded.updated_at
+      `,
+      )
+      .run(...upstreamMcpServerValues(server));
   }
 }
 
@@ -782,6 +1040,24 @@ function readOptionalString(row: unknown, key: string): string | undefined {
   }
 
   return value;
+}
+
+function incrementMcpCatalogRevision(database: DatabaseSync, updatedAt: string): number {
+  const row = database
+    .prepare(
+      `
+      update mcp_catalog_state
+      set revision = revision + 1, updated_at = ?
+      where id = 1
+      returning revision
+    `,
+    )
+    .get(updatedAt);
+  return readUpstreamMcpInteger(row, "revision");
+}
+
+function isSqliteConstraintError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && String(error.code).startsWith("SQLITE_CONSTRAINT");
 }
 
 function parseJson<T>(value: string): T {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "Overview",
     "providers": "Providers",
+    "mcpServers": "MCP Servers",
     "actions": "Actions",
     "runs": "Runs",
     "access": "API Key",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "Providers",
         "subtitle": "Connect providers and review provider capabilities."
+      },
+      "mcpServers": {
+        "title": "MCP Servers",
+        "subtitle": "Configure upstream MCP servers and published tools."
       },
       "actions": {
         "title": "Actions",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} calls",
     "noRecentCallsTitle": "No recent calls",
     "noRecentCallsDescription": "Run an action to see provider call counts."
+  },
+  "mcpServers": {
+    "title": "Upstream MCP Servers",
+    "description": "Connect Streamable HTTP MCP servers and publish approved tools as actions.",
+    "add": "Add server",
+    "create": "Create and sync",
+    "creating": "Creating and synchronizing MCP server...",
+    "created": "MCP server created.",
+    "sync": "Sync",
+    "syncing": "Synchronizing tool contracts...",
+    "synced": "Tool contracts synchronized.",
+    "enable": "Enable",
+    "disable": "Disable",
+    "delete": "Delete",
+    "deleteConfirm": "Delete {{name}} and its stored connections?",
+    "revision": "Revision",
+    "reviewRequired": "Review required",
+    "tools": "Published tools",
+    "toolsDescription": "New and changed tools stay disabled until you approve them.",
+    "saveTools": "Save tool selection",
+    "savingTools": "Saving tool selection...",
+    "toolsSaved": "Tool selection saved.",
+    "emptyTitle": "No upstream MCP servers",
+    "emptyDescription": "Add a Streamable HTTP endpoint to make its approved tools available to agents.",
+    "noToolsTitle": "No discovered tools",
+    "noToolsDescription": "Synchronize the server to load its tool contracts.",
+    "fields": {
+      "name": "Display name",
+      "slug": "Slug",
+      "endpoint": "MCP endpoint",
+      "auth": "Authentication",
+      "headerName": "API key header",
+      "credential": "Credential"
+    },
+    "auth": {
+      "none": "No authentication",
+      "bearer": "Bearer token",
+      "apiKeyHeader": "Custom API key header"
+    },
+    "syncStatus": {
+      "never": "Not synchronized",
+      "ok": "Synchronized",
+      "error": "Sync failed"
+    },
+    "toolStatus": {
+      "available": "Available",
+      "review_required": "Review required",
+      "removed": "Removed upstream",
+      "invalid": "Invalid contract"
+    }
   },
   "providers": {
     "catalogTitle": "Providers",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "Vue d’ensemble",
     "providers": "Fournisseurs",
+    "mcpServers": "Serveurs MCP",
     "actions": "Actions",
     "runs": "Exécutions",
     "access": "API Key",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "Fournisseurs",
         "subtitle": "Connectez des fournisseurs et examinez leurs capacités."
+      },
+      "mcpServers": {
+        "title": "Serveurs MCP",
+        "subtitle": "Configurez les serveurs MCP en amont et les outils publiés."
       },
       "actions": {
         "title": "Actions",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} appels",
     "noRecentCallsTitle": "Aucun appel récent",
     "noRecentCallsDescription": "Exécutez une action pour voir les appels par fournisseur."
+  },
+  "mcpServers": {
+    "title": "Serveurs MCP en amont",
+    "description": "Connectez des serveurs MCP Streamable HTTP et publiez les outils approuvés comme actions.",
+    "add": "Ajouter un serveur",
+    "create": "Créer et synchroniser",
+    "creating": "Création et synchronisation du serveur MCP...",
+    "created": "Serveur MCP créé.",
+    "sync": "Synchroniser",
+    "syncing": "Synchronisation des contrats d’outils...",
+    "synced": "Contrats d’outils synchronisés.",
+    "enable": "Activer",
+    "disable": "Désactiver",
+    "delete": "Supprimer",
+    "deleteConfirm": "Supprimer {{name}} et ses connexions enregistrées ?",
+    "revision": "Révision",
+    "reviewRequired": "Révision requise",
+    "tools": "Outils publiés",
+    "toolsDescription": "Les outils nouveaux ou modifiés restent désactivés jusqu’à leur approbation.",
+    "saveTools": "Enregistrer la sélection",
+    "savingTools": "Enregistrement de la sélection...",
+    "toolsSaved": "Sélection d’outils enregistrée.",
+    "emptyTitle": "Aucun serveur MCP en amont",
+    "emptyDescription": "Ajoutez un endpoint Streamable HTTP pour proposer les outils approuvés aux Agent.",
+    "noToolsTitle": "Aucun outil découvert",
+    "noToolsDescription": "Synchronisez le serveur pour charger les contrats d’outils.",
+    "fields": {
+      "name": "Nom affiché",
+      "slug": "Slug",
+      "endpoint": "Endpoint MCP",
+      "auth": "Authentification",
+      "headerName": "En-tête API Key",
+      "credential": "Identifiant"
+    },
+    "auth": {
+      "none": "Aucune authentification",
+      "bearer": "Bearer Token",
+      "apiKeyHeader": "En-tête API Key personnalisé"
+    },
+    "syncStatus": {
+      "never": "Non synchronisé",
+      "ok": "Synchronisé",
+      "error": "Échec de synchronisation"
+    },
+    "toolStatus": {
+      "available": "Disponible",
+      "review_required": "Révision requise",
+      "removed": "Supprimé en amont",
+      "invalid": "Contrat invalide"
+    }
   },
   "providers": {
     "catalogTitle": "Fournisseurs",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "概要",
     "providers": "プロバイダー",
+    "mcpServers": "MCP サーバー",
     "actions": "アクション",
     "runs": "実行履歴",
     "access": "API Key",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "プロバイダー",
         "subtitle": "プロバイダーを接続し、機能を確認します。"
+      },
+      "mcpServers": {
+        "title": "MCP サーバー",
+        "subtitle": "上流 MCP サーバーと公開ツールを設定します。"
       },
       "actions": {
         "title": "アクション",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} 回の呼び出し",
     "noRecentCallsTitle": "最近の呼び出しはありません",
     "noRecentCallsDescription": "アクションを実行するとプロバイダー別の呼び出し数が表示されます。"
+  },
+  "mcpServers": {
+    "title": "上流 MCP サーバー",
+    "description": "Streamable HTTP MCP サーバーを接続し、承認済みツールをアクションとして公開します。",
+    "add": "サーバーを追加",
+    "create": "作成して同期",
+    "creating": "MCP サーバーを作成して同期しています...",
+    "created": "MCP サーバーを作成しました。",
+    "sync": "同期",
+    "syncing": "ツール契約を同期しています...",
+    "synced": "ツール契約を同期しました。",
+    "enable": "有効化",
+    "disable": "無効化",
+    "delete": "削除",
+    "deleteConfirm": "{{name}} と保存済み接続を削除しますか？",
+    "revision": "リビジョン",
+    "reviewRequired": "レビューが必要",
+    "tools": "公開ツール",
+    "toolsDescription": "新規または変更されたツールは、承認するまで無効です。",
+    "saveTools": "ツール選択を保存",
+    "savingTools": "ツール選択を保存しています...",
+    "toolsSaved": "ツール選択を保存しました。",
+    "emptyTitle": "上流 MCP サーバーがありません",
+    "emptyDescription": "Streamable HTTP エンドポイントを追加して、承認済みツールを Agent に提供します。",
+    "noToolsTitle": "検出されたツールはありません",
+    "noToolsDescription": "サーバーを同期してツール契約を読み込んでください。",
+    "fields": {
+      "name": "表示名",
+      "slug": "スラッグ",
+      "endpoint": "MCP エンドポイント",
+      "auth": "認証",
+      "headerName": "API Key ヘッダー",
+      "credential": "認証情報"
+    },
+    "auth": {
+      "none": "認証なし",
+      "bearer": "Bearer Token",
+      "apiKeyHeader": "カスタム API Key ヘッダー"
+    },
+    "syncStatus": {
+      "never": "未同期",
+      "ok": "同期済み",
+      "error": "同期失敗"
+    },
+    "toolStatus": {
+      "available": "利用可能",
+      "review_required": "レビューが必要",
+      "removed": "上流で削除済み",
+      "invalid": "無効な契約"
+    }
   },
   "providers": {
     "catalogTitle": "プロバイダー",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "Обзор",
     "providers": "Провайдеры",
+    "mcpServers": "MCP-серверы",
     "actions": "Действия",
     "runs": "Запуски",
     "access": "API Key",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "Провайдеры",
         "subtitle": "Подключайте провайдеры и проверяйте их возможности."
+      },
+      "mcpServers": {
+        "title": "MCP-серверы",
+        "subtitle": "Настройка внешних MCP-серверов и опубликованных инструментов."
       },
       "actions": {
         "title": "Действия",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} вызовов",
     "noRecentCallsTitle": "Недавних вызовов нет",
     "noRecentCallsDescription": "Запустите действие, чтобы увидеть вызовы по провайдерам."
+  },
+  "mcpServers": {
+    "title": "Внешние MCP-серверы",
+    "description": "Подключайте MCP-серверы Streamable HTTP и публикуйте одобренные инструменты как действия.",
+    "add": "Добавить сервер",
+    "create": "Создать и синхронизировать",
+    "creating": "Создание и синхронизация MCP-сервера...",
+    "created": "MCP-сервер создан.",
+    "sync": "Синхронизировать",
+    "syncing": "Синхронизация контрактов инструментов...",
+    "synced": "Контракты инструментов синхронизированы.",
+    "enable": "Включить",
+    "disable": "Отключить",
+    "delete": "Удалить",
+    "deleteConfirm": "Удалить {{name}} и сохранённые подключения?",
+    "revision": "Ревизия",
+    "reviewRequired": "Требуется проверка",
+    "tools": "Опубликованные инструменты",
+    "toolsDescription": "Новые и изменённые инструменты отключены до одобрения.",
+    "saveTools": "Сохранить выбор",
+    "savingTools": "Сохранение выбора инструментов...",
+    "toolsSaved": "Выбор инструментов сохранён.",
+    "emptyTitle": "Нет внешних MCP-серверов",
+    "emptyDescription": "Добавьте endpoint Streamable HTTP, чтобы предоставить Agent одобренные инструменты.",
+    "noToolsTitle": "Инструменты не обнаружены",
+    "noToolsDescription": "Синхронизируйте сервер для загрузки контрактов.",
+    "fields": {
+      "name": "Отображаемое имя",
+      "slug": "Slug",
+      "endpoint": "MCP endpoint",
+      "auth": "Аутентификация",
+      "headerName": "Заголовок API Key",
+      "credential": "Учётные данные"
+    },
+    "auth": {
+      "none": "Без аутентификации",
+      "bearer": "Bearer Token",
+      "apiKeyHeader": "Пользовательский заголовок API Key"
+    },
+    "syncStatus": {
+      "never": "Не синхронизирован",
+      "ok": "Синхронизирован",
+      "error": "Ошибка синхронизации"
+    },
+    "toolStatus": {
+      "available": "Доступен",
+      "review_required": "Требуется проверка",
+      "removed": "Удалён на сервере",
+      "invalid": "Недопустимый контракт"
+    }
   },
   "providers": {
     "catalogTitle": "Провайдеры",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "概览",
     "providers": "提供商",
+    "mcpServers": "MCP 服务器",
     "actions": "操作",
     "runs": "运行记录",
     "access": "API Key",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "提供商",
         "subtitle": "连接提供商并查看能力配置。"
+      },
+      "mcpServers": {
+        "title": "MCP 服务器",
+        "subtitle": "配置上游 MCP 服务器和对外开放的工具。"
       },
       "actions": {
         "title": "操作",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} 次调用",
     "noRecentCallsTitle": "暂无最近调用",
     "noRecentCallsDescription": "运行一个操作后会显示提供商调用次数。"
+  },
+  "mcpServers": {
+    "title": "上游 MCP 服务器",
+    "description": "接入 Streamable HTTP MCP 服务器，将审核通过的工具发布为操作。",
+    "add": "添加服务器",
+    "create": "创建并同步",
+    "creating": "正在创建并同步 MCP 服务器...",
+    "created": "MCP 服务器已创建。",
+    "sync": "同步",
+    "syncing": "正在同步工具契约...",
+    "synced": "工具契约已同步。",
+    "enable": "启用",
+    "disable": "停用",
+    "delete": "删除",
+    "deleteConfirm": "删除 {{name}} 及其已保存的连接吗？",
+    "revision": "修订版本",
+    "reviewRequired": "需要审核",
+    "tools": "发布的工具",
+    "toolsDescription": "新增和发生变更的工具默认停用，需要人工审核后启用。",
+    "saveTools": "保存工具选择",
+    "savingTools": "正在保存工具选择...",
+    "toolsSaved": "工具选择已保存。",
+    "emptyTitle": "尚未配置上游 MCP 服务器",
+    "emptyDescription": "添加 Streamable HTTP 端点，即可向 Agent 提供审核通过的工具。",
+    "noToolsTitle": "尚未发现工具",
+    "noToolsDescription": "请同步服务器以加载工具契约。",
+    "fields": {
+      "name": "显示名称",
+      "slug": "标识",
+      "endpoint": "MCP 端点",
+      "auth": "身份验证",
+      "headerName": "API Key 请求头",
+      "credential": "凭证"
+    },
+    "auth": {
+      "none": "无需身份验证",
+      "bearer": "Bearer Token",
+      "apiKeyHeader": "自定义 API Key 请求头"
+    },
+    "syncStatus": {
+      "never": "未同步",
+      "ok": "已同步",
+      "error": "同步失败"
+    },
+    "toolStatus": {
+      "available": "可用",
+      "review_required": "需要审核",
+      "removed": "上游已移除",
+      "invalid": "契约无效"
+    }
   },
   "providers": {
     "catalogTitle": "提供商",

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -40,6 +40,7 @@
   "nav": {
     "overview": "總覽",
     "providers": "服務提供者",
+    "mcpServers": "MCP 伺服器",
     "actions": "動作",
     "runs": "執行記錄",
     "access": "API 金鑰",
@@ -66,6 +67,10 @@
       "providers": {
         "title": "服務提供者",
         "subtitle": "連線至服務提供者並檢視其功能。"
+      },
+      "mcpServers": {
+        "title": "MCP 伺服器",
+        "subtitle": "設定上游 MCP 伺服器與已發佈工具。"
       },
       "actions": {
         "title": "動作",
@@ -118,6 +123,56 @@
     "callCountMany": "{{count}} 次呼叫",
     "noRecentCallsTitle": "沒有近期呼叫",
     "noRecentCallsDescription": "執行一個動作以查看服務提供者的呼叫次數。"
+  },
+  "mcpServers": {
+    "title": "上游 MCP 伺服器",
+    "description": "連接 Streamable HTTP MCP 伺服器，將審核通過的工具發佈為動作。",
+    "add": "新增伺服器",
+    "create": "建立並同步",
+    "creating": "正在建立並同步 MCP 伺服器...",
+    "created": "MCP 伺服器已建立。",
+    "sync": "同步",
+    "syncing": "正在同步工具契約...",
+    "synced": "工具契約已同步。",
+    "enable": "啟用",
+    "disable": "停用",
+    "delete": "刪除",
+    "deleteConfirm": "刪除 {{name}} 及其已儲存的連線嗎？",
+    "revision": "修訂版本",
+    "reviewRequired": "需要審核",
+    "tools": "已發佈工具",
+    "toolsDescription": "新增及變更的工具會維持停用，直到您核准為止。",
+    "saveTools": "儲存工具選擇",
+    "savingTools": "正在儲存工具選擇...",
+    "toolsSaved": "工具選擇已儲存。",
+    "emptyTitle": "沒有上游 MCP 伺服器",
+    "emptyDescription": "新增 Streamable HTTP 端點，讓 Agent 使用核准的工具。",
+    "noToolsTitle": "尚未發現工具",
+    "noToolsDescription": "請同步伺服器以載入工具契約。",
+    "fields": {
+      "name": "顯示名稱",
+      "slug": "代稱",
+      "endpoint": "MCP 端點",
+      "auth": "驗證",
+      "headerName": "API Key 標頭",
+      "credential": "憑證"
+    },
+    "auth": {
+      "none": "無需驗證",
+      "bearer": "Bearer Token",
+      "apiKeyHeader": "自訂 API Key 標頭"
+    },
+    "syncStatus": {
+      "never": "尚未同步",
+      "ok": "已同步",
+      "error": "同步失敗"
+    },
+    "toolStatus": {
+      "available": "可用",
+      "review_required": "需要審核",
+      "removed": "上游已移除",
+      "invalid": "契約無效"
+    }
   },
   "providers": {
     "catalogTitle": "服務提供者",

--- a/web/src/mcp-servers-page.test.ts
+++ b/web/src/mcp-servers-page.test.ts
@@ -1,0 +1,18 @@
+import { I18nProvider } from "@embra/i18n/react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { createAppI18n } from "./i18n";
+import { McpServersPage } from "./mcp-servers-page";
+
+describe("McpServersPage", () => {
+  it("renders the empty-state registration workflow", () => {
+    const markup = renderToStaticMarkup(
+      createElement(I18nProvider, { i18n: createAppI18n("en") }, createElement(McpServersPage, { onRefresh() {} })),
+    );
+
+    expect(markup).toContain("Upstream MCP Servers");
+    expect(markup).toContain("Add server");
+    expect(markup).toContain("No upstream MCP servers");
+  });
+});

--- a/web/src/mcp-servers-page.tsx
+++ b/web/src/mcp-servers-page.tsx
@@ -1,0 +1,420 @@
+import type { UpstreamMcpAuth, UpstreamMcpServer, UpstreamMcpServerWithTools } from "./model";
+import type { FormEvent, ReactNode } from "react";
+
+import { useTranslate } from "@embra/i18n/react";
+import { Check, Loader2, Plus, RefreshCw, Save, Server, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { apiDelete, apiGet, apiPost, apiPut } from "./api";
+import { Badge, EmptyState, FormStatus, InlineError } from "./shared-ui";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+interface McpServersPageProps {
+  onRefresh(): void;
+}
+
+type AuthType = UpstreamMcpAuth["type"];
+
+export function McpServersPage(props: McpServersPageProps): ReactNode {
+  const t = useTranslate();
+  const [servers, setServers] = useState<UpstreamMcpServer[]>([]);
+  const [selectedService, setSelectedService] = useState("");
+  const [detail, setDetail] = useState<UpstreamMcpServerWithTools | null>(null);
+  const [enabledTools, setEnabledTools] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [slug, setSlug] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [endpoint, setEndpoint] = useState("");
+  const [authType, setAuthType] = useState<AuthType>("none");
+  const [headerName, setHeaderName] = useState("X-API-Key");
+  const [credential, setCredential] = useState("");
+
+  const currentServer = servers.find((server) => server.service === selectedService);
+  const reviewCount = useMemo(
+    () => detail?.tools.filter((tool) => tool.status === "review_required").length ?? 0,
+    [detail],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void apiGet<UpstreamMcpServer[]>("/api/mcp-servers")
+      .then((value) => {
+        if (!cancelled) {
+          setServers(value);
+        }
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(errorMessage(caught));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (servers.length === 0) {
+      setSelectedService("");
+      setDetail(null);
+      return;
+    }
+    if (!servers.some((server) => server.service === selectedService)) {
+      setSelectedService(servers[0]!.service);
+    }
+  }, [servers, selectedService]);
+
+  useEffect(() => {
+    if (!selectedService) {
+      return;
+    }
+    let cancelled = false;
+    void apiGet<UpstreamMcpServerWithTools>(`/api/mcp-servers/${encodeURIComponent(selectedService)}`)
+      .then((value) => {
+        if (!cancelled) {
+          setDetail(value);
+          setEnabledTools(value.tools.filter((tool) => tool.enabled).map((tool) => tool.upstreamName));
+        }
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(errorMessage(caught));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedService, servers]);
+
+  async function createServer(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setBusy(true);
+    setError(null);
+    setStatus(t("mcpServers.creating"));
+    try {
+      const auth: UpstreamMcpAuth = authType === "api_key_header" ? { type: authType, headerName } : { type: authType };
+      const created = await apiPost<UpstreamMcpServerWithTools>("/api/mcp-servers", {
+        slug,
+        displayName,
+        endpoint,
+        auth,
+        credential: authType === "none" ? undefined : credential,
+        sync: true,
+      });
+      setSelectedService(created.server.service);
+      setCreating(false);
+      setSlug("");
+      setDisplayName("");
+      setEndpoint("");
+      setCredential("");
+      setStatus(t("mcpServers.created"));
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setStatus(null);
+    } finally {
+      await refreshAfterMutation();
+      setBusy(false);
+    }
+  }
+
+  async function syncServer(): Promise<void> {
+    if (!detail) return;
+    setBusy(true);
+    setError(null);
+    setStatus(t("mcpServers.syncing"));
+    try {
+      await apiPost(`/api/mcp-servers/${encodeURIComponent(detail.server.service)}/sync`, {});
+      setStatus(t("mcpServers.synced"));
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setStatus(null);
+    } finally {
+      await refreshAfterMutation();
+      setBusy(false);
+    }
+  }
+
+  async function saveTools(): Promise<void> {
+    if (!detail) return;
+    setBusy(true);
+    setError(null);
+    setStatus(t("mcpServers.savingTools"));
+    try {
+      await apiPut(`/api/mcp-servers/${encodeURIComponent(detail.server.service)}/tools`, {
+        expectedRevision: detail.server.revision,
+        enabledTools,
+      });
+      setStatus(t("mcpServers.toolsSaved"));
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setStatus(null);
+    } finally {
+      await refreshAfterMutation();
+      setBusy(false);
+    }
+  }
+
+  async function toggleServer(): Promise<void> {
+    if (!detail) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiPut(`/api/mcp-servers/${encodeURIComponent(detail.server.service)}`, {
+        enabled: !detail.server.enabled,
+        sync: false,
+      });
+    } catch (caught) {
+      setError(errorMessage(caught));
+    } finally {
+      await refreshAfterMutation();
+      setBusy(false);
+    }
+  }
+
+  async function deleteServer(): Promise<void> {
+    if (!detail || !window.confirm(t("mcpServers.deleteConfirm", { name: detail.server.displayName }))) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await apiDelete(`/api/mcp-servers/${encodeURIComponent(detail.server.service)}`);
+      setSelectedService("");
+      setDetail(null);
+    } catch (caught) {
+      setError(errorMessage(caught));
+    } finally {
+      await refreshAfterMutation();
+      setBusy(false);
+    }
+  }
+
+  async function refreshAfterMutation(): Promise<void> {
+    await reloadServers(setServers).catch(() => undefined);
+    props.onRefresh();
+  }
+
+  function toggleTool(name: string): void {
+    setEnabledTools((current) =>
+      current.includes(name) ? current.filter((candidate) => candidate !== name) : [...current, name],
+    );
+  }
+
+  return (
+    <section className="mcp-servers-page">
+      <div className="mcp-servers-toolbar">
+        <div>
+          <h2>{t("mcpServers.title")}</h2>
+          <p>{t("mcpServers.description")}</p>
+        </div>
+        <Button onClick={() => setCreating((value) => !value)}>
+          <Plus size={15} />
+          {t("mcpServers.add")}
+        </Button>
+      </div>
+
+      {error ? <InlineError message={error} /> : null}
+      {status ? <FormStatus message={status} /> : null}
+
+      {creating ? (
+        <Card className="mcp-create-card">
+          <form className="mcp-create-grid" onSubmit={createServer}>
+            <Label className="field">
+              <span>{t("mcpServers.fields.name")}</span>
+              <Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} required />
+            </Label>
+            <Label className="field">
+              <span>{t("mcpServers.fields.slug")}</span>
+              <Input
+                value={slug}
+                onChange={(event) => setSlug(event.target.value.toLowerCase())}
+                pattern="[a-z][a-z0-9-]*"
+                required
+              />
+            </Label>
+            <Label className="field mcp-wide-field">
+              <span>{t("mcpServers.fields.endpoint")}</span>
+              <Input
+                type="url"
+                value={endpoint}
+                onChange={(event) => setEndpoint(event.target.value)}
+                placeholder="https://mcp.example.com/mcp"
+                required
+              />
+            </Label>
+            <Label className="field">
+              <span>{t("mcpServers.fields.auth")}</span>
+              <Select value={authType} onValueChange={(value) => setAuthType(value as AuthType)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">{t("mcpServers.auth.none")}</SelectItem>
+                  <SelectItem value="bearer">{t("mcpServers.auth.bearer")}</SelectItem>
+                  <SelectItem value="api_key_header">{t("mcpServers.auth.apiKeyHeader")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </Label>
+            {authType === "api_key_header" ? (
+              <Label className="field">
+                <span>{t("mcpServers.fields.headerName")}</span>
+                <Input value={headerName} onChange={(event) => setHeaderName(event.target.value)} required />
+              </Label>
+            ) : null}
+            {authType !== "none" ? (
+              <Label className="field">
+                <span>{t("mcpServers.fields.credential")}</span>
+                <Input
+                  type="password"
+                  value={credential}
+                  onChange={(event) => setCredential(event.target.value)}
+                  required
+                />
+              </Label>
+            ) : null}
+            <div className="button-row mcp-wide-field">
+              <Button type="submit" disabled={busy}>
+                {busy ? <Loader2 className="spin" size={15} /> : <Check size={15} />}
+                {t("mcpServers.create")}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => setCreating(false)}>
+                {t("common.close")}
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      {servers.length === 0 && !creating ? (
+        <EmptyState
+          title={t("mcpServers.emptyTitle")}
+          description={t("mcpServers.emptyDescription")}
+          icon={<Server />}
+        />
+      ) : (
+        <div className="mcp-server-layout">
+          <Card className="mcp-server-list">
+            {servers.map((server) => (
+              <button
+                type="button"
+                key={server.service}
+                className={server.service === selectedService ? "mcp-server-row active" : "mcp-server-row"}
+                onClick={() => setSelectedService(server.service)}
+              >
+                <span>
+                  <strong>{server.displayName}</strong>
+                  <small>{server.endpoint}</small>
+                </span>
+                <Badge tone={syncTone(server.syncStatus)}>{t(`mcpServers.syncStatus.${server.syncStatus}`)}</Badge>
+              </button>
+            ))}
+          </Card>
+
+          {detail && currentServer ? (
+            <Card className="mcp-server-detail">
+              <div className="mcp-detail-heading">
+                <div>
+                  <h3>{detail.server.displayName}</h3>
+                  <p>{detail.server.service}</p>
+                </div>
+                <div className="button-row">
+                  <Button variant="outline" size="sm" onClick={syncServer} disabled={busy}>
+                    <RefreshCw className={busy ? "spin" : ""} size={14} />
+                    {t("mcpServers.sync")}
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={toggleServer} disabled={busy}>
+                    {detail.server.enabled ? t("mcpServers.disable") : t("mcpServers.enable")}
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={deleteServer} disabled={busy}>
+                    <Trash2 size={14} />
+                    {t("mcpServers.delete")}
+                  </Button>
+                </div>
+              </div>
+              <dl className="mcp-server-meta">
+                <div>
+                  <dt>{t("mcpServers.fields.endpoint")}</dt>
+                  <dd>{detail.server.endpoint}</dd>
+                </div>
+                <div>
+                  <dt>{t("mcpServers.fields.auth")}</dt>
+                  <dd>{detail.server.auth.type}</dd>
+                </div>
+                <div>
+                  <dt>{t("mcpServers.revision")}</dt>
+                  <dd>{detail.server.revision}</dd>
+                </div>
+                <div>
+                  <dt>{t("mcpServers.reviewRequired")}</dt>
+                  <dd>{reviewCount}</dd>
+                </div>
+              </dl>
+              {detail.server.lastSyncError ? <InlineError message={detail.server.lastSyncError} /> : null}
+
+              <div className="mcp-tools-heading">
+                <div>
+                  <h3>{t("mcpServers.tools")}</h3>
+                  <p>{t("mcpServers.toolsDescription")}</p>
+                </div>
+                <Button onClick={saveTools} disabled={busy}>
+                  <Save size={14} />
+                  {t("mcpServers.saveTools")}
+                </Button>
+              </div>
+              <div className="mcp-tool-list">
+                {detail.tools.length === 0 ? (
+                  <EmptyState
+                    density="compact"
+                    title={t("mcpServers.noToolsTitle")}
+                    description={t("mcpServers.noToolsDescription")}
+                  />
+                ) : (
+                  detail.tools.map((tool) => {
+                    const selectable = tool.status !== "removed" && tool.status !== "invalid";
+                    return (
+                      <label key={tool.upstreamName} className="mcp-tool-row">
+                        <input
+                          type="checkbox"
+                          checked={enabledTools.includes(tool.upstreamName)}
+                          disabled={!selectable || busy}
+                          onChange={() => toggleTool(tool.upstreamName)}
+                        />
+                        <span>
+                          <strong>{tool.title ?? tool.upstreamName}</strong>
+                          <small>{tool.description ?? tool.upstreamName}</small>
+                        </span>
+                        <Badge tone={toolTone(tool.status)}>{t(`mcpServers.toolStatus.${tool.status}`)}</Badge>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </Card>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function syncTone(status: UpstreamMcpServer["syncStatus"]): "success" | "warning" | "error" {
+  return status === "ok" ? "success" : status === "error" ? "error" : "warning";
+}
+
+function toolTone(status: "available" | "review_required" | "removed" | "invalid") {
+  return status === "available" ? "success" : status === "review_required" ? "warning" : "error";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Request failed.";
+}
+
+async function reloadServers(setServers: (servers: UpstreamMcpServer[]) => void): Promise<void> {
+  setServers(await apiGet<UpstreamMcpServer[]>("/api/mcp-servers"));
+}

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -169,6 +169,43 @@ export interface RuntimeActionResponse {
   errorCode?: string;
 }
 
+export type UpstreamMcpAuth = { type: "none" } | { type: "bearer" } | { type: "api_key_header"; headerName: string };
+
+export interface UpstreamMcpServer {
+  service: string;
+  slug: string;
+  displayName: string;
+  description?: string;
+  endpoint: string;
+  auth: UpstreamMcpAuth;
+  enabled: boolean;
+  revision: number;
+  syncStatus: "never" | "ok" | "error";
+  lastSyncAt?: string;
+  lastSyncError?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpstreamMcpTool {
+  service: string;
+  upstreamName: string;
+  actionName: string;
+  title?: string;
+  description?: string;
+  enabled: boolean;
+  status: "available" | "review_required" | "removed" | "invalid";
+  invalidReason?: string;
+  contractHash: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface UpstreamMcpServerWithTools {
+  server: UpstreamMcpServer;
+  tools: UpstreamMcpTool[];
+}
+
 export interface AppData {
   providers: ProviderDefinition[];
   connections: ConnectionRecord[];

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -7,6 +7,7 @@
 @import "./styles/shell.css";
 @import "./styles/overview.css";
 @import "./styles/providers.css";
+@import "./styles/mcp-servers.css";
 @import "./styles/actions.css";
 @import "./styles/runs.css";
 @import "./styles/access.css";

--- a/web/src/styles/mcp-servers.css
+++ b/web/src/styles/mcp-servers.css
@@ -1,0 +1,143 @@
+.mcp-servers-page {
+  display: grid;
+  gap: 16px;
+}
+
+.mcp-servers-toolbar,
+.mcp-detail-heading,
+.mcp-tools-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.mcp-servers-toolbar p,
+.mcp-detail-heading p,
+.mcp-tools-heading p {
+  margin-top: 4px;
+  color: var(--muted-foreground);
+}
+
+.mcp-create-card,
+.mcp-server-detail {
+  padding: 20px;
+}
+
+.mcp-create-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.mcp-wide-field {
+  grid-column: 1 / -1;
+}
+
+.mcp-server-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.34fr) minmax(0, 1fr);
+  gap: 16px;
+  min-height: 520px;
+}
+
+.mcp-server-list {
+  align-self: start;
+  overflow: hidden;
+}
+
+.mcp-server-row,
+.mcp-tool-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+.mcp-server-row {
+  cursor: pointer;
+}
+
+.mcp-server-row:hover,
+.mcp-server-row.active {
+  background: var(--accent);
+}
+
+.mcp-server-row > span,
+.mcp-tool-row > span {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  gap: 4px;
+}
+
+.mcp-server-row small,
+.mcp-tool-row small {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mcp-server-detail {
+  display: grid;
+  align-content: start;
+  gap: 20px;
+}
+
+.mcp-server-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.mcp-server-meta div {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.mcp-server-meta dt {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.mcp-server-meta dd {
+  margin: 6px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.mcp-tool-list {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.mcp-tool-row:last-child,
+.mcp-server-row:last-child {
+  border-bottom: 0;
+}
+
+@media (max-width: 960px) {
+  .mcp-server-layout,
+  .mcp-create-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mcp-wide-field {
+    grid-column: auto;
+  }
+
+  .mcp-detail-heading,
+  .mcp-tools-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/web/src/ui.tsx
+++ b/web/src/ui.tsx
@@ -21,6 +21,7 @@ import {
   Loader2,
   Monitor,
   Moon,
+  Network,
   RefreshCw,
   Sun,
   TerminalSquare,
@@ -32,6 +33,7 @@ import { ActionsPage } from "./actions-page";
 import { ApiError, apiGet, apiPost } from "./api";
 import oomolConnectLogoUrl from "./assets/oomol-connect-logo.png";
 import { persistLang, supportedLangs } from "./i18n";
+import { McpServersPage } from "./mcp-servers-page";
 import { emptyData } from "./model";
 import { OverviewPage } from "./overview-page";
 import { ProvidersPage } from "./providers-page";
@@ -47,6 +49,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 const navItems = [
   { path: "/overview", labelKey: "nav.overview", icon: Home },
   { path: "/providers", labelKey: "nav.providers", icon: Cable },
+  { path: "/mcp-servers", labelKey: "nav.mcpServers", icon: Network },
   { path: "/actions", labelKey: "nav.actions", icon: TerminalSquare },
   { path: "/runs", labelKey: "nav.runs", icon: Activity },
   { path: "/access", labelKey: "nav.access", icon: KeyRound },
@@ -130,9 +133,9 @@ export interface RuntimeLoadResult {
 /**
  * Loads dashboard state.
  *
- * The provider catalog is generated at build time and cannot change while the
- * server runs, so `cachedProviders` lets refreshes skip re-downloading it and
- * re-fetch only mutable data.
+ * `cachedProviders` is retained for callers that already own a current
+ * revision. The console itself reloads providers because upstream MCP
+ * synchronization can change the runtime catalog.
  */
 export async function loadRuntimeData(
   unlockToken: string,
@@ -145,7 +148,6 @@ export async function loadRuntimeData(
 
   const catalogRequest =
     cachedProviders !== undefined ? Promise.resolve(cachedProviders) : apiGet<ProviderDefinition[]>("/api/providers");
-
   const [providers, connections, oauthConfigs, runtimeTokens, runtimePolicy, runPage] = await Promise.all([
     catalogRequest,
     apiGet<ConnectionRecord[]>("/api/connections"),
@@ -178,9 +180,6 @@ export function App(): ReactNode {
     authenticated: true,
   });
   const pendingUnlockToken = useRef("");
-  // Catalog is immutable while the server runs, so it is fetched once and
-  // reused across refreshes instead of being re-downloaded on every action.
-  const cachedProviders = useRef<ProviderDefinition[] | undefined>(undefined);
   const [locked, setLocked] = useState(false);
   const [loading, setLoading] = useState(true);
   const [runtimeChecked, setRuntimeChecked] = useState(false);
@@ -199,10 +198,9 @@ export function App(): ReactNode {
     let cancelled = false;
     const requestUnlockToken = pendingUnlockToken.current;
     setLoading(true);
-    loadRuntimeData(requestUnlockToken, cachedProviders.current)
+    loadRuntimeData(requestUnlockToken)
       .then(({ authSession: session, data: nextData }) => {
         if (!cancelled) {
-          cachedProviders.current = session.authenticated ? nextData.providers : undefined;
           const nextAuth = nextAuthLoadState(
             {
               pendingUnlockToken: pendingUnlockToken.current,
@@ -224,7 +222,6 @@ export function App(): ReactNode {
         }
         if (caught instanceof ApiError && caught.status === 401) {
           pendingUnlockToken.current = "";
-          cachedProviders.current = undefined;
           setData(emptyData);
           setAuthSession({ adminAuthConfigured: true, authenticated: false });
           setLocked(true);
@@ -247,6 +244,10 @@ export function App(): ReactNode {
 
   function refresh(): void {
     setRefreshToken((value) => value + 1);
+  }
+
+  function refreshCatalog(): void {
+    refresh();
   }
 
   function unlock(token: string): void {
@@ -284,6 +285,7 @@ export function App(): ReactNode {
       error={error}
       theme={theme}
       onRefresh={refresh}
+      onCatalogRefresh={refreshCatalog}
       onThemeChange={setTheme}
       onLogout={logout}
     />
@@ -310,6 +312,7 @@ function AppShell(props: {
   error: string | null;
   theme: ThemeMode;
   onRefresh(): void;
+  onCatalogRefresh(): void;
   onThemeChange(theme: ThemeMode): void;
   onLogout(): void;
 }): ReactNode {
@@ -402,6 +405,7 @@ function AppShell(props: {
               path="/providers/:service"
               element={<ProvidersPage data={props.data} onRefresh={props.onRefresh} />}
             />
+            <Route path="/mcp-servers" element={<McpServersPage onRefresh={props.onCatalogRefresh} />} />
             <Route path="/actions" element={<ActionsPage data={props.data} onRefresh={props.onRefresh} />} />
             <Route path="/actions/:actionId" element={<ActionsPage data={props.data} onRefresh={props.onRefresh} />} />
             <Route
@@ -559,6 +563,9 @@ function headingForPath(pathname: string): string {
   const section = pathname.split("/").filter(Boolean)[0];
   if (section === "providers") {
     return "providers";
+  }
+  if (section === "mcp-servers") {
+    return "mcpServers";
   }
   if (section === "actions") {
     return "actions";


### PR DESCRIPTION
## Summary

- register multiple remote Streamable HTTP MCP servers as runtime providers
- discover upstream tools and publish explicitly approved tools as OpenConnector Actions
- add SQLite and D1 persistence, optimistic revisions, contract review states, and Web Console management
- preserve the fixed downstream MCP meta-tool surface while refreshing the dynamic Action catalog

## Security and compatibility

- route upstream requests through the shared SSRF-guarded fetch
- strip runtime authentication headers on cross-origin redirects
- disable new or changed tools until explicit review
- pause actions when endpoint or authentication configuration changes
- reject static provider service collisions and stale executor use

## Validation

- `npm run fix-check`
- `npm --prefix web run build`
- `npm test` (60 test files, 525 tests)
- real MCP SDK Streamable HTTP discovery and tool execution regression coverage

## Documentation

- add `docs/upstream-mcp.md`
- update README and runtime API documentation