### PR TITLE
feat(provider): add AgentMail (QQ) agent_qq provider

### DIFF
--- a/src/providers/agent_qq/actions.ts
+++ b/src/providers/agent_qq/actions.ts
@@ -1,0 +1,185 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "agent_qq";
+
+const noInput = s.object({}, { description: "No input parameters are required for this action." });
+
+const emailRecipient = s.object(
+  {
+    email: s.email("Email address."),
+    name: s.string("Display name."),
+  },
+  { description: "An email recipient with optional display name.", optional: ["name"], additionalProperties: true },
+);
+
+const messageSummary = s.object(
+  {
+    message_id: s.string("The message identifier."),
+    subject: s.string("The message subject."),
+    snippet: s.string("A short preview of the message body."),
+    is_read: s.boolean("Whether the message has been read."),
+    created_at: s.dateTime("The message creation time."),
+    from: emailRecipient,
+  },
+  { description: "A message summary from a mailbox list.", additionalProperties: true },
+);
+
+const pagination = s.object(
+  {
+    has_more: s.boolean("Whether more results exist."),
+    next_cursor: s.string("Cursor for the next page."),
+    previous_cursor: s.string("Cursor for the previous page."),
+  },
+  { description: "Pagination information.", optional: ["next_cursor", "previous_cursor"], additionalProperties: true },
+);
+
+const listMessagesInput = s.object(
+  {
+    alias_id: s.nonEmptyString("The alias identifier to use as the mailbox."),
+    q: s.string("Full-text search query. When provided, the search endpoint is used."),
+    dir: s.stringEnum("Mailbox folder.", ["inbox", "sent", "trash", "spam"]),
+    limit: s.integer("Maximum messages to return (max 50).", { minimum: 1, maximum: 50, default: 10 }),
+    cursor: s.string("Pagination cursor from a previous response."),
+    before: s.dateTime("Only messages before this ISO 8601 time."),
+    after: s.dateTime("Only messages after this ISO 8601 time."),
+    is_read: s.boolean("Only return messages with this read state."),
+    is_unread: s.boolean("Only return unread messages (translated to is_read=false)."),
+    has_attachments: s.boolean("Only return messages that have attachments."),
+  },
+  {
+    description: "Input for listing or searching messages in an alias mailbox.",
+    required: ["alias_id"],
+    optional: ["q", "dir", "limit", "cursor", "before", "after", "is_read", "is_unread", "has_attachments"],
+  },
+);
+
+const listMessagesOutput = s.object(
+  {
+    ok: s.boolean("Whether the request succeeded."),
+    data: s.object(
+      {
+        data: s.array("Messages.", messageSummary),
+        pagination,
+      },
+      { optional: ["pagination"], description: "The message list result.", additionalProperties: true },
+    ),
+  },
+  { description: "Response from listing or searching messages.", required: ["ok", "data"], additionalProperties: true },
+);
+
+const readMessageInput = s.object(
+  {
+    alias_id: s.nonEmptyString("The alias identifier that owns the message."),
+    message_id: s.nonEmptyString("The message identifier."),
+  },
+  { description: "Input for reading a single message.", required: ["alias_id", "message_id"] },
+);
+
+const readMessageOutput = s.object(
+  {
+    ok: s.boolean("Whether the request succeeded."),
+    data: s.unknownObject("The full message object returned by the AgentMail API."),
+  },
+  { description: "Response from reading a message.", required: ["ok", "data"], additionalProperties: true },
+);
+
+const sendMessageInput = s.object(
+  {
+    alias_id: s.nonEmptyString("The alias identifier to send from."),
+    to: s.array("Recipient email addresses.", s.email("Recipient email address."), { minItems: 1 }),
+    cc: s.array("CC recipient email addresses.", s.email("CC email address.")),
+    bcc: s.array("BCC recipient email addresses.", s.email("BCC email address.")),
+    subject: s.nonEmptyString("The message subject."),
+    body: s.nonEmptyString("The message body."),
+    body_format: s.stringEnum("Body format.", ["auto", "plain", "html"]),
+    confirmation_token: s.string("Confirmation token from a previous send request."),
+  },
+  {
+    description: "Input for sending a new message.",
+    required: ["alias_id", "to", "subject", "body"],
+    optional: ["cc", "bcc", "body_format", "confirmation_token"],
+  },
+);
+
+const sendMessageOutput = s.object(
+  { ok: s.boolean("Whether the request succeeded.") },
+  { description: "Response from sending a message.", additionalProperties: true },
+);
+
+const deleteMessageInput = s.object(
+  {
+    alias_id: s.nonEmptyString("The alias identifier that owns the message."),
+    message_id: s.nonEmptyString("The message identifier."),
+  },
+  { description: "Input for deleting a message.", required: ["alias_id", "message_id"] },
+);
+
+const deleteMessageOutput = s.object(
+  {
+    ok: s.boolean("Whether the request succeeded."),
+    deleted: s.literal(true, { description: "True when the message was moved to trash." }),
+  },
+  { description: "Response from deleting a message.", required: ["ok", "deleted"], additionalProperties: true },
+);
+
+const alias = s.object(
+  {
+    alias_id: s.string("The alias identifier."),
+    email: s.email("The alias email address."),
+    is_primary: s.boolean("Whether this is the primary alias."),
+  },
+  { description: "An AgentMail alias.", optional: ["is_primary"], additionalProperties: true },
+);
+
+const listAliasesOutput = s.object(
+  {
+    ok: s.boolean("Whether the request succeeded."),
+    data: s.object(
+      { aliases: s.array("Aliases.", alias) },
+      { description: "Alias list result.", additionalProperties: true },
+    ),
+  },
+  { description: "Response from listing aliases.", required: ["ok", "data"], additionalProperties: true },
+);
+
+export const agentQQActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_aliases",
+    description: "List the current user's AgentMail aliases and account limits.",
+    requiredScopes: [],
+    inputSchema: noInput,
+    outputSchema: listAliasesOutput,
+  }),
+  defineProviderAction(service, {
+    name: "list_messages",
+    description: "List or search messages in an alias mailbox.",
+    requiredScopes: [],
+    inputSchema: listMessagesInput,
+    outputSchema: listMessagesOutput,
+  }),
+  defineProviderAction(service, {
+    name: "read_message",
+    description: "Read a single message including body and attachments.",
+    requiredScopes: [],
+    inputSchema: readMessageInput,
+    outputSchema: readMessageOutput,
+  }),
+  defineProviderAction(service, {
+    name: "send_message",
+    description:
+      "Send a new message. When confirmation_token is omitted, the first phase returns a confirmation token; the action automatically completes the second phase.",
+    requiredScopes: [],
+    inputSchema: sendMessageInput,
+    outputSchema: sendMessageOutput,
+  }),
+  defineProviderAction(service, {
+    name: "delete_message",
+    description: "Move a message to trash (soft delete).",
+    requiredScopes: [],
+    inputSchema: deleteMessageInput,
+    outputSchema: deleteMessageOutput,
+  }),
+];

