### PR TITLE
fix(oauth): parse string and zero expires_in lifetimes

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { requestAuthorizationCodeToken } from "./oauth-token.ts";
+import { requestAuthorizationCodeToken, requestRefreshToken } from "./oauth-token.ts";
 
 const authorizationCodeRequest = {
   clientId: "client-id",
@@ -11,9 +11,24 @@ const authorizationCodeRequest = {
   tokenUrl: "https://provider.example.com/oauth/token",
 };
 
+function stubTokenResponse(expiresIn: unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      Response.json({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        token_type: "Bearer",
+        expires_in: expiresIn,
+      }),
+    ),
+  );
+}
+
 describe("OAuth token requests", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("exchanges an authorization code as a form POST that never follows redirects", async () => {
@@ -66,44 +81,55 @@ describe("OAuth token requests", () => {
     );
   });
 
-  it("stores expiresAt for numeric, string, and zero expires_in values", async () => {
+  it("stores expiresAt for numeric and numeric-string expires_in values", async () => {
     const now = Date.now();
     vi.spyOn(Date, "now").mockReturnValue(now);
 
     for (const [expiresIn, expectedMs] of [
       [3600, 3600_000],
       ["3600", 3600_000],
-      [0, 0],
-      ["0", 0],
+      ["  3600  ", 3600_000],
+      ["1.5", 1500],
     ] as const) {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () =>
-          Response.json({
-            access_token: "access-token",
-            token_type: "Bearer",
-            expires_in: expiresIn,
-          }),
-        ),
-      );
+      stubTokenResponse(expiresIn);
 
       await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).resolves.toMatchObject({
         accessToken: "access-token",
         expiresAt: new Date(now + expectedMs).toISOString(),
       });
     }
+  });
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        Response.json({
-          access_token: "access-token",
-          token_type: "Bearer",
-          expires_in: "not-a-number",
-        }),
-      ),
-    );
-    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).resolves.toMatchObject({
+  it("reports unusable expires_in lifetimes as missing instead of expired or out of range", async () => {
+    // A provider that answers 0 or a negative lifetime means "no expiry known".
+    // Trusting it literally would expire the credential the moment it is stored,
+    // and an out-of-range lifetime would overflow `new Date(...).toISOString()`.
+    for (const expiresIn of [0, "0", -3600, "-3600", 1e300, "1e20", "not-a-number", "", null, true]) {
+      stubTokenResponse(expiresIn);
+
+      await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).resolves.toMatchObject({
+        accessToken: "access-token",
+        expiresAt: undefined,
+      });
+    }
+  });
+
+  it("applies the same expires_in parsing when refreshing a token", async () => {
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const refreshRequest = {
+      ...authorizationCodeRequest,
+      refreshToken: "stored-refresh-token",
+    };
+
+    stubTokenResponse("3600");
+    await expect(requestRefreshToken(refreshRequest)).resolves.toMatchObject({
+      accessToken: "access-token",
+      expiresAt: new Date(now + 3600_000).toISOString(),
+    });
+
+    stubTokenResponse(0);
+    await expect(requestRefreshToken(refreshRequest)).resolves.toMatchObject({
       accessToken: "access-token",
       expiresAt: undefined,
     });

--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -65,4 +65,47 @@ describe("OAuth token requests", () => {
       "OAuth token request timed out.",
     );
   });
+
+  it("stores expiresAt for numeric, string, and zero expires_in values", async () => {
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    for (const [expiresIn, expectedMs] of [
+      [3600, 3600_000],
+      ["3600", 3600_000],
+      [0, 0],
+      ["0", 0],
+    ] as const) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          Response.json({
+            access_token: "access-token",
+            token_type: "Bearer",
+            expires_in: expiresIn,
+          }),
+        ),
+      );
+
+      await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).resolves.toMatchObject({
+        accessToken: "access-token",
+        expiresAt: new Date(now + expectedMs).toISOString(),
+      });
+    }
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          access_token: "access-token",
+          token_type: "Bearer",
+          expires_in: "not-a-number",
+        }),
+      ),
+    );
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).resolves.toMatchObject({
+      accessToken: "access-token",
+      expiresAt: undefined,
+    });
+  });
 });

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -113,13 +113,14 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
 
   const accessToken = requiredString(payload.access_token ?? payload.token, "access_token", input.createError);
   const tokenType = optionalString(payload.token_type) ?? "Bearer";
