### PR TITLE
feat(provider): add Mux video

### DIFF
--- a/src/providers/mux/actions.ts
+++ b/src/providers/mux/actions.ts
@@ -59,7 +59,7 @@ export const muxActions: ActionDefinition[] = [
         videoQuality: s.stringEnum(["basic", "plus", "premium"], {
           description: "The cost and encoding-quality tier. Mux uses the environment default when omitted.",
         }),
-        maxResolutionTier: s.stringEnum(["720p", "1080p", "1440p", "2160p"], {
+        maxResolutionTier: s.stringEnum(["1080p", "1440p", "2160p"], {
           description: "The maximum resolution tier Mux should produce.",
         }),
         passthrough: s.string({

--- a/src/providers/mux/actions.ts
+++ b/src/providers/mux/actions.ts
@@ -1,0 +1,160 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "mux";
+const videoReadPermission = "video:read";
+const videoWritePermission = "video:write";
+
+const assetId = s.nonEmptyString("The Mux asset ID.");
+const playbackPolicy = s.stringEnum(["public", "signed", "drm"], {
+  description: "The access policy for a Mux playback ID.",
+});
+const playbackId = s.looseObject("A Mux playback ID attached to an asset.", {
+  id: s.nonEmptyString("The playback ID used in Mux streaming URLs."),
+  policy: playbackPolicy,
+  drm_configuration_id: s.nonEmptyString("The DRM configuration ID when the policy is drm."),
+});
+const asset = s.looseObject("A Mux video asset, including its current processing state and media details.", {
+  id: assetId,
+  status: s.stringEnum(["preparing", "ready", "errored"], {
+    description: "The current asset processing status.",
+  }),
+  created_at: s.nonEmptyString("The Unix timestamp when Mux created the asset."),
+  duration: s.number("The asset duration in seconds.", { minimum: 0 }),
+  aspect_ratio: s.nonEmptyString("The source aspect ratio in width:height form."),
+  resolution_tier: s.nonEmptyString("The highest resolution tier available for the asset."),
+  video_quality: s.stringEnum(["basic", "plus", "premium"], {
+    description: "The Mux video quality tier used to encode the asset.",
+  }),
+  passthrough: s.nullableString("User-supplied passthrough metadata."),
+  playback_ids: s.array("Playback IDs currently attached to the asset.", playbackId),
+  tracks: s.array("Audio, video, and text tracks in the asset.", s.looseObject("A Mux asset track.")),
+  errors: s.looseObject("Processing errors reported by Mux when the asset is errored."),
+  meta: s.looseObject("Customer-provided structured metadata for the asset."),
+});
+const assetOutput = s.actionOutput({ asset }, "A Mux asset response.");
+const assetLifecycle = {
+  startActionId: "mux.create_asset",
+  statusActionId: "mux.get_asset",
+};
+
+export const muxActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "create_asset",
+    description:
+      "Create a Mux on-demand video asset from a publicly accessible media URL and return its initial processing state.",
+    providerPermissions: [videoWritePermission],
+    followUpActions: ["mux.get_asset", "mux.create_playback_id"],
+    asyncLifecycle: assetLifecycle,
+    inputSchema: s.actionInput(
+      {
+        sourceUrl: s.url("A publicly accessible HTTP(S) URL that Mux can download as the primary media input."),
+        playbackPolicies: s.array(
+          "Playback policies to create with the asset. Omit this field to create an asset without a playback ID.",
+          s.stringEnum(["public", "signed"], { description: "A non-DRM Mux playback policy." }),
+          { minItems: 1, maxItems: 2 },
+        ),
+        videoQuality: s.stringEnum(["basic", "plus", "premium"], {
+          description: "The cost and encoding-quality tier. Mux uses the environment default when omitted.",
+        }),
+        maxResolutionTier: s.stringEnum(["720p", "1080p", "1440p", "2160p"], {
+          description: "The maximum resolution tier Mux should produce.",
+        }),
+        passthrough: s.string({
+          minLength: 1,
+          maxLength: 255,
+          description: "Opaque metadata returned in asset details and related webhooks.",
+        }),
+        test: s.boolean("Whether to create a free, watermarked test asset limited to 10 seconds and 24 hours."),
+        meta: s.object(
+          "Structured asset metadata. Do not include sensitive or personally identifiable information.",
+          {
+            title: s.string("A human-readable asset title.", { maxLength: 512 }),
+            creatorId: s.string("Your identifier for the asset creator.", { maxLength: 128 }),
+            externalId: s.string("Your identifier linking the asset to an external record.", { maxLength: 128 }),
+          },
+          { optional: ["title", "creatorId", "externalId"] },
+        ),
+      },
+      ["sourceUrl"],
+      "Settings for creating a Mux asset from a remote media file.",
+    ),
+    outputSchema: assetOutput,
+  }),
+  defineProviderAction(service, {
+    name: "list_assets",
+    description: "List Mux video assets with cursor or page-based pagination and optional source filters.",
+    providerPermissions: [videoReadPermission],
+    followUpActions: ["mux.get_asset"],
+    inputSchema: s.object(
+      "Filters and pagination for Mux assets.",
+      {
+        limit: s.integer("The maximum number of assets to return.", { minimum: 1, default: 25 }),
+        page: s.positiveInteger("The one-based page number. Do not combine this with cursor."),
+        cursor: s.nonEmptyString("The next_cursor value from a previous list_assets response."),
+        liveStreamId: s.nonEmptyString("Return only assets created by this Mux live stream."),
+        uploadId: s.nonEmptyString("Return only the asset created by this Mux direct upload."),
+      },
+      { optional: ["limit", "page", "cursor", "liveStreamId", "uploadId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        assets: s.array("Mux assets in this page.", asset),
+        nextCursor: s.nullableString("The cursor for the next page, or null when no cursor was returned."),
+      },
+      "A page of Mux assets.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_asset",
+    description: "Retrieve the latest processing state and media details for one Mux video asset.",
+    providerPermissions: [videoReadPermission],
+    followUpActions: ["mux.create_playback_id", "mux.delete_asset"],
+    asyncLifecycle: assetLifecycle,
+    inputSchema: s.actionInput({ assetId }, ["assetId"], "The Mux asset to retrieve."),
+    outputSchema: assetOutput,
+  }),
+  defineProviderAction(service, {
+    name: "delete_asset",
+    description: "Permanently delete a Mux video asset and all of its data.",
+    providerPermissions: [videoWritePermission],
+    inputSchema: s.actionInput({ assetId }, ["assetId"], "The Mux asset to delete."),
+    outputSchema: s.actionOutput(
+      {
+        deleted: s.literal(true, { description: "Whether Mux accepted the deletion." }),
+        assetId,
+      },
+      "Confirmation that a Mux asset was deleted.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_playback_id",
+    description: "Create a public, signed, or DRM playback ID for an existing Mux video asset.",
+    providerPermissions: [videoWritePermission],
+    inputSchema: s.oneOf(
+      [
+        s.object(
+          {
+            assetId,
+            policy: s.stringEnum(["public", "signed"], {
+              description: "The playback policy for a non-DRM playback ID.",
+            }),
+          },
+          { required: ["assetId", "policy"] },
+        ),
+        s.object(
+          {
+            assetId,
+            policy: s.literal("drm", { description: "Create a DRM-protected playback ID." }),
+            drmConfigurationId: s.nonEmptyString("The Mux DRM configuration to apply."),
+          },
+          { required: ["assetId", "policy", "drmConfigurationId"] },
+        ),
+      ],
+      { description: "The asset and access policy for a new Mux playback ID." },
+    ),
+    outputSchema: s.actionOutput({ playbackId }, "The playback ID created by Mux."),
+  }),
+];

--- a/src/providers/mux/definition.ts
+++ b/src/providers/mux/definition.ts
@@ -1,0 +1,39 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { muxActions } from "./actions.ts";
+
+const service = "mux";
+
+/**
+ * Mux provider backed by the public Mux Video API.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Mux",
+  description: "Create, inspect, publish, and delete on-demand video assets with Mux Video.",
+  categories: ["Video", "Developer Tools"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "Token Secret",
+      placeholder: "MUX_TOKEN_SECRET",
+      description:
+        "Mux access token secret used as the HTTP Basic Auth password. Create a token in the Mux Dashboard under Settings > Access Tokens: https://dashboard.mux.com/settings/access-tokens.",
+      extraFields: [
+        {
+          key: "tokenId",
+          label: "Token ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "MUX_TOKEN_ID",
+          description:
+            "Mux access token ID used as the HTTP Basic Auth username. Copy it together with the token secret from the Mux Dashboard.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.mux.com/",
+  actions: muxActions,
+};

--- a/src/providers/mux/executors.ts
+++ b/src/providers/mux/executors.ts
@@ -1,0 +1,38 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { MuxContext } from "./runtime.ts";
+
+import { requiredString } from "../../core/cast.ts";
+import { defineProviderExecutors, ProviderRequestError, requireApiKeyCredential } from "../provider-runtime.ts";
+import { muxActionHandlers, validateMuxCredential } from "./runtime.ts";
+
+const service = "mux";
+
+export const executors: ProviderExecutors = defineProviderExecutors<MuxContext>({
+  service,
+  handlers: muxActionHandlers,
+  skipDnsValidation: true,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<MuxContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return {
+      tokenId: requireMuxTokenId(credential.values.tokenId),
+      tokenSecret: credential.apiKey,
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validateMuxCredential({
+      tokenId: requireMuxTokenId(input.values.tokenId),
+      tokenSecret: input.apiKey,
+      fetcher,
+      signal,
+    });
+  },
+};
+
+function requireMuxTokenId(value: unknown): string {
+  return requiredString(value, "tokenId", (message) => new ProviderRequestError(400, message));
+}

--- a/src/providers/mux/runtime.ts
+++ b/src/providers/mux/runtime.ts
@@ -28,21 +28,11 @@ export interface MuxContext {
 type MuxActionHandler = (input: Record<string, unknown>, context: MuxContext) => Promise<unknown>;
 
 export const muxActionHandlers: Record<string, MuxActionHandler> = {
-  create_asset(input, context) {
-    return createAsset(input, context);
-  },
-  list_assets(input, context) {
-    return listAssets(input, context);
-  },
-  get_asset(input, context) {
-    return getAsset(input, context);
-  },
-  delete_asset(input, context) {
-    return deleteAsset(input, context);
-  },
-  create_playback_id(input, context) {
-    return createPlaybackId(input, context);
-  },
+  create_asset: createAsset,
+  list_assets: listAssets,
+  get_asset: getAsset,
+  delete_asset: deleteAsset,
+  create_playback_id: createPlaybackId,
 };
 
 export async function validateMuxCredential(context: MuxContext): Promise<CredentialValidationResult> {
@@ -118,9 +108,9 @@ async function listAssets(input: Record<string, unknown>, context: MuxContext): 
   }
 
   const payload = await requestMuxJson({ path: "/video/v1/assets", query, context, phase: "execute" });
-  const response = requiredRecord(payload, "Mux list assets response", inputError);
+  const response = requiredRecord(payload, "Mux list assets response", muxResponseError);
   return {
-    assets: objectArray(response.data, "Mux asset", inputError),
+    assets: objectArray(response.data, "Mux asset", muxResponseError),
     nextCursor: optionalString(response.next_cursor) ?? null,
   };
 }
@@ -212,22 +202,39 @@ async function requestMuxJson(options: MuxRequestOptions): Promise<unknown> {
     return payload;
   }
 
-  const status = options.phase === "validate" ? 401 : response.status >= 500 ? 502 : response.status;
+  const status =
+    options.phase === "validate" && (response.status === 401 || response.status === 403)
+      ? 401
+      : response.status >= 500
+        ? 502
+        : response.status;
   throw new ProviderRequestError(status, muxErrorMessage(payload, response.status), payload);
 }
 
 function muxDataRecord(payload: unknown, source: string): Record<string, unknown> {
-  const envelope = requiredRecord(payload, source, () => new ProviderRequestError(502, `${source} was invalid`));
-  return requiredRecord(envelope.data, `${source} data`, () => new ProviderRequestError(502, `${source} was invalid`));
+  const envelope = requiredRecord(payload, source, muxResponseError);
+  return requiredRecord(envelope.data, `${source} data`, muxResponseError);
 }
 
 function muxErrorMessage(payload: unknown, status: number): string {
   const envelope = optionalRecord(payload);
   const error = optionalRecord(envelope?.error);
-  const messages = Array.isArray(error?.messages)
+  const errorMessages = Array.isArray(error?.messages)
     ? error.messages.filter((message): message is string => typeof message === "string" && message.length > 0)
     : [];
-  return messages.join("; ") || optionalString(error?.type) || `Mux request failed with HTTP ${status}`;
+  const responseMessages = Array.isArray(envelope?.errors)
+    ? envelope.errors.filter((message): message is string => typeof message === "string" && message.length > 0)
+    : [];
+  return (
+    errorMessages.join("; ") ||
+    optionalString(error?.type) ||
+    responseMessages.join("; ") ||
+    `Mux request failed with HTTP ${status}`
+  );
+}
+
+function muxResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
 }
 
 function createMuxAuthorization(context: Pick<MuxContext, "tokenId" | "tokenSecret">): string {

--- a/src/providers/mux/runtime.ts
+++ b/src/providers/mux/runtime.ts
@@ -1,0 +1,258 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { Buffer } from "node:buffer";
+import {
+  compactObject,
+  objectArray,
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import { ProviderRequestError, providerUserAgent, readProviderJsonBody } from "../provider-runtime.ts";
+
+const muxApiOrigin = "https://api.mux.com";
+const muxWhoAmIPath = "/system/v1/whoami";
+
+export interface MuxContext {
+  tokenId: string;
+  tokenSecret: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+type MuxActionHandler = (input: Record<string, unknown>, context: MuxContext) => Promise<unknown>;
+
+export const muxActionHandlers: Record<string, MuxActionHandler> = {
+  create_asset(input, context) {
+    return createAsset(input, context);
+  },
+  list_assets(input, context) {
+    return listAssets(input, context);
+  },
+  get_asset(input, context) {
+    return getAsset(input, context);
+  },
+  delete_asset(input, context) {
+    return deleteAsset(input, context);
+  },
+  create_playback_id(input, context) {
+    return createPlaybackId(input, context);
+  },
+};
+
+export async function validateMuxCredential(context: MuxContext): Promise<CredentialValidationResult> {
+  const payload = await requestMuxJson({ path: muxWhoAmIPath, context, phase: "validate" });
+  const profile = muxDataRecord(payload, "Mux access token response");
+  const environmentId = optionalString(profile.environment_id);
+  const environmentName = optionalString(profile.environment_name);
+  const organizationName = optionalString(profile.organization_name);
+  const permissions = Array.isArray(profile.permissions)
+    ? profile.permissions.filter((permission): permission is string => typeof permission === "string")
+    : [];
+
+  return {
+    profile: {
+      accountId: environmentId ?? context.tokenId,
+      displayName: [organizationName, environmentName].filter(Boolean).join(" / ") || "Mux Access Token",
+      grantedScopes: permissions,
+    },
+    grantedScopes: permissions,
+    metadata: compactObject({
+      organizationId: optionalString(profile.organization_id),
+      organizationName,
+      environmentId,
+      environmentName,
+      environmentType: optionalString(profile.environment_type),
+      accessTokenName: optionalString(profile.access_token_name),
+      validationEndpoint: muxWhoAmIPath,
+    }),
+  };
+}
+
+async function createAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const sourceUrl = assertPublicHttpUrl(requiredInputString(input.sourceUrl, "sourceUrl"), {
+    fieldName: "sourceUrl",
+    createError: inputError,
+  });
+  const meta = optionalRecord(input.meta);
+  const body = compactObject({
+    inputs: [{ url: sourceUrl.toString() }],
+    playback_policies: readOptionalStringArray(input.playbackPolicies, "playbackPolicies"),
+    video_quality: optionalString(input.videoQuality),
+    max_resolution_tier: optionalString(input.maxResolutionTier),
+    passthrough: optionalString(input.passthrough),
+    test: optionalBoolean(input.test),
+    meta: meta
+      ? compactObject({
+          title: optionalString(meta.title),
+          creator_id: optionalString(meta.creatorId),
+          external_id: optionalString(meta.externalId),
+        })
+      : undefined,
+  });
+  const payload = await requestMuxJson({
+    path: "/video/v1/assets",
+    method: "POST",
+    body,
+    context,
+    phase: "execute",
+  });
+  return { asset: muxDataRecord(payload, "Mux create asset response") };
+}
+
+async function listAssets(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const query = compactObject({
+    limit: stringifyInteger(input.limit),
+    page: stringifyInteger(input.page),
+    cursor: optionalString(input.cursor),
+    live_stream_id: optionalString(input.liveStreamId),
+    upload_id: optionalString(input.uploadId),
+  });
+  if (query.page && query.cursor) {
+    throw inputError("page and cursor cannot be used together");
+  }
+
+  const payload = await requestMuxJson({ path: "/video/v1/assets", query, context, phase: "execute" });
+  const response = requiredRecord(payload, "Mux list assets response", inputError);
+  return {
+    assets: objectArray(response.data, "Mux asset", inputError),
+    nextCursor: optionalString(response.next_cursor) ?? null,
+  };
+}
+
+async function getAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const assetId = requiredInputString(input.assetId, "assetId");
+  const payload = await requestMuxJson({
+    path: `/video/v1/assets/${encodeURIComponent(assetId)}`,
+    context,
+    phase: "execute",
+  });
+  return { asset: muxDataRecord(payload, "Mux asset response") };
+}
+
+async function deleteAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const assetId = requiredInputString(input.assetId, "assetId");
+  await requestMuxJson({
+    path: `/video/v1/assets/${encodeURIComponent(assetId)}`,
+    method: "DELETE",
+    context,
+    phase: "execute",
+  });
+  return { deleted: true, assetId };
+}
+
+async function createPlaybackId(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const assetId = requiredInputString(input.assetId, "assetId");
+  const policy = requiredInputString(input.policy, "policy");
+  const drmConfigurationId = optionalString(input.drmConfigurationId);
+  if (policy === "drm" && !drmConfigurationId) {
+    throw inputError("drmConfigurationId is required when policy is drm");
+  }
+  if (policy !== "drm" && drmConfigurationId) {
+    throw inputError("drmConfigurationId can only be used when policy is drm");
+  }
+
+  const payload = await requestMuxJson({
+    path: `/video/v1/assets/${encodeURIComponent(assetId)}/playback-ids`,
+    method: "POST",
+    body: compactObject({ policy, drm_configuration_id: drmConfigurationId }),
+    context,
+    phase: "execute",
+  });
+  return { playbackId: muxDataRecord(payload, "Mux create playback ID response") };
+}
+
+interface MuxRequestOptions {
+  path: string;
+  context: MuxContext;
+  phase: "validate" | "execute";
+  method?: string;
+  query?: Record<string, string | undefined>;
+  body?: unknown;
+}
+
+async function requestMuxJson(options: MuxRequestOptions): Promise<unknown> {
+  const url = new URL(options.path, muxApiOrigin);
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await options.context.fetcher(url, {
+      method: options.method ?? "GET",
+      headers: {
+        accept: "application/json",
+        authorization: createMuxAuthorization(options.context),
+        ...(options.body === undefined ? {} : { "content-type": "application/json" }),
+        "user-agent": providerUserAgent,
+      },
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: options.context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Mux request failed: ${error.message}` : "Mux request failed",
+    );
+  }
+
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "Mux returned invalid JSON",
+  });
+  if (response.ok) {
+    return payload;
+  }
+
+  const status = options.phase === "validate" ? 401 : response.status >= 500 ? 502 : response.status;
+  throw new ProviderRequestError(status, muxErrorMessage(payload, response.status), payload);
+}
+
+function muxDataRecord(payload: unknown, source: string): Record<string, unknown> {
+  const envelope = requiredRecord(payload, source, () => new ProviderRequestError(502, `${source} was invalid`));
+  return requiredRecord(envelope.data, `${source} data`, () => new ProviderRequestError(502, `${source} was invalid`));
+}
+
+function muxErrorMessage(payload: unknown, status: number): string {
+  const envelope = optionalRecord(payload);
+  const error = optionalRecord(envelope?.error);
+  const messages = Array.isArray(error?.messages)
+    ? error.messages.filter((message): message is string => typeof message === "string" && message.length > 0)
+    : [];
+  return messages.join("; ") || optionalString(error?.type) || `Mux request failed with HTTP ${status}`;
+}
+
+function createMuxAuthorization(context: Pick<MuxContext, "tokenId" | "tokenSecret">): string {
+  return `Basic ${Buffer.from(`${context.tokenId}:${context.tokenSecret}`, "utf8").toString("base64")}`;
+}
+
+function requiredInputString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, inputError);
+}
+
+function inputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function stringifyInteger(value: unknown): string | undefined {
+  const integer = optionalInteger(value);
+  return integer === undefined ? undefined : String(integer);
+}
+
+function readOptionalStringArray(value: unknown, fieldName: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw inputError(`${fieldName} must be an array of strings`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- add a locally executable Mux provider using Token ID and Token Secret Basic Auth
- add asset create, list, retrieve, delete, and playback ID actions
- validate credentials through Mux `whoami` and expose environment identity and granted permissions
- validate remote media inputs as public HTTP(S) URLs and route all provider egress through the guarded fetcher

## Why

Mux Video asset workflows were not available through the open-source connector. This adds the smallest useful asset lifecycle while preserving Mux pagination, async processing status, playback policies, and API error details.

## Impact

Users can configure their own Mux access token and manage on-demand video assets locally. The create action accepts a provider-fetchable media URL; video bytes do not pass through the connector runtime.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- Mux runtime smoke checks covering request mapping, Basic Auth, pagination, deletion, playback IDs, credential validation, and SSRF rejection
- `npm test` (56 test files, 516 tests)