--- a/src/providers/agent_qq/actions.ts
+++ b/src/providers/agent_qq/actions.ts
@@ -55,6 +55,16 @@ const listMessagesInput = s.object(
     optional: ["q", "dir", "limit", "cursor", "before", "after", "is_read", "is_unread", "has_attachments"],
   },
 );
+listMessagesInput.not = s.object(
+  {
+    is_read: s.literal(true),
+    is_unread: s.literal(true),
+  },
+  {
+    required: ["is_read", "is_unread"],
+    additionalProperties: true,
+  },
+);
 
 const listMessagesOutput = s.object(
   {
@@ -177,7 +187,7 @@ export const agentQQActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "delete_message",
-    description: "Move a message to trash (soft delete).",
+    description: "Move a message to trash (soft delete), automatically completing the provider confirmation flow.",
     requiredScopes: [],
     inputSchema: deleteMessageInput,
     outputSchema: deleteMessageOutput,

--- a/src/providers/agent_qq/definition.ts
+++ b/src/providers/agent_qq/definition.ts
@@ -1,0 +1,23 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { agentQQActions } from "./actions.ts";
+
+const service = "agent_qq";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "AgentMail (QQ)",
+  categories: ["Communication", "Productivity"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "OAuth Access Token",
+      placeholder: "at_...",
+      description:
+        "AgentMail OAuth access token used with the Authorization Bearer header. Get one by running `agently-cli auth login` or completing the OAuth device flow.",
+    },
+  ],
+  homepageUrl: "https://agent.qq.com",
+  actions: agentQQActions,
+};