-  const expiresIn = typeof payload.expires_in === "number" ? payload.expires_in : undefined;
+  const expiresIn = readExpiresInSeconds(payload.expires_in);
   return {
     authType: "oauth2",
     accessToken,
     tokenType,
     refreshToken: optionalString(payload.refresh_token),
-    expiresAt: expiresIn ? new Date(Date.now() + expiresIn * 1000).toISOString() : undefined,
+    expiresAt:
+      expiresIn === undefined ? undefined : new Date(Date.now() + expiresIn * 1000).toISOString(),
     profile: {
       accountId: "oauth2",
       displayName: "OAuth Credential",
@@ -162,6 +163,21 @@ function createTokenMetadata(payload: Record<string, unknown>): Record<string, u
   metadata.rawTokenType = payload.token_type;
   metadata.scope = payload.scope;
   return metadata;
+}
+
+/**
+ * Parse OAuth `expires_in` lifetimes. Providers commonly return a JSON number,
+ * but some return a decimal string. Zero is a valid (already-expired) lifetime.
+ */
+function readExpiresInSeconds(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
 }
 
 function isSensitiveTokenResponseField(key: string): boolean {

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -6,6 +6,8 @@ import { providerFetch } from "../providers/provider-runtime.ts";
 
 const oauthTokenRequestTimeoutMs = 30_000;
 const oauthTokenResponseMaxBytes = 1024 * 1024;
+/** Longest `expires_in` we accept; anything larger overflows the ECMAScript `Date` range. */
+const maxExpiresInSeconds = 100 * 365 * 24 * 60 * 60;
 
 export interface OAuthTokenRequestOptions {
   clientId: string;
@@ -119,8 +121,7 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
     accessToken,
     tokenType,
     refreshToken: optionalString(payload.refresh_token),
-    expiresAt:
-      expiresIn === undefined ? undefined : new Date(Date.now() + expiresIn * 1000).toISOString(),
+    expiresAt: expiresIn === undefined ? undefined : new Date(Date.now() + expiresIn * 1000).toISOString(),
     profile: {
       accountId: "oauth2",
       displayName: "OAuth Credential",
@@ -167,17 +168,20 @@ function createTokenMetadata(payload: Record<string, unknown>): Record<string, u
 
 /**
  * Parse OAuth `expires_in` lifetimes. Providers commonly return a JSON number,
- * but some return a decimal string. Zero is a valid (already-expired) lifetime.
+ * but some return the same value as a string, which used to be dropped so the
+ * credential never carried an `expiresAt` and was never proactively refreshed.
+ *
+ * Non-positive and absurd lifetimes are reported as missing instead. A provider
+ * that answers `0` almost always means "no expiry known", not "this token is
+ * already dead": honouring it literally would make every request refresh (or,
+ * without a refresh token, fail) right after a successful connect. Values past
+ * `maxExpiresInSeconds` would overflow `new Date(...).toISOString()` into a
+ * `RangeError` that escapes the OAuth error wrapper.
  */
 function readExpiresInSeconds(value: unknown): number | undefined {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : undefined;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
+  const parsed =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= maxExpiresInSeconds ? parsed : undefined;
 }
 
 function isSensitiveTokenResponseField(key: string): boolean {


### PR DESCRIPTION
## Summary

- Accept numeric strings (e.g. `"3600"`) and zero for OAuth `expires_in`.
- Previously only `typeof === "number"` was accepted, and `0` was treated as missing via truthiness, so many tokens never got `expiresAt` and were never proactively refreshed.

## Test plan

- [x] `npm test -- src/oauth/oauth-token.test.ts`