### PR TITLE
feat(provider): add Upstash Redis REST actions

### DIFF
--- a/src/providers/upstash_redis/actions.ts
+++ b/src/providers/upstash_redis/actions.ts
@@ -1,0 +1,113 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "upstash_redis";
+
+const keySchema = s.nonEmptyString("The Redis key.");
+const valueSchema = s.nonEmptyString("The string value stored for the Redis key.");
+const expirationSecondsSchema = s.positiveInteger("Expiration time in seconds.");
+
+export const upstashRedisActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get",
+    description: "Get the string value stored for one Redis key.",
+    inputSchema: s.actionInput({ key: keySchema }, ["key"], "The Redis key to retrieve."),
+    outputSchema: s.actionOutput(
+      { value: s.nullableString("The stored string value, or null when the key does not exist.") },
+      "The value returned for the Redis key.",
+    ),
+    followUpActions: ["upstash_redis.set", "upstash_redis.delete", "upstash_redis.expire", "upstash_redis.ttl"],
+  }),
+  defineProviderAction(service, {
+    name: "set",
+    description: "Store a string value for one Redis key, optionally with an expiration or conditional write.",
+    inputSchema: s.object(
+      "The Redis string value to store.",
+      {
+        key: keySchema,
+        value: valueSchema,
+        expirationSeconds: expirationSecondsSchema,
+        condition: s.stringEnum(["NX", "XX"], {
+          description: "Optional Redis write condition: NX stores only a new key; XX stores only an existing key.",
+        }),
+      },
+      { required: ["key", "value"], optional: ["expirationSeconds", "condition"] },
+    ),
+    outputSchema: s.actionOutput(
+      { stored: s.boolean("Whether Redis stored the value. False means the requested condition was not met.") },
+      "The result of the Redis SET command.",
+    ),
+    followUpActions: ["upstash_redis.get", "upstash_redis.ttl"],
+  }),
+  defineProviderAction(service, {
+    name: "delete",
+    description: "Delete one Redis key.",
+    inputSchema: s.actionInput({ key: keySchema }, ["key"], "The Redis key to delete."),
+    outputSchema: s.actionOutput(
+      { deleted: s.boolean("Whether Redis deleted an existing key.") },
+      "The result of the Redis DEL command.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "exists",
+    description: "Check whether one Redis key exists.",
+    inputSchema: s.actionInput({ key: keySchema }, ["key"], "The Redis key to check."),
+    outputSchema: s.actionOutput(
+      { exists: s.boolean("Whether the Redis key exists.") },
+      "The result of the Redis EXISTS command.",
+    ),
+    followUpActions: ["upstash_redis.get", "upstash_redis.ttl"],
+  }),
+  defineProviderAction(service, {
+    name: "expire",
+    description: "Set or replace the expiration time for one Redis key.",
+    inputSchema: s.actionInput(
+      { key: keySchema, expirationSeconds: expirationSecondsSchema },
+      ["key", "expirationSeconds"],
+      "The Redis key and its new expiration time.",
+    ),
+    outputSchema: s.actionOutput(
+      { updated: s.boolean("Whether Redis updated the expiration for an existing key.") },
+      "The result of the Redis EXPIRE command.",
+    ),
+    followUpActions: ["upstash_redis.ttl"],
+  }),
+  defineProviderAction(service, {
+    name: "ttl",
+    description: "Get the remaining expiration time for one Redis key.",
+    inputSchema: s.actionInput({ key: keySchema }, ["key"], "The Redis key whose expiration to retrieve."),
+    outputSchema: s.actionOutput(
+      {
+        ttlSeconds: s.integer(
+          "Remaining expiration in seconds. -2 means the key does not exist; -1 means the key has no expiration.",
+        ),
+      },
+      "The result of the Redis TTL command.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "scan",
+    description: "Scan one page of Redis keys without reading the full keyspace.",
+    inputSchema: s.object(
+      "Cursor pagination and optional filters for Redis SCAN.",
+      {
+        cursor: s.nonEmptyString("The cursor returned by a previous scan. Omit it to start at cursor 0."),
+        match: s.nonEmptyString("Optional Redis glob pattern used to filter keys."),
+        count: s.integer("Optional scan work hint from 1 to 1000.", { minimum: 1, maximum: 1000 }),
+      },
+      { optional: ["cursor", "match", "count"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        nextCursor: s.nonEmptyString(
+          "Cursor to pass to the next scan request. A value of 0 means scanning is complete.",
+        ),
+        keys: s.stringArray("Keys returned in this scan page."),
+        complete: s.boolean("Whether this scan reached cursor 0."),
+      },
+      "One page returned by Redis SCAN.",
+    ),
+  }),
+];

--- a/src/providers/upstash_redis/actions.ts
+++ b/src/providers/upstash_redis/actions.ts
@@ -15,7 +15,11 @@ export const upstashRedisActions: ActionDefinition[] = [
     description: "Get the string value stored for one Redis key.",
     inputSchema: s.actionInput({ key: keySchema }, ["key"], "The Redis key to retrieve."),
     outputSchema: s.actionOutput(
-      { value: s.nullableString("The stored string value, or null when the key does not exist.") },
+      {
+        value: s.nullableString(
+          "The stored string value, or null when the key does not exist. Upstash replaces bytes that are not valid UTF-8 with U+FFFD, so only text values round-trip exactly.",
+        ),
+      },
       "The value returned for the Redis key.",
     ),
     followUpActions: ["upstash_redis.set", "upstash_redis.delete", "upstash_redis.expire", "upstash_redis.ttl"],

--- a/src/providers/upstash_redis/definition.ts
+++ b/src/providers/upstash_redis/definition.ts
@@ -35,7 +35,7 @@ export const provider: ProviderDefinition = {
           secret: true,
           placeholder: "Your Upstash REST token",
           description:
-            "The Upstash Redis REST token sent as a Bearer token. A read-only token can run read actions but cannot write keys.",
+            "The Upstash Redis REST token sent as a Bearer token. A read-only token can run get, exists, and ttl, but Upstash also blocks scan for read-only tokens, so the standard token is required for scan and for every write action.",
         },
       ],
     },

--- a/src/providers/upstash_redis/definition.ts
+++ b/src/providers/upstash_redis/definition.ts
@@ -1,0 +1,45 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { upstashRedisActions } from "./actions.ts";
+
+const service = "upstash_redis";
+
+/**
+ * Upstash Redis provider backed by the official REST API.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Upstash Redis",
+  description: "Read and manage string keys in an Upstash Redis database through its REST API.",
+  categories: ["Data", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "restUrl",
+          label: "REST URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://your-database.upstash.io",
+          description:
+            "The HTTPS REST URL shown for an Upstash Redis database in the Upstash console. Only official upstash.io endpoints are supported.",
+        },
+        {
+          key: "restToken",
+          label: "REST Token",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Your Upstash REST token",
+          description:
+            "The Upstash Redis REST token sent as a Bearer token. A read-only token can run read actions but cannot write keys.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://upstash.com/redis",
+  actions: upstashRedisActions,
+};

--- a/src/providers/upstash_redis/executors.ts
+++ b/src/providers/upstash_redis/executors.ts
@@ -1,4 +1,5 @@
 import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { UpstashRedisContext } from "./runtime.ts";
 
 import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
 import { createUpstashRedisContext, upstashRedisActionHandlers, validateUpstashRedisCredential } from "./runtime.ts";
@@ -8,7 +9,7 @@ const service = "upstash_redis";
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: upstashRedisActionHandlers,
-  async createContext(context: ExecutionContext, fetcher): Promise<ReturnType<typeof createUpstashRedisContext>> {
+  async createContext(context: ExecutionContext, fetcher): Promise<UpstashRedisContext> {
     const credential = await requireCustomCredential(context, service);
     return createUpstashRedisContext(credential.values, fetcher, context.signal);
   },

--- a/src/providers/upstash_redis/executors.ts
+++ b/src/providers/upstash_redis/executors.ts
@@ -1,0 +1,21 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createUpstashRedisContext, upstashRedisActionHandlers, validateUpstashRedisCredential } from "./runtime.ts";
+
+const service = "upstash_redis";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: upstashRedisActionHandlers,
+  async createContext(context: ExecutionContext, fetcher): Promise<ReturnType<typeof createUpstashRedisContext>> {
+    const credential = await requireCustomCredential(context, service);
+    return createUpstashRedisContext(credential.values, fetcher, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }) {
+    return validateUpstashRedisCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/upstash_redis/runtime.ts
+++ b/src/providers/upstash_redis/runtime.ts
@@ -1,0 +1,315 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { optionalIntegerLike, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  isAbortSignalError,
+  parseProviderJsonBodyText,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderTextBody,
+} from "../provider-runtime.ts";
+
+const service = "upstash_redis";
+const requestTimeoutMs = 30_000;
+const upstashHostnameSuffix = ".upstash.io";
+
+type UpstashRequestPhase = "validate" | "execute";
+type UpstashCommandArgument = string | number;
+
+export interface UpstashRedisContext {
+  restToken: string;
+  restUrl: URL;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+export const upstashRedisActionHandlers: Record<string, ProviderRuntimeHandler<UpstashRedisContext>> = {
+  async get(input, context) {
+    const result = await executeUpstashCommand(context, ["GET", readKey(input)], "execute");
+    return { value: readStringOrNullResult(result, "GET") };
+  },
+  async set(input, context) {
+    const command: UpstashCommandArgument[] = [
+      "SET",
+      readKey(input),
+      requiredString(input.value, "value", providerInputError),
+    ];
+    const expirationSeconds = readOptionalPositiveInteger(input.expirationSeconds, "expirationSeconds");
+    if (expirationSeconds !== undefined) {
+      command.push("EX", expirationSeconds);
+    }
+    const condition = optionalString(input.condition);
+    if (condition !== undefined) {
+      if (condition !== "NX" && condition !== "XX") {
+        throw providerInputError("condition must be NX or XX");
+      }
+      command.push(condition);
+    }
+
+    const result = await executeUpstashCommand(context, command, "execute");
+    if (result !== "OK" && result !== null) {
+      throw providerResponseError("Upstash Redis returned an invalid SET result");
+    }
+    return { stored: result === "OK" };
+  },
+  async delete(input, context) {
+    const result = await executeUpstashCommand(context, ["DEL", readKey(input)], "execute");
+    return { deleted: readBooleanCommandResult(result, "DEL") };
+  },
+  async exists(input, context) {
+    const result = await executeUpstashCommand(context, ["EXISTS", readKey(input)], "execute");
+    return { exists: readBooleanCommandResult(result, "EXISTS") };
+  },
+  async expire(input, context) {
+    const result = await executeUpstashCommand(
+      context,
+      ["EXPIRE", readKey(input), readRequiredPositiveInteger(input.expirationSeconds, "expirationSeconds")],
+      "execute",
+    );
+    return { updated: readBooleanCommandResult(result, "EXPIRE") };
+  },
+  async ttl(input, context) {
+    const result = await executeUpstashCommand(context, ["TTL", readKey(input)], "execute");
+    return { ttlSeconds: readIntegerResult(result, "TTL") };
+  },
+  async scan(input, context) {
+    const command: UpstashCommandArgument[] = ["SCAN", optionalString(input.cursor) ?? "0"];
+    const match = optionalString(input.match);
+    if (match !== undefined) {
+      command.push("MATCH", match);
+    }
+    const count = readOptionalPositiveInteger(input.count, "count", 1000);
+    if (count !== undefined) {
+      command.push("COUNT", count);
+    }
+
+    const result = await executeUpstashCommand(context, command, "execute");
+    const [nextCursor, keys] = readScanResult(result);
+    return { nextCursor, keys, complete: nextCursor === "0" };
+  },
+};
+
+export function createUpstashRedisContext(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): UpstashRedisContext {
+  return {
+    restToken: requiredString(values.restToken, "restToken", providerInputError),
+    restUrl: normalizeUpstashRestUrl(values.restUrl),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateUpstashRedisCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createUpstashRedisContext(values, fetcher, signal);
+  const result = await executeUpstashCommand(context, ["PING"], "validate");
+  if (result !== "PONG") {
+    throw providerResponseError("Upstash Redis returned an invalid PING result");
+  }
+
+  return {
+    profile: {
+      accountId: `${service}:${context.restUrl.hostname}`,
+      displayName: `Upstash Redis - ${context.restUrl.hostname}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      restUrl: context.restUrl.origin,
+      validationCommand: "PING",
+    },
+  };
+}
+
+async function executeUpstashCommand(
+  context: UpstashRedisContext,
+  command: readonly UpstashCommandArgument[],
+  phase: UpstashRequestPhase,
+): Promise<unknown> {
+  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  try {
+    const response = await context.fetcher(new URL(context.restUrl), {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${context.restToken}`,
+        "content-type": "application/json",
+        "user-agent": providerUserAgent,
+      },
+      body: JSON.stringify(command),
+      signal: timeout.signal,
+    });
+    const text = await readProviderTextBody(response, "Upstash Redis response");
+    if (!response.ok) {
+      const payload = parseProviderJsonBodyText(text, {
+        emptyBody: {},
+        invalidJsonMessage: "Upstash Redis returned invalid JSON",
+        invalidJsonFallback: (body) => ({ error: body }),
+      });
+      throw createUpstashError(response.status, payload, phase);
+    }
+    const payload = parseProviderJsonBodyText(text, {
+      emptyBody: undefined,
+      invalidJsonMessage: "Upstash Redis returned invalid JSON",
+    });
+    return readUpstashResult(payload);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "Upstash Redis request timed out", error);
+    }
+    if (isAbortSignalError(context.signal, error)) {
+      throw new ProviderRequestError(499, "Upstash Redis request was cancelled", error);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Upstash Redis request failed: ${error.message}` : "Upstash Redis request failed",
+      error,
+    );
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function normalizeUpstashRestUrl(value: string | undefined): URL {
+  const restUrl = assertPublicHttpUrl(requiredString(value, "restUrl", providerInputError), {
+    fieldName: "restUrl",
+    createError: providerInputError,
+  });
+  if (restUrl.protocol !== "https:") {
+    throw providerInputError("restUrl must use https");
+  }
+  if (restUrl.username || restUrl.password) {
+    throw providerInputError("restUrl must not include credentials");
+  }
+  if (restUrl.port) {
+    throw providerInputError("restUrl must not include a port");
+  }
+  if (restUrl.pathname !== "/" || restUrl.search || restUrl.hash) {
+    throw providerInputError("restUrl must not include a path, query, or fragment");
+  }
+  if (!restUrl.hostname.endsWith(upstashHostnameSuffix) || restUrl.hostname === "upstash.io") {
+    throw providerInputError("restUrl must use an official upstash.io endpoint");
+  }
+  return restUrl;
+}
+
+function readUpstashResult(payload: unknown): unknown {
+  const record = requiredRecord(payload, "Upstash Redis response");
+  const error = optionalString(record.error);
+  if (error !== undefined) {
+    throw new ProviderRequestError(400, error, payload);
+  }
+  if (!Object.hasOwn(record, "result")) {
+    throw providerResponseError("Upstash Redis response is missing result");
+  }
+  return record.result;
+}
+
+function createUpstashError(status: number, payload: unknown, phase: UpstashRequestPhase): ProviderRequestError {
+  const record = optionalRecord(payload);
+  const message =
+    optionalString(record?.error) ??
+    optionalString(record?.message) ??
+    `Upstash Redis request failed with status ${status}`;
+  if (status === 400) {
+    return new ProviderRequestError(400, message, payload);
+  }
+  if ((status === 401 || status === 403) && phase === "validate") {
+    return new ProviderRequestError(400, message, payload);
+  }
+  if (status === 401 || status === 403 || status === 429) {
+    return new ProviderRequestError(status, message, payload);
+  }
+  return new ProviderRequestError(status >= 500 ? 502 : status || 502, message, payload);
+}
+
+function readKey(input: Record<string, unknown>): string {
+  return requiredString(input.key, "key", providerInputError);
+}
+
+function readRequiredPositiveInteger(value: unknown, fieldName: string): number {
+  const result = readOptionalPositiveInteger(value, fieldName);
+  if (result === undefined) {
+    throw providerInputError(`${fieldName} is required`);
+  }
+  return result;
+}
+
+function readOptionalPositiveInteger(value: unknown, fieldName: string, maximum?: number): number | undefined {
+  const result = optionalIntegerLike(value, fieldName, providerInputError);
+  if (result === undefined) {
+    return undefined;
+  }
+  if (result < 1 || (maximum !== undefined && result > maximum)) {
+    throw providerInputError(
+      maximum === undefined
+        ? `${fieldName} must be greater than zero`
+        : `${fieldName} must be between 1 and ${maximum}`,
+    );
+  }
+  return result;
+}
+
+function readStringOrNullResult(result: unknown, command: string): string | null {
+  if (result === null || typeof result === "string") {
+    return result;
+  }
+  throw providerResponseError(`Upstash Redis returned an invalid ${command} result`);
+}
+
+function readBooleanCommandResult(result: unknown, command: string): boolean {
+  const value = readIntegerResult(result, command);
+  if (value !== 0 && value !== 1) {
+    throw providerResponseError(`Upstash Redis returned an invalid ${command} result`);
+  }
+  return value === 1;
+}
+
+function readIntegerResult(result: unknown, command: string): number {
+  if (typeof result !== "number" || !Number.isInteger(result)) {
+    throw providerResponseError(`Upstash Redis returned an invalid ${command} result`);
+  }
+  return result;
+}
+
+function readScanResult(result: unknown): [string, string[]] {
+  if (!Array.isArray(result) || result.length !== 2) {
+    throw providerResponseError("Upstash Redis returned an invalid SCAN result");
+  }
+  const cursor = result[0];
+  const rawKeys = result[1];
+  if ((typeof cursor !== "string" && typeof cursor !== "number") || !Array.isArray(rawKeys)) {
+    throw providerResponseError("Upstash Redis returned an invalid SCAN result");
+  }
+  if (rawKeys.some((key) => typeof key !== "string")) {
+    throw providerResponseError("Upstash Redis returned an invalid SCAN key");
+  }
+  return [String(cursor), rawKeys];
+}
+
+function requiredRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  const record = optionalRecord(value);
+  if (record !== undefined) {
+    return record;
+  }
+  throw providerResponseError(`${fieldName} must be an object`);
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/upstash_redis/runtime.ts
+++ b/src/providers/upstash_redis/runtime.ts
@@ -1,7 +1,13 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
-import { optionalIntegerLike, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import {
+  optionalIntegerLike,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
   createProviderTimeout,
@@ -32,11 +38,7 @@ export const upstashRedisActionHandlers: Record<string, ProviderRuntimeHandler<U
     return { value: readStringOrNullResult(result, "GET") };
   },
   async set(input, context) {
-    const command: UpstashCommandArgument[] = [
-      "SET",
-      readKey(input),
-      requiredString(input.value, "value", providerInputError),
-    ];
+    const command: UpstashCommandArgument[] = ["SET", readKey(input), readValue(input)];
     const expirationSeconds = readOptionalPositiveInteger(input.expirationSeconds, "expirationSeconds");
     if (expirationSeconds !== undefined) {
       command.push("EX", expirationSeconds);
@@ -198,7 +200,7 @@ function normalizeUpstashRestUrl(value: string | undefined): URL {
   if (restUrl.pathname !== "/" || restUrl.search || restUrl.hash) {
     throw providerInputError("restUrl must not include a path, query, or fragment");
   }
-  if (!restUrl.hostname.endsWith(upstashHostnameSuffix) || restUrl.hostname === "upstash.io") {
+  if (!restUrl.hostname.endsWith(upstashHostnameSuffix)) {
     throw providerInputError("restUrl must use an official upstash.io endpoint");
   }
   return restUrl;
@@ -222,20 +224,38 @@ function createUpstashError(status: number, payload: unknown, phase: UpstashRequ
     optionalString(record?.error) ??
     optionalString(record?.message) ??
     `Upstash Redis request failed with status ${status}`;
-  if (status === 400) {
-    return new ProviderRequestError(400, message, payload);
-  }
   if ((status === 401 || status === 403) && phase === "validate") {
     return new ProviderRequestError(400, message, payload);
   }
-  if (status === 401 || status === 403 || status === 429) {
-    return new ProviderRequestError(status, message, payload);
+  if (isUpstashQuotaMessage(message)) {
+    return new ProviderRequestError(429, message, payload);
   }
-  return new ProviderRequestError(status >= 500 ? 502 : status || 502, message, payload);
+  return new ProviderRequestError(status >= 500 ? 502 : status, message, payload);
+}
+
+/**
+ * Upstash reports quota and throttling as Redis errors inside a 400 response,
+ * so the message is the only signal that the request should be retried later.
+ */
+function isUpstashQuotaMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes("limit exceeded") || normalized.includes("connections exceeded");
 }
 
 function readKey(input: Record<string, unknown>): string {
   return requiredString(input.key, "key", providerInputError);
+}
+
+/**
+ * Read the SET payload verbatim. Redis strings are opaque, so surrounding
+ * whitespace must reach the database and match what GET reads back.
+ */
+function readValue(input: Record<string, unknown>): string {
+  const value = optionalRawString(input.value);
+  if (value === undefined) {
+    throw providerInputError("value is required");
+  }
+  return value;
 }
 
 function readRequiredPositiveInteger(value: unknown, fieldName: string): number {


### PR DESCRIPTION
## Summary / 概要

- Add a locally executable Upstash Redis provider backed by the official REST API.
- 新增基于 Upstash 官方 REST API 的本地可执行 Redis Provider。

## Changes / 改动内容

- Add custom credentials with estUrl and secret estToken, validated through PING.
- 新增 estUrl 与敏感 estToken 凭据，并使用 PING 校验连接。

- Add seven string-key actions: get, set, delete, exists, expire, 	tl, and single-page scan.
- 新增 7 个字符串键操作：get、set、delete、exists、expire、	tl 和单页 scan。

- Support atomic SET key value [EX seconds] [NX|XX] writes and preserve Redis TTL semantics.
- 支持原子 SET key value [EX seconds] [NX|XX] 写入，并保留 Redis TTL 语义。

- Restrict REST URLs to public https://*.upstash.io root endpoints and route requests through the injected SSRF-protected fetcher.
- REST URL 仅允许公网 https://*.upstash.io 根路径端点，所有请求均使用注入的 SSRF 防护 Fetch。

- Handle timeouts, cancellation, JSON response envelopes, upstream errors, and non-JSON error bodies while preserving relevant HTTP status codes.
- 处理超时、取消、JSON 响应包络、上游错误和非 JSON 错误响应，并保留关键 HTTP 状态码。

## Validation / 验证

- scripts/generate-catalog.ts
- 
pm run typecheck
- itest run - 57 files and 548 tests passed
- Mock Fetch smoke tests for credential validation, command encoding, output normalization, URL validation, and non-JSON upstream errors

## Notes / 说明

- No npm dependencies or shared runtime changes were added.
- 未新增 npm 依赖，也未修改共享运行时。

- package-lock.json is intentionally excluded because it is unrelated local user work.
- package-lock.json 为无关的本地用户修改，未包含在本 PR 中。