--- a/src/providers/agent_qq/executors.ts
+++ b/src/providers/agent_qq/executors.ts
@@ -56,9 +56,8 @@ const agentQQActionHandlers: Record<string, AgentQQActionHandler> = {
     }
 
     const initial = await agentQQRequest<unknown>(context, { path, method: "POST", body, mode: "execute" });
-    const data = optionalRecord(optionalRecord(initial as Record<string, unknown>)?.data);
-    const firstToken = optionalString(data?.confirmation_token);
-    if (optionalBoolean(data?.confirmation_required) && firstToken) {
+    const firstToken = readConfirmationToken(initial);
+    if (firstToken) {
       return agentQQRequest(context, {
         path,
         method: "POST",
@@ -73,13 +72,25 @@ const agentQQActionHandlers: Record<string, AgentQQActionHandler> = {
   async delete_message(input, context) {
     const aliasId = requireFieldString(input, "alias_id");
     const messageId = requireFieldString(input, "message_id");
-    const response = await agentQQRequest<unknown>(context, {
-      path: `/v1/aliases/${encodeURIComponent(aliasId)}/messages/${encodeURIComponent(messageId)}`,
+    const path = `/v1/aliases/${encodeURIComponent(aliasId)}/messages/${encodeURIComponent(messageId)}`;
+    let response = await agentQQRequest<unknown>(context, {
+      path,
       method: "DELETE",
       mode: "execute",
     });
-    if (optionalRecord(response as Record<string, unknown>)) {
-      return response;
+    const firstToken = readConfirmationToken(response);
+    if (firstToken) {
+      response = await agentQQRequest(context, {
+        path,
+        method: "DELETE",
+        body: { confirmation_token: firstToken },
+        mode: "execute",
+      });
+    }
+
+    const result = optionalRecord(response);
+    if (optionalBoolean(result?.ok) === true && optionalBoolean(result?.deleted) === true) {
+      return result;
     }
     return { ok: true, deleted: true, alias_id: aliasId, message_id: messageId };
   },
@@ -91,7 +102,7 @@ export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
     const context: ApiKeyProviderContext = { apiKey: input.apiKey, fetcher, signal };
     const payload = await agentQQRequest<unknown>(context, { path: "/v1/me", mode: "validate" });
-    const data = optionalRecord(payload as Record<string, unknown>);
+    const data = optionalRecord(payload);
     const inner = optionalRecord(data?.data);
     const aliases = optionalObjectArray(inner?.aliases);
     const primary = aliases[0];
@@ -127,8 +138,16 @@ async function agentQQRequest<T>(context: ApiKeyProviderContext, request: AgentQ
     signal: context.signal,
   });
 
-  await assertAgentQQResponse(response, request.mode);
   const text = await response.text().catch(() => "");
+  if (!response.ok) {
+    if (request.mode === "execute" && response.status === 428) {
+      const confirmation = parseAgentQQConfirmation(text);
+      if (confirmation) {
+        return confirmation as T;
+      }
+    }
+    assertAgentQQResponse(response, request.mode, text);
+  }
   if (!text) {
     return {} as T;
   }
@@ -150,12 +169,15 @@ function buildAgentQQUrl(path: string, query?: Record<string, string>): string {
 }
 
 function agentQQHeaders(apiKey: string, hasJsonBody: boolean): Record<string, string> {
-  return {
+  const headers: Record<string, string> = {
     authorization: `Bearer ${apiKey}`,
     accept: "application/json",
-    ...(hasJsonBody ? { "content-type": "application/json" } : {}),
     "user-agent": providerUserAgent,
   };
+  if (hasJsonBody) {
+    headers["content-type"] = "application/json";
+  }
+  return headers;
 }
 
 function requireFieldString(input: Record<string, unknown>, key: string): string {
@@ -164,6 +186,36 @@ function requireFieldString(input: Record<string, unknown>, key: string): string
     throw new ProviderRequestError(400, `${key} is required`);
   }
   return value;
+}
+
+function readConfirmationToken(response: unknown): string | undefined {
+  const data = optionalRecord(optionalRecord(response)?.data);
+  if (optionalBoolean(data?.confirmation_required) !== true) {
+    return undefined;
+  }
+  return optionalString(data?.confirmation_token);
+}
+
+function parseAgentQQConfirmation(raw: string): Record<string, unknown> | undefined {
+  try {
+    const payload = optionalRecord(JSON.parse(raw));
+    const error = optionalRecord(payload?.error);
+    const details = optionalRecord(error?.details) ?? optionalRecord(payload?.data);
+    const token = optionalString(details?.confirmation_token);
+    if (!details || !token) {
+      return undefined;
+    }
+    return {
+      ok: true,
+      data: {
+        ...details,
+        confirmation_required: true,
+        confirmation_token: token,
+      },
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function buildListMessagesQuery(input: Record<string, unknown>): Record<string, string> {
@@ -250,12 +302,12 @@ function normalizeBodyFormat(value: string | undefined): string | undefined {
   return value.toUpperCase();
 }
 
-async function assertAgentQQResponse(response: Response, mode: "validate" | "execute"): Promise<void> {
+function assertAgentQQResponse(response: Response, mode: "validate" | "execute", raw: string): void {
   if (response.ok) {
     return;
   }
 
-  const { message, type } = await readAgentQQError(response);
+  const { message, type } = readAgentQQError(raw, response.status);
   const status = response.status;
   if (status === 429) {
     throw new ProviderRequestError(429, message, { type });
@@ -269,8 +321,7 @@ async function assertAgentQQResponse(response: Response, mode: "validate" | "exe
   throw new ProviderRequestError(status || 500, message, { type });
 }
 
-async function readAgentQQError(response: Response): Promise<{ message: string; type: string }> {
-  const raw = await response.text().catch(() => "");
+function readAgentQQError(raw: string, status: number): { message: string; type: string } {
   try {
     const payload = optionalRecord(JSON.parse(raw));
     const nested = optionalRecord(payload?.error);
@@ -281,12 +332,12 @@ async function readAgentQQError(response: Response): Promise<{ message: string; 
           optionalString(payload?.message) ??
           optionalString(payload?.error) ??
           raw) ||
-        `AgentMail (QQ) request failed with ${response.status}`,
+        `AgentMail (QQ) request failed with ${status}`,
     };
   } catch {
     return {
       type: "provider_error",
-      message: raw || `AgentMail (QQ) request failed with ${response.status}`,
+      message: raw || `AgentMail (QQ) request failed with ${status}`,
     };
   }
 }

--- a/src/providers/agent_qq/executors.ts
+++ b/src/providers/agent_qq/executors.ts
@@ -1,0 +1,292 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalObjectArray,
+  optionalRecord,
+  optionalString,
+} from "../../core/cast.ts";
+import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+const service = "agent_qq";
+const agentQQApiBaseUrl = "https://api.agent.qq.com";
+
+type AgentQQActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+
+const agentQQActionHandlers: Record<string, AgentQQActionHandler> = {
+  list_aliases(_input, context) {
+    return agentQQRequest(context, { path: "/v1/me", mode: "execute" });
+  },
+
+  list_messages(input, context) {
+    const aliasId = requireFieldString(input, "alias_id");
+    const q = optionalString(input.q);
+    const query = buildListMessagesQuery(input);
+    const path = q
+      ? `/v1/aliases/${encodeURIComponent(aliasId)}/messages/search`
+      : `/v1/aliases/${encodeURIComponent(aliasId)}/messages`;
+    return agentQQRequest(context, { path, query, mode: "execute" });
+  },
+
+  read_message(input, context) {
+    const aliasId = requireFieldString(input, "alias_id");
+    const messageId = requireFieldString(input, "message_id");
+    return agentQQRequest(context, {
+      path: `/v1/aliases/${encodeURIComponent(aliasId)}/messages/${encodeURIComponent(messageId)}`,
+      mode: "execute",
+    });
+  },
+
+  async send_message(input, context) {
+    const aliasId = requireFieldString(input, "alias_id");
+    const body = buildSendBody(input);
+    const path = `/v1/aliases/${encodeURIComponent(aliasId)}/messages/send`;
+    const confirmationToken = optionalString(input.confirmation_token);
+
+    if (confirmationToken) {
+      return agentQQRequest(context, {
+        path,
+        method: "POST",
+        body: { ...body, confirmation_token: confirmationToken },
+        mode: "execute",
+      });
+    }
+
+    const initial = await agentQQRequest<unknown>(context, { path, method: "POST", body, mode: "execute" });
+    const data = optionalRecord(optionalRecord(initial as Record<string, unknown>)?.data);
+    const firstToken = optionalString(data?.confirmation_token);
+    if (optionalBoolean(data?.confirmation_required) && firstToken) {
+      return agentQQRequest(context, {
+        path,
+        method: "POST",
+        body: { ...body, confirmation_token: firstToken },
+        mode: "execute",
+      });
+    }
+
+    return initial;
+  },
+
+  async delete_message(input, context) {
+    const aliasId = requireFieldString(input, "alias_id");
+    const messageId = requireFieldString(input, "message_id");
+    const response = await agentQQRequest<unknown>(context, {
+      path: `/v1/aliases/${encodeURIComponent(aliasId)}/messages/${encodeURIComponent(messageId)}`,
+      method: "DELETE",
+      mode: "execute",
+    });
+    if (optionalRecord(response as Record<string, unknown>)) {
+      return response;
+    }
+    return { ok: true, deleted: true, alias_id: aliasId, message_id: messageId };
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, agentQQActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    const context: ApiKeyProviderContext = { apiKey: input.apiKey, fetcher, signal };
+    const payload = await agentQQRequest<unknown>(context, { path: "/v1/me", mode: "validate" });
+    const data = optionalRecord(payload as Record<string, unknown>);
+    const inner = optionalRecord(data?.data);
+    const aliases = optionalObjectArray(inner?.aliases);
+    const primary = aliases[0];
+
+    return {
+      profile: {
+        displayName: optionalString(primary?.email) ?? "AgentMail (QQ)",
+      },
+      grantedScopes: [],
+      metadata: compactObject({
+        aliasCount: aliases.length,
+        scopes: inner?.scopes,
+      }),
+    };
+  },
+};
+
+interface AgentQQRequestOptions {
+  path: string;
+  method?: "GET" | "POST" | "DELETE";
+  query?: Record<string, string>;
+  body?: Record<string, unknown>;
+  mode: "validate" | "execute";
+}
+
+async function agentQQRequest<T>(context: ApiKeyProviderContext, request: AgentQQRequestOptions): Promise<T> {
+  const url = buildAgentQQUrl(request.path, request.query);
+  const hasJsonBody = request.body !== undefined;
+  const response = await context.fetcher(url, {
+    method: request.method ?? "GET",
+    headers: agentQQHeaders(context.apiKey, hasJsonBody),
+    body: hasJsonBody ? JSON.stringify(request.body) : undefined,
+    signal: context.signal,
+  });
+
+  await assertAgentQQResponse(response, request.mode);
+  const text = await response.text().catch(() => "");
+  if (!text) {
+    return {} as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new ProviderRequestError(502, "AgentMail (QQ) returned invalid JSON");
+  }
+}
+
+function buildAgentQQUrl(path: string, query?: Record<string, string>): string {
+  const url = new URL(path, agentQQApiBaseUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+function agentQQHeaders(apiKey: string, hasJsonBody: boolean): Record<string, string> {
+  return {
+    authorization: `Bearer ${apiKey}`,
+    accept: "application/json",
+    ...(hasJsonBody ? { "content-type": "application/json" } : {}),
+    "user-agent": providerUserAgent,
+  };
+}
+
+function requireFieldString(input: Record<string, unknown>, key: string): string {
+  const value = optionalString(input[key]);
+  if (value === undefined) {
+    throw new ProviderRequestError(400, `${key} is required`);
+  }
+  return value;
+}
+
+function buildListMessagesQuery(input: Record<string, unknown>): Record<string, string> {
+  const query: Record<string, string> = {};
+  const limit = optionalInteger(input.limit);
+  if (limit !== undefined) {
+    query.limit = String(limit);
+  }
+  const dir = optionalString(input.dir);
+  if (dir) {
+    query.dir = dir;
+  }
+  const cursor = optionalString(input.cursor);
+  if (cursor) {
+    query.cursor = cursor;
+  }
+  const before = optionalString(input.before);
+  if (before) {
+    query.before = before;
+  }
+  const after = optionalString(input.after);
+  if (after) {
+    query.after = after;
+  }
+  const hasAttachments = optionalBoolean(input.has_attachments);
+  if (hasAttachments === true) {
+    query.has_attachments = "true";
+  }
+  const isUnread = optionalBoolean(input.is_unread);
+  if (isUnread === true) {
+    query.is_read = "false";
+  } else {
+    const isRead = optionalBoolean(input.is_read);
+    if (isRead !== undefined) {
+      query.is_read = String(isRead);
+    }
+  }
+  const q = optionalString(input.q);
+  if (q) {
+    query.q = q;
+  }
+  return query;
+}
+
+function buildSendBody(input: Record<string, unknown>): Record<string, unknown> {
+  const to = toRecipients(input.to, "to");
+  const cc = optionalRecipients(input.cc);
+  const bcc = optionalRecipients(input.bcc);
+  const subject = requireFieldString(input, "subject");
+  const body = requireFieldString(input, "body");
+  const bodyFormat = normalizeBodyFormat(optionalString(input.body_format));
+
+  const msg: Record<string, unknown> = { to, subject, body };
+  if (cc && cc.length > 0) {
+    msg.cc = cc;
+  }
+  if (bcc && bcc.length > 0) {
+    msg.bcc = bcc;
+  }
+  if (bodyFormat) {
+    msg.body_format = bodyFormat;
+  }
+  return msg;
+}
+
+function toRecipients(value: unknown, field: string): Array<{ email: string }> {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ProviderRequestError(400, `${field} must be a non-empty array of email addresses`);
+  }
+  return value.map((email) => ({ email: String(email).trim() }));
+}
+
+function optionalRecipients(value: unknown): Array<{ email: string }> | undefined {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  return value.map((email) => ({ email: String(email).trim() }));
+}
+
+function normalizeBodyFormat(value: string | undefined): string | undefined {
+  if (!value || value === "auto") {
+    return undefined;
+  }
+  return value.toUpperCase();
+}
+
+async function assertAgentQQResponse(response: Response, mode: "validate" | "execute"): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const { message, type } = await readAgentQQError(response);
+  const status = response.status;
+  if (status === 429) {
+    throw new ProviderRequestError(429, message, { type });
+  }
+  if (mode === "validate" && (status === 401 || status === 403)) {
+    throw new ProviderRequestError(400, message, { type });
+  }
+  if (status === 400 || status === 422) {
+    throw new ProviderRequestError(400, message, { type });
+  }
+  throw new ProviderRequestError(status || 500, message, { type });
+}
+
+async function readAgentQQError(response: Response): Promise<{ message: string; type: string }> {
+  const raw = await response.text().catch(() => "");
+  try {
+    const payload = optionalRecord(JSON.parse(raw));
+    const nested = optionalRecord(payload?.error);
+    return {
+      type: optionalString(nested?.type) ?? optionalString(payload?.type) ?? "provider_error",
+      message:
+        (optionalString(nested?.message) ??
+          optionalString(payload?.message) ??
+          optionalString(payload?.error) ??
+          raw) ||
+        `AgentMail (QQ) request failed with ${response.status}`,
+    };
+  } catch {
+    return {
+      type: "provider_error",
+      message: raw || `AgentMail (QQ) request failed with ${response.status}`,
+    };
+  }
+}


### PR DESCRIPTION
Closes #181

## Summary

Adds a new provider, `agent_qq`, for Tencent Agent Mail (`https://agent.qq.com`). It uses the public `https://api.agent.qq.com/v1` REST API.

### Actions

| Action | Method | Path |
|---|---|---|
| `list_aliases` | GET | `/v1/me` |
| `list_messages` | GET | `/v1/aliases/{alias_id}/messages` |
| `read_message` | GET | `/v1/aliases/{alias_id}/messages/{message_id}` |
| `send_message` | POST | `/v1/aliases/{alias_id}/messages/send` |
| `delete_message` | DELETE | `/v1/aliases/{alias_id}/messages/{message_id}` |

- Auth is modeled as `api_key` (the AgentMail OAuth access token) and sent as `Authorization: Bearer <token>`. Users get a token by running `agently-cli auth login` or completing the OAuth device flow.
- `list_messages` falls back to the search endpoint when `q` is provided, and supports filtering by `dir`, `is_read`/`is_unread`, `before`/`after`, `has_attachments`, and cursor pagination.
- `send_message` implements the two-phase confirmation flow automatically: the first POST may return `confirmation_required` + `confirmation_token`, and the executor immediately retries with the token.
- All network egress goes through `context.fetcher` with `providerUserAgent`.

The new service id is `agent_qq` because the existing `agent_mail` provider is already tied to `agentmail.to`.

`npm run fix-check` passes, and the actions have been exercised live: `list_aliases` returns the account aliases while `list_messages` returns the inbox.