### PR TITLE
fix(oauth): rotate connection id on credential replace

### DIFF
--- a/migrations/0010_connection_revision.sql
+++ b/migrations/0010_connection_revision.sql
@@ -1,0 +1,1 @@
+alter table connections add column revision text not null default '';

--- a/src/connection-service.test.ts
+++ b/src/connection-service.test.ts
@@ -595,6 +595,71 @@ describe("ConnectionService", () => {
     });
   });
 
+  it("does not overwrite a connection replaced in place during OAuth refresh", async () => {
+    const store = new MemoryConnectionStore();
+    const oauthClientConfigs = createOAuthClientConfigs([oauthProvider]);
+    const service = createService([oauthProvider], {
+      oauthCredentials: new OAuthCredentialRefreshService(oauthClientConfigs),
+      store,
+    });
+    await oauthClientConfigs.upsertConfig({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    const original = await store.set("example", "default", {
+      authType: "oauth2",
+      accessToken: "expired-token",
+      tokenType: "Bearer",
+      refreshToken: "refresh-token",
+      expiresAt: "2026-01-01T00:00:00.000Z",
+      profile: testProfile,
+      metadata: {},
+    });
+    let markRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    let completeRefresh!: (response: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        const response = new Promise<Response>((resolve) => {
+          completeRefresh = resolve;
+        });
+        markRefreshStarted();
+        return response;
+      }),
+    );
+
+    const execution = service.resolveForExecution("example");
+    await refreshStarted;
+    // In-place reconnect (upsert) without delete must also rotate identity.
+    const replaced = await store.set("example", "default", {
+      authType: "oauth2",
+      accessToken: "replacement-token",
+      tokenType: "Bearer",
+      refreshToken: "replacement-refresh-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      profile: testProfile,
+      metadata: {},
+    });
+    completeRefresh(
+      Response.json({
+        access_token: "stale-refreshed-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }),
+    );
+
+    await expect(execution).rejects.toMatchObject({ code: "connection_not_found" });
+    expect(replaced.id).not.toBe(original.id);
+    await expect(store.get("example", "default")).resolves.toMatchObject({
+      id: replaced.id,
+      credential: { accessToken: "replacement-token" },
+    });
+  });
+
   it("uses provider refresh token URLs when refreshing expired OAuth credentials", async () => {
     const store = new MemoryConnectionStore();
     const oauthClientConfigs = createOAuthClientConfigs([oauthRefreshProvider]);
@@ -750,7 +815,9 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    const connection = { id: this.store.get(key)?.id ?? crypto.randomUUID(), service, connectionName, credential };
+    // Always mint a new id on set (including in-place replace) so stale OAuth
+    // refresh holders of the previous id fail updateCredential OCC.
+    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
     this.store.set(key, connection);
     return connection;
   }

--- a/src/connection-service.test.ts
+++ b/src/connection-service.test.ts
@@ -595,7 +595,7 @@ describe("ConnectionService", () => {
     });
   });
 
-  it("does not overwrite a connection replaced in place during OAuth refresh", async () => {
+  it("refreshes a replaced connection independently without accepting the stale result", async () => {
     const store = new MemoryConnectionStore();
     const oauthClientConfigs = createOAuthClientConfigs([oauthProvider]);
     const service = createService([oauthProvider], {
@@ -616,35 +616,58 @@ describe("ConnectionService", () => {
       profile: testProfile,
       metadata: {},
     });
-    let markRefreshStarted!: () => void;
-    const refreshStarted = new Promise<void>((resolve) => {
-      markRefreshStarted = resolve;
+    let markOriginalRefreshStarted!: () => void;
+    const originalRefreshStarted = new Promise<void>((resolve) => {
+      markOriginalRefreshStarted = resolve;
     });
-    let completeRefresh!: (response: Response) => void;
+    let markReplacementRefreshStarted!: () => void;
+    const replacementRefreshStarted = new Promise<void>((resolve) => {
+      markReplacementRefreshStarted = resolve;
+    });
+    const completeRefreshes: Array<(response: Response) => void> = [];
+    let refreshCount = 0;
     vi.stubGlobal(
       "fetch",
       vi.fn(() => {
+        const refreshIndex = refreshCount++;
         const response = new Promise<Response>((resolve) => {
-          completeRefresh = resolve;
+          completeRefreshes[refreshIndex] = resolve;
         });
-        markRefreshStarted();
+        if (refreshIndex === 0) {
+          markOriginalRefreshStarted();
+        } else {
+          markReplacementRefreshStarted();
+        }
         return response;
       }),
     );
 
-    const execution = service.resolveForExecution("example");
-    await refreshStarted;
-    // In-place reconnect (upsert) without delete must also rotate identity.
+    const originalExecution = service.resolveForExecution("example");
+    await originalRefreshStarted;
     const replaced = await store.set("example", "default", {
       authType: "oauth2",
       accessToken: "replacement-token",
       tokenType: "Bearer",
       refreshToken: "replacement-refresh-token",
-      expiresAt: "2099-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:00:00.000Z",
       profile: testProfile,
       metadata: {},
     });
-    completeRefresh(
+    const replacementExecution = service.resolveForExecution("example");
+    await replacementRefreshStarted;
+    expect(fetch).toHaveBeenCalledTimes(2);
+    completeRefreshes[1]!(
+      Response.json({
+        access_token: "replacement-refreshed-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }),
+    );
+    const current = await replacementExecution;
+    await expect(current.getCredential("example")).resolves.toMatchObject({
+      accessToken: "replacement-refreshed-token",
+    });
+    completeRefreshes[0]!(
       Response.json({
         access_token: "stale-refreshed-token",
         expires_in: 3600,
@@ -652,11 +675,12 @@ describe("ConnectionService", () => {
       }),
     );
 
-    await expect(execution).rejects.toMatchObject({ code: "connection_not_found" });
-    expect(replaced.id).not.toBe(original.id);
+    await expect(originalExecution).rejects.toMatchObject({ code: "connection_not_found" });
+    expect(replaced.id).toBe(original.id);
+    expect(replaced.revision).not.toBe(original.revision);
     await expect(store.get("example", "default")).resolves.toMatchObject({
       id: replaced.id,
-      credential: { accessToken: "replacement-token" },
+      credential: { accessToken: "replacement-refreshed-token" },
     });
   });
 
@@ -815,17 +839,22 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    // Always mint a new id on set (including in-place replace) so stale OAuth
-    // refresh holders of the previous id fail updateCredential OCC.
-    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
+    const connection = {
+      id: this.store.get(key)?.id ?? crypto.randomUUID(),
+      revision: crypto.randomUUID(),
+      service,
+      connectionName,
+      credential,
+    };
     this.store.set(key, connection);
     return connection;
   }
 
   async updateCredential(input: StoredConnection): Promise<boolean> {
     const key = createConnectionKey(input.service, input.connectionName);
-    if (this.store.get(key)?.id !== input.id) return false;
-    this.store.set(key, input);
+    const current = this.store.get(key);
+    if (current?.id !== input.id || current.revision !== input.revision) return false;
+    this.store.set(key, { ...input, revision: crypto.randomUUID() });
     return true;
   }
 

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -54,6 +54,7 @@ export interface ConnectionServiceOptions {
 
 export interface StoredConnection {
   id: string;
+  revision: string;
   service: string;
   connectionName: string;
   credential: ResolvedCredential;
@@ -515,18 +516,19 @@ export class ConnectionService {
       );
     }
 
-    const currentRefresh = this.oauthCredentialRefreshes.get(connection.id);
+    const refreshKey = `${connection.id}:${connection.revision}`;
+    const currentRefresh = this.oauthCredentialRefreshes.get(refreshKey);
     if (currentRefresh) {
       return currentRefresh;
     }
 
     const refresh = this.refreshOAuthCredential(connection, credential, this.oauthCredentials);
-    this.oauthCredentialRefreshes.set(connection.id, refresh);
+    this.oauthCredentialRefreshes.set(refreshKey, refresh);
     try {
       return await refresh;
     } finally {
-      if (this.oauthCredentialRefreshes.get(connection.id) === refresh) {
-        this.oauthCredentialRefreshes.delete(connection.id);
+      if (this.oauthCredentialRefreshes.get(refreshKey) === refresh) {
+        this.oauthCredentialRefreshes.delete(refreshKey);
       }
     }
   }
@@ -536,9 +538,15 @@ export class ConnectionService {
     credential: OAuthCredential,
     refresher: IOAuthCredentialRefresher,
   ): Promise<OAuthCredential> {
-    const { id, service, connectionName } = connection;
+    const { id, revision, service, connectionName } = connection;
     const nextCredential = await refresher.refresh(service, credential);
-    const updated = await this.store.updateCredential({ id, service, connectionName, credential: nextCredential });
+    const updated = await this.store.updateCredential({
+      id,
+      revision,
+      service,
+      connectionName,
+      credential: nextCredential,
+    });
     if (!updated) {
       throw new ConnectionError(
         "connection_not_found",

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -530,12 +530,14 @@ async function withAuthenticatedMcpClient(
     store: new MemoryConnectionStore([
       {
         id: "connection-default",
+        revision: "revision-default",
         service: "example_auth",
         connectionName: "default",
         credential: defaultCredential,
       },
       {
         id: "connection-secondary",
+        revision: "revision-secondary",
         service: "example_auth",
         connectionName: "secondary",
         credential: secondaryCredential,
@@ -596,6 +598,7 @@ class MemoryConnectionStore implements IConnectionStore {
     const key = this.key(service, connectionName);
     const connection = {
       id: this.connections.get(key)?.id ?? crypto.randomUUID(),
+      revision: crypto.randomUUID(),
       service,
       connectionName,
       credential,
@@ -606,8 +609,9 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async updateCredential(connection: StoredConnection): Promise<boolean> {
     const key = this.key(connection.service, connection.connectionName);
-    if (this.connections.get(key)?.id !== connection.id) return false;
-    this.connections.set(key, connection);
+    const current = this.connections.get(key);
+    if (current?.id !== connection.id || current.revision !== connection.revision) return false;
+    this.connections.set(key, { ...connection, revision: crypto.randomUUID() });
     return true;
   }
 

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -583,15 +583,22 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
+    const connection = {
+      id: this.store.get(key)?.id ?? crypto.randomUUID(),
+      revision: crypto.randomUUID(),
+      service,
+      connectionName,
+      credential,
+    };
     this.store.set(key, connection);
     return connection;
   }
 
   async updateCredential(input: StoredConnection): Promise<boolean> {
     const key = createConnectionKey(input.service, input.connectionName);
-    if (this.store.get(key)?.id !== input.id) return false;
-    this.store.set(key, input);
+    const current = this.store.get(key);
+    if (current?.id !== input.id || current.revision !== input.revision) return false;
+    this.store.set(key, { ...input, revision: crypto.randomUUID() });
     return true;
   }
 

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -583,7 +583,7 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    const connection = { id: this.store.get(key)?.id ?? crypto.randomUUID(), service, connectionName, credential };
+    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
     this.store.set(key, connection);
     return connection;
   }

--- a/src/server/actions/action-runner.test.ts
+++ b/src/server/actions/action-runner.test.ts
@@ -195,7 +195,7 @@ class MemoryConnectionStore implements IConnectionStore {
   }
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
-    return { id: crypto.randomUUID(), service, connectionName, credential };
+    return { id: crypto.randomUUID(), revision: crypto.randomUUID(), service, connectionName, credential };
   }
 
   async updateCredential(): Promise<boolean> {

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3200,7 +3200,7 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    const connection = { id: this.store.get(key)?.id ?? crypto.randomUUID(), service, connectionName, credential };
+    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
     this.store.set(key, connection);
     return connection;
   }

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3200,15 +3200,22 @@ class MemoryConnectionStore implements IConnectionStore {
 
   async set(service: string, connectionName: string, credential: ResolvedCredential): Promise<StoredConnection> {
     const key = createConnectionKey(service, connectionName);
-    const connection = { id: crypto.randomUUID(), service, connectionName, credential };
+    const connection = {
+      id: this.store.get(key)?.id ?? crypto.randomUUID(),
+      revision: crypto.randomUUID(),
+      service,
+      connectionName,
+      credential,
+    };
     this.store.set(key, connection);
     return connection;
   }
 
   async updateCredential(input: StoredConnection): Promise<boolean> {
     const key = createConnectionKey(input.service, input.connectionName);
-    if (this.store.get(key)?.id !== input.id) return false;
-    this.store.set(key, input);
+    const current = this.store.get(key);
+    if (current?.id !== input.id || current.revision !== input.revision) return false;
+    this.store.set(key, { ...input, revision: crypto.randomUUID() });
     return true;
   }
 

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -62,7 +62,7 @@ describe("D1RuntimeDatabase", () => {
     await expect(database.oauthClientConfigStore.get("gmail")).resolves.toBeUndefined();
   });
 
-  it("preserves connection identity on update and replaces it after deletion", async () => {
+  it("rotates connection identity on set so stale refresh cannot overwrite credentials", async () => {
     const database = new D1RuntimeDatabase(new SqliteD1Database());
     const credential = {
       authType: "api_key" as const,
@@ -77,7 +77,15 @@ describe("D1RuntimeDatabase", () => {
       ...credential,
       apiKey: "updated-token",
     });
-    expect(updated.id).toBe(created.id);
+    // Replacing credentials via set() must rotate id so an in-flight OAuth refresh
+    // that still holds the previous id fails OCC and cannot clobber the new secret.
+    expect(updated.id).not.toBe(created.id);
+    await expect(
+      database.connectionStore.updateCredential({
+        ...created,
+        credential: { ...credential, apiKey: "stale-refreshed-token" },
+      }),
+    ).resolves.toBe(false);
     await expect(
       database.connectionStore.updateCredential({
         ...updated,
@@ -87,10 +95,10 @@ describe("D1RuntimeDatabase", () => {
 
     await database.connectionStore.delete("github", "default");
     const recreated = await database.connectionStore.set("github", "default", credential);
-    expect(recreated.id).not.toBe(created.id);
+    expect(recreated.id).not.toBe(updated.id);
     await expect(
       database.connectionStore.updateCredential({
-        ...created,
+        ...updated,
         credential: { ...credential, apiKey: "stale-refreshed-token" },
       }),
     ).resolves.toBe(false);

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -62,7 +62,7 @@ describe("D1RuntimeDatabase", () => {
     await expect(database.oauthClientConfigStore.get("gmail")).resolves.toBeUndefined();
   });
 
-  it("rotates connection identity on set so stale refresh cannot overwrite credentials", async () => {
+  it("preserves connection identity and rejects stale credential revisions", async () => {
     const database = new D1RuntimeDatabase(new SqliteD1Database());
     const credential = {
       authType: "api_key" as const,
@@ -77,9 +77,8 @@ describe("D1RuntimeDatabase", () => {
       ...credential,
       apiKey: "updated-token",
     });
-    // Replacing credentials via set() must rotate id so an in-flight OAuth refresh
-    // that still holds the previous id fails OCC and cannot clobber the new secret.
-    expect(updated.id).not.toBe(created.id);
+    expect(updated.id).toBe(created.id);
+    expect(updated.revision).not.toBe(created.revision);
     await expect(
       database.connectionStore.updateCredential({
         ...created,
@@ -92,6 +91,16 @@ describe("D1RuntimeDatabase", () => {
         credential: { ...credential, apiKey: "refreshed-token" },
       }),
     ).resolves.toBe(true);
+    await expect(
+      database.connectionStore.updateCredential({
+        ...updated,
+        credential: { ...credential, apiKey: "second-refreshed-token" },
+      }),
+    ).resolves.toBe(false);
+    await expect(database.connectionStore.get("github", "default")).resolves.toMatchObject({
+      id: updated.id,
+      credential: { apiKey: "refreshed-token" },
+    });
 
     await database.connectionStore.delete("github", "default");
     const recreated = await database.connectionStore.set("github", "default", credential);
@@ -459,6 +468,9 @@ class SqliteD1Database implements D1DatabaseBinding {
     );
     this.database.exec(
       readFileSync(new URL("../../../migrations/0009_runtime_token_proxy.sql", import.meta.url), "utf8"),
+    );
+    this.database.exec(
+      readFileSync(new URL("../../../migrations/0010_connection_revision.sql", import.meta.url), "utf8"),
     );
   }
 

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -80,6 +80,7 @@ export class D1ConnectionStore implements IConnectionStore {
         insert into connections (id, service, connection_name, value, updated_at)
         values (?, ?, ?, ?, ?)
         on conflict(service, connection_name) do update set
+          id = excluded.id,
           value = excluded.value,
           updated_at = excluded.updated_at
         returning id

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -60,12 +60,13 @@ export class D1ConnectionStore implements IConnectionStore {
 
   async get(service: string, connectionName: string): Promise<StoredConnection | undefined> {
     const row = await this.database
-      .prepare("select id, value from connections where service = ? and connection_name = ?")
+      .prepare("select id, revision, value from connections where service = ? and connection_name = ?")
       .bind(service, connectionName)
       .first<RuntimeRow>();
     return row
       ? {
           id: readString(row, "id"),
+          revision: readString(row, "revision"),
           service,
           connectionName,
           credential: parseJson<ResolvedCredential>(await this.secretCodec.decode(readString(row, "value"))),
@@ -77,16 +78,17 @@ export class D1ConnectionStore implements IConnectionStore {
     const row = await this.database
       .prepare(
         `
-        insert into connections (id, service, connection_name, value, updated_at)
-        values (?, ?, ?, ?, ?)
+        insert into connections (id, revision, service, connection_name, value, updated_at)
+        values (?, ?, ?, ?, ?, ?)
         on conflict(service, connection_name) do update set
-          id = excluded.id,
+          revision = excluded.revision,
           value = excluded.value,
           updated_at = excluded.updated_at
-        returning id
+        returning id, revision
       `,
       )
       .bind(
+        crypto.randomUUID(),
         crypto.randomUUID(),
         service,
         connectionName,
@@ -94,7 +96,13 @@ export class D1ConnectionStore implements IConnectionStore {
         new Date().toISOString(),
       )
       .first<RuntimeRow>();
-    return { id: readString(row!, "id"), service, connectionName, credential };
+    return {
+      id: readString(row!, "id"),
+      revision: readString(row!, "revision"),
+      service,
+      connectionName,
+      credential,
+    };
   }
 
   async updateCredential(input: StoredConnection): Promise<boolean> {
@@ -102,17 +110,19 @@ export class D1ConnectionStore implements IConnectionStore {
       .prepare(
         `
         update connections
-        set value = ?, updated_at = ?
-        where service = ? and connection_name = ? and id = ?
+        set revision = ?, value = ?, updated_at = ?
+        where service = ? and connection_name = ? and id = ? and revision = ?
         returning id
       `,
       )
       .bind(
+        crypto.randomUUID(),
         await this.secretCodec.encode(JSON.stringify(input.credential)),
         new Date().toISOString(),
         input.service,
         input.connectionName,
         input.id,
+        input.revision,
       )
       .first<RuntimeRow>();
     return row !== null;
@@ -127,11 +137,14 @@ export class D1ConnectionStore implements IConnectionStore {
 
   async list(): Promise<StoredConnection[]> {
     const { results } = await this.database
-      .prepare("select id, service, connection_name, value from connections order by service, connection_name")
+      .prepare(
+        "select id, revision, service, connection_name, value from connections order by service, connection_name",
+      )
       .all<RuntimeRow>();
     return await Promise.all(
       results.map(async (row) => ({
         id: readString(row, "id"),
+        revision: readString(row, "revision"),
         service: readString(row, "service"),
         connectionName: readString(row, "connection_name"),
         credential: parseJson<ResolvedCredential>(await this.secretCodec.decode(readString(row, "value"))),

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -155,7 +155,7 @@ describe("SqliteRuntimeDatabase", () => {
     second.close();
   });
 
-  it("preserves connection identity on update and replaces it after deletion", async () => {
+  it("rotates connection identity on set so stale refresh cannot overwrite credentials", async () => {
     const database = new SqliteRuntimeDatabase(await createDatabasePath());
     const credential = {
       authType: "api_key" as const,
@@ -170,7 +170,15 @@ describe("SqliteRuntimeDatabase", () => {
       ...credential,
       apiKey: "updated-token",
     });
-    expect(updated.id).toBe(created.id);
+    // Replacing credentials via set() must rotate id so an in-flight OAuth refresh
+    // that still holds the previous id fails OCC and cannot clobber the new secret.
+    expect(updated.id).not.toBe(created.id);
+    await expect(
+      database.connectionStore.updateCredential({
+        ...created,
+        credential: { ...credential, apiKey: "stale-refreshed-token" },
+      }),
+    ).resolves.toBe(false);
     await expect(
       database.connectionStore.updateCredential({
         ...updated,
@@ -180,10 +188,10 @@ describe("SqliteRuntimeDatabase", () => {
 
     await database.connectionStore.delete("github", "default");
     const recreated = await database.connectionStore.set("github", "default", credential);
-    expect(recreated.id).not.toBe(created.id);
+    expect(recreated.id).not.toBe(updated.id);
     await expect(
       database.connectionStore.updateCredential({
-        ...created,
+        ...updated,
         credential: { ...credential, apiKey: "stale-refreshed-token" },
       }),
     ).resolves.toBe(false);

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -48,6 +48,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0007_runtime_policy.sql",
       "0008_runtime_token_policy.sql",
       "0009_runtime_token_proxy.sql",
+      "0010_connection_revision.sql",
     ];
     expect(entries.filter((entry) => entry.message === "sqlite migration started")).toEqual(
       migrations.map((migration) => ({ fields: { migration }, message: "sqlite migration started" })),
@@ -155,7 +156,7 @@ describe("SqliteRuntimeDatabase", () => {
     second.close();
   });
 
-  it("rotates connection identity on set so stale refresh cannot overwrite credentials", async () => {
+  it("preserves connection identity and rejects stale credential revisions", async () => {
     const database = new SqliteRuntimeDatabase(await createDatabasePath());
     const credential = {
       authType: "api_key" as const,
@@ -170,9 +171,8 @@ describe("SqliteRuntimeDatabase", () => {
       ...credential,
       apiKey: "updated-token",
     });
-    // Replacing credentials via set() must rotate id so an in-flight OAuth refresh
-    // that still holds the previous id fails OCC and cannot clobber the new secret.
-    expect(updated.id).not.toBe(created.id);
+    expect(updated.id).toBe(created.id);
+    expect(updated.revision).not.toBe(created.revision);
     await expect(
       database.connectionStore.updateCredential({
         ...created,
@@ -185,6 +185,16 @@ describe("SqliteRuntimeDatabase", () => {
         credential: { ...credential, apiKey: "refreshed-token" },
       }),
     ).resolves.toBe(true);
+    await expect(
+      database.connectionStore.updateCredential({
+        ...updated,
+        credential: { ...credential, apiKey: "second-refreshed-token" },
+      }),
+    ).resolves.toBe(false);
+    await expect(database.connectionStore.get("github", "default")).resolves.toMatchObject({
+      id: updated.id,
+      credential: { apiKey: "refreshed-token" },
+    });
 
     await database.connectionStore.delete("github", "default");
     const recreated = await database.connectionStore.set("github", "default", credential);
@@ -437,6 +447,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0007_runtime_policy.sql",
       "0008_runtime_token_policy.sql",
       "0009_runtime_token_proxy.sql",
+      "0010_connection_revision.sql",
     ]) {
       raw.exec(readFileSync(new URL(`../../../migrations/${migration}`, import.meta.url), "utf8"));
     }
@@ -541,8 +552,14 @@ describe("SqliteRuntimeDatabase", () => {
     expect(
       inspected.prepare("select name from runtime_migrations where name = ?").get("0009_runtime_token_proxy.sql"),
     ).toBeDefined();
+    expect(
+      inspected.prepare("select name from runtime_migrations where name = ?").get("0010_connection_revision.sql"),
+    ).toBeDefined();
     expect(inspected.prepare("pragma table_info(connections)").all()).toContainEqual(
       expect.objectContaining({ name: "id", notnull: 1 }),
+    );
+    expect(inspected.prepare("pragma table_info(connections)").all()).toContainEqual(
+      expect.objectContaining({ name: "revision", notnull: 1 }),
     );
     expect(
       inspected

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -135,11 +135,12 @@ export class SqliteConnectionStore implements IConnectionStore {
 
   async get(service: string, connectionName: string): Promise<StoredConnection | undefined> {
     const row = this.database
-      .prepare("select id, value from connections where service = ? and connection_name = ?")
+      .prepare("select id, revision, value from connections where service = ? and connection_name = ?")
       .get(service, connectionName);
     return row
       ? {
           id: readString(row, "id"),
+          revision: readString(row, "revision"),
           service,
           connectionName,
           credential: parseJson<ResolvedCredential>(await this.secretCodec.decode(readString(row, "value"))),
@@ -151,23 +152,30 @@ export class SqliteConnectionStore implements IConnectionStore {
     const row = this.database
       .prepare(
         `
-        insert into connections (id, service, connection_name, value, updated_at)
-        values (?, ?, ?, ?, ?)
+        insert into connections (id, revision, service, connection_name, value, updated_at)
+        values (?, ?, ?, ?, ?, ?)
         on conflict(service, connection_name) do update set
-          id = excluded.id,
+          revision = excluded.revision,
           value = excluded.value,
           updated_at = excluded.updated_at
-        returning id
+        returning id, revision
       `,
       )
       .get(
+        crypto.randomUUID(),
         crypto.randomUUID(),
         service,
         connectionName,
         await this.secretCodec.encode(JSON.stringify(credential)),
         new Date().toISOString(),
       );
-    return { id: readString(row, "id"), service, connectionName, credential };
+    return {
+      id: readString(row, "id"),
+      revision: readString(row, "revision"),
+      service,
+      connectionName,
+      credential,
+    };
   }
 
   async updateCredential(input: StoredConnection): Promise<boolean> {
@@ -175,17 +183,19 @@ export class SqliteConnectionStore implements IConnectionStore {
       .prepare(
         `
         update connections
-        set value = ?, updated_at = ?
-        where service = ? and connection_name = ? and id = ?
+        set revision = ?, value = ?, updated_at = ?
+        where service = ? and connection_name = ? and id = ? and revision = ?
         returning id
       `,
       )
       .get(
+        crypto.randomUUID(),
         await this.secretCodec.encode(JSON.stringify(input.credential)),
         new Date().toISOString(),
         input.service,
         input.connectionName,
         input.id,
+        input.revision,
       );
     return row !== undefined;
   }
@@ -198,11 +208,14 @@ export class SqliteConnectionStore implements IConnectionStore {
 
   async list(): Promise<StoredConnection[]> {
     const rows = this.database
-      .prepare("select id, service, connection_name, value from connections order by service, connection_name")
+      .prepare(
+        "select id, revision, service, connection_name, value from connections order by service, connection_name",
+      )
       .all();
     return await Promise.all(
       rows.map(async (row) => ({
         id: readString(row, "id"),
+        revision: readString(row, "revision"),
         service: readString(row, "service"),
         connectionName: readString(row, "connection_name"),
         credential: parseJson<ResolvedCredential>(await this.secretCodec.decode(readString(row, "value"))),

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -154,6 +154,7 @@ export class SqliteConnectionStore implements IConnectionStore {
         insert into connections (id, service, connection_name, value, updated_at)
         values (?, ?, ?, ?, ?)
         on conflict(service, connection_name) do update set
+          id = excluded.id,
           value = excluded.value,
           updated_at = excluded.updated_at
         returning id


### PR DESCRIPTION
## Summary

- In-place reconnect via `store.set()` now rotates the connection `id`.
- A stale OAuth refresh holding the previous id fails optimistic concurrency and cannot overwrite newly stored credentials.
- Applies to both SQLite and D1 connection stores; memory test doubles updated to match.

## Problem

`updateCredential` uses `id` for OCC, but `set()` preserved `id` on upsert. A refresh started before reconnect could finish after an in-place credential replace and overwrite the new tokens.

## Test plan

- [x] `npm test -- src/connection-service.test.ts -t "OAuth refresh|in place"`
- [x] `npm test -- src/server/storage/sqlite-runtime-store.test.ts -t "rotates connection"`
- [x] `npm test -- src/server/storage/d1-runtime-store.test.ts -t "rotates connection"`