### PR TITLE
fix(api): return connection errors from action agent.md

### DIFF
--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -1790,6 +1790,31 @@ describe("ConnectServer", () => {
     expect(markdown).toContain("`messages:read`");
   });
 
+  it("returns connection errors for action agent.md instead of 500", async () => {
+    const app = createTestServer([
+      {
+        ...apiKeyProvider,
+        actions: [echoAction],
+      },
+    ]).createApp();
+
+    const missing = await app.request("/api/actions/example.echo/agent.md?connectionName=work");
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({
+      error: {
+        code: "connection_not_found",
+      },
+    });
+
+    const invalid = await app.request("/api/actions/example.echo/agent.md?connectionName=bad name");
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({
+      error: {
+        code: "invalid_connection_name",
+      },
+    });
+  });
+
   it("renders markdown descriptions and escapes union type separators in parameter tables", async () => {
     const app = createTestServer([
       {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -334,18 +334,31 @@ export class ConnectServer {
       return notFound(context);
     }
 
-    const policy = (await this.getPolicySnapshot(context)).evaluate(action);
-    return context.text(
-      renderActionMarkdown(action, {
-        connection: await this.options.connections.getConnectionSummary(action.service, readConnectionName(context)),
-        providerPermissions: action.providerPermissions,
-        policy,
-      }),
-      200,
-      {
-        "content-type": "text/markdown; charset=utf-8",
-      },
-    );
+    try {
+      const policy = (await this.getPolicySnapshot(context)).evaluate(action);
+      return context.text(
+        renderActionMarkdown(action, {
+          connection: await this.options.connections.getConnectionSummary(action.service, readConnectionName(context)),
+          providerPermissions: action.providerPermissions,
+          policy,
+        }),
+        200,
+        {
+          "content-type": "text/markdown; charset=utf-8",
+        },
+      );
+    } catch (error) {
+      if (error instanceof ConnectionError) {
+        const status = mapConnectionErrorStatus(error);
+        // agent.md uses the admin JSON error envelope; mapConnectionErrorStatus may
+        // return 409 for OAuth refresh failures, which jsonError does not accept.
+        if (status === 409) {
+          return context.json({ error: { code: error.code, message: error.message } }, 409);
+        }
+        return jsonError(context, status, error.code, error.message);
+      }
+      throw error;
+    }
   }
 
   private listRuntimeProviders(context: Context): Response {


### PR DESCRIPTION
## Summary

- Map missing or invalid `connectionName` on `GET /api/actions/:id/agent.md` to structured 4xx JSON.
- Previously uncaught `ConnectionError` became a 500 internal error via the global handler.

## Test plan

- [x] `npm test -- src/server/connect-server.test.ts -t "returns connection errors for action agent"`