### PR TITLE
feat: add Excalidraw MCP provider

### DIFF
--- a/src/providers/excalidraw_mcp/actions.ts
+++ b/src/providers/excalidraw_mcp/actions.ts
@@ -1,0 +1,51 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "excalidraw_mcp";
+
+const readMeOutputSchema = s.actionOutput(
+  {
+    content: s.string("The Excalidraw MCP reference text returned by read_me."),
+  },
+  "The Excalidraw MCP reference text.",
+);
+
+const createViewInputSchema = s.actionInput(
+  {
+    elements: s.string(
+      "A compact JSON array string of Excalidraw elements. Call read_me first for the element format and ordering rules.",
+      { minLength: 2 },
+    ),
+  },
+  ["elements"],
+  "Input for rendering a diagram with the Excalidraw MCP create_view tool.",
+);
+
+const createViewOutputSchema = s.actionOutput(
+  {
+    checkpointId: s.string("The Excalidraw checkpoint ID returned by the tool."),
+    content: s.string("The confirmation message returned by the tool."),
+  },
+  "The result of rendering a diagram with Excalidraw MCP.",
+);
+
+export const excalidrawMcpActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "read_me",
+    description: "Fetch the Excalidraw element format guide and drawing tips from the MCP server.",
+    requiredScopes: [],
+    inputSchema: s.actionInput({}, [], "No input is required."),
+    outputSchema: readMeOutputSchema,
+    followUpActions: ["excalidraw_mcp.create_view"],
+  }),
+  defineProviderAction(service, {
+    name: "create_view",
+    description: "Render a hand-drawn Excalidraw diagram from a JSON array string of elements.",
+    requiredScopes: [],
+    inputSchema: createViewInputSchema,
+    outputSchema: createViewOutputSchema,
+    followUpActions: ["excalidraw_mcp.read_me"],
+  }),
+];

--- a/src/providers/excalidraw_mcp/definition.ts
+++ b/src/providers/excalidraw_mcp/definition.ts
@@ -1,0 +1,36 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { excalidrawMcpActions } from "./actions.ts";
+
+const service = "excalidraw_mcp";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Excalidraw MCP",
+  description: "Draw and inspect Excalidraw diagrams through the Excalidraw MCP server.",
+  categories: ["Design", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "mcpEndpoint",
+          label: "MCP Endpoint URL",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "https://mcp.excalidraw.com",
+          description:
+            "Optional Excalidraw MCP endpoint. Leave blank to use the public hosted server. Self-hosted remote deployments can point at their own MCP URL, such as a /mcp endpoint.",
+        },
+      ],
+      testAction: {
+        actionName: "read_me",
+        input: {},
+      },
+    },
+  ],
+  homepageUrl: "https://excalidraw.com",
+  actions: excalidrawMcpActions,
+};

--- a/src/providers/excalidraw_mcp/executors.ts
+++ b/src/providers/excalidraw_mcp/executors.ts
@@ -1,0 +1,28 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { createProviderFetch, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createExcalidrawMcpContext, excalidrawMcpActionHandlers, validateExcalidrawCredential } from "./runtime.ts";
+
+const service = "excalidraw_mcp";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: excalidrawMcpActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch) {
+    const credential = await requireCustomCredential(context, service);
+    return createExcalidrawMcpContext(credential.values, fetcher, context.signal, isPrivateNetworkAccessAllowed());
+  },
+  fallbackMessage: "Excalidraw MCP request failed",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({
+      fetch: fetcher,
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+    return validateExcalidrawCredential(input.values, guardedFetcher, signal);
+  },
+};

