### PR TITLE
docs: clarify Wanta open-source positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,22 +220,19 @@ latest `main` build.
 
 See [docs/docker-ghcr.md](docs/docker-ghcr.md) for tags, pulling, and running.
 
-## Want to Use It Directly?
+## Build a Desktop Agent with Wanta
 
-The paths above are for teams integrating connectors into their own products, runtimes, or
-infrastructure. If you want to try the SaaS connection experience first, or use it directly in
-day-to-day work, you do not need to deploy OpenConnector or integrate the SDK, CLI, MCP, or HTTP API
-first.
+OpenConnector and [Wanta](https://github.com/oomol-lab/wanta) are two open-source projects for AI
+Agents in the OOMOL ecosystem. OpenConnector connects Agents to external services such as Gmail,
+Slack, and Notion. Wanta provides a complete desktop Agent application powered by OpenCode and uses
+OpenConnector to work with connected SaaS services.
 
-[Wanta](https://wanta.ai/) is the desktop product entry point using the same shared 1,000+
-SaaS/provider coverage. Connect accounts once, then use natural language to search, organize,
-create, and sync across connected tools.
+- **Run locally:** Use your own OpenAI-compatible model without creating a Wanta account.
+- **Build your own:** Fork Wanta and customize its prompts, tools, interface, models, and branding.
+- **Use hosted services:** The optional [hosted experience](https://wanta.ai/) provides managed
+  models, OAuth connections, and team workspaces.
 
-| If You Want to                           | Wanta Provides                                                                                                                  |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Try 1,000+ SaaS connections directly     | Use the same SaaS/provider coverage without deploying a runtime or integrating SDK/CLI first.                                   |
-| Use Agents in daily work                 | Work across email, chat, docs, data, projects, support, developer tools, and marketing tools in natural language.               |
-| Share connected capabilities with a team | Configure connections and access scopes once; teammates use them without setup while keys, tokens, and credentials stay hidden. |
+Issues and pull requests are welcome.
 
 ## Documentation
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -222,22 +222,20 @@ Exécutez OpenConnector depuis une image préconstruite sur GitHub Packages (GHC
 
 Consultez [docker-ghcr.md (anglais)](docker-ghcr.md) pour les tags d'image, le pull et l'exécution.
 
-## Vous voulez l'utiliser directement ?
+## Construire un Agent desktop avec Wanta
 
-Les parcours ci-dessus s'adressent aux équipes qui intègrent le connector dans leurs produits,
-runtimes ou infrastructures d'entreprise. Si vous voulez d'abord essayer l'expérience de connexion
-SaaS, ou l'utiliser directement dans le travail quotidien, vous n'avez pas besoin de déployer
-OpenConnector ni d'intégrer d'abord le SDK, la CLI, MCP ou l'API HTTP.
+OpenConnector et [Wanta](https://github.com/oomol-lab/wanta) sont deux projets open source pour les
+Agents IA dans l'écosystème OOMOL. OpenConnector connecte les Agents à des services externes comme
+Gmail, Slack et Notion. Wanta fournit une application Agent desktop complète propulsée par OpenCode
+et utilise OpenConnector pour accéder aux services SaaS connectés.
 
-[Wanta](https://wanta.ai/) est le point d'entrée desktop product qui utilise la même couverture
-1,000+ SaaS/providers. Après avoir connecté des comptes, vous pouvez chercher, organiser, créer et
-synchroniser dans les outils connectés en natural language.
+- **Exécution locale :** utilisez votre propre modèle compatible OpenAI sans créer de compte Wanta.
+- **Développement personnalisé :** forkez Wanta et adaptez prompts, outils, interface, modèles et
+  identité.
+- **Services hébergés :** l'expérience [hébergée](https://wanta.ai/), facultative, fournit modèles
+  gérés, connexions OAuth et espaces d'équipe.
 
-| Si Vous Voulez                                       | Wanta Fournit                                                                                                                       |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Essayer directement les connexions 1,000+ SaaS       | Utiliser la même couverture SaaS/provider sans déployer un runtime ni intégrer d'abord le SDK/la CLI.                               |
-| Utiliser des Agents dans le travail quotidien        | Travailler en natural language à travers email, chat, docs, data, projets, support, developer tools et marketing tools.             |
-| Partager des capabilities connectées avec une équipe | Configurer connections et access scopes une fois ; les teammates les utilisent sans setup, avec keys, tokens et credentials cachés. |
+Issues et pull requests sont les bienvenues.
 
 ## Documentation
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -207,20 +207,19 @@ Fly app 作成、volume、secret、deployment、custom domain、scaling につ�
 
 イメージの tag、pull、実行については [docker-ghcr.md（英語）](docker-ghcr.md) を参照してください。
 
-## 先に接続せず直接使う場合
+## Wanta で desktop Agent を構築する
 
-上記の path は、connector を自分たちの product、runtime、または enterprise infrastructure に統合する
-team 向けです。SaaS connection の体験をまず試したい場合や、日々の業務でそのまま使いたい場合は、先に
-OpenConnector を deploy したり、SDK、CLI、MCP、HTTP API を統合したりする必要はありません。
+OpenConnector と [Wanta](https://github.com/oomol-lab/wanta) は、OOMOL の open-source ecosystem で
+AI Agent を支える二つのプロジェクトです。OpenConnector は Gmail、Slack、Notion などの外部サービスを
+Agent に接続します。Wanta は OpenCode で動作する完全な desktop Agent application で、OpenConnector
+を通じて接続済み SaaS サービスを利用します。
 
-[Wanta](https://wanta.ai/) は、同じ 1,000+ SaaS/provider coverage を使う desktop product entry point です。
-account を接続すれば、自然言語で connected tool を検索、整理、生成、同期できます。
+- **ローカル実行：** Wanta account を作成せず、自分の OpenAI-compatible model を使用できます。
+- **独自開発：** Wanta を fork し、prompts、tools、interface、models、branding をカスタマイズできます。
+- **Hosted services：** 任意の [hosted experience](https://wanta.ai/) では、managed models、OAuth
+  connections、team workspaces を利用できます。
 
-| やりたいこと                           | Wanta が提供するもの                                                                                           |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| 1,000+ SaaS connection を直接試す      | runtime の deploy や SDK/CLI integration なしで、同じ SaaS/provider coverage を利用できます。                  |
-| 日々の業務で Agent を使う              | email、chat、docs、data、project、support、developer tool、marketing tool を自然言語で横断できます。           |
-| 接続済み capability を team で共有する | connection と access scope を一度設定すれば、teammate は setup なしで使え、key、token、credential は隠れます。 |
+Issue と pull request による貢献を歓迎します。
 
 ## ドキュメント
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -214,20 +214,19 @@ version, 최신 `main` build에는 `tip`을 사용하세요.
 
 Image tag, 가져오기, 실행 방법은 [docker-ghcr.md](docker-ghcr.md)를 참조하세요.
 
-## 바로 사용하고 싶으신가요?
+## Wanta로 데스크톱 Agent 만들기
 
-위의 경로는 connector를 자체 제품, runtime 또는 인프라에 통합하려는 팀을 위한 것입니다. SaaS 연결
-환경을 먼저 체험하거나 일상 업무에서 바로 사용하려면 OpenConnector를 배포하거나 SDK, CLI, MCP,
-HTTP API를 먼저 통합할 필요가 없습니다.
+OpenConnector와 [Wanta](https://github.com/oomol-lab/wanta)는 OOMOL 오픈 소스 생태계에서 AI Agent를
+지원하는 두 프로젝트입니다. OpenConnector는 Gmail, Slack, Notion 같은 외부 서비스를 Agent에 연결합니다.
+Wanta는 OpenCode로 실행되는 완전한 데스크톱 Agent 애플리케이션이며, OpenConnector를 통해 연결된 SaaS
+서비스를 사용합니다.
 
-[Wanta](https://wanta.ai/)는 동일한 1,000개 이상의 SaaS/provider 범위를 사용하는 데스크톱 제품입니다.
-계정을 한 번 연결한 뒤 자연어로 연결된 도구 전반에서 검색, 정리, 생성, 동기화할 수 있습니다.
+- **로컬 실행:** Wanta 계정 없이 자신의 OpenAI 호환 모델을 사용할 수 있습니다.
+- **직접 개발:** Wanta를 fork하여 prompt, 도구, 인터페이스, 모델, branding을 맞춤 설정할 수 있습니다.
+- **호스팅 서비스:** 선택 사항인 [호스팅 환경](https://wanta.ai/)은 managed model, OAuth 연결, 팀
+  workspace를 제공합니다.
 
-| 원하는 작업                          | Wanta가 제공하는 기능                                                                                                         |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| 1,000개 이상의 SaaS 연결을 바로 체험 | Runtime 배포나 SDK/CLI 통합 없이 동일한 SaaS/provider 범위를 사용합니다.                                                      |
-| 일상 업무에서 Agent 사용             | 이메일, 채팅, 문서, 데이터, 프로젝트, 지원, 개발 도구, 마케팅 도구를 자연어로 다룹니다.                                       |
-| 팀과 연결 기능 공유                  | Connection과 access scope를 한 번 구성하면 팀원이 별도 설정 없이 사용할 수 있으며 key, token, credential은 노출되지 않습니다. |
+Issue와 pull request를 통한 기여를 환영합니다.
 
 ## 문서
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -218,22 +218,20 @@ Fly volume.
 
 О тегах образа, pull и запуске см. [docker-ghcr.md (на английском)](docker-ghcr.md).
 
-## Хотите Использовать Напрямую?
+## Создайте desktop Agent с Wanta
 
-Пути выше предназначены для команд, которые интегрируют connector в свои продукты, runtimes или
-enterprise infrastructure. Если вы хотите сначала попробовать SaaS connection experience или сразу
-использовать это в работе, вам не обязательно сначала deploy OpenConnector или интегрировать SDK,
-CLI, MCP либо HTTP API.
+OpenConnector и [Wanta](https://github.com/oomol-lab/wanta) — два open-source проекта для AI Agents
+в экосистеме OOMOL. OpenConnector подключает Agents к внешним сервисам, таким как Gmail, Slack и
+Notion. Wanta предоставляет полноценное desktop Agent приложение на базе OpenCode и использует
+OpenConnector для работы с подключенными SaaS сервисами.
 
-[Wanta](https://wanta.ai/) — desktop product entry point с тем же 1,000+ SaaS/provider coverage.
-После подключения accounts можно через natural language искать, организовывать, создавать и
-синхронизировать данные между connected tools.
+- **Локальный запуск:** используйте свою OpenAI-compatible model без учетной записи Wanta.
+- **Собственная разработка:** сделайте fork Wanta и настройте prompts, tools, interface, models и
+  branding.
+- **Hosted-сервисы:** необязательный [hosted-сервис](https://wanta.ai/) предоставляет managed models,
+  OAuth connections и team workspaces.
 
-| Если Вы Хотите                          | Что Дает Wanta                                                                                                          |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Попробовать 1,000+ SaaS connections     | Использовать то же SaaS/provider coverage без runtime deploy или предварительной SDK/CLI integration.                   |
-| Использовать Agents в ежедневной работе | Работать через natural language с email, chat, docs, data, projects, support, developer tools и marketing tools.        |
-| Делиться подключенными capabilities     | Один раз настроить connections и access scopes; teammates используют их без setup, а keys, tokens и credentials скрыты. |
+Issues и pull requests приветствуются.
 
 ## Документация
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -197,20 +197,17 @@ release 用 `latest`，生产环境固定版本号（如 `v1.0.0`），想用最
 
 镜像标签、拉取和运行的说明见 [docker-ghcr.zh-CN.md](docker-ghcr.zh-CN.md)。
 
-## 不想先接入？可以直接使用 Wanta
+## 用 Wanta 构建你的桌面 Agent
 
-上面的路径更适合把 connector 接入自己的产品、runtime 或企业基础设施。如果你只是想先体验连接各种
-SaaS 的效果，或者想直接在业务中使用这些能力，不一定要先部署 OpenConnector，也不一定要接入 SDK、CLI、MCP 或
-HTTP API。
+OpenConnector 与 [Wanta](https://github.com/oomol-lab/wanta) 是 OOMOL 开源生态中面向 AI Agent
+的两个项目。OpenConnector 负责把 Gmail、Slack、Notion 等外部服务接入 Agent；Wanta 则提供一套基于 OpenCode
+运行的完整桌面 Agent 应用，并通过 OpenConnector 使用已连接的 SaaS 服务。
 
-[Wanta](https://wanta.ai/) 是使用同一套 1,000+ SaaS/provider 覆盖的桌面端产品入口。用户连接账号后，就可以用自然语言让 AI
-跨已连接工具查询、整理、生成和同步。
+- **本地运行：** 使用自己的 OpenAI 兼容模型，无需注册 Wanta 账号。
+- **二次开发：** Fork Wanta，自定义提示词、工具、界面、模型和品牌，构建自己的桌面 Agent。
+- **托管服务：** 可选的[托管服务](https://wanta.ai/)提供托管模型、OAuth 连接和团队工作区。
 
-| 如果你想要             | Wanta 提供                                                                               |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| 直接体验 SaaS 连接能力 | 使用同一套 1,000+ SaaS/provider 覆盖，不需要先部署 runtime 或接入 SDK/CLI。              |
-| 直接在业务中使用       | 用自然语言跨邮件、沟通、文档、数据、项目、客服、开发和营销等工具查询、整理、生成和同步。 |
-| 团队一起使用           | 一人配置连接和授权范围，成员免配置使用；Key、Token 和账号凭据不外露。                    |
+欢迎通过 Issue 和 Pull Request 参与贡献。
 
 ## 文档
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -194,19 +194,17 @@ OpenConnector 也可部署至 Fly.io，使用 Node Docker 執行階段，並將 
 
 標籤、拉取及執行方式，請參閱 [docker-ghcr.md（英文）](docker-ghcr.md)。
 
-## 想直接使用？
+## 用 Wanta 建構你的桌面 Agent
 
-上述方式適合將連接器整合進自有產品、執行階段或基礎架構的團隊。如果只想先體驗 SaaS 連線，
-或直接用於日常工作，不必先部署 OpenConnector，也不必先整合 SDK、CLI、MCP 或 HTTP API。
+OpenConnector 與 [Wanta](https://github.com/oomol-lab/wanta) 是 OOMOL 開源生態中面向 AI Agent
+的兩個專案。OpenConnector 負責將 Gmail、Slack、Notion 等外部服務接入 Agent；Wanta 則提供一套以 OpenCode
+執行的完整桌面 Agent 應用程式，並透過 OpenConnector 使用已連接的 SaaS 服務。
 
-[Wanta](https://wanta.ai/) 是使用相同 1,000 多項 SaaS/服務提供者涵蓋範圍的桌面產品入口。
-帳號只需連線一次，就能用自然語言在已連線的工具間搜尋、整理、建立及同步內容。
+- **本機執行：** 使用自己的 OpenAI 相容模型，無須註冊 Wanta 帳號。
+- **二次開發：** Fork Wanta，自訂提示詞、工具、介面、模型與品牌，建構自己的桌面 Agent。
+- **託管服務：** 選用的[託管服務](https://wanta.ai/)提供託管模型、OAuth 連線與團隊工作區。
 
-| 如果你想要                    | Wanta 提供                                                                         |
-| ----------------------------- | ---------------------------------------------------------------------------------- |
-| 直接體驗 1,000 多項 SaaS 連線 | 使用相同的 SaaS/服務提供者涵蓋範圍，不必先部署執行階段或整合 SDK/CLI。             |
-| 在日常工作中使用 Agent        | 以自然語言操作電子郵件、聊天、文件、資料、專案、客服、開發者工具及行銷工具。       |
-| 與團隊共用已連線的功能        | 連線與存取範圍只需設定一次；團隊成員無須設定即可使用，而金鑰、權杖及憑證不會外露。 |
+歡迎透過 Issue 和 Pull Request 參與貢獻。
 
 ## 文件
 


### PR DESCRIPTION
## Summary

OpenConnector's README files previously described Wanta mainly as a hosted product entry point for trying SaaS connections. Since Wanta is now available as an open-source desktop Agent project, that framing no longer explained the relationship between the two repositories or the ways open-source users can run, adapt, and contribute to Wanta.

This change presents OpenConnector and Wanta as two projects in the same OOMOL open-source ecosystem. It explains that OpenConnector connects Agents to external services, while Wanta provides a complete desktop Agent application powered by OpenCode and uses OpenConnector for connected SaaS services.

The revised section gives readers three concrete paths:

- run Wanta locally with an OpenAI-compatible model and no Wanta account;
- fork and customize Wanta to build a desktop Agent;
- optionally use hosted models, OAuth connections, and team workspaces.

It also links Wanta's GitHub repository directly and invites issues and pull requests. The wording is synchronized across the English, Simplified Chinese, Traditional Chinese, French, Japanese, Korean, and Russian README files.

## User impact

Readers can now understand what each project does, how the projects relate technically, and which parts can be used locally or customized. The section remains compact while providing enough context to avoid presenting Wanta only as a commercial or hosted path.

## Validation

- `npm run lint`
- `npm run fix-check`
- `git diff --check`
