### PR TITLE
fix(auth): match the bearer scheme case-insensitively

### DIFF
--- a/src/server/api/auth.test.ts
+++ b/src/server/api/auth.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createLocalAuthMiddleware } from "./auth.ts";
 
 describe("createLocalAuthMiddleware", () => {
@@ -69,6 +69,61 @@ describe("createLocalAuthMiddleware", () => {
     ).toBe(200);
   });
 
+  it.each(["Bearer", "bearer", "BEARER", "BeArEr"])(
+    "accepts the %s authorization scheme on every auth scope",
+    async (scheme) => {
+      const app = createSchemeApp();
+
+      expect((await app.request("/api/connections", { headers: authorize(scheme, "admin-secret") })).status).toBe(200);
+      expect((await app.request("/v1/actions", { headers: authorize(scheme, "runtime-secret") })).status).toBe(200);
+      expect((await app.request("/mcp/tools", { headers: authorize(scheme, "runtime-secret") })).status).toBe(200);
+    },
+  );
+
+  it.each([
+    "Basic admin-secret",
+    "BearerX admin-secret",
+    "Bearer-Foo admin-secret",
+    "Bearer",
+    "Bearer\tadmin-secret",
+    // A case-insensitive scheme must not loosen anything else: the credentials stay
+    // case-sensitive and are still matched byte-for-byte after a single separator space.
+    "bearer admin-Secret",
+    "bearer  admin-secret",
+  ])("rejects the %j authorization header", async (authorization) => {
+    const app = createSchemeApp();
+
+    expect((await app.request("/api/connections", { headers: { authorization } })).status).toBe(401);
+  });
+
+  it("issues the admin session cookie for a lowercase bearer scheme", async () => {
+    const app = createSchemeApp();
+
+    const response = await app.request("/api/connections", {
+      headers: authorize("bearer", "admin-secret"),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toContain("oomol_connect_admin_session=");
+    expect(response.headers.get("set-cookie")).not.toContain("admin-secret");
+  });
+
+  it("resolves dynamic runtime tokens for a lowercase bearer scheme", async () => {
+    const resolveRuntimeToken = vi.fn(async (token: string) =>
+      token === "oct_valid"
+        ? { tokenId: "token-1", allowedActions: [], blockedActions: [], allowedProxies: [] }
+        : undefined,
+    );
+    const app = new Hono();
+    app.use("*", createLocalAuthMiddleware({ hasRuntimeTokens: async () => true, resolveRuntimeToken }));
+    app.get("/v1/actions", (context) => context.json({ ok: true }));
+
+    const response = await app.request("/v1/actions", { headers: authorize("bearer", "oct_valid") });
+
+    expect(response.status).toBe(200);
+    expect(resolveRuntimeToken).toHaveBeenCalledWith("oct_valid");
+  });
+
   it("allows configured admin tokens to elevate POST /v1/actions", async () => {
     const app = new Hono();
     app.use(
@@ -102,6 +157,15 @@ describe("createLocalAuthMiddleware", () => {
         })
       ).status,
     ).toBe(200);
+    expect(
+      (
+        await app.request("/v1/actions/example.echo", {
+          method: "POST",
+          headers: { ...authorize("BEARER", "admin-secret"), "content-type": "application/json" },
+          body: JSON.stringify({ input: {} }),
+        })
+      ).status,
+    ).toBe(200);
   });
 
   it("matches configured tokens byte-for-byte after the bearer scheme", async () => {
@@ -130,3 +194,16 @@ describe("createLocalAuthMiddleware", () => {
     );
   });
 });
+
+function createSchemeApp(): Hono {
+  const app = new Hono();
+  app.use("*", createLocalAuthMiddleware({ adminToken: "admin-secret", runtimeToken: "runtime-secret" }));
+  app.get("/api/connections", (context) => context.json({ ok: true }));
+  app.get("/v1/actions", (context) => context.json({ ok: true }));
+  app.get("/mcp/tools", (context) => context.json({ ok: true }));
+  return app;
+}
+
+function authorize(scheme: string, token: string): Record<string, string> {
+  return { authorization: `${scheme} ${token}` };
+}

--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -6,6 +6,7 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { isConsoleShellRequest } from "./console-paths.ts";
 import { jsonError } from "./http-utils.ts";
 
+const bearerScheme = "bearer";
 const authCookieName = "oomol_connect_admin_session";
 const authCookieVersion = "v1";
 const authCookieMaxAgeSeconds = 2_592_000;
@@ -266,9 +267,18 @@ function readBearerToken(context: Context): string | undefined {
   return normalizeToken(readBearerCredential(context));
 }
 
-/** Bearer credential exactly as sent, so configured tokens still require a byte-for-byte match. */
+/**
+ * Bearer credential exactly as sent, so configured tokens still require a byte-for-byte match.
+ *
+ * Authentication schemes are case-insensitive (RFC 9110), so `bearer` and `BEARER` are accepted;
+ * only the credentials stay case-sensitive.
+ */
 function readBearerCredential(context: Context): string {
   const authorization = context.req.header("authorization") ?? "";
-  const prefix = "Bearer ";
-  return authorization.startsWith(prefix) ? authorization.slice(prefix.length) : "";
+  const separator = authorization.indexOf(" ");
+  if (separator < 0 || authorization.slice(0, separator).toLowerCase() !== bearerScheme) {
+    return "";
+  }
+
+  return authorization.slice(separator + 1);
 }

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -1102,6 +1102,17 @@ describe("ConnectServer", () => {
       authenticated: true,
     });
 
+    const lowercaseBearer = await app.request("/api/auth/session", {
+      headers: { authorization: "bearer local-token" },
+    });
+    expect(lowercaseBearer.status).toBe(200);
+    expect(lowercaseBearer.headers.get("set-cookie")).toContain("oomol_connect_admin_session=");
+    expect(lowercaseBearer.headers.get("set-cookie")).not.toContain("local-token");
+    await expect(lowercaseBearer.json()).resolves.toEqual({
+      adminAuthConfigured: true,
+      authenticated: true,
+    });
+
     const authorized = await app.request("/api/providers", {
       headers: { authorization: "Bearer local-token" },
     });
@@ -1183,6 +1194,17 @@ describe("ConnectServer", () => {
       headers: { authorization: `Bearer ${createdBody.token}` },
     });
     expect(runtimeTokenCall.status).toBe(200);
+
+    // A case-insensitive scheme widens the scheme only, never the auth scope.
+    const lowercaseRuntimeTokenCall = await app.request("/v1/actions", {
+      headers: { authorization: `bearer ${createdBody.token}` },
+    });
+    expect(lowercaseRuntimeTokenCall.status).toBe(200);
+
+    const lowercaseAdminTokenRuntimeCall = await app.request("/v1/actions", {
+      headers: { authorization: "bearer local-token" },
+    });
+    expect(lowercaseAdminTokenRuntimeCall.status).toBe(401);
   });
 
   it("manages runtime tokens and gates runtime API calls after one is created", async () => {


### PR DESCRIPTION
Closes #188

Rebased onto `main` after #197 landed. That PR touched the same functions, so this one is now scoped down to the single thing #188 is about — see "Relationship to #197" below.

## Summary

- HTTP authentication schemes are case-insensitive (RFC 9110 §11.1), but `readBearerCredential` matched the header against a literal `Bearer ` prefix. Clients that normalize the scheme to `bearer` or `BEARER` were rejected with 401 even with a valid token.
- Split the header into scheme + credentials and compare the scheme with `toLowerCase()`. Nothing else about the parse changes.

## Relationship to #197

#188 asked for two things: case-insensitive scheme matching, and a constant-time compare for the secret. **#197 already landed the constant-time half** (`matchesConfiguredToken` / `constantTimeEqual`). This PR is only the scheme half, layered on top — 8 lines of production change.

#197 also made a deliberate decision I have preserved rather than reworked: `readBearerCredential` returns the credential **verbatim**, so configured tokens still require a byte-for-byte match. Concretely, that means:

- Repeated separator spaces are still rejected. RFC 9110's ABNF is `1*SP`, so `bearer  token` is arguably legal, but #197 pins `Bearer  admin-secret` → 401, and loosening it would silently reverse that call in a PR about scheme casing. Left alone; worth a separate issue if anyone wants it.
- No `.trim()` was added anywhere. The credential still reaches `constantTimeEqual` exactly as sent.

The only behavior that changes is which scheme spellings parse.

## Changes

`readBearerCredential` now finds the first space, compares `slice(0, separator).toLowerCase()` against `"bearer"`, and returns the remainder untouched. It is the only place in `src/` that reads an inbound `Authorization` header, so both call sites (`matchesConfiguredToken` for the env tokens, `readBearerToken` for runtime-token lookup) pick the fix up.

Deliberately **not** widened:

- `Bearer\t<token>` still 401s — RFC 9110 allows only `1*SP` as the separator, and `\s`-based splits over-accept HTAB/NBSP, creating a parser differential with strict intermediaries.
- `BearerX ...` / `Bearer-Foo ...` still 401 — the scheme is compared as a whole slice, not with `startsWith`. `toLowerCase().startsWith("bearer")` would accept these and hand back `X <token>` as the credential.

## Test plan

- [x] `npm test -- src/server/api/auth.test.ts` — scheme-casing matrix across all three auth scopes (`/api`, `/v1`, `/mcp`), cookie issuance for a lowercase scheme, admin elevation on `POST /v1/actions` with `BEARER`, and the dynamic runtime-token resolver path with a lowercase scheme (asserting it receives `"oct_valid"`, not a padded string).
- [x] `npm test -- src/server/connect-server.test.ts` — `/api/auth/session` is a public path that authenticates through `readLocalAuthSession` rather than the middleware, so it needs its own coverage; plus an end-to-end `bearer oct_…` runtime-token call and a `bearer local-token` → 401 on `/v1/actions` proving the scope boundary did not move with the scheme.
- [x] 6-case negative matrix, chosen not to overlap #197's byte-for-byte test. The load-bearing ones are `bearer admin-Secret` (credentials stay case-sensitive even when the scheme is lowercased — this catches the likeliest wrong fix, lowercasing the whole header) and `bearer  admin-secret` (pins that case-insensitivity did not loosen separator handling either).
- [x] Verified the new assertions are load-bearing: 8 of them fail against `origin/main` as it stands today, post-#197.
- [x] `npm run fix-check` and the full `npm test` (548 tests) pass.
- [x] Differential check old-vs-new over a large header/config matrix: zero inputs that authenticated before and 401 now. Every difference is the intended widening.

## Notes

Checked on both runtimes, since this file runs on Node and on Workers via `cloudflare.ts`. The change adds no imports and nothing outside plain ECMAScript.

Two adjacent gaps found while working on this, left out as out of scope:

- 401 responses carry no `WWW-Authenticate` header anywhere in the repo (RFC 9110 §15.5.2 requires it; RFC 6750 §3 gives the Bearer form). MCP/OAuth clients use it to decide whether to refresh.
- `src/server/api/openapi.ts` emits no `securitySchemes`, though `docs/runtime-api.md` advertises `/openapi.json` for importers.

Happy to file either separately.
