### PR TITLE
fix(auth): require admin token for action-run elevation

### DIFF
--- a/src/server/api/auth.test.ts
+++ b/src/server/api/auth.test.ts
@@ -27,4 +27,76 @@ describe("createLocalAuthMiddleware", () => {
     ).toBe(200);
     expect((await app.request("/mcp-not-runtime")).status).toBe(200);
   });
+
+  it("does not open POST /v1/actions when runtime tokens exist but admin token is unset", async () => {
+    const app = new Hono();
+    app.use(
+      "*",
+      createLocalAuthMiddleware({
+        hasRuntimeTokens: async () => true,
+        resolveRuntimeToken: async (token) =>
+          token === "oct_valid" ? { tokenId: "token-1", allowedActions: [], blockedActions: [] } : undefined,
+      }),
+    );
+    app.post("/v1/actions/:actionId", (context) => context.json({ ok: true, actionId: context.req.param("actionId") }));
+    app.get("/v1/actions", (context) => context.json({ ok: true }));
+
+    expect((await app.request("/v1/actions")).status).toBe(401);
+    expect(
+      (
+        await app.request("/v1/actions/example.echo", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ input: {} }),
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await app.request("/v1/actions/example.echo", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer oct_valid",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ input: {} }),
+        })
+      ).status,
+    ).toBe(200);
+  });
+
+  it("allows configured admin tokens to elevate POST /v1/actions", async () => {
+    const app = new Hono();
+    app.use(
+      "*",
+      createLocalAuthMiddleware({
+        adminToken: "admin-secret",
+        hasRuntimeTokens: async () => true,
+        resolveRuntimeToken: async () => undefined,
+      }),
+    );
+    app.post("/v1/actions/:actionId", (context) => context.json({ ok: true }));
+
+    expect(
+      (
+        await app.request("/v1/actions/example.echo", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ input: {} }),
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await app.request("/v1/actions/example.echo", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer admin-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ input: {} }),
+        })
+      ).status,
+    ).toBe(200);
+  });
 });

--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -65,7 +65,14 @@ export function createLocalAuthMiddleware(options: LocalAuthOptions): Middleware
       return;
     }
 
-    if (canUseAdminAuth(context.req.path, context.req.method) && (await hasValidToken(context, options, "admin"))) {
+    // Admin elevation for action runs is only available when an admin token is
+    // configured. Without that, a missing admin token must not open POST
+    // /v1/actions/* while runtime tokens/JWT are otherwise enforcing auth.
+    if (
+      canUseAdminAuth(context.req.path, context.req.method) &&
+      normalizeToken(options.adminToken) &&
+      (await hasValidToken(context, options, "admin"))
+    ) {
       await installAdminCookieForBearer(context, options);
       await next();
       return;

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -1215,6 +1215,13 @@ describe("ConnectServer", () => {
     const unauthorized = await app.request("/v1/actions");
     expect(unauthorized.status).toBe(401);
 
+    const unauthorizedActionRun = await app.request("/v1/actions/example.echo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {} }),
+    });
+    expect(unauthorizedActionRun.status).toBe(401);
+
     const authorized = await app.request("/v1/actions", {
       headers: { authorization: `Bearer ${createdBody.token}` },
     });


### PR DESCRIPTION
## Summary

- Close an authentication gap where `POST /v1/actions/*` treated a **missing** `OOMOL_CONNECT_ADMIN_TOKEN` as always-allowed admin elevation.
- After runtime tokens exist (so `GET /v1/*` correctly returns 401 without a bearer), unauthenticated action runs could still succeed through the admin fallback path.
- Admin elevation for action runs now requires a **configured** admin token that is actually presented on the request.

## Problem

`canUseAdminAuth` allows `POST /v1/actions/:actionId` to fall back to admin scope. When no admin token is configured, `hasValidToken(..., "admin")` returned `true` unconditionally. Combined with stored runtime tokens enforcing runtime auth on GETs, this left action execution open without credentials.

## Changes

- Only attempt admin elevation for action runs when `OOMOL_CONNECT_ADMIN_TOKEN` is set.
- Regression tests for unauthenticated `POST /v1/actions/*` when runtime tokens exist, and for configured admin elevation.

## Test plan

- [x] `npm test -- src/server/api/auth.test.ts`
- [x] `npm test -- src/server/connect-server.test.ts -t "runtime token"`
- [ ] Manual: create a runtime token without admin env, confirm unauthenticated action POST is 401