### PR TITLE
docs(readme): add star history section to translated READMEs

### DIFF
--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -318,3 +318,10 @@ Merci à toutes les personnes qui ont contribué à OpenConnector. Vous souhaite
 Consultez le [guide de contribution](../CONTRIBUTING.md).
 
 [![Contributeurs OpenConnector](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Historique des Stars
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Historique des Stars" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -296,3 +296,10 @@ OpenConnector の開発にご協力いただいたすべての皆さまに感謝
 [コントリビューションガイド](../CONTRIBUTING.md) をご覧ください。
 
 [![OpenConnector コントリビューター](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Star 履歴
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 履歴" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -305,3 +305,10 @@ OpenConnector를 함께 만들어 주신 모든 기여자께 감사드립니다.
 [기여 안내](../CONTRIBUTING.md)를 확인하고 함께해 주세요.
 
 [![OpenConnector 기여자](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Star 히스토리
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 히스토리" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -312,3 +312,10 @@ files в этот repository.
 [руководством по участию](../CONTRIBUTING.md).
 
 [![Участники OpenConnector](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## История звёзд
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="История звёзд" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -280,3 +280,10 @@ Provider 和 app 名称、metadata、链接、scope、permission 以及可选 lo
 感谢每一位参与建设 OpenConnector 的贡献者。欢迎查看 [贡献指南](../CONTRIBUTING.md)，加入我们。
 
 [![OpenConnector 贡献者](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Star 历史
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 历史" src="../assets/star-history/star-history-light.svg">
+</picture>

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -278,3 +278,10 @@ npm test
 感謝每一位參與建設 OpenConnector 的貢獻者。歡迎參閱 [貢獻指南](../CONTRIBUTING.md)，加入我們。
 
 [![OpenConnector 貢獻者](https://contrib.rocks/image?repo=oomol-lab/open-connector)](https://github.com/oomol-lab/open-connector/graphs/contributors)
+
+## Star 歷史
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/star-history/star-history-dark.svg">
+  <img alt="Star 歷史" src="../assets/star-history/star-history-light.svg">
+</picture>


### PR DESCRIPTION
The root README embeds a star-growth chart that the daily star-history workflow refreshes in place, but none of the six translated READMEs under `docs/` carried it. This adds the same `<picture>` block (light/dark SVG) with localized headings and alt text to the fr, ja, ko, ru, zh-CN, and zh-TW READMEs, pointing at `../assets/star-history/`.

No workflow change is needed: the chart SVG filenames are stable and only their contents change on each refresh, so the translated copies stay current automatically. The `<!-- star-history:start/end -->` marker comments are deliberately omitted from the translations — the action's `readme` input only rewrites the root `README.md`, and if it were ever pointed at `docs/` it would embed repo-root-relative paths that break from there; a static block avoids implying automation that doesn't exist.