### PR TITLE
fix(cloudflare): avoid application-level API compression

### DIFF
--- a/src/server/cloudflare.test.ts
+++ b/src/server/cloudflare.test.ts
@@ -63,6 +63,23 @@ describe("cloudflare worker", () => {
     expect(JSON.stringify(info.mock.calls)).not.toContain("unused-secret");
   });
 
+  it("leaves dashboard JSON uncompressed for edge compression", async () => {
+    const response = await worker.fetch(
+      new Request("https://compression.example.com/api/auth/session", {
+        headers: { "accept-encoding": "gzip" },
+      }),
+      createEnv(),
+      createExecutionContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      adminAuthConfigured: false,
+      authenticated: true,
+    });
+  });
+
   it("selects the KV backend and round-trips a file when TRANSIT_FILES_BACKEND is kv", async () => {
     const namespace = new MemoryKVNamespace();
     // A distinct host keeps this out of the R2 test's cached app instance.

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -88,6 +88,10 @@ async function createCloudflareApp(env: CloudflareEnv, publicOrigin: string): Pr
     }),
     logger: workerLogger,
     computeRuntimeAuthConfigured: false,
+    // Cloudflare negotiates and applies response compression at the edge. Using
+    // Hono's CompressionStream middleware here can serve gzip bytes without a
+    // matching Content-Encoding header, which makes dashboard JSON unreadable.
+    compressApiResponses: false,
   });
 }
 

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -88,9 +88,14 @@ async function createCloudflareApp(env: CloudflareEnv, publicOrigin: string): Pr
     }),
     logger: workerLogger,
     computeRuntimeAuthConfigured: false,
-    // Cloudflare negotiates and applies response compression at the edge. Using
-    // Hono's CompressionStream middleware here can serve gzip bytes without a
-    // matching Content-Encoding header, which makes dashboard JSON unreadable.
+    // Cloudflare compresses on egress itself: Response defaults to
+    // `encodeBody: "automatic"`, so the runtime re-encodes a body that Hono's
+    // compress() already gzipped. Depending on what the client negotiates, the
+    // wire then carries gzip-in-gzip or gzip bytes with no Content-Encoding at
+    // all, and dashboard JSON stops parsing either way. Hono's middleware
+    // rebuilds the Response from the previous one and cannot pass
+    // `encodeBody: "manual"`, so application-level compression stays off here.
+    // https://developers.cloudflare.com/workers/runtime-apis/response/
     compressApiResponses: false,
   });
 }

--- a/src/server/connect-app.ts
+++ b/src/server/connect-app.ts
@@ -30,6 +30,7 @@ export interface ConnectAppOptions {
   registerStaticRoutes?: (app: Hono) => void;
   logger?: Logger;
   computeRuntimeAuthConfigured?: boolean;
+  compressApiResponses?: boolean;
 }
 
 export interface ConnectApp {
@@ -88,6 +89,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
       },
       actionPolicy: options.actionPolicy,
       logger: options.logger,
+      compressApiResponses: options.compressApiResponses,
     }).createApp(),
     runtimeAuthConfigured:
       Boolean(options.runtimeToken) ||

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -223,6 +223,26 @@ describe("ConnectServer", () => {
     expect(stale.status).toBe(200);
   });
 
+  // Runtimes that compress on egress themselves opt out via compressApiResponses
+  // (see src/server/cloudflare.ts); everyone else must keep getting gzip here.
+  it("compresses /api/* JSON by default for clients that advertise gzip", async () => {
+    const app = createTestServer([apiKeyProvider]).createApp();
+
+    const compressed = await app.request("/api/providers", {
+      headers: { "accept-encoding": "gzip" },
+    });
+    expect(compressed.status).toBe(200);
+    expect(compressed.headers.get("content-encoding")).toBe("gzip");
+
+    const bytes = await compressed.arrayBuffer();
+    expect([...new Uint8Array(bytes.slice(0, 2))]).toEqual([0x1f, 0x8b]);
+    const decoded = await new Response(new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"))).json();
+
+    const plain = await app.request("/api/providers");
+    expect(plain.headers.get("content-encoding")).toBeNull();
+    await expect(plain.json()).resolves.toEqual(decoded);
+  });
+
   it("serves catalog and standard connection errors without opening a port", async () => {
     const app = createTestServer([apiKeyProvider]).createApp();
 

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -75,6 +75,7 @@ export interface IConnectServerOptions {
   actionSearch?: ActionSearchIndexProvider;
   registerStaticRoutes?: (app: Hono) => void;
   logger?: Logger;
+  compressApiResponses?: boolean;
 }
 
 /**
@@ -119,11 +120,13 @@ export class ConnectServer {
       }
     });
     app.get("/health", (context) => context.json({ ok: true }));
-    // Compress dashboard JSON responses. Scoped to /api/* so the streaming
-    // /mcp transport and /v1/proxy pass-through are never buffered/re-encoded.
-    // The middleware's content-type filter already skips non-text bodies
-    // (e.g. transit file downloads).
-    app.use("/api/*", compress());
+    if (this.options.compressApiResponses !== false) {
+      // Compress dashboard JSON responses. Scoped to /api/* so the streaming
+      // /mcp transport and /v1/proxy pass-through are never buffered/re-encoded.
+      // The middleware's content-type filter already skips non-text bodies
+      // (e.g. transit file downloads).
+      app.use("/api/*", compress());
+    }
     app.use("*", createLocalAuthMiddleware(auth));
     app.get("/v1/health", (context) => writeRuntimeSuccess(context, { ok: true, runtime: "oomol-connect" }));
     app.get("/v1/providers", (context) => this.listRuntimeProviders(context));


### PR DESCRIPTION
## Summary

- disable Hono's application-level `/api/*` compression for the Cloudflare Workers entrypoint
- keep API compression enabled by default for Node.js and other deployments
- add a regression test proving `/api/auth/session` remains readable JSON when the client advertises gzip support

## Root cause

PR #173 added `compress()` to all `/api/*` responses. On a production Cloudflare Workers deployment of v1.3.1, `/api/auth/session` returns HTTP 200 but the browser receives a gzip payload (`1f 8b`) that it cannot decode as JSON. `web/src/api.ts` consequently resolves the failed JSON parse to `null`, and the dashboard crashes while reading `authSession.authenticated`.

Cloudflare already negotiates and applies response compression at the edge. Avoiding the extra `CompressionStream` layer in the Workers entrypoint prevents the encoded-body/header mismatch while preserving the catalog-size improvements from #173. Other runtimes retain the existing Hono compression behavior.

Cloudflare documentation: https://developers.cloudflare.com/workers/runtime-apis/fetch/#how-the-accept-encoding-header-is-handled

## Validation

- `vitest run src/server/cloudflare.test.ts`
- `npm run fix-check`

## Release request

Thanks for the excellent dashboard performance work in #173; the smaller catalog and lazy loading are substantial improvements. @l1shen, could you please publish a patch release containing this fix after it is merged? The current v1.3.1 release leaves Cloudflare-hosted dashboards unable to authenticate or load their API data, so a repaired release would help existing release-based deployments recover without carrying a local patch.