--- a/src/providers/excalidraw_mcp/runtime.test.ts
+++ b/src/providers/excalidraw_mcp/runtime.test.ts
@@ -1,37 +1,250 @@
-import { describe, expect, it } from "vitest";
-import { createExcalidrawMcpContext, normalizeExcalidrawMcpEndpoint } from "./runtime.ts";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createExcalidrawMcpContext,
+  excalidrawMcpActionHandlers,
+  normalizeExcalidrawMcpEndpoint,
+  validateExcalidrawCredential,
+} from "./runtime.ts";
+
+const mockSdk = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let callToolImpl: any = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let connectImpl: any = vi.fn().mockResolvedValue(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let listToolsImpl: any = vi.fn();
+  return {
+    Client: function () {
+      return {
+        connect: connectImpl,
+        callTool: callToolImpl,
+        listTools: listToolsImpl,
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setCallToolImpl: (fn: any) => {
+      callToolImpl = fn;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setConnectImpl: (fn: any) => {
+      connectImpl = fn;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setListToolsImpl: (fn: any) => {
+      listToolsImpl = fn;
+    },
+    resetImpls: () => {
+      callToolImpl = vi.fn();
+      connectImpl = vi.fn().mockResolvedValue(undefined);
+      listToolsImpl = vi.fn();
+    },
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => mockSdk);
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@modelcontextprotocol/sdk/client/streamableHttp.js")>();
+  return { ...actual, StreamableHTTPClientTransport: vi.fn() };
+});
+
+function testContext(signal?: AbortSignal) {
+  return {
+    endpoint: new URL("https://mcp.excalidraw.com/"),
+    fetcher: vi.fn() as unknown as typeof fetch,
+    signal,
+  };
+}
 
 describe("Excalidraw MCP runtime", () => {
-  it("defaults to the public endpoint and strips query or hash", () => {
-    expect(normalizeExcalidrawMcpEndpoint(undefined).toString()).toBe("https://mcp.excalidraw.com/");
-    expect(normalizeExcalidrawMcpEndpoint("https://mcp.excalidraw.com/?x=1#y").toString()).toBe(
-      "https://mcp.excalidraw.com/",
-    );
+  beforeEach(() => {
+    mockSdk.resetImpls();
   });
 
-  it("rejects embedded credentials", () => {
-    expect(() => normalizeExcalidrawMcpEndpoint("https://user:pass@mcp.excalidraw.com/")).toThrow(
-      "mcpEndpoint must not include username or password",
-    );
+  describe("normalizeExcalidrawMcpEndpoint", () => {
+    it("defaults to the public endpoint and strips query or hash", () => {
+      expect(normalizeExcalidrawMcpEndpoint(undefined).toString()).toBe("https://mcp.excalidraw.com/");
+      expect(normalizeExcalidrawMcpEndpoint("https://mcp.excalidraw.com/?x=1#y").toString()).toBe(
+        "https://mcp.excalidraw.com/",
+      );
+    });
+
+    it("rejects embedded credentials", () => {
+      expect(() => normalizeExcalidrawMcpEndpoint("https://user:pass@mcp.excalidraw.com/")).toThrow(
+        "mcpEndpoint must not include username or password",
+      );
+    });
+
+    it("accepts a self-hosted remote MCP endpoint", () => {
+      expect(normalizeExcalidrawMcpEndpoint("https://example.vercel.app/mcp").toString()).toBe(
+        "https://example.vercel.app/mcp",
+      );
+    });
+
+    it("requires the private-network opt-in for http endpoints", () => {
+      expect(() => normalizeExcalidrawMcpEndpoint("http://mcp.example.com/mcp", false)).toThrow(
+        "http mcpEndpoint URLs require private-network access to be enabled",
+      );
+    });
+
+    it("allows private network endpoints when opted in", () => {
+      expect(normalizeExcalidrawMcpEndpoint("http://192.168.1.50/mcp", true).toString()).toBe(
+        "http://192.168.1.50/mcp",
+      );
+      expect(
+        createExcalidrawMcpContext(
+          { mcpEndpoint: "http://192.168.1.50/mcp" },
+          (() => {
+            throw new Error("unused");
+          }) as never,
+          undefined,
+          true,
+        ).endpoint.toString(),
+      ).toBe("http://192.168.1.50/mcp");
+    });
   });
 
-  it("accepts a self-hosted remote MCP endpoint", () => {
-    expect(normalizeExcalidrawMcpEndpoint("https://example.vercel.app/mcp").toString()).toBe(
-      "https://example.vercel.app/mcp",
-    );
+  describe("action handlers", () => {
+    it("returns checkpointId and content for create_view", async () => {
+      mockSdk.setCallToolImpl(
+        vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "Rendered." }],
+          structuredContent: { checkpointId: "cp_123" },
+        }),
+      );
+
+      await expect(excalidrawMcpActionHandlers.create_view({ elements: "[]" }, testContext())).resolves.toEqual({
+        checkpointId: "cp_123",
+        content: "Rendered.",
+      });
+    });
+
+    it("rejects create_view results that report isError", async () => {
+      mockSdk.setCallToolImpl(
+        vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "invalid elements" }],
+          isError: true,
+        }),
+      );
+
+      await expect(excalidrawMcpActionHandlers.create_view({ elements: "[]" }, testContext())).rejects.toMatchObject({
+        status: 502,
+        message: "Excalidraw MCP create_view failed: invalid elements",
+      });
+    });
+
+    it("rejects create_view results without a checkpointId", async () => {
+      mockSdk.setCallToolImpl(vi.fn().mockResolvedValue({ content: [{ type: "text", text: "done" }] }));
+
+      await expect(excalidrawMcpActionHandlers.create_view({ elements: "[]" }, testContext())).rejects.toMatchObject({
+        status: 502,
+        message: "Excalidraw MCP create_view response missing checkpointId",
+      });
+    });
+
+    it("returns read_me content with a fallback for empty responses", async () => {
+      mockSdk.setCallToolImpl(vi.fn().mockResolvedValue({ content: [] }));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).resolves.toEqual({
+        content: "empty content",
+      });
+    });
+
+    it("forwards the execution signal to connect and tool calls", async () => {
+      const controller = new AbortController();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const connectOptions: any[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const callToolOptions: any[] = [];
+      mockSdk.setConnectImpl(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        vi.fn().mockImplementation((_transport: any, options: any) => {
+          connectOptions.push(options);
+          return Promise.resolve(undefined);
+        }),
+      );
+      mockSdk.setCallToolImpl(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        vi.fn().mockImplementation((_params: any, _schema: any, options: any) => {
+          callToolOptions.push(options);
+          return Promise.resolve({ content: [{ type: "text", text: "guide" }] });
+        }),
+      );
+
+      await excalidrawMcpActionHandlers.read_me({}, testContext(controller.signal));
+
+      expect(connectOptions[0]?.signal).toBe(controller.signal);
+      expect(callToolOptions[0]?.signal).toBe(controller.signal);
+    });
   });
 
-  it("allows private network endpoints when opted in", () => {
-    expect(normalizeExcalidrawMcpEndpoint("http://192.168.1.50/mcp", true).toString()).toBe("http://192.168.1.50/mcp");
-    expect(
-      createExcalidrawMcpContext(
-        { mcpEndpoint: "http://192.168.1.50/mcp" },
-        (() => {
-          throw new Error("unused");
-        }) as never,
-        undefined,
-        true,
-      ).endpoint.toString(),
-    ).toBe("http://192.168.1.50/mcp");
+  describe("validateExcalidrawCredential", () => {
+    it("stores a bounded tool summary instead of the raw server tool list", async () => {
+      mockSdk.setListToolsImpl(
+        vi.fn().mockResolvedValue({
+          tools: [{ name: "read_me" }, { name: "create_view" }, { name: "export_to_excalidraw" }],
+        }),
+      );
+
+      const result = await validateExcalidrawCredential({}, vi.fn() as unknown as typeof fetch);
+
+      expect(result.metadata).toEqual({
+        mcpEndpoint: "https://mcp.excalidraw.com",
+        discoveredToolCount: 3,
+        availableActions: ["read_me", "create_view"],
+      });
+      expect(result.profile?.accountId).toMatch(/^excalidraw_mcp:mcp:[0-9a-f]{16}$/u);
+    });
+
+    it("rejects endpoints that do not expose the expected tools", async () => {
+      mockSdk.setListToolsImpl(vi.fn().mockResolvedValue({ tools: [{ name: "read_me" }] }));
+
+      await expect(validateExcalidrawCredential({}, vi.fn() as unknown as typeof fetch)).rejects.toMatchObject({
+        status: 502,
+        message: "Excalidraw MCP endpoint did not expose the expected tools",
+      });
+    });
+  });
+
+  describe("error mapping", () => {
+    it("maps endpoint HTTP 404 to a 400 configuration error", async () => {
+      mockSdk.setConnectImpl(vi.fn().mockRejectedValue(new StreamableHTTPError(404, "Error POSTing to endpoint")));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("maps endpoint HTTP 401 to a 401 authorization error", async () => {
+      mockSdk.setConnectImpl(vi.fn().mockRejectedValue(new StreamableHTTPError(401, "Unauthorized")));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).rejects.toMatchObject({ status: 401 });
+    });
+
+    it("maps endpoint HTTP 500 to a 502 upstream error", async () => {
+      mockSdk.setConnectImpl(vi.fn().mockRejectedValue(new StreamableHTTPError(500, "Internal Server Error")));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).rejects.toMatchObject({ status: 502 });
+    });
+
+    it("maps MCP request timeouts to 504", async () => {
+      mockSdk.setConnectImpl(vi.fn().mockRejectedValue(new McpError(ErrorCode.RequestTimeout, "Request timed out")));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).rejects.toMatchObject({
+        status: 504,
+        message: "Excalidraw MCP request timed out",
+      });
+    });
+
+    it("keeps ProviderRequestError instances unchanged", async () => {
+      mockSdk.setConnectImpl(vi.fn().mockRejectedValue(new ProviderRequestError(400, "bad input")));
+
+      await expect(excalidrawMcpActionHandlers.read_me({}, testContext())).rejects.toMatchObject({
+        status: 400,
+        message: "bad input",
+      });
+    });
   });
 });

--- a/src/providers/excalidraw_mcp/runtime.test.ts
+++ b/src/providers/excalidraw_mcp/runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createExcalidrawMcpContext, normalizeExcalidrawMcpEndpoint } from "./runtime.ts";
+
+describe("Excalidraw MCP runtime", () => {
+  it("defaults to the public endpoint and strips query or hash", () => {
+    expect(normalizeExcalidrawMcpEndpoint(undefined).toString()).toBe("https://mcp.excalidraw.com/");
+    expect(normalizeExcalidrawMcpEndpoint("https://mcp.excalidraw.com/?x=1#y").toString()).toBe(
+      "https://mcp.excalidraw.com/",
+    );
+  });
+
+  it("rejects embedded credentials", () => {
+    expect(() => normalizeExcalidrawMcpEndpoint("https://user:pass@mcp.excalidraw.com/")).toThrow(
+      "mcpEndpoint must not include username or password",
+    );
+  });
+
+  it("accepts a self-hosted remote MCP endpoint", () => {
+    expect(normalizeExcalidrawMcpEndpoint("https://example.vercel.app/mcp").toString()).toBe(
+      "https://example.vercel.app/mcp",
+    );
+  });
+
+  it("allows private network endpoints when opted in", () => {
+    expect(normalizeExcalidrawMcpEndpoint("http://192.168.1.50/mcp", true).toString()).toBe("http://192.168.1.50/mcp");
+    expect(
+      createExcalidrawMcpContext(
+        { mcpEndpoint: "http://192.168.1.50/mcp" },
+        (() => {
+          throw new Error("unused");
+        }) as never,
+        undefined,
+        true,
+      ).endpoint.toString(),
+    ).toBe("http://192.168.1.50/mcp");
+  });
+});

--- a/src/providers/excalidraw_mcp/runtime.ts
+++ b/src/providers/excalidraw_mcp/runtime.ts
@@ -1,0 +1,236 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { createHash } from "node:crypto";
+import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+export interface ExcalidrawMcpContext {
+  endpoint: URL;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+type ExcalidrawMcpActionHandler = (input: Record<string, unknown>, context: ExcalidrawMcpContext) => Promise<unknown>;
+type ExcalidrawMcpToolResult = {
+  isError?: boolean;
+  content?: Array<{
+    type?: string;
+    text?: string;
+    uri?: string;
+    resource?: { text?: string; uri?: string };
+  }>;
+  structuredContent?: unknown;
+  toolResult?: unknown;
+};
+const defaultEndpoint = "https://mcp.excalidraw.com";
+const requestTimeoutMs = 30_000;
+
+export const excalidrawMcpActionHandlers: Record<string, ExcalidrawMcpActionHandler> = {
+  read_me(_input, context) {
+    return callExcalidrawMcpTool(context, "read_me", {});
+  },
+  create_view(input, context) {
+    return callExcalidrawMcpTool(context, "create_view", {
+      elements: requireString(input.elements, "elements"),
+    });
+  },
+};
+
+export function createExcalidrawMcpContext(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): ExcalidrawMcpContext {
+  return {
+    endpoint: normalizeExcalidrawMcpEndpoint(optionalString(values.mcpEndpoint), allowPrivateNetwork),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateExcalidrawCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createExcalidrawMcpContext(values, fetcher, signal);
+  const tools = await listExcalidrawMcpTools(context);
+  if (!tools.includes("read_me") || !tools.includes("create_view")) {
+    throw new ProviderRequestError(502, "Excalidraw MCP endpoint did not expose the expected tools");
+  }
+
+  const endpointId = formatEndpointId(context.endpoint);
+  const endpointHash = createHash("sha256").update(endpointId).digest("hex").slice(0, 16);
+  return {
+    profile: {
+      accountId: `excalidraw_mcp:mcp:${endpointHash}`,
+      displayName: `Excalidraw MCP · ${context.endpoint.host}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpEndpoint: endpointId,
+      mcpTools: [...tools].sort(),
+    },
+  };
+}
+
+export function normalizeExcalidrawMcpEndpoint(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): URL {
+  const raw = optionalString(value) ?? defaultEndpoint;
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "mcpEndpoint",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password) {
+    throw new ProviderRequestError(400, "mcpEndpoint must not include username or password");
+  }
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+export async function callExcalidrawMcpTool(
+  context: ExcalidrawMcpContext,
+  toolName: "read_me" | "create_view",
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const result = await withExcalidrawMcpClient(context, async (client) =>
+    client.callTool(
+      {
+        name: toolName,
+        arguments: args,
+      },
+      undefined,
+      {
+        timeout: requestTimeoutMs,
+      },
+    ),
+  );
+
+  return toolName === "create_view" ? normalizeCreateViewResult(result) : normalizeReadMeResult(result);
+}
+
+async function listExcalidrawMcpTools(context: ExcalidrawMcpContext): Promise<string[]> {
+  const result = await withExcalidrawMcpClient(context, async (client) =>
+    client.listTools(
+      {},
+      {
+        timeout: requestTimeoutMs,
+      },
+    ),
+  );
+  return result.tools.map((tool) => tool.name);
+}
+
+async function withExcalidrawMcpClient<T>(
+  context: ExcalidrawMcpContext,
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const transport = new StreamableHTTPClientTransport(context.endpoint, {
+    fetch: context.fetcher,
+    requestInit: {
+      headers: {
+        "user-agent": providerUserAgent,
+      },
+      signal: context.signal,
+    },
+  });
+  const client = new Client({ name: "oomol-connect-excalidraw-mcp", version: "1.0.0" });
+
+  try {
+    await client.connect(transport, { timeout: requestTimeoutMs });
+    return await run(client);
+  } catch (error) {
+    throw mapExcalidrawMcpError(error);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function normalizeCreateViewResult(result: ExcalidrawMcpToolResult): Record<string, unknown> {
+  if (result.isError) {
+    throw new ProviderRequestError(502, `Excalidraw MCP create_view failed: ${formatMcpToolContent(result)}`, result);
+  }
+
+  const structured = optionalRecord(result.structuredContent);
+  const checkpointId = optionalString(structured?.checkpointId);
+  if (!checkpointId) {
+    throw new ProviderRequestError(502, "Excalidraw MCP create_view response missing checkpointId", result);
+  }
+
+  return {
+    checkpointId,
+    content: formatMcpToolContent(result),
+  };
+}
+
+function normalizeReadMeResult(result: ExcalidrawMcpToolResult): Record<string, unknown> {
+  if (result.isError) {
+    throw new ProviderRequestError(502, `Excalidraw MCP read_me failed: ${formatMcpToolContent(result)}`, result);
+  }
+
+  return {
+    content: formatMcpToolContent(result),
+  };
+}
+
+function formatMcpToolContent(result: ExcalidrawMcpToolResult): string {
+  const text = (result.content ?? [])
+    .map((content) => {
+      if (content.type === "text") {
+        return content.text;
+      }
+      if (
+        content.type === "resource" &&
+        content.resource &&
+        typeof content.resource === "object" &&
+        "text" in content.resource
+      ) {
+        return content.resource.text;
+      }
+      if (content.type === "resource_link") {
+        return content.uri;
+      }
+      return content.type;
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+  return text || "empty content";
+}
+
+function formatEndpointId(endpoint: URL): string {
+  const pathname = endpoint.pathname === "/" ? "" : endpoint.pathname.replace(/\/+$/u, "");
+  return `${endpoint.origin}${pathname}`;
+}
+
+function mapExcalidrawMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) {
+    return error;
+  }
+  if (isAbortError(error)) {
+    return new ProviderRequestError(504, "Excalidraw MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `Excalidraw MCP request failed: ${error.message}` : "Excalidraw MCP request failed",
+    error,
+  );
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}

--- a/src/providers/excalidraw_mcp/runtime.ts
+++ b/src/providers/excalidraw_mcp/runtime.ts
@@ -1,8 +1,10 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { createHash } from "node:crypto";
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
@@ -40,6 +42,8 @@ export const excalidrawMcpActionHandlers: Record<string, ExcalidrawMcpActionHand
   },
 };
 
+const excalidrawMcpToolNames = Object.keys(excalidrawMcpActionHandlers);
+
 export function createExcalidrawMcpContext(
   values: Record<string, string>,
   fetcher: ProviderFetch,
@@ -59,8 +63,9 @@ export async function validateExcalidrawCredential(
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const context = createExcalidrawMcpContext(values, fetcher, signal);
-  const tools = await listExcalidrawMcpTools(context);
-  if (!tools.includes("read_me") || !tools.includes("create_view")) {
+  const discoveredTools = await listExcalidrawMcpTools(context);
+  const availableActions = excalidrawMcpToolNames.filter((toolName) => discoveredTools.includes(toolName));
+  if (availableActions.length < excalidrawMcpToolNames.length) {
     throw new ProviderRequestError(502, "Excalidraw MCP endpoint did not expose the expected tools");
   }
 
@@ -74,7 +79,8 @@ export async function validateExcalidrawCredential(
     grantedScopes: [],
     metadata: {
       mcpEndpoint: endpointId,
-      mcpTools: [...tools].sort(),
+      discoveredToolCount: discoveredTools.length,
+      availableActions,
     },
   };
 }
@@ -91,6 +97,9 @@ export function normalizeExcalidrawMcpEndpoint(
   });
   if (url.username || url.password) {
     throw new ProviderRequestError(400, "mcpEndpoint must not include username or password");
+  }
+  if (url.protocol === "http:" && !allowPrivateNetwork) {
+    throw new ProviderRequestError(400, "http mcpEndpoint URLs require private-network access to be enabled");
   }
   url.search = "";
   url.hash = "";
@@ -111,6 +120,7 @@ export async function callExcalidrawMcpTool(
       undefined,
       {
         timeout: requestTimeoutMs,
+        signal: context.signal,
       },
     ),
   );
@@ -124,6 +134,7 @@ async function listExcalidrawMcpTools(context: ExcalidrawMcpContext): Promise<st
       {},
       {
         timeout: requestTimeoutMs,
+        signal: context.signal,
       },
     ),
   );
@@ -140,13 +151,12 @@ async function withExcalidrawMcpClient<T>(
       headers: {
         "user-agent": providerUserAgent,
       },
-      signal: context.signal,
     },
   });
   const client = new Client({ name: "oomol-connect-excalidraw-mcp", version: "1.0.0" });
 
   try {
-    await client.connect(transport, { timeout: requestTimeoutMs });
+    await client.connect(transport, { timeout: requestTimeoutMs, signal: context.signal });
     return await run(client);
   } catch (error) {
     throw mapExcalidrawMcpError(error);
@@ -216,6 +226,22 @@ function formatEndpointId(endpoint: URL): string {
 function mapExcalidrawMcpError(error: unknown): ProviderRequestError {
   if (error instanceof ProviderRequestError) {
     return error;
+  }
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "Excalidraw MCP endpoint requires authorization", error);
+  }
+  if (error instanceof StreamableHTTPError) {
+    const status = error.code;
+    return new ProviderRequestError(
+      status === 401 || status === 403 ? 401 : status && status >= 400 && status < 500 ? 400 : 502,
+      `Excalidraw MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof McpError) {
+    return error.code === ErrorCode.RequestTimeout
+      ? new ProviderRequestError(504, "Excalidraw MCP request timed out", error)
+      : new ProviderRequestError(502, `Excalidraw MCP request failed: ${error.message}`, error);
   }
   if (isAbortError(error)) {
     return new ProviderRequestError(504, "Excalidraw MCP request timed out", error);


### PR DESCRIPTION
Adds an `excalidraw_mcp` provider that connects to Excalidraw's MCP server and exposes two actions:

- `read_me` for the Excalidraw element-format reference
- `create_view` for rendering a diagram from Excalidraw elements

Details:

- Optional custom MCP endpoint configuration, defaulting to the public `https://mcp.excalidraw.com`
- Credential validation that verifies the endpoint exposes the expected MCP tools
- Catalog regeneration and provider wiring
- Unit coverage for endpoint normalization and provider behavior

Verified live end-to-end against the public Excalidraw MCP endpoint:

- `read_me`
- `create_view`
- `export_to_excalidraw`
