### PR TITLE
fix(auth): compare env bearer tokens in constant time

### DIFF
--- a/src/server/api/auth.test.ts
+++ b/src/server/api/auth.test.ts
@@ -103,4 +103,30 @@ describe("createLocalAuthMiddleware", () => {
       ).status,
     ).toBe(200);
   });
+
+  it("matches configured tokens byte-for-byte after the bearer scheme", async () => {
+    const app = new Hono();
+    app.use("*", createLocalAuthMiddleware({ adminToken: "admin-secret", runtimeToken: "runtime-secret" }));
+    app.get("/api/connections", (context) => context.json({ ok: true }));
+    app.get("/v1/actions", (context) => context.json({ ok: true }));
+
+    const adminStatus = async (authorization: string): Promise<number> =>
+      (await app.request("/api/connections", { headers: { authorization } })).status;
+
+    expect(await adminStatus("Bearer admin-secret")).toBe(200);
+    // Same length as the configured token, so a length check alone cannot reject it.
+    expect(await adminStatus("Bearer admin-secreT")).toBe(401);
+    expect(await adminStatus("Bearer admin-secre")).toBe(401);
+    expect(await adminStatus("Bearer admin-secret-extra")).toBe(401);
+    expect(await adminStatus("Bearer  admin-secret")).toBe(401);
+    expect(await adminStatus("admin-secret")).toBe(401);
+    // The runtime bootstrap token must not unlock the admin surface, and vice versa.
+    expect(await adminStatus("Bearer runtime-secret")).toBe(401);
+    expect((await app.request("/v1/actions", { headers: { authorization: "Bearer runtime-secret" } })).status).toBe(
+      200,
+    );
+    expect((await app.request("/v1/actions", { headers: { authorization: "Bearer runtime-secreT" } })).status).toBe(
+      401,
+    );
+  });
 });

--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -137,7 +137,7 @@ export function clearLocalAuthCookie(context: Context): void {
 
 async function installAdminCookieForBearer(context: Context, options: LocalAuthOptions): Promise<void> {
   const token = normalizeToken(options.adminToken);
-  if (token && context.req.header("authorization") === `Bearer ${token}`) {
+  if (token && matchesConfiguredToken(context, token)) {
     await installLocalAuthCookie(context, options);
   }
 }
@@ -165,8 +165,7 @@ async function hasValidToken(context: Context, options: LocalAuthOptions, scope:
 }
 
 async function hasRequestToken(context: Context, token: string): Promise<boolean> {
-  const authorization = context.req.header("authorization") ?? "";
-  return authorization === `Bearer ${token}` || (await hasValidAuthCookie(context, token));
+  return matchesConfiguredToken(context, token) || (await hasValidAuthCookie(context, token));
 }
 
 async function hasValidAuthCookie(context: Context, token: string): Promise<boolean> {
@@ -209,6 +208,14 @@ function base64Url(value: ArrayBuffer | ArrayBufferView): string {
       ? new Uint8Array(value)
       : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
   return Buffer.from(bytes).toString("base64url");
+}
+
+// Deployment secrets (`OOMOL_CONNECT_ADMIN_TOKEN` / `OOMOL_CONNECT_RUNTIME_TOKEN`) are long-lived,
+// so the credential is compared in constant time instead of with `===`, which short-circuits on the
+// first differing character and leaks how much of the token an attacker already guessed. Stored
+// runtime tokens already get the same treatment through `timingSafeEqual` on their hashes.
+function matchesConfiguredToken(context: Context, token: string): boolean {
+  return constantTimeEqual(readBearerCredential(context), token);
 }
 
 function constantTimeEqual(left: string, right: string): boolean {
@@ -256,7 +263,12 @@ async function hasValidRuntimeToken(context: Context, options: LocalAuthOptions)
 }
 
 function readBearerToken(context: Context): string | undefined {
+  return normalizeToken(readBearerCredential(context));
+}
+
+/** Bearer credential exactly as sent, so configured tokens still require a byte-for-byte match. */
+function readBearerCredential(context: Context): string {
   const authorization = context.req.header("authorization") ?? "";
   const prefix = "Bearer ";
-  return authorization.startsWith(prefix) ? normalizeToken(authorization.slice(prefix.length)) : undefined;
+  return authorization.startsWith(prefix) ? authorization.slice(prefix.length) : "";
 }


### PR DESCRIPTION
Closes #189.

## What the issue claimed, and what I found

Confirmed. `src/server/api/auth.ts` matched the configured deployment secrets with a plain `===` against the whole header:

- `hasRequestToken` (line 169) — `authorization === \`Bearer ${token}\``
- `installAdminCookieForBearer` (line 140) — same shape

The inconsistency the issue points at is real too: cookie signatures in the same file already go through `constantTimeEqual`, and stored runtime tokens go through `timingSafeEqual` on their hashes (`runtime-token-service.ts`). The env-token path was the only inbound bearer comparison without that treatment.

I swept `src/server/`, `src/oauth/` and `src/mcp.ts` for other secret comparisons — these two were the only ones. (The thousands of `Bearer ${...}` hits across `src/providers/` are all outbound request headers.)

On severity I agree with the issue's own framing: over remote HTTP the leaked timing is nanosecond-scale and drowned by network jitter, so this is hardening rather than an exploitable bug. It is still worth doing — `OOMOL_CONNECT_ADMIN_TOKEN` is a long-lived, highest-privilege secret and the fix costs nothing.

## The change

Both call sites now go through `matchesConfiguredToken`, reusing the existing `constantTimeEqual` helper. No `node:crypto` import — `auth.ts` deliberately sticks to WebCrypto so it keeps working on workerd.

`readBearerCredential` returns the credential **verbatim** after the `Bearer ` scheme (no trim), so matching stays byte-for-byte exact and the semantics are unchanged from `=== \`Bearer ${token}\``. The existing `readBearerToken` is now `normalizeToken(readBearerCredential(...))`, preserving its trimming behaviour for the runtime-token lookup path.

A length mismatch still returns early, which leaks the token length. That matches what the issue suggested ("reject on length mismatch") and matches the constraint Node's own `timingSafeEqual` imposes.

## Tests

Added `matches configured tokens byte-for-byte after the bearer scheme`, covering an equal-length near miss (so a length check alone cannot pass it), truncation, extra suffix, extra internal whitespace, a missing scheme, and that the admin and runtime tokens do not unlock each other's surface.

Full suite: **56 files / 524 tests passing**. `tsc -p src/tsconfig.json` clean, `oxlint` and `oxfmt --check` clean.