### PR TITLE
fix(auth): keep runtime token auth working when last-use write fails

### DIFF
--- a/src/server/connect-app.ts
+++ b/src/server/connect-app.ts
@@ -38,7 +38,7 @@ export interface ConnectApp {
 }
 
 export async function createConnectApp(options: ConnectAppOptions): Promise<ConnectApp> {
-  const runtimeTokens = new RuntimeTokenService(options.runtimeDatabase.runtimeTokenStore);
+  const runtimeTokens = new RuntimeTokenService(options.runtimeDatabase.runtimeTokenStore, options.logger);
   const hasStoredRuntimeTokens = async (): Promise<boolean> => (await runtimeTokens.listTokens()).length > 0;
   const oauthClientConfigs = new OAuthClientConfigService({
     catalog: options.catalog,

--- a/src/server/storage/runtime-token-service.test.ts
+++ b/src/server/storage/runtime-token-service.test.ts
@@ -50,4 +50,39 @@ describe("RuntimeTokenService", () => {
     expect(store.list).not.toHaveBeenCalled();
     expect(store.markUsed).toHaveBeenCalledWith("token-1", expect.any(String));
   });
+
+  it("keeps a matched token valid when the last-use write fails", async () => {
+    const token = "oct_secret";
+    const record = {
+      id: "token-1",
+      name: "Issue bot",
+      tokenHash: hashRuntimeToken(token),
+      allowedActions: [],
+      blockedActions: [],
+      allowedProxies: [],
+      createdAt: "2026-07-20T00:00:00.000Z",
+    };
+    const store: IRuntimeTokenStore = {
+      add: vi.fn(),
+      list: vi.fn(async () => [record]),
+      findByHash: vi.fn(async () => record),
+      updatePolicy: vi.fn(),
+      revoke: vi.fn(async () => false),
+      markUsed: vi.fn(async () => {
+        throw new Error("D1_ERROR: network connection lost");
+      }),
+    };
+    const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
+
+    await expect(new RuntimeTokenService(store, logger).resolveToken(token)).resolves.toEqual({
+      tokenId: "token-1",
+      allowedActions: [],
+      blockedActions: [],
+      allowedProxies: [],
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { tokenId: "token-1", err: expect.any(Error) },
+      "runtime token last use update failed",
+    );
+  });
 });

--- a/src/server/storage/runtime-token-service.ts
+++ b/src/server/storage/runtime-token-service.ts
@@ -1,4 +1,5 @@
 import type { TokenPolicy } from "../../core/action-policy.ts";
+import type { RuntimeLogger } from "../../core/types.ts";
 
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 
@@ -45,9 +46,11 @@ export interface RuntimeGrant extends TokenPolicy {
 
 export class RuntimeTokenService {
   private readonly store: IRuntimeTokenStore;
+  private readonly logger?: RuntimeLogger;
 
-  constructor(store: IRuntimeTokenStore) {
+  constructor(store: IRuntimeTokenStore, logger?: RuntimeLogger) {
     this.store = store;
+    this.logger = logger;
   }
 
   async createToken(
@@ -92,7 +95,7 @@ export class RuntimeTokenService {
       return undefined;
     }
 
-    await this.store.markUsed(matched.id, new Date().toISOString());
+    await this.recordLastUsed(matched.id);
     return {
       tokenId: matched.id,
       allowedActions: matched.allowedActions,
@@ -103,6 +106,18 @@ export class RuntimeTokenService {
 
   async verifyToken(token: string): Promise<boolean> {
     return Boolean(await this.resolveToken(token));
+  }
+
+  /**
+   * `last_used_at` is best-effort audit metadata, so a failed write is logged
+   * instead of turning an authenticated caller into a failed request.
+   */
+  private async recordLastUsed(tokenId: string): Promise<void> {
+    try {
+      await this.store.markUsed(tokenId, new Date().toISOString());
+    } catch (error) {
+      this.logger?.warn({ tokenId, err: error }, "runtime token last use update failed");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- `RuntimeTokenService.resolveToken` awaited `store.markUsed` before returning the grant, so a failed `last_used_at` write rejected an otherwise valid `oct_...` runtime token.
- `last_used_at` is best-effort audit metadata. It is now recorded through a private `recordLastUsed` helper that logs write failures and still returns the grant.

Closes #187.

## Problem

Nothing between `resolveToken` and the auth middleware catches, so a `markUsed` rejection propagates from `resolveToken` (`runtime-token-service.ts`) through `hasValidRuntimeToken` / `hasValidToken` (`api/auth.ts`) into the global `app.onError` handler.

Verified with a throwaway test that drives the real middleware plus `ConnectServer`'s error handler against a store whose `markUsed` throws `D1_ERROR: network connection lost`:

```
STATUS: 500 BODY: {"error":{"code":"internal_error","message":"Internal server error."}}
```

Two corrections to the issue report:

- The observed failure is **500 `internal_error`**, not 401. The availability impact is the same, but the symptom to grep for in logs is different.
- The throw also skips the `verifyRuntimeJwt` fallback further down `hasValidRuntimeToken`.

## Changes

- `RuntimeTokenService` takes an optional `RuntimeLogger` (the existing storage-layer logging abstraction — compatible with both pino and the Workers `console` shim); `createConnectApp` passes the app logger through.
- `resolveToken` calls `recordLastUsed`, which swallows and logs write failures as `runtime token last use update failed`.
- Regression test: a store whose `markUsed` rejects still yields the grant, and the failure is logged.

## Not included: `waitUntil`

The issue also suggests `waitUntil(markUsed(...))` on Workers so auth latency is not tied to the write. Left out deliberately:

- It is a latency optimization, not the reported defect — the issue's *Expected* behaviour is fully satisfied by this change.
- There is no `ExecutionContext` available today: `src/server/cloudflare.ts` discards `_ctx` and calls `app.fetch(request, env)` without it. Wiring it up means touching the Workers entry point *and* adding a per-request defer hook to `LocalAuthOptions.resolveRuntimeToken`, leaking a Workers concept into the shared auth layer and making `last_used_at` eventually consistent on Workers.

Happy to do it as a separate PR.

## Test plan

- [x] `npx vitest run` — 56 files / 524 tests pass
- [x] `npx oxlint .` and `oxfmt --check .` clean
- [x] `tsc -p src/tsconfig.json` clean
