### PR TITLE
fix(policy): deny proxy for action-allowlisted runtime tokens

### DIFF
--- a/src/core/action-policy.test.ts
+++ b/src/core/action-policy.test.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from "./types.ts";
 
 import { describe, expect, it } from "vitest";
-import { ActionPolicyService, parseActionPolicyList } from "./action-policy.ts";
+import { ActionPolicyService, emptyPolicyRules, parseActionPolicyList } from "./action-policy.ts";
 
 const action: ActionDefinition = {
   id: "github.create_issue",
@@ -61,7 +61,9 @@ describe("ActionPolicyService", () => {
     expect(new ActionPolicyService().evaluateProxy("github")).toEqual({ allowed: true, checks: [] });
   });
 
-  it("ignores action policy when evaluating proxies", () => {
+  it("ignores deployment action policy when evaluating proxies", () => {
+    // Deployment action allow/block lists do not apply to proxy; only dedicated
+    // proxy rules and (separately) token action allowlists do.
     expect(new ActionPolicyService({ allowedActions: ["github.get_current_user"] }).evaluateProxy("github")).toEqual({
       allowed: true,
       checks: [],
@@ -78,6 +80,30 @@ describe("ActionPolicyService", () => {
       allowed: true,
       checks: [],
     });
+  });
+
+  it("denies proxy for runtime tokens with a concrete action allowlist", () => {
+    const restricted = new ActionPolicyService().createSnapshot(emptyPolicyRules(), {
+      allowedActions: ["hackernews.get_item"],
+      blockedActions: [],
+    });
+    expect(restricted.evaluateProxy("github")).toMatchObject({
+      allowed: false,
+      code: "proxy_not_allowed",
+      checks: [{ source: "token", outcome: "allow_miss" }],
+    });
+
+    const unrestricted = new ActionPolicyService().createSnapshot(emptyPolicyRules(), {
+      allowedActions: [],
+      blockedActions: ["github.delete_repository"],
+    });
+    expect(unrestricted.evaluateProxy("github")).toEqual({ allowed: true, checks: [] });
+
+    const wildcardToken = new ActionPolicyService().createSnapshot(emptyPolicyRules(), {
+      allowedActions: ["*"],
+      blockedActions: [],
+    });
+    expect(wildcardToken.evaluateProxy("github")).toEqual({ allowed: true, checks: [] });
   });
 
   it("ignores proxy policy when evaluating actions", () => {

--- a/src/core/action-policy.ts
+++ b/src/core/action-policy.ts
@@ -64,6 +64,13 @@ export class ActionPolicySnapshot {
   readonly state: RuntimePolicyState;
   private readonly layers: CompiledLayer[];
   private readonly proxyLayers: CompiledLayer[];
+  /**
+   * When a runtime token carries a non-wildcard action allowlist, proxy is
+   * denied so least-privilege tokens cannot bypass action policy via /v1/proxy.
+   * Unrestricted tokens (empty allowlist, or allowlist containing `*`) still
+   * use deployment/runtime proxy rules only.
+   */
+  private readonly tokenRestrictsProxy: boolean;
 
   constructor(deployment: PolicyRules, runtime: PolicyRules, token?: TokenActionPolicy, updatedAt?: string) {
     const deploymentRules = immutablePolicyRules(deployment);
@@ -71,6 +78,7 @@ export class ActionPolicySnapshot {
     this.state = Object.freeze({ deployment: deploymentRules, runtime: runtimeRules, updatedAt });
     this.proxyLayers = [compileLayer("deployment", deploymentRules), compileLayer("runtime", runtimeRules)];
     this.layers = [...this.proxyLayers];
+    this.tokenRestrictsProxy = tokenRestrictsProxy(token);
     if (token) {
       const tokenRules = immutablePolicyRules({
         allowedActions: token.allowedActions,
@@ -116,6 +124,15 @@ export class ActionPolicySnapshot {
   }
 
   evaluateProxy(service: string): ActionPolicyDecision {
+    if (this.tokenRestrictsProxy) {
+      return {
+        allowed: false,
+        code: "proxy_not_allowed",
+        message: `${service} proxy is not available for runtime tokens with an action allowlist.`,
+        checks: [{ source: "token", outcome: "allow_miss" }],
+      };
+    }
+
     for (const layer of this.proxyLayers) {
       const blocked = layer.blockedProxies.find((rule) => rule.matches(service));
       if (blocked) {
@@ -147,6 +164,18 @@ export class ActionPolicySnapshot {
 
     return { allowed: true, checks };
   }
+}
+
+/**
+ * Tokens with a concrete action allowlist are least-privilege credentials and
+ * must not use open proxy. An empty allowlist (no restriction) or an allowlist
+ * that includes `*` remains eligible for deployment/runtime proxy rules.
+ */
+function tokenRestrictsProxy(token: TokenActionPolicy | undefined): boolean {
+  if (!token || token.allowedActions.length === 0) {
+    return false;
+  }
+  return !token.allowedActions.includes("*");
 }
 
 /**

--- a/src/server/proxy/proxy-runner.test.ts
+++ b/src/server/proxy/proxy-runner.test.ts
@@ -81,7 +81,7 @@ describe("ProxyRunner", () => {
     expect(connections.getConnectionSummary).not.toHaveBeenCalled();
   });
 
-  it("combines deployment and Runtime proxy policy while ignoring token action rules", async () => {
+  it("combines deployment and Runtime proxy policy", async () => {
     const loadProxyExecutor = vi.fn();
     const actionPolicy = new ActionPolicyService({ allowedProxies: ["example"] });
     const runner = createRunner({
@@ -99,6 +99,7 @@ describe("ProxyRunner", () => {
         allowedProxies: [],
         blockedProxies: ["example"],
       },
+      // Token with no action allowlist still uses deployment/runtime proxy rules.
       { allowedActions: [], blockedActions: ["example.*"] },
     );
 
@@ -107,6 +108,36 @@ describe("ProxyRunner", () => {
     ).resolves.toMatchObject({
       ok: false,
       errorCode: "proxy_blocked",
+    });
+    expect(loadProxyExecutor).not.toHaveBeenCalled();
+  });
+
+  it("denies proxy for tokens that carry an action allowlist", async () => {
+    const loadProxyExecutor = vi.fn();
+    const actionPolicy = new ActionPolicyService({ allowedProxies: ["example"] });
+    const runner = createRunner({
+      actionPolicy,
+      providerLoader: {
+        loadActionExecutor: async () => undefined,
+        loadCredentialValidators: async () => undefined,
+        loadProxyExecutor,
+      },
+    });
+    const policy = actionPolicy.createSnapshot(
+      {
+        allowedActions: [],
+        blockedActions: [],
+        allowedProxies: ["example"],
+        blockedProxies: [],
+      },
+      { allowedActions: ["example.echo"], blockedActions: [] },
+    );
+
+    await expect(
+      runner.run({ service: "example", input: { endpoint: "/items", method: "GET" }, policy }),
+    ).resolves.toMatchObject({
+      ok: false,
+      errorCode: "proxy_not_allowed",
     });
     expect(loadProxyExecutor).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- Runtime tokens with a **concrete** action allowlist can no longer call `/v1/proxy`.
- Previously, token action rules were ignored for proxy evaluation, so least-privilege tokens could still drive arbitrary provider HTTP with stored credentials.
- Unrestricted tokens (empty allowlist, or allowlist containing `*`) still use deployment/runtime proxy rules only.

## Test plan

- [x] `npm test -- src/core/action-policy.test.ts`
- [x] `npm test -- src/server/proxy/proxy-runner.test.ts`