### PR TITLE
feat(provider): add Vultr API actions

### DIFF
--- a/src/providers/vultr/actions.ts
+++ b/src/providers/vultr/actions.ts
@@ -1,0 +1,393 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "vultr";
+
+const subscriptionReadPermission = "subscriptions_view";
+const subscriptionWritePermission = "subscriptions";
+const provisioningPermission = "provisioning";
+const firewallPermission = "firewall";
+const dnsPermission = "dns";
+
+const instanceIdSchema = s.uuid("The Vultr instance ID.");
+const cursorSchema = s.nonEmptyString("The next or previous cursor returned in pagination metadata.");
+const perPageSchema = s.integer("Maximum number of items to return, from 1 to 500.", {
+  minimum: 1,
+  maximum: 500,
+});
+const paginationInputFields = {
+  perPage: perPageSchema,
+  cursor: cursorSchema,
+};
+const paginationMetaSchema = s.object(
+  "Vultr cursor pagination metadata.",
+  {
+    total: s.nonNegativeInteger("Total number of matching resources."),
+    links: s.object(
+      "Cursors for adjacent result pages.",
+      {
+        next: s.string("Cursor for the next page. An empty string means there is no next page."),
+        prev: s.string("Cursor for the previous page. An empty string means there is no previous page."),
+      },
+      { optional: ["next", "prev"] },
+    ),
+  },
+  { optional: ["total", "links"] },
+);
+
+const accountSchema = s.looseObject("The Vultr account and billing profile.", {
+  name: s.nonEmptyString("Account user name."),
+  email: s.email("Account email address."),
+  acls: s.stringArray("Vultr ACL permissions granted to the connected user."),
+  balance: s.number("Current account balance."),
+  pending_charges: s.number("Unbilled charges for the current month."),
+  last_payment_date: s.string("Date of the last payment."),
+  last_payment_amount: s.number("Amount of the last payment."),
+});
+
+const instanceSchema = s.looseObject("A Vultr VPS instance.", {
+  id: instanceIdSchema,
+  os: s.string("Installed operating system name."),
+  os_id: s.integer("Installed operating system ID."),
+  ram: s.nonNegativeInteger("Memory in MB."),
+  disk: s.nonNegativeInteger("Disk capacity in GB."),
+  main_ip: s.string("Main IPv4 address."),
+  vcpu_count: s.nonNegativeInteger("Number of virtual CPUs."),
+  region: s.string("Vultr region ID."),
+  plan: s.string("Vultr plan ID."),
+  date_created: s.string("Timestamp when the instance was created."),
+  status: s.string("Current provisioning status."),
+  power_status: s.stringEnum(["running", "stopped"], { description: "Current power state." }),
+  server_status: s.string("Current server health state."),
+  hostname: s.string("Instance hostname."),
+  label: s.string("User-supplied instance label."),
+  internal_ip: s.string("Private IP address when a VPC is attached."),
+  firewall_group_id: s.string("Attached firewall group ID."),
+  snapshot_id: s.string("Snapshot used to deploy this instance."),
+  features: s.stringArray("Enabled instance features."),
+  tags: s.stringArray("Tags applied to the instance."),
+  default_password: s.string("Deployment password, available only briefly after creation."),
+});
+
+const regionSchema = s.looseObject("A Vultr deployment region.", {
+  id: s.nonEmptyString("Unique region ID."),
+  city: s.string("Region city."),
+  country: s.string("Two-letter country code."),
+  continent: s.string("Continent name."),
+  options: s.stringArray("Product features available in the region."),
+  connectivity: s.stringArray("Connectivity options available in the region."),
+});
+
+const planSchema = s.looseObject("A Vultr VPS plan.", {
+  id: s.nonEmptyString("Unique plan ID."),
+  name: s.string("Plan name."),
+  vcpu_count: s.nonNegativeInteger("Number of virtual CPUs."),
+  ram: s.nonNegativeInteger("Memory in MB."),
+  disk: s.nonNegativeInteger("Disk capacity in GB."),
+  disk_count: s.nonNegativeInteger("Number of included disks."),
+  bandwidth: s.nonNegativeInteger("Monthly bandwidth quota in GB."),
+  monthly_cost: s.number("Monthly price in US dollars."),
+  hourly_cost: s.number("Hourly price in US dollars."),
+  type: s.string("Vultr plan type."),
+  locations: s.stringArray("Region IDs where the plan is available."),
+  location_cost: s.record("Location-specific pricing keyed by region ID.", s.unknownObject("Regional pricing.")),
+});
+
+const operatingSystemSchema = s.looseObject("A Vultr operating system image.", {
+  id: s.integer("Operating system ID."),
+  name: s.string("Operating system name."),
+  arch: s.string("CPU architecture."),
+  family: s.string("Operating system family."),
+});
+
+const snapshotSchema = s.looseObject("A Vultr instance snapshot.", {
+  id: s.uuid("Snapshot ID."),
+  date_created: s.string("Timestamp when the snapshot was created."),
+  description: s.string("User-supplied snapshot description."),
+  size: s.nonNegativeInteger("Snapshot size in bytes."),
+  compressed_size: s.nonNegativeInteger("Compressed snapshot size in bytes."),
+  status: s.stringEnum(["pending", "complete", "deleted"], { description: "Snapshot status." }),
+  os_id: s.integer("Operating system ID associated with the snapshot."),
+  app_id: s.integer("Application ID associated with the snapshot."),
+});
+
+const firewallGroupSchema = s.looseObject("A Vultr firewall group.", {
+  id: s.uuid("Firewall group ID."),
+  description: s.string("User-supplied firewall group description."),
+  date_created: s.string("Timestamp when the firewall group was created."),
+  date_modified: s.string("Timestamp when the firewall group was last modified."),
+  instance_count: s.nonNegativeInteger("Number of attached instances."),
+  rule_count: s.nonNegativeInteger("Number of firewall rules."),
+  max_rule_count: s.nonNegativeInteger("Maximum allowed firewall rules."),
+});
+
+const domainSchema = s.looseObject("A Vultr DNS domain.", {
+  domain: s.nonEmptyString("Registered domain name."),
+  date_created: s.string("Timestamp when the DNS domain was created."),
+  dns_sec: s.stringEnum(["enabled", "disabled"], { description: "DNSSEC status." }),
+});
+
+const dnsRecordSchema = s.looseObject("A Vultr DNS record.", {
+  id: s.uuid("DNS record ID."),
+  type: s.stringEnum(["A", "AAAA", "CNAME", "NS", "MX", "SRV", "TXT", "CAA", "SSHFP"], {
+    description: "DNS record type.",
+  }),
+  name: s.string("Record hostname."),
+  data: s.string("Record data."),
+  priority: s.nonNegativeInteger("Record priority when applicable."),
+  ttl: s.nonNegativeInteger("Time to live in seconds."),
+});
+
+const createInstanceFields = {
+  region: s.nonEmptyString("Region ID where the instance will be deployed."),
+  plan: s.nonEmptyString("VPS plan ID for the instance."),
+  osId: s.integer("Operating system ID used to deploy the instance."),
+  isoId: s.nonEmptyString("ISO ID used to deploy the instance."),
+  snapshotId: s.nonEmptyString("Snapshot ID used to deploy the instance."),
+  appId: s.integer("Marketplace application ID used to deploy the instance."),
+  imageId: s.nonEmptyString("Marketplace application image ID used to deploy the instance."),
+  label: s.nonEmptyString("User-supplied instance label."),
+  hostname: s.nonEmptyString("Hostname assigned during deployment."),
+  enableIpv6: s.boolean("Whether to enable IPv6."),
+  disablePublicIpv4: s.boolean("Whether to omit public IPv4 when IPv6 is enabled."),
+  backups: s.stringEnum(["enabled", "disabled"], { description: "Automatic backup setting." }),
+  ddosProtection: s.boolean("Whether to enable paid DDoS protection."),
+  activationEmail: s.boolean("Whether Vultr should email after deployment."),
+  firewallGroupId: s.nonEmptyString("Firewall group ID to attach."),
+  sshKeyIds: s.stringArray("SSH key IDs to install.", { minItems: 1, itemDescription: "A Vultr SSH key ID." }),
+  vpcIds: s.stringArray("VPC IDs to attach.", { minItems: 1, itemDescription: "A Vultr VPC ID." }),
+  tags: s.stringArray("Tags to apply to the instance.", { minItems: 1, itemDescription: "An instance tag." }),
+  userData: s.nonEmptyString("Base64-encoded user data attached to the instance."),
+  userScheme: s.stringEnum(["root", "limited"], { description: "Linux login user scheme." }),
+};
+const deploymentSourceFields = ["osId", "isoId", "snapshotId", "appId", "imageId"];
+const createInstanceOptionalFields = Object.keys(createInstanceFields).filter(
+  (field) => field !== "region" && field !== "plan",
+);
+const createInstanceInputSchema = s.oneOf(
+  deploymentSourceFields.map((sourceField) =>
+    s.object(createInstanceFields, {
+      required: ["region", "plan", sourceField],
+      optional: createInstanceOptionalFields.filter((field) => field !== sourceField),
+    }),
+  ),
+  {
+    description:
+      "Vultr instance deployment settings. Supply region, plan, and exactly one deployment source: osId, isoId, snapshotId, appId, or imageId.",
+  },
+);
+
+const updateInstanceFields = {
+  label: s.nonEmptyString("New user-supplied instance label."),
+  plan: s.nonEmptyString("Plan ID to upgrade the instance to."),
+  backups: s.stringEnum(["enabled", "disabled"], { description: "Automatic backup setting." }),
+  firewallGroupId: s.nonEmptyString("Firewall group ID to attach."),
+  enableIpv6: s.boolean("Whether to enable IPv6."),
+  ddosProtection: s.boolean("Whether to enable paid DDoS protection."),
+  tags: s.stringArray("Replacement tags for the instance.", { itemDescription: "An instance tag." }),
+};
+const updateInstanceInputSchema = s.object(
+  "Fields to update on an existing Vultr instance.",
+  { instanceId: instanceIdSchema, ...updateInstanceFields },
+  { required: ["instanceId"], optional: Object.keys(updateInstanceFields) },
+) as JsonSchema;
+updateInstanceInputSchema.anyOf = Object.keys(updateInstanceFields).map((field) => ({ required: [field] }));
+
+export const vultrActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_account",
+    description: "Retrieve the connected Vultr account profile, ACL permissions, balance, and billing summary.",
+    inputSchema: s.object({}, { description: "No input is required." }),
+    outputSchema: s.actionOutput({ account: accountSchema }, "The connected Vultr account."),
+  }),
+  defineProviderAction(service, {
+    name: "list_instances",
+    description: "List Vultr VPS instances with cursor pagination and common instance filters.",
+    requiredScopes: [subscriptionReadPermission],
+    inputSchema: s.object(
+      "Filters and pagination for Vultr instances.",
+      {
+        ...paginationInputFields,
+        label: s.nonEmptyString("Only return instances with this label."),
+        mainIp: s.nonEmptyString("Only return the instance with this main IP address."),
+        region: s.nonEmptyString("Only return instances in this region ID."),
+        firewallGroupId: s.nonEmptyString("Only return instances attached to this firewall group ID."),
+        hostname: s.nonEmptyString("Only return instances with this hostname."),
+        showPendingCharges: s.boolean("Whether to include pending charges for each instance."),
+      },
+      {
+        optional: [
+          "perPage",
+          "cursor",
+          "label",
+          "mainIp",
+          "region",
+          "firewallGroupId",
+          "hostname",
+          "showPendingCharges",
+        ],
+      },
+    ),
+    outputSchema: listOutputSchema("instances", "Vultr instances in this page.", instanceSchema),
+    followUpActions: ["vultr.get_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "get_instance",
+    description: "Retrieve one Vultr VPS instance by ID.",
+    requiredScopes: [subscriptionReadPermission],
+    inputSchema: s.actionInput({ instanceId: instanceIdSchema }, ["instanceId"], "The Vultr instance to retrieve."),
+    outputSchema: s.actionOutput({ instance: instanceSchema }, "The requested Vultr instance."),
+    followUpActions: ["vultr.update_instance", "vultr.manage_instance_power", "vultr.delete_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "create_instance",
+    description: "Create a Vultr VPS instance from an OS, ISO, snapshot, application, or application image.",
+    requiredScopes: [provisioningPermission],
+    inputSchema: createInstanceInputSchema,
+    outputSchema: s.actionOutput({ instance: instanceSchema }, "The newly created Vultr instance."),
+    followUpActions: ["vultr.get_instance", "vultr.manage_instance_power"],
+    asyncLifecycle: {
+      startActionId: "vultr.create_instance",
+      statusActionId: "vultr.get_instance",
+    },
+  }),
+  defineProviderAction(service, {
+    name: "update_instance",
+    description: "Update common settings on a Vultr VPS instance without reinstalling it.",
+    requiredScopes: [subscriptionWritePermission],
+    inputSchema: updateInstanceInputSchema,
+    outputSchema: s.actionOutput({ instance: instanceSchema }, "The updated Vultr instance."),
+    followUpActions: ["vultr.get_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "delete_instance",
+    description: "Permanently delete a Vultr VPS instance.",
+    requiredScopes: [subscriptionWritePermission],
+    inputSchema: s.actionInput({ instanceId: instanceIdSchema }, ["instanceId"], "The Vultr instance to delete."),
+    outputSchema: s.actionOutput(
+      {
+        deleted: s.literal(true, { description: "Whether Vultr accepted the deletion." }),
+        instanceId: instanceIdSchema,
+      },
+      "Confirmation that a Vultr instance was deleted.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "manage_instance_power",
+    description: "Start, reboot, or halt a Vultr VPS instance.",
+    requiredScopes: [subscriptionWritePermission],
+    inputSchema: s.actionInput(
+      {
+        instanceId: instanceIdSchema,
+        operation: s.stringEnum(["start", "reboot", "halt"], {
+          description: "Power operation to perform on the instance.",
+        }),
+      },
+      ["instanceId", "operation"],
+      "A Vultr instance power operation.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        accepted: s.literal(true, { description: "Whether Vultr accepted the power operation." }),
+        instanceId: instanceIdSchema,
+        operation: s.stringEnum(["start", "reboot", "halt"], {
+          description: "Accepted power operation.",
+        }),
+      },
+      "Acknowledgement for a Vultr instance power operation.",
+    ),
+    followUpActions: ["vultr.get_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_regions",
+    description: "List Vultr deployment regions and the product features available in each region.",
+    inputSchema: paginationInputSchema("Pagination for Vultr regions."),
+    outputSchema: listOutputSchema("regions", "Vultr regions in this page.", regionSchema),
+    followUpActions: ["vultr.list_plans", "vultr.create_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_plans",
+    description: "List Vultr VPS plans with optional plan-type and Windows compatibility filters.",
+    inputSchema: s.object(
+      "Filters and pagination for Vultr plans.",
+      {
+        ...paginationInputFields,
+        type: s.stringEnum(["all", "vc2", "vdc", "vhf", "vhp", "voc", "voc-g", "voc-c", "voc-m", "voc-s", "vcg"], {
+          description: "Vultr plan type to return.",
+        }),
+        operatingSystem: s.literal("windows", { description: "Return only plans that support Windows." }),
+      },
+      { optional: ["perPage", "cursor", "type", "operatingSystem"] },
+    ),
+    outputSchema: listOutputSchema("plans", "Vultr plans in this page.", planSchema),
+    followUpActions: ["vultr.list_regions", "vultr.create_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_operating_systems",
+    description: "List operating system images available for Vultr instance deployment.",
+    inputSchema: paginationInputSchema("Pagination for Vultr operating systems."),
+    outputSchema: listOutputSchema("operatingSystems", "Vultr operating systems in this page.", operatingSystemSchema),
+    followUpActions: ["vultr.create_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_snapshots",
+    description: "List snapshots in the connected Vultr account, optionally filtered by description.",
+    requiredScopes: [subscriptionReadPermission],
+    inputSchema: s.object(
+      "Filters and pagination for Vultr snapshots.",
+      {
+        ...paginationInputFields,
+        description: s.nonEmptyString("Only return snapshots matching this description filter."),
+      },
+      { optional: ["perPage", "cursor", "description"] },
+    ),
+    outputSchema: listOutputSchema("snapshots", "Vultr snapshots in this page.", snapshotSchema),
+    followUpActions: ["vultr.create_instance"],
+  }),
+  defineProviderAction(service, {
+    name: "list_firewall_groups",
+    description: "List firewall groups in the connected Vultr account.",
+    requiredScopes: [firewallPermission],
+    inputSchema: paginationInputSchema("Pagination for Vultr firewall groups."),
+    outputSchema: listOutputSchema("firewallGroups", "Vultr firewall groups in this page.", firewallGroupSchema),
+  }),
+  defineProviderAction(service, {
+    name: "list_domains",
+    description: "List DNS domains in the connected Vultr account.",
+    requiredScopes: [dnsPermission],
+    inputSchema: paginationInputSchema("Pagination for Vultr DNS domains."),
+    outputSchema: listOutputSchema("domains", "Vultr DNS domains in this page.", domainSchema),
+    followUpActions: ["vultr.list_domain_records"],
+  }),
+  defineProviderAction(service, {
+    name: "list_domain_records",
+    description: "List DNS records for one domain in the connected Vultr account.",
+    requiredScopes: [dnsPermission],
+    inputSchema: s.object(
+      "Domain and pagination for Vultr DNS records.",
+      {
+        domain: s.nonEmptyString("Registered domain name whose DNS records should be listed."),
+        ...paginationInputFields,
+      },
+      { required: ["domain"], optional: ["perPage", "cursor"] },
+    ),
+    outputSchema: listOutputSchema("records", "Vultr DNS records in this page.", dnsRecordSchema),
+  }),
+];
+
+function paginationInputSchema(description: string): JsonSchema {
+  return s.object(description, paginationInputFields, { optional: ["perPage", "cursor"] });
+}
+
+function listOutputSchema(key: string, description: string, itemSchema: JsonSchema): JsonSchema {
+  return s.object(
+    `A cursor-paginated Vultr ${key} response.`,
+    {
+      [key]: s.array(description, itemSchema),
+      meta: paginationMetaSchema,
+    },
+    { required: [key], optional: ["meta"] },
+  );
+}

--- a/src/providers/vultr/actions.ts
+++ b/src/providers/vultr/actions.ts
@@ -188,12 +188,14 @@ const updateInstanceFields = {
   ddosProtection: s.boolean("Whether to enable paid DDoS protection."),
   tags: s.stringArray("Replacement tags for the instance.", { itemDescription: "An instance tag." }),
 };
-const updateInstanceInputSchema = s.object(
-  "Fields to update on an existing Vultr instance.",
-  { instanceId: instanceIdSchema, ...updateInstanceFields },
-  { required: ["instanceId"], optional: Object.keys(updateInstanceFields) },
-) as JsonSchema;
-updateInstanceInputSchema.anyOf = Object.keys(updateInstanceFields).map((field) => ({ required: [field] }));
+const updateInstanceInputSchema: JsonSchema = {
+  ...s.object(
+    "Fields to update on an existing Vultr instance.",
+    { instanceId: instanceIdSchema, ...updateInstanceFields },
+    { required: ["instanceId"], optional: Object.keys(updateInstanceFields) },
+  ),
+  anyOf: Object.keys(updateInstanceFields).map((field) => ({ required: [field] })),
+};
 
 export const vultrActions: ActionDefinition[] = [
   defineProviderAction(service, {

--- a/src/providers/vultr/definition.ts
+++ b/src/providers/vultr/definition.ts
@@ -1,0 +1,27 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { vultrActions } from "./actions.ts";
+
+const service = "vultr";
+
+/**
+ * Vultr provider backed by the public Vultr API v2.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Vultr",
+  description: "Provision and inspect Vultr cloud instances, infrastructure options, firewalls, snapshots, and DNS.",
+  categories: ["Developer Tools"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "VULTR_API_KEY",
+      description:
+        "Vultr API key sent as a Bearer token. Create a key in the Vultr customer portal under Account > API, and restrict it to the runtime's public IP when possible: https://my.vultr.com/settings/#settingsapi",
+    },
+  ],
+  homepageUrl: "https://www.vultr.com/",
+  actions: vultrActions,
+};

--- a/src/providers/vultr/executors.ts
+++ b/src/providers/vultr/executors.ts
@@ -1,0 +1,16 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+
+import { defineApiKeyProviderExecutors } from "../provider-runtime.ts";
+import { validateVultrCredential, vultrActionHandlers } from "./runtime.ts";
+
+const service = "vultr";
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, vultrActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validateVultrCredential(input.apiKey, fetcher, signal);
+  },
+};

--- a/src/providers/vultr/runtime.ts
+++ b/src/providers/vultr/runtime.ts
@@ -14,7 +14,7 @@ import {
 import { compactJson, encodePathSegment, jsonObject } from "../../core/request.ts";
 import {
   createProviderTimeout,
-  isAbortLikeError,
+  isAbortSignalError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
@@ -91,7 +91,8 @@ export async function validateVultrCredential(
   const account = await getAccount({ apiKey, fetcher, signal }, "validate");
   const email = requiredString(account.email, "account.email", providerResponseError);
   const name = optionalString(account.name);
-  const acls = readOptionalStringArray(account.acls) ?? [];
+  const acls =
+    account.acls === undefined ? [] : requiredStringArray(account.acls, "account.acls", providerResponseError);
 
   return {
     profile: {
@@ -287,8 +288,11 @@ async function vultrFetch(input: VultrRequestInput): Promise<Response> {
       signal: timeout.signal,
     });
   } catch (error) {
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
+    if (timeout.didTimeout()) {
       throw new ProviderRequestError(504, "Vultr request timed out", error);
+    }
+    if (isAbortSignalError(input.signal, error)) {
+      throw new ProviderRequestError(499, "Vultr request was cancelled", error);
     }
     throw new ProviderRequestError(
       502,

--- a/src/providers/vultr/runtime.ts
+++ b/src/providers/vultr/runtime.ts
@@ -1,0 +1,361 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalIntegerLike,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+  requiredStringArray,
+} from "../../core/cast.ts";
+import { compactJson, encodePathSegment, jsonObject } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+  readProviderJsonBody,
+} from "../provider-runtime.ts";
+
+const vultrApiBaseUrl = "https://api.vultr.com/v2";
+const requestTimeoutMs = 30_000;
+
+type VultrRequestPhase = "validate" | "execute";
+
+export const vultrActionHandlers: Record<string, ProviderRuntimeHandler<ApiKeyProviderContext>> = {
+  async get_account(_input, context) {
+    return { account: await getAccount(context, "execute") };
+  },
+  list_instances(input, context) {
+    return listVultrCollection(input, context, "/instances", "instances", "instances", {
+      label: optionalString(input.label),
+      main_ip: optionalString(input.mainIp),
+      region: optionalString(input.region),
+      firewall_group_id: optionalString(input.firewallGroupId),
+      hostname: optionalString(input.hostname),
+      show_pending_charges: optionalBoolean(input.showPendingCharges),
+    });
+  },
+  get_instance(input, context) {
+    return getInstance(input, context);
+  },
+  create_instance(input, context) {
+    return createInstance(input, context);
+  },
+  update_instance(input, context) {
+    return updateInstance(input, context);
+  },
+  delete_instance(input, context) {
+    return deleteInstance(input, context);
+  },
+  manage_instance_power(input, context) {
+    return manageInstancePower(input, context);
+  },
+  list_regions(input, context) {
+    return listVultrCollection(input, context, "/regions", "regions", "regions");
+  },
+  list_plans(input, context) {
+    return listVultrCollection(input, context, "/plans", "plans", "plans", {
+      type: optionalString(input.type),
+      os: optionalString(input.operatingSystem),
+    });
+  },
+  list_operating_systems(input, context) {
+    return listVultrCollection(input, context, "/os", "os", "operatingSystems");
+  },
+  list_snapshots(input, context) {
+    return listVultrCollection(input, context, "/snapshots", "snapshots", "snapshots", {
+      description: optionalString(input.description),
+    });
+  },
+  list_firewall_groups(input, context) {
+    return listVultrCollection(input, context, "/firewalls", "firewall_groups", "firewallGroups");
+  },
+  list_domains(input, context) {
+    return listVultrCollection(input, context, "/domains", "domains", "domains");
+  },
+  list_domain_records(input, context) {
+    const domain = requiredString(input.domain, "domain", providerInputError);
+    return listVultrCollection(input, context, `/domains/${encodePathSegment(domain)}/records`, "records", "records");
+  },
+};
+
+export async function validateVultrCredential(
+  apiKey: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const account = await getAccount({ apiKey, fetcher, signal }, "validate");
+  const email = requiredString(account.email, "account.email", providerResponseError);
+  const name = optionalString(account.name);
+  const acls = readOptionalStringArray(account.acls) ?? [];
+
+  return {
+    profile: {
+      accountId: email,
+      displayName: name ?? email,
+    },
+    grantedScopes: acls,
+    metadata: jsonObject({
+      validationEndpoint: "/account",
+      email,
+      name,
+    }),
+  };
+}
+
+async function getAccount(context: ApiKeyProviderContext, phase: VultrRequestPhase): Promise<Record<string, unknown>> {
+  const payload = await requestVultrJson({
+    apiKey: context.apiKey,
+    path: "/account",
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase,
+  });
+  return requireWrappedObject(payload, "account");
+}
+
+async function getInstance(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown> {
+  const instanceId = requiredString(input.instanceId, "instanceId", providerInputError);
+  const payload = await requestVultrJson({
+    apiKey: context.apiKey,
+    path: `/instances/${encodePathSegment(instanceId)}`,
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return { instance: requireWrappedObject(payload, "instance") };
+}
+
+async function createInstance(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown> {
+  const payload = await requestVultrJson({
+    apiKey: context.apiKey,
+    path: "/instances",
+    method: "POST",
+    body: {
+      region: requiredString(input.region, "region", providerInputError),
+      plan: requiredString(input.plan, "plan", providerInputError),
+      os_id: optionalInteger(input.osId),
+      iso_id: optionalString(input.isoId),
+      snapshot_id: optionalString(input.snapshotId),
+      app_id: optionalInteger(input.appId),
+      image_id: optionalString(input.imageId),
+      label: optionalString(input.label),
+      hostname: optionalString(input.hostname),
+      enable_ipv6: optionalBoolean(input.enableIpv6),
+      disable_public_ipv4: optionalBoolean(input.disablePublicIpv4),
+      backups: optionalString(input.backups),
+      ddos_protection: optionalBoolean(input.ddosProtection),
+      activation_email: optionalBoolean(input.activationEmail),
+      firewall_group_id: optionalString(input.firewallGroupId),
+      sshkey_id: readOptionalStringArray(input.sshKeyIds),
+      attach_vpc: readOptionalStringArray(input.vpcIds),
+      tags: readOptionalStringArray(input.tags),
+      user_data: optionalString(input.userData),
+      user_scheme: optionalString(input.userScheme),
+    },
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return { instance: requireWrappedObject(payload, "instance") };
+}
+
+async function updateInstance(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown> {
+  const instanceId = requiredString(input.instanceId, "instanceId", providerInputError);
+  const payload = await requestVultrJson({
+    apiKey: context.apiKey,
+    path: `/instances/${encodePathSegment(instanceId)}`,
+    method: "PATCH",
+    body: {
+      label: optionalString(input.label),
+      plan: optionalString(input.plan),
+      backups: optionalString(input.backups),
+      firewall_group_id: optionalString(input.firewallGroupId),
+      enable_ipv6: optionalBoolean(input.enableIpv6),
+      ddos_protection: optionalBoolean(input.ddosProtection),
+      tags: readOptionalStringArray(input.tags),
+    },
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return { instance: requireWrappedObject(payload, "instance") };
+}
+
+async function deleteInstance(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown> {
+  const instanceId = requiredString(input.instanceId, "instanceId", providerInputError);
+  await requestVultrJson({
+    apiKey: context.apiKey,
+    path: `/instances/${encodePathSegment(instanceId)}`,
+    method: "DELETE",
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return { deleted: true, instanceId };
+}
+
+async function manageInstancePower(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown> {
+  const instanceId = requiredString(input.instanceId, "instanceId", providerInputError);
+  const operation = requiredString(input.operation, "operation", providerInputError);
+  if (operation !== "start" && operation !== "reboot" && operation !== "halt") {
+    throw providerInputError("operation must be start, reboot, or halt");
+  }
+  await requestVultrJson({
+    apiKey: context.apiKey,
+    path: `/instances/${encodePathSegment(instanceId)}/${operation}`,
+    method: "POST",
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return { accepted: true, instanceId, operation };
+}
+
+async function listVultrCollection(
+  input: Record<string, unknown>,
+  context: ApiKeyProviderContext,
+  path: string,
+  upstreamKey: string,
+  outputKey: string,
+  filters: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> {
+  const payload = await requestVultrJson({
+    apiKey: context.apiKey,
+    path,
+    query: {
+      per_page: readOptionalPerPage(input.perPage),
+      cursor: optionalString(input.cursor),
+      ...filters,
+    },
+    fetcher: context.fetcher,
+    signal: context.signal,
+    phase: "execute",
+  });
+  return normalizeCollection(payload, upstreamKey, outputKey);
+}
+
+interface VultrRequestInput {
+  apiKey: string;
+  path: string;
+  fetcher: ProviderFetch;
+  phase: VultrRequestPhase;
+  signal?: AbortSignal;
+  query?: Record<string, unknown>;
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: Record<string, unknown>;
+}
+
+async function requestVultrJson(input: VultrRequestInput): Promise<unknown> {
+  const response = await vultrFetch(input);
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "Vultr returned invalid JSON",
+  });
+  if (!response.ok) {
+    throw createVultrError(response.status, payload, input.phase);
+  }
+  return payload;
+}
+
+async function vultrFetch(input: VultrRequestInput): Promise<Response> {
+  const url = new URL(`${vultrApiBaseUrl}${input.path}`);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  try {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      authorization: `Bearer ${input.apiKey}`,
+      "user-agent": providerUserAgent,
+    };
+    if (input.body !== undefined) {
+      headers["content-type"] = "application/json";
+    }
+    return await input.fetcher(url, {
+      method: input.method ?? "GET",
+      headers,
+      body: input.body === undefined ? undefined : JSON.stringify(compactJson(input.body)),
+      signal: timeout.signal,
+    });
+  } catch (error) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, "Vultr request timed out", error);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Vultr request failed: ${error.message}` : "Vultr request failed",
+      error,
+    );
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function createVultrError(status: number, payload: unknown, phase: VultrRequestPhase): ProviderRequestError {
+  const message = extractVultrErrorMessage(payload) ?? `Vultr request failed with status ${status}`;
+  if ((status === 401 || status === 403) && phase === "validate") {
+    return new ProviderRequestError(400, message, payload);
+  }
+  return new ProviderRequestError(status || 502, message, payload);
+}
+
+function extractVultrErrorMessage(payload: unknown): string | undefined {
+  if (typeof payload === "string") {
+    return optionalString(payload);
+  }
+  const record = optionalRecord(payload);
+  return optionalString(record?.error) ?? optionalString(record?.message);
+}
+
+function normalizeCollection(payload: unknown, upstreamKey: string, outputKey: string): Record<string, unknown> {
+  const record = requiredRecord(payload, "Vultr response", providerResponseError);
+  const items = requireResponseArray(record[upstreamKey], upstreamKey);
+  return jsonObject({
+    [outputKey]: items,
+    meta: optionalRecord(record.meta),
+  });
+}
+
+function requireWrappedObject(value: unknown, fieldName: string): Record<string, unknown> {
+  const record = requiredRecord(value, "Vultr response", providerResponseError);
+  return requiredRecord(record[fieldName], fieldName, providerResponseError);
+}
+
+function requireResponseArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw providerResponseError(`Vultr response missing ${fieldName}`);
+  }
+  return value.map((item) => requiredRecord(item, fieldName, providerResponseError));
+}
+
+function readOptionalPerPage(value: unknown): number | undefined {
+  const perPage = optionalIntegerLike(value, "perPage", providerInputError);
+  if (perPage === undefined) {
+    return undefined;
+  }
+  if (perPage < 1 || perPage > 500) {
+    throw providerInputError("perPage must be between 1 and 500");
+  }
+  return perPage;
+}
+
+function readOptionalStringArray(value: unknown): string[] | undefined {
+  return value === undefined ? undefined : requiredStringArray(value, "array value", providerInputError);
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}


### PR DESCRIPTION
## Summary

- add a Vultr API v2 provider with API-key credential validation
- expose 14 locally executable actions for instances, regions, plans, operating systems, snapshots, firewalls, and DNS
- preserve Vultr cursor pagination, ACL metadata, request semantics, and structured provider errors

## Validation

- npm run generate:catalog
- npm run fix-check
- npm test (57 test files, 548 tests)
- Vultr runtime and action-schema smoke tests