### PR TITLE
ci: add self-updating star history chart workflow

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,37 @@
+name: Star History
+
+# Renders this repo's star-growth chart (light/dark SVG + PNG) into
+# assets/star-history/ and rewrites the marker block in README.md. The action
+# detects whether star data actually changed and only commits when it did, with
+# a "[skip ci]" commit message so chart refreshes don't trigger the CI workflow.
+# Daily schedule keeps commit noise low; use workflow_dispatch for an on-demand
+# refresh (e.g. the first run after merging this workflow).
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+# Serialize refreshes so a manual dispatch can't race the scheduled push.
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+# The action commits the refreshed chart and README and pushes to main.
+permissions:
+  contents: write
+
+jobs:
+  star-history:
+    name: Render & Commit Chart
+    runs-on: ubuntu-latest
+    steps:
+      # Unlike ci.yml this checkout keeps persist-credentials on (the default):
+      # the action's push step authenticates with the persisted GITHUB_TOKEN.
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Pinned to an immutable SHA rather than the mutable v1 tag: this
+      # third-party action holds contents:write and pushes to the repo, so its
+      # supply chain must not be silently updatable.
+      - name: Render and commit star history
+        uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4

--- a/README.md
+++ b/README.md
@@ -305,3 +305,8 @@ Thanks to everyone who has helped build OpenConnector. Want to join them? See
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 [![OpenConnector contributors](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Star History
+
+<!-- star-history:start -->
+<!-- star-history:end -->


### PR DESCRIPTION
Adds narayann7/star-history-action on a daily schedule (plus `workflow_dispatch`) to render the repo's star-growth chart as light/dark SVGs into `assets/star-history/` and keep the new marker block at the bottom of `README.md` up to date. The action only commits when star data actually changed, and its commit message carries `[skip ci]`, so refreshes neither spam history nor trigger the CI workflow.

Two deliberate deviations from the upstream example: the action is pinned to an immutable SHA instead of the mutable `v1` tag, since a third-party action holding `contents: write` that pushes to this repo shouldn't be silently updatable; and the per-star `watch` trigger is left out to avoid a commit for every star event — daily is enough.

The first chart appears after a manual `workflow_dispatch` run once this lands on main; until then the marker block renders as empty. Localized READMEs under `docs/` are untouched for now — they can reference the same generated SVGs once the first run produces them.