### PR TITLE
docs: clarify hosted OAuth and expand localized READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](README.md) | [简体中文](docs/README.zh-CN.md) | [繁體中文](docs/README.zh-TW.md) | [日本語](docs/README.ja.md) | [Русский](docs/README.ru.md) | [Français](docs/README.fr.md)
+[English](README.md) | [简体中文](docs/README.zh-CN.md) | [繁體中文](docs/README.zh-TW.md) | [日本語](docs/README.ja.md) | [한국어](docs/README.ko.md) | [Русский](docs/README.ru.md) | [Français](docs/README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -18,6 +18,12 @@
 OpenConnector is an open-source connector gateway for AI agents and an alternative to Composio.
 Connect user app accounts once, then expose a shared catalog of 1,000+ providers and 10,000+
 prebuilt Actions to agents and applications.
+
+> [!IMPORTANT]
+> **Need OAuth ready to use?** [OOMOL-hosted connectors](https://oomol.com/apps) include managed OAuth
+> apps for supported providers and monthly Connect credits for roughly 15,000–20,000 calls,
+> depending on usage. Self-hosted OpenConnector includes the OAuth flow, credential storage, and
+> token refresh, but you provide your own OAuth apps.
 
 Use the [Connector SDK](https://github.com/oomol-lab/connector-sdk) from app code,
 [oo CLI](https://github.com/oomol-lab/oo-cli) as the local-agent relay, MCP from agent hosts,
@@ -108,12 +114,12 @@ safe account labels, and execution results needed for the run.
 
 ## Usage Paths
 
-| Path                         | Best for                                            | Includes                                                                                                                                                                  |
-| ---------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Open-source self-host        | Developers and teams that want full control         | Local Docker or Node runtime, SQLite storage, MCP, HTTP, OpenAPI, and Web Console                                                                                         |
-| Fly.io self-host             | Teams that want a hosted Docker runtime             | Node Docker runtime, SQLite storage on a Fly volume, TLS, health checks, MCP, HTTP, OpenAPI, and Web Console                                                              |
-| Cloudflare-compatible deploy | Teams that want a lightweight hosted runtime        | Workers runtime, D1 state, R2 transit files, and Static Assets for the console                                                                                            |
-| [OOMOL](https://oomol.com/)  | Teams blocked by OAuth approval or launch deadlines | Hosted auth and runtime infrastructure with the same provider and Action contracts; compatible with the open-source interface for later private or self-hosted deployment |
+| Path                            | Best for                                                | Includes                                                                                                                                                                                           |
+| ------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Open-source self-host           | Developers and teams that want full control             | Local Docker or Node runtime, SQLite storage, MCP, HTTP, OpenAPI, and Web Console                                                                                                                  |
+| Fly.io self-host                | Teams that want a hosted Docker runtime                 | Node Docker runtime, SQLite storage on a Fly volume, TLS, health checks, MCP, HTTP, OpenAPI, and Web Console                                                                                       |
+| Cloudflare-compatible deploy    | Teams that want a lightweight hosted runtime            | Workers runtime, D1 state, R2 transit files, and Static Assets for the console                                                                                                                     |
+| [OOMOL](https://oomol.com/apps) | Teams that want users to authorize accounts immediately | OOMOL-provided OAuth apps, monthly included Connect credits, and hosted runtime infrastructure; the same provider and Action contracts keep a path open to later private or self-hosted deployment |
 
 ## Cloudflare Quick Start Video
 
@@ -127,6 +133,11 @@ the same flow as [docs/cloudflare.md](docs/cloudflare.md): create Cloudflare res
 run `npm run deploy:cloudflare`.
 
 ## Quick Start
+
+> [!NOTE]
+> This starts a self-hosted runtime. OAuth providers require OAuth client credentials from apps you
+> register with those providers. To let users authorize supported providers without setting up your
+> own OAuth apps, use [OOMOL-hosted connectors](https://oomol.com/apps).
 
 Start the runtime from the published image with Docker Compose:
 

--- a/README.md
+++ b/README.md
@@ -298,3 +298,10 @@ Prefer linking to official public assets instead of copying brand files into thi
 
 Please keep issues and pull requests focused, respectful, and actionable. Participation in this
 project is governed by [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Contributors
+
+Thanks to everyone who has helped build OpenConnector. Want to join them? See
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+[![OpenConnector contributors](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -2,7 +2,7 @@
 
 <img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -18,6 +18,13 @@
 OpenConnector est un connector gateway open source pour AI agents, et une alternative à Composio.
 Connectez les comptes d'apps utilisateur une fois, puis exposez un catalog partagé de 1,000+
 providers et 10 000+ Actions prêtes à l'emploi aux agents et applications.
+
+> [!IMPORTANT]
+> **Besoin d'un OAuth prêt à l'emploi ?** Les
+> [connectors hébergés par OOMOL](https://oomol.com/apps) incluent des apps OAuth configurées pour
+> les providers pris en charge et des Connect credits mensuels représentant environ 15 000 à 20 000
+> appels gratuits selon l'utilisation. OpenConnector self-hosted prend également en charge OAuth,
+> mais vous devez enregistrer et configurer vos propres apps OAuth.
 
 Utilisez le [Connector SDK](https://github.com/oomol-lab/connector-sdk) dans le code applicatif,
 [oo CLI](https://github.com/oomol-lab/oo-cli) comme relais pour les agents locaux, MCP pour les
@@ -130,6 +137,12 @@ suit le même flux que [cloudflare.md](cloudflare.md) : créer les ressources Cl
 secrets requis et exécuter `npm run deploy:cloudflare`.
 
 ## Démarrage Rapide
+
+> [!NOTE]
+> Ces étapes démarrent un runtime self-hosted. Les providers OAuth nécessitent les OAuth client
+> credentials des apps que vous enregistrez auprès de ces providers. Pour permettre aux
+> utilisateurs d'autoriser les providers pris en charge sans configurer vos propres apps OAuth,
+> utilisez les [connectors hébergés par OOMOL](https://oomol.com/apps).
 
 Démarrez le runtime depuis l'image publiée avec Docker Compose :
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -303,3 +303,10 @@ copier des fichiers de marque dans ce repository.
 
 Gardez les issues et pull requests ciblées, respectueuses et actionnables. La participation à ce
 projet est régie par [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+
+## Contributeurs
+
+Merci à toutes les personnes qui ont contribué à OpenConnector. Vous souhaitez les rejoindre ?
+Consultez le [guide de contribution](../CONTRIBUTING.md).
+
+[![Contributeurs OpenConnector](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -2,7 +2,7 @@
 
 <img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -18,6 +18,12 @@
 OpenConnector は AI Agent 向けのオープンソース connector gateway であり、Composio の代替です。
 ユーザーのアプリアカウントを一度接続すれば、1,000+ の provider と 10,000+ の事前定義済み Action を含む共有
 catalog を Agent とアプリケーションに公開できます。
+
+> [!IMPORTANT]
+> **OAuth をすぐに使いたい場合は？** [OOMOL hosted connectors](https://oomol.com/apps) には、対応
+> provider 向けに設定済みの OAuth app と、利用量に応じて約 15,000～20,000 回の無料呼び出しに相当する
+> 毎月の Connect credits が含まれます。Self-hosted OpenConnector も OAuth に対応していますが、
+> OAuth app は自身で登録、設定する必要があります。
 
 アプリコードには [Connector SDK](https://github.com/oomol-lab/connector-sdk)、ローカル
 Agent の relay には [oo CLI](https://github.com/oomol-lab/oo-cli)、Agent host には
@@ -118,6 +124,11 @@ OpenConnector を Cloudflare の Workers、D1、R2、Web Console で起動する
 を設定して `npm run deploy:cloudflare` を実行します。
 
 ## クイックスタート
+
+> [!NOTE]
+> 以下では self-hosted runtime を起動します。OAuth provider を使うには、各 provider で登録した
+> OAuth client credential が必要です。独自の OAuth app を設定せずに、対応 provider をユーザーが
+> 直接認可できるようにするには、[OOMOL hosted connectors](https://oomol.com/apps) を利用してください。
 
 公開イメージから Docker Compose で runtime を起動します。
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -280,3 +280,10 @@ provider metadata や asset を提供する場合は、提出できる権利を�
 
 issue と pull request は、焦点が合い、敬意があり、実行可能な内容にしてください。この project への参加には
 [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) が適用されます。
+
+## コントリビューター
+
+OpenConnector の開発にご協力いただいたすべての皆さまに感謝します。参加方法については
+[コントリビューションガイド](../CONTRIBUTING.md) をご覧ください。
+
+[![OpenConnector コントリビューター](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,291 @@
+<div align="center">
+
+<img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
+
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
+![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
+![Cloudflare compatible](https://img.shields.io/badge/Cloudflare-compatible-F38020)
+![MCP](https://img.shields.io/badge/MCP-ready-111827)
+![OpenAPI](https://img.shields.io/badge/OpenAPI-3.1-6BA539)
+
+[![Providers](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.providerCount&label=Providers&color=%237d7fe9)](https://oomol.com/apps)
+[![Actions](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fconnector.oomol.com%2Fv1%2Fcatalog&query=data.actionCount&label=Actions&color=%237d7fe9)](https://oomol.com/apps)
+
+</div>
+
+OpenConnector는 AI Agent를 위한 오픈 소스 connector gateway이자 Composio의 대안입니다.
+사용자의 앱 계정을 한 번 연결하면 1,000개 이상의 provider와 10,000개 이상의 사전 구축된 Action을
+Agent와 애플리케이션에 공통 catalog로 제공할 수 있습니다.
+
+> [!IMPORTANT]
+> **OAuth를 바로 사용하고 싶으신가요?** [OOMOL hosted connector](https://oomol.com/apps)는 지원되는
+> provider의 OAuth app을 미리 구성해 두어 사용자가 즉시 계정을 승인할 수 있습니다. 또한 매월 제공되는
+> Connect credits로 사용량에 따라 약 15,000~20,000회의 호출을 무료로 이용할 수 있습니다. Self-hosted
+> OpenConnector도 OAuth를 지원하지만 OAuth app은 직접 등록하고 구성해야 합니다.
+
+애플리케이션 코드에서는 [Connector SDK](https://github.com/oomol-lab/connector-sdk), 로컬 Agent
+relay에는 [oo CLI](https://github.com/oomol-lab/oo-cli), Agent host에는 MCP, custom client에는
+HTTP/OpenAPI를 사용합니다. 관리와 디버깅에는 Web Console을 사용할 수 있습니다.
+
+- Credential, scope, schema, policy, 실행 로그를 검사 가능한 runtime 내부에 보관합니다.
+- 로컬, Fly.io, Cloudflare 호환 인프라 또는 OOMOL hosted runtime에서 실행할 수 있습니다.
+- 오픈 소스와 상용 SaaS 배포에서 동일한 provider id, Action id, schema, contract를 사용합니다.
+
+## 주요 기능
+
+- GitHub, Gmail, Notion, BigQuery, Google Analytics, Supabase, Airtable, Slack 등을 지원하는
+  즉시 사용 가능한 connector catalog.
+- API key, OAuth2, custom credential, 인증이 필요 없는 provider를 위한 credential 관리.
+- Request/response schema, required scope, 지연 로드되는 executor source를 포함하는 검사 가능한
+  Action contract.
+- Connection identity, scope, runtime token, Action 허용/차단 policy, 임시 파일 전송, 민감 정보가
+  제거된 실행 로그를 위한 runtime 제어.
+- 로컬 Docker 또는 Node.js, 영구 SQLite storage를 사용하는 Fly.io, D1/R2/Static Assets를 사용하는
+  Cloudflare Workers, OOMOL hosted runtime을 포함한 다양한 배포 방식.
+
+## 적합한 사용 사례
+
+OpenConnector는 provider credential을 Agent 프로세스에 직접 전달하지 않으면서 Agent가 사용자의 기존
+도구에 지속적으로 접근해야 하는 제품에 적합합니다.
+
+- 업무용 앱, 개발자 도구, 데이터 시스템, 커뮤니케이션 플랫폼, AI 서비스 전반에 걸쳐 재사용 가능한
+  접근 계층이 필요한 Agent 제품.
+- 사용자 앱에 접근할 때 안정적이고 검사 가능한 Action contract가 필요한 Agent workflow 제품.
+- 빠르게 hosted auth를 시작하면서도 향후 private 또는 self-hosted runtime으로 전환할 수 있는 경로를
+  유지하려는 팀.
+
+## 개발자 도구
+
+| 도구                                                        | 용도                                                                                                                                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Connector SDK](https://github.com/oomol-lab/connector-sdk) | 경량 TypeScript HTTP client. Self-hosted runtime에는 `OpenConnector`, OOMOL hosted 개인 및 SaaS 최종 사용자 연결에는 `Connector` / `ProjectConnector`를 사용합니다. |
+| [oo CLI](https://github.com/oomol-lab/oo-cli)               | 로컬 Agent용 connector Action relay. `oo connector`로 OOMOL hosted 또는 self-hosted OpenConnector runtime의 Action을 검색하고 검사하고 실행할 수 있습니다.          |
+| MCP                                                         | `http://localhost:3000/mcp`를 통해 앱 Action을 MCP 지원 Agent host에 제공합니다.                                                                                    |
+| HTTP / OpenAPI                                              | `/v1/actions/*`를 직접 호출하거나 생성된 `/openapi.json` 문서를 확인합니다.                                                                                         |
+
+Endpoint 세부 정보, response envelope, 인증 header, MCP tool, Action guide 예제는
+[runtime-api.md](runtime-api.md)를 참조하세요.
+
+## Dashboard 미리 보기
+
+OpenConnector에는 connector 탐색, credential 구성, runtime token 생성, runtime 사용량 확인을 위한
+로컬 Dashboard가 포함되어 있습니다.
+
+### Connector Catalog
+
+Connector catalog에서 사용 가능한 서비스를 확인하고 provider를 검색하며 Action과 credential 설정을
+한곳에서 열 수 있습니다.
+
+![OpenConnector connector catalog dashboard](../assets/open-console-en.jpg)
+
+### 사용량 개요
+
+배포 후 Overview 페이지에서 runtime 준비 상태, 사용 가능한 provider, 실행 가능한 Action, 최근 오류,
+tool call 추이, 최근 호출을 확인할 수 있습니다.
+
+![OpenConnector runtime overview dashboard](../assets/overview-page-en.jpg)
+
+Provider 이름과 상표는 각 권리자에게 있으며, 식별과 상호 운용 목적으로만 사용됩니다.
+
+## 작동 방식
+
+```mermaid
+flowchart LR
+  Agent["AI Agent / App"] -->|"SDK / CLI / MCP / HTTP"| Gateway["OpenConnector Gateway"]
+  Gateway --> Auth["Credential & OAuth Boundary"]
+  Gateway --> Catalog["Provider Catalog"]
+  Gateway --> Actions["Open-source Action Executors"]
+  Gateway --> Policy["Tokens, Scopes, Allow/Block Policy"]
+  Gateway --> Logs["Run Logs"]
+  Actions --> Providers["1,000+ Providers"]
+  Console["Web Console"] --> Gateway
+  Cloudflare["Cloudflare Workers, D1, R2"] -. deploy .-> Gateway
+```
+
+앱과 Agent는 Action을 검색하고 schema와 scope를 검사하며 connection alias를 선택한 뒤 gateway를 통해
+실행합니다. Provider secret은 runtime 경계 안에 유지되고, Agent에는 실행에 필요한 metadata, 안전한
+계정 label, 실행 결과만 전달됩니다.
+
+## 사용 경로
+
+| 경로                            | 적합한 대상                             | 포함 항목                                                                                                                                                                           |
+| ------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 오픈 소스 self-host             | 인프라를 완전히 제어하려는 개발자와 팀  | 로컬 Docker 또는 Node runtime, SQLite storage, MCP, HTTP, OpenAPI, Web Console                                                                                                      |
+| Fly.io self-host                | Hosted Docker runtime이 필요한 팀       | Node Docker runtime, Fly volume의 SQLite storage, TLS, health check, MCP, HTTP, OpenAPI, Web Console                                                                                |
+| Cloudflare 호환 배포            | 가벼운 hosted runtime이 필요한 팀       | Workers runtime, D1 state, R2 transit file, Console용 Static Assets                                                                                                                 |
+| [OOMOL](https://oomol.com/apps) | 사용자가 계정을 즉시 승인하게 하려는 팀 | 지원되는 provider용 OAuth app, 매월 제공되는 Connect credits, hosted runtime 인프라. 동일한 provider 및 Action contract를 사용하므로 향후 private 또는 self-hosted 배포로 전환 가능 |
+
+## Cloudflare 빠른 시작 동영상
+
+[![Cloudflare Workers에 OpenConnector 배포](../assets/cloudflare-quickstart-video.png)](https://www.youtube.com/watch?v=R0V1ZdCuTgc)
+
+[Cloudflare Workers 배포 안내 동영상](https://www.youtube.com/watch?v=R0V1ZdCuTgc)에서는 Workers,
+D1, R2, Web Console을 사용해 Cloudflare에서 OpenConnector를 실행하는 방법을 보여 줍니다. 동영상은
+[cloudflare.md](cloudflare.md)의 흐름과 동일합니다. Cloudflare resource를 생성하고
+`wrangler.example.jsonc`를 `wrangler.local.jsonc`로 복사한 뒤 D1 migration을 적용하고 필요한
+secret을 설정한 다음 `npm run deploy:cloudflare`를 실행합니다.
+
+## 빠른 시작
+
+> [!NOTE]
+> 다음 단계에서는 self-hosted runtime을 시작합니다. OAuth provider를 사용하려면 해당 provider에 직접
+> 등록한 OAuth app의 client credential이 필요합니다. OAuth app을 직접 구성하지 않고 사용자가 지원되는
+> provider를 승인하게 하려면 [OOMOL hosted connector](https://oomol.com/apps)를 사용하세요.
+
+배포된 이미지에서 Docker Compose로 runtime을 시작합니다.
+
+```bash
+docker compose up
+```
+
+이 명령은 `ghcr.io/oomol-lab/open-connector:latest`를 가져옵니다. 소스에서 직접 빌드하려면 다음을
+실행하세요.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml up --build
+```
+
+로컬 Console과 생성된 API reference를 엽니다.
+
+```text
+http://localhost:3000
+http://localhost:3000/docs
+```
+
+인증이 필요 없는 Action을 실행하여 runtime이 정상 작동하는지 확인합니다.
+
+```bash
+curl -s -X POST http://localhost:3000/v1/actions/hackernews.get_top_stories \
+  -H 'content-type: application/json' \
+  -d '{"input":{}}'
+```
+
+전체 로컬 설정, 첫 provider 연결, OAuth flow, runtime 설정은 [quickstart.md](quickstart.md)를
+참조하세요.
+
+## Provider 연결
+
+GitHub는 personal access token을 사용할 수 있어 credential이 필요한 예제로 가장 간단합니다.
+
+```bash
+curl -s -X PUT http://localhost:3000/api/connections/github \
+  -H 'content-type: application/json' \
+  -d '{"authType":"api_key","values":{"apiKey":"github_pat_..."}}'
+
+curl -s -X POST http://localhost:3000/v1/actions/github.get_current_user \
+  -H 'content-type: application/json' \
+  -d '{"input":{}}'
+```
+
+OAuth2 app, named connection, credential 암호화, token refresh, Action policy에 대해서는
+[credentials.md](credentials.md)와 [configuration.md](configuration.md)를 참조하세요.
+
+## Web Console
+
+npm 기반 로컬 개발에서는 `http://localhost:5173`을 엽니다. Web Console dev server는
+`http://localhost:3000`의 runtime으로 API request를 proxy합니다. Docker 또는 빌드된 Node runtime에서는
+Console이 `http://localhost:3000`에서 제공됩니다.
+
+Console은 provider 탐색, API key 및 OAuth client 구성, runtime token 생성, Action schema 검사,
+Action 디버깅, 최근 실행 검토, 생성된 OpenAPI 및 MCP metadata 접근을 지원합니다.
+
+## Cloudflare 배포
+
+OpenConnector는 runtime에 Workers, 상태 저장에 D1, transit file에 R2, Web Console에 Static Assets를
+사용하여 Cloudflare에서 실행할 수 있습니다.
+
+Resource 생성, migration, secret, 로컬 Worker preview, 원격 배포는
+[cloudflare.md](cloudflare.md)를 참조하세요.
+
+## Fly.io 배포
+
+OpenConnector는 Node Docker runtime과 Fly volume의 영구 SQLite storage를 사용하여 Fly.io에서도
+실행할 수 있습니다.
+
+앱 생성, volume 설정, secret, 배포, custom domain, scaling은 [fly-io.md](fly-io.md)를 참조하세요.
+
+## Docker 이미지(GHCR)
+
+GitHub Packages(GHCR)의 사전 빌드된 이미지 `ghcr.io/oomol-lab/open-connector`로 OpenConnector를
+실행할 수 있습니다. 최신 release에는 `latest`, 재현 가능한 production 배포에는 `v1.0.0` 같은 고정
+version, 최신 `main` build에는 `tip`을 사용하세요.
+
+Image tag, 가져오기, 실행 방법은 [docker-ghcr.md](docker-ghcr.md)를 참조하세요.
+
+## 바로 사용하고 싶으신가요?
+
+위의 경로는 connector를 자체 제품, runtime 또는 인프라에 통합하려는 팀을 위한 것입니다. SaaS 연결
+환경을 먼저 체험하거나 일상 업무에서 바로 사용하려면 OpenConnector를 배포하거나 SDK, CLI, MCP,
+HTTP API를 먼저 통합할 필요가 없습니다.
+
+[Wanta](https://wanta.ai/)는 동일한 1,000개 이상의 SaaS/provider 범위를 사용하는 데스크톱 제품입니다.
+계정을 한 번 연결한 뒤 자연어로 연결된 도구 전반에서 검색, 정리, 생성, 동기화할 수 있습니다.
+
+| 원하는 작업                          | Wanta가 제공하는 기능                                                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| 1,000개 이상의 SaaS 연결을 바로 체험 | Runtime 배포나 SDK/CLI 통합 없이 동일한 SaaS/provider 범위를 사용합니다.                                                      |
+| 일상 업무에서 Agent 사용             | 이메일, 채팅, 문서, 데이터, 프로젝트, 지원, 개발 도구, 마케팅 도구를 자연어로 다룹니다.                                       |
+| 팀과 연결 기능 공유                  | Connection과 access scope를 한 번 구성하면 팀원이 별도 설정 없이 사용할 수 있으며 key, token, credential은 노출되지 않습니다. |
+
+## 문서
+
+- [빠른 시작](quickstart.md)
+- [개발자 도구](sdk-cli.md)
+- [Gmail OAuth 및 SDK 튜토리얼(영문)](gmail-oauth-sdk.md)
+- [Runtime API 및 MCP](runtime-api.md)
+- [Fly.io 배포](fly-io.md)
+- [Cloudflare 배포](cloudflare.md)
+- [Docker 이미지(GHCR)](docker-ghcr.md)
+- [구성](configuration.md)
+- [Credential 및 OAuth](credentials.md)
+- [Catalog 형식](catalog-format.md)
+- [검증 언어](verification.md)
+- [기여 안내](../CONTRIBUTING.md)
+- [행동 강령](../CODE_OF_CONDUCT.md)
+- [보안](../SECURITY.md)
+
+## 개발
+
+Node.js 22 이상을 사용하세요.
+
+```bash
+npm install
+npm run dev
+```
+
+로컬 API runtime은 `http://localhost:3000`에서 실행됩니다. Web Console dev server는
+`http://localhost:5173`에서 실행되며 API request를 runtime으로 proxy합니다.
+
+Pull request를 열기 전에 다음을 실행하세요.
+
+```bash
+npm run fix-check
+npm test
+```
+
+Provider 코드는 `src/providers/<service>`에 있습니다. Provider 기여 규칙은
+[CONTRIBUTING.md](../CONTRIBUTING.md#adding-providers)를 참조하세요.
+
+## 라이선스 범위
+
+별도로 명시하지 않는 한 이 repository를 위해 작성된 source code, script, 생성된 project scaffolding,
+test, 문서는 Apache License Version 2.0에 따라 사용이 허가됩니다.
+[LICENSE.txt](../LICENSE.txt)를 참조하세요.
+
+이 repository의 Apache-2.0 license는 각 권리자가 소유한 타사 제품, provider, app, API, 상표,
+service mark, trade name, logo, icon, brand asset, 문서, screenshot 또는 기타 저작물에 대한 권리를
+부여하지 않습니다.
+
+Provider와 app 이름, metadata, link, scope, permission, 선택적 logo/icon은 서비스를 식별하고 상호
+운용성을 제공하기 위한 목적으로만 포함됩니다. 모든 타사 brand 및 제품 권리는 각 권리자에게 있습니다.
+Catalog에 포함되었다고 해서 해당 권리자의 보증, 후원, 파트너십, 인증 또는 검증을 의미하지 않습니다.
+
+Provider metadata나 asset을 기여할 때는 제출할 권리가 있는 자료만 포함하세요. Brand file을 복사하는
+대신 공식 공개 asset에 연결하는 방식을 우선하세요.
+
+## 커뮤니티
+
+Issue와 pull request는 주제에 집중하고 서로 존중하며 실행 가능하게 작성해 주세요. 이 프로젝트 참여에는
+[CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)가 적용됩니다.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -289,3 +289,10 @@ Provider metadata나 asset을 기여할 때는 제출할 권리가 있는 자료
 
 Issue와 pull request는 주제에 집중하고 서로 존중하며 실행 가능하게 작성해 주세요. 이 프로젝트 참여에는
 [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)가 적용됩니다.
+
+## 기여자
+
+OpenConnector를 함께 만들어 주신 모든 기여자께 감사드립니다.
+[기여 안내](../CONTRIBUTING.md)를 확인하고 함께해 주세요.
+
+[![OpenConnector 기여자](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -297,3 +297,10 @@ files в этот repository.
 
 Пожалуйста, делайте issues и pull requests сфокусированными, уважительными и пригодными к
 исполнению. Участие в проекте регулируется [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+
+## Участники
+
+Спасибо всем, кто помогает развивать OpenConnector. Хотите присоединиться? Ознакомьтесь с
+[руководством по участию](../CONTRIBUTING.md).
+
+[![Участники OpenConnector](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -2,7 +2,7 @@
 
 <img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -18,6 +18,12 @@
 OpenConnector — open-source connector gateway для AI agents и альтернатива Composio. Подключите
 пользовательские аккаунты приложений один раз, а затем откройте общий catalog из 1,000+ providers и
 10 000+ готовых Actions для агентов и приложений.
+
+> [!IMPORTANT]
+> **Нужен готовый OAuth?** [OOMOL-hosted connectors](https://oomol.com/apps) включают настроенные
+> OAuth apps для поддерживаемых providers и ежемесячные Connect credits примерно на 15 000–20 000
+> бесплатных вызовов в зависимости от использования. Self-hosted OpenConnector также поддерживает
+> OAuth, но OAuth apps потребуется зарегистрировать и настроить самостоятельно.
 
 В application code используйте [Connector SDK](https://github.com/oomol-lab/connector-sdk), для
 local-agent relay — [oo CLI](https://github.com/oomol-lab/oo-cli), для agent hosts — MCP, для
@@ -127,6 +133,12 @@ flowchart LR
 обязательные secrets и выполнить `npm run deploy:cloudflare`.
 
 ## Быстрый Старт
+
+> [!NOTE]
+> Эти шаги запускают self-hosted runtime. Для OAuth providers нужны OAuth client credentials из
+> приложений, которые вы самостоятельно регистрируете у соответствующих providers. Чтобы
+> пользователи могли авторизовать поддерживаемые providers без настройки собственных OAuth apps,
+> используйте [OOMOL-hosted connectors](https://oomol.com/apps).
 
 Запустите runtime из опубликованного образа через Docker Compose:
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 <img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -18,6 +18,11 @@
 OpenConnector 是面向 AI Agent 的开源 connector gateway，也是 Composio 的开源替代方案。
 连接一次用户应用账号，就可以把包含 1,000+ 个 provider 和 10,000+ 个预置 Action 的共享 catalog 暴露给
 Agent 和应用。
+
+> [!IMPORTANT]
+> **希望 OAuth 开箱即用？** [OOMOL 官方托管 Connector](https://oomol.com/apps) 已为支持的 provider
+> 配置好 OAuth 应用，用户可以直接授权；每月赠送的 Connect 点数约可支持 15,000–20,000 次免费调用，实际次数
+> 取决于具体用量。自托管 OpenConnector 同样支持 OAuth，但需要自行申请和配置 OAuth 应用。
 
 应用代码使用 [Connector SDK](https://github.com/oomol-lab/connector-sdk)，本地 Agent 使用
 [oo CLI](https://github.com/oomol-lab/oo-cli) 中继，Agent host 使用 MCP，自定义客户端使用
@@ -95,12 +100,12 @@ secret 保留在运行时边界内；Agent 拿到本次运行所需的 metadata�
 
 ## 使用路径
 
-| 路径                        | 适合谁                                | 提供什么                                                                                                       |
-| --------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| 开源自托管                  | 希望完全掌控基础设施的开发者和团队    | 本地 Docker 或 Node runtime、SQLite 存储、MCP、HTTP、OpenAPI 和 Web 控制台                                     |
-| Fly.io 自托管               | 希望使用托管 Docker runtime 的团队    | Node Docker runtime、Fly volume 上的 SQLite 存储、TLS、健康检查、MCP、HTTP、OpenAPI 和 Web 控制台              |
-| Cloudflare 兼容部署         | 希望快速获得轻量托管运行时的团队      | Workers runtime、D1 状态存储、R2 文件中转和控制台 Static Assets                                                |
-| [OOMOL](https://oomol.com/) | 被 OAuth 申请周期或上线时间卡住的团队 | 托管鉴权和运行时基础设施，使用同一套 provider 和 Action 契约；接口与开源版兼容，后续可迁移到私有化或自托管部署 |
+| 路径                            | 适合谁                             | 提供什么                                                                                                                                                 |
+| ------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 开源自托管                      | 希望完全掌控基础设施的开发者和团队 | 本地 Docker 或 Node runtime、SQLite 存储、MCP、HTTP、OpenAPI 和 Web 控制台                                                                               |
+| Fly.io 自托管                   | 希望使用托管 Docker runtime 的团队 | Node Docker runtime、Fly volume 上的 SQLite 存储、TLS、健康检查、MCP、HTTP、OpenAPI 和 Web 控制台                                                        |
+| Cloudflare 兼容部署             | 希望快速获得轻量托管运行时的团队   | Workers runtime、D1 状态存储、R2 文件中转和控制台 Static Assets                                                                                          |
+| [OOMOL](https://oomol.com/apps) | 希望用户立即授权账号的团队         | OOMOL 为支持的 provider 提供 OAuth 应用、每月赠送的 Connect 点数和托管 runtime；继续使用同一套 provider 和 Action 契约，后续仍可迁移到私有化或自托管部署 |
 
 ## Cloudflare 快速启动视频
 
@@ -113,6 +118,11 @@ OpenConnector 跑到 Cloudflare 的 Workers、D1、R2 和 Web 控制台上。视
 secret，然后运行 `npm run deploy:cloudflare`。
 
 ## 快速开始
+
+> [!NOTE]
+> 以下步骤启动的是自托管 runtime。使用 OAuth provider 时，你需要提供自行向对应平台申请的 OAuth
+> client 凭据。如果希望用户无需配置 OAuth 应用就能直接授权支持的 provider，请使用
+> [OOMOL 官方托管 Connector](https://oomol.com/apps)。
 
 使用 Docker Compose 从发布的镜像启动运行时：
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -267,3 +267,9 @@ Provider 和 app 名称、metadata、链接、scope、permission 以及可选 lo
 ## 社区
 
 请让 issue 和 pull request 保持聚焦、尊重且可执行。参与本项目需遵守 [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)。
+
+## 贡献者
+
+感谢每一位参与建设 OpenConnector 的贡献者。欢迎查看 [贡献指南](../CONTRIBUTING.md)，加入我们。
+
+[![OpenConnector 贡献者](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -264,3 +264,9 @@ npm test
 
 請確保 Issue 與 Pull Request 主題明確、尊重他人且可採取行動。參與本專案須遵守
 [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)。
+
+## 貢獻者
+
+感謝每一位參與建設 OpenConnector 的貢獻者。歡迎參閱 [貢獻指南](../CONTRIBUTING.md)，加入我們。
+
+[![OpenConnector 貢獻者](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -2,7 +2,7 @@
 
 <img src="../assets/openconnector-readme-banner.png" alt="OpenConnector - Connect Once. Use Everywhere." width="100%" />
 
-[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [Русский](README.ru.md) | [Français](README.fr.md)
+[English](../README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Русский](README.ru.md) | [Français](README.fr.md)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../LICENSE.txt)
 ![Node.js 22+](https://img.shields.io/badge/Node.js-22%2B-339933)
@@ -17,6 +17,11 @@
 
 OpenConnector 是一套供 AI Agent 使用的開放原始碼連接器閘道，也是 Composio 的替代方案。
 只要連線一次使用者的應用程式帳號，就能向 Agent 與應用程式提供共用目錄，其中包含 1,000 多個服務提供者及 10,000 多個預先建置的 Action。
+
+> [!IMPORTANT]
+> **希望 OAuth 開箱即用？** [OOMOL 官方代管 Connector](https://oomol.com/apps) 已為支援的服務提供者
+> 設定好 OAuth 應用程式，使用者可直接授權；每月贈送的 Connect 點數約可支援 15,000–20,000 次免費呼叫，
+> 實際次數取決於用量。自行代管的 OpenConnector 同樣支援 OAuth，但需要自行申請並設定 OAuth 應用程式。
 
 在應用程式程式碼中使用 [Connector SDK](https://github.com/oomol-lab/connector-sdk)，以
 [oo CLI](https://github.com/oomol-lab/oo-cli) 作為本機 Agent 的轉接工具；Agent 主機可使用 MCP，
@@ -109,6 +114,11 @@ flowchart LR
 `npm run deploy:cloudflare`。
 
 ## 快速開始
+
+> [!NOTE]
+> 以下步驟會啟動自行代管的執行階段。使用 OAuth 服務提供者時，你必須提供自行向對應平台申請的
+> OAuth 用戶端憑證。若希望使用者無須設定 OAuth 應用程式即可直接授權支援的服務提供者，請使用
+> [OOMOL 官方代管 Connector](https://oomol.com/apps)。
 
 使用 Docker Compose 從已發布的映像檔啟動執行階段：
 


### PR DESCRIPTION
## Summary

The public documentation did not clearly distinguish the hosted OAuth flow from self-hosted credential setup, and Korean readers did not have a localized README. The contributor sections were also inconsistent across the available README translations.

This PR clarifies that `connect.oomol.com` provides the hosted OAuth path while self-hosted deployments use their own provider credentials. It adds a full Korean README, updates the language navigation and corresponding localized wording, and adds consistent contributor-wall sections to the English, French, Japanese, Korean, Russian, Simplified Chinese, and Traditional Chinese READMEs.

These changes make the supported authentication paths easier to understand, extend the project documentation to Korean-speaking users, and keep contributor recognition consistent across translations.

## Validation

- `npm run lint`
- `npm run fix-check`
