### PR TITLE
feat(provider): add Qdrant Cloud REST provider

### DIFF
--- a/src/providers/qdrant/actions.ts
+++ b/src/providers/qdrant/actions.ts
@@ -5,15 +5,33 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 
 const service = "qdrant";
 
-const collectionNameSchema = s.nonEmptyString("The Qdrant collection name.");
-const pointIdSchema = s.union([s.nonNegativeInteger("A non-negative numeric point ID."), s.uuid("A UUID point ID.")]);
+const collectionNameSchema = {
+  ...s.nonEmptyString("The Qdrant collection name. The names `.` and `..` are not supported."),
+  not: { enum: [".", ".."] },
+};
+export const qdrantUuidPattern =
+  "^(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}|[uU][rR][nN]:[uU][uU][iI][dD]:[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})$";
+const pointIdSchema = s.union(
+  [
+    s.nonNegativeInteger("A numeric point ID within the JavaScript safe-integer range.", {
+      maximum: Number.MAX_SAFE_INTEGER,
+    }),
+    s.stringPattern(qdrantUuidPattern, {
+      description: "A Qdrant UUID point ID in simple, hyphenated, or URN form.",
+    }),
+  ],
+  { description: "A Qdrant numeric or UUID point ID." },
+);
 const vectorSchema = s.array("A dense unnamed vector.", s.number("One vector component."), { minItems: 1 });
 const payloadSchema = s.looseObject("A JSON object stored with the point.");
 const filterSchema = s.looseObject("A Qdrant filter. Nested conditions are validated by Qdrant.", {
   must: s.unknown("Conditions that must match."),
   must_not: s.unknown("Conditions that must not match."),
   should: s.unknown("Conditions where at least one should match."),
-  min_should: s.unknown("Minimum number of should conditions that must match."),
+  min_should: s.requiredObject("Conditions where at least `min_count` entries must match.", {
+    conditions: s.array("The Qdrant filter conditions to evaluate.", s.unknown("One Qdrant filter condition.")),
+    min_count: s.nonNegativeInteger("The minimum number of conditions that must match."),
+  }),
 });
 
 const pointSchema = s.object(
@@ -134,7 +152,11 @@ export const qdrantActions: ProviderActionDefinition[] = [
     ),
     outputSchema: s.actionOutput(
       {
-        operationId: s.nullable(s.nonNegativeInteger("The Qdrant operation ID when returned.")),
+        operationId: s.nullable(
+          s.nonNegativeInteger("The Qdrant operation ID when returned, within the JavaScript safe-integer range.", {
+            maximum: Number.MAX_SAFE_INTEGER,
+          }),
+        ),
         status: s.stringEnum("The Qdrant write status.", ["acknowledged", "completed", "wait_timeout"]),
       },
       "The Qdrant upsert operation result.",

--- a/src/providers/qdrant/actions.ts
+++ b/src/providers/qdrant/actions.ts
@@ -1,0 +1,192 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "qdrant";
+
+const collectionNameSchema = s.nonEmptyString("The Qdrant collection name.");
+const pointIdSchema = s.union([s.nonNegativeInteger("A non-negative numeric point ID."), s.uuid("A UUID point ID.")]);
+const vectorSchema = s.array("A dense unnamed vector.", s.number("One vector component."), { minItems: 1 });
+const payloadSchema = s.looseObject("A JSON object stored with the point.");
+const filterSchema = s.looseObject("A Qdrant filter. Nested conditions are validated by Qdrant.", {
+  must: s.unknown("Conditions that must match."),
+  must_not: s.unknown("Conditions that must not match."),
+  should: s.unknown("Conditions where at least one should match."),
+  min_should: s.unknown("Minimum number of should conditions that must match."),
+});
+
+const pointSchema = s.object(
+  "A Qdrant point to insert or update.",
+  {
+    id: pointIdSchema,
+    vector: vectorSchema,
+    payload: payloadSchema,
+  },
+  { optional: ["payload"] },
+);
+
+const recordSchema = s.looseRequiredObject(
+  "A Qdrant point record.",
+  {
+    id: pointIdSchema,
+    payload: s.nullable(payloadSchema),
+    vector: s.nullable(vectorSchema),
+    shard_key: s.unknown("The Qdrant shard key when present."),
+    order_value: s.unknown("The Qdrant order value when present."),
+  },
+  { optional: ["payload", "vector", "shard_key", "order_value"] },
+);
+
+const scoredPointSchema = s.looseRequiredObject(
+  "A Qdrant scored point.",
+  {
+    id: pointIdSchema,
+    version: s.nonNegativeInteger("The point version."),
+    score: s.number("The similarity score."),
+    payload: s.nullable(payloadSchema),
+    vector: s.nullable(vectorSchema),
+    shard_key: s.unknown("The Qdrant shard key when present."),
+    order_value: s.unknown("The Qdrant order value when present."),
+  },
+  { optional: ["payload", "vector", "shard_key", "order_value"] },
+);
+
+const collectionSchema = s.looseRequiredObject(
+  "A Qdrant collection description.",
+  {
+    status: s.unknown("The collection status."),
+    optimizer_status: s.unknown("The collection optimizer status."),
+    indexed_vectors_count: s.nullable(s.nonNegativeInteger("The approximate indexed vector count.")),
+    points_count: s.nullable(s.nonNegativeInteger("The approximate point count.")),
+    segments_count: s.nonNegativeInteger("The number of collection segments."),
+    config: s.looseObject("The collection configuration."),
+    payload_schema: s.looseObject("The collection payload index schema."),
+    warnings: s.array("Collection warnings.", s.looseObject("A collection warning.")),
+  },
+  { optional: ["indexed_vectors_count", "points_count", "warnings"] },
+);
+
+const filterInputFields = {
+  filter: filterSchema,
+  limit: s.integer("The maximum number of points to return.", { minimum: 1, maximum: 1000 }),
+  withPayload: s.boolean("Whether to include point payloads."),
+  withVector: s.boolean("Whether to include point vectors."),
+};
+
+export const qdrantActions: ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_collections",
+    description: "List the Qdrant collections visible to the authenticated API key.",
+    inputSchema: s.actionInput({}, [], "Input parameters for listing Qdrant collections."),
+    outputSchema: s.actionOutput(
+      {
+        collections: s.array(
+          "The visible Qdrant collections.",
+          s.requiredObject("A Qdrant collection name.", { name: s.nonEmptyString("The collection name.") }),
+        ),
+      },
+      "The Qdrant collection list response.",
+    ),
+    followUpActions: ["qdrant.get_collection", "qdrant.create_collection"],
+  }),
+  defineProviderAction(service, {
+    name: "get_collection",
+    description: "Retrieve configuration and status information for one Qdrant collection.",
+    inputSchema: s.actionInput(
+      { collectionName: collectionNameSchema },
+      ["collectionName"],
+      "Input parameters for retrieving a Qdrant collection.",
+    ),
+    outputSchema: s.actionOutput({ collection: collectionSchema }, "The Qdrant collection description response."),
+    followUpActions: ["qdrant.query_points", "qdrant.scroll_points", "qdrant.upsert_points"],
+  }),
+  defineProviderAction(service, {
+    name: "create_collection",
+    description: "Create a Qdrant Cloud collection with one unnamed dense vector configuration.",
+    inputSchema: s.actionInput(
+      {
+        collectionName: collectionNameSchema,
+        vectorSize: s.positiveInteger("The dense vector dimension."),
+        distance: s.stringEnum("The distance function used by the collection.", [
+          "Cosine",
+          "Euclid",
+          "Dot",
+          "Manhattan",
+        ]),
+      },
+      ["collectionName", "vectorSize", "distance"],
+      "Input parameters for creating a dense-vector Qdrant collection.",
+    ),
+    outputSchema: s.actionOutput({ created: s.boolean("Whether Qdrant created the collection.") }),
+    followUpActions: ["qdrant.get_collection", "qdrant.upsert_points"],
+  }),
+  defineProviderAction(service, {
+    name: "upsert_points",
+    description: "Insert or replace dense-vector points in a Qdrant collection and wait for the write to commit.",
+    inputSchema: s.actionInput(
+      {
+        collectionName: collectionNameSchema,
+        points: s.array("The points to upsert.", pointSchema, { minItems: 1, maxItems: 1000 }),
+      },
+      ["collectionName", "points"],
+      "Input parameters for upserting Qdrant points.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        operationId: s.nullable(s.nonNegativeInteger("The Qdrant operation ID when returned.")),
+        status: s.stringEnum("The Qdrant write status.", ["acknowledged", "completed", "wait_timeout"]),
+      },
+      "The Qdrant upsert operation result.",
+    ),
+    followUpActions: ["qdrant.get_point", "qdrant.query_points", "qdrant.scroll_points"],
+  }),
+  defineProviderAction(service, {
+    name: "get_point",
+    description: "Retrieve one point by numeric ID or UUID from a Qdrant collection.",
+    inputSchema: s.actionInput(
+      { collectionName: collectionNameSchema, id: pointIdSchema },
+      ["collectionName", "id"],
+      "Input parameters for retrieving a Qdrant point.",
+    ),
+    outputSchema: s.actionOutput({ point: recordSchema }, "The Qdrant point record response."),
+  }),
+  defineProviderAction(service, {
+    name: "query_points",
+    description: "Search a dense-vector Qdrant collection with an optional payload filter.",
+    inputSchema: s.actionInput(
+      {
+        collectionName: collectionNameSchema,
+        vector: vectorSchema,
+        ...filterInputFields,
+        offset: s.nonNegativeInteger("The number of matching points to skip."),
+        scoreThreshold: s.number("The minimum score a result must have."),
+      },
+      ["collectionName", "vector"],
+      "Input parameters for querying Qdrant points.",
+    ),
+    outputSchema: s.actionOutput(
+      { points: s.array("The scored points returned by Qdrant.", scoredPointSchema) },
+      "The Qdrant query response.",
+    ),
+    followUpActions: ["qdrant.get_point", "qdrant.scroll_points"],
+  }),
+  defineProviderAction(service, {
+    name: "scroll_points",
+    description: "Read one page of points from a Qdrant collection with an optional payload filter.",
+    inputSchema: s.actionInput(
+      { collectionName: collectionNameSchema, offset: pointIdSchema, ...filterInputFields },
+      ["collectionName"],
+      "Input parameters for scrolling through Qdrant points.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        points: s.array("The point records returned by Qdrant.", recordSchema),
+        nextOffset: s.nullable(pointIdSchema),
+        complete: s.boolean("Whether there is no next page."),
+      },
+      "One page of Qdrant scroll results.",
+    ),
+    followUpActions: ["qdrant.scroll_points", "qdrant.get_point"],
+  }),
+];

--- a/src/providers/qdrant/definition.ts
+++ b/src/providers/qdrant/definition.ts
@@ -1,0 +1,44 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { qdrantActions } from "./actions.ts";
+
+const service = "qdrant";
+
+/**
+ * Qdrant Cloud provider backed by the official REST API.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Qdrant Cloud",
+  description: "Create, inspect, write, and query dense-vector collections in Qdrant Cloud.",
+  categories: ["Data", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "clusterUrl",
+          label: "Cluster URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://your-cluster.cloud.qdrant.io:6333",
+          description:
+            "The HTTPS REST URL for a Qdrant Cloud cluster. Only official cloud.qdrant.io endpoints on port 6333 are supported.",
+        },
+        {
+          key: "apiKey",
+          label: "API Key",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Your Qdrant Cloud database API key",
+          description: "A Qdrant Cloud database API key with access to the target collections.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://qdrant.tech/cloud/",
+  actions: qdrantActions,
+};

--- a/src/providers/qdrant/definition.ts
+++ b/src/providers/qdrant/definition.ts
@@ -23,9 +23,9 @@ export const provider: ProviderDefinition = {
           inputType: "text",
           required: true,
           secret: false,
-          placeholder: "https://your-cluster.cloud.qdrant.io:6333",
+          placeholder: "https://your-cluster.cloud.qdrant.io",
           description:
-            "The HTTPS REST URL for a Qdrant Cloud cluster. Only official cloud.qdrant.io endpoints on port 6333 are supported.",
+            "The HTTPS REST URL for a Qdrant Cloud cluster. Only official cloud.qdrant.io endpoints on port 443 or 6333 are supported.",
         },
         {
           key: "apiKey",

--- a/src/providers/qdrant/executors.ts
+++ b/src/providers/qdrant/executors.ts
@@ -1,0 +1,21 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createQdrantContext, qdrantActionHandlers, validateQdrantCredential } from "./runtime.ts";
+
+const service = "qdrant";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: qdrantActionHandlers,
+  async createContext(context: ExecutionContext, fetcher): Promise<ReturnType<typeof createQdrantContext>> {
+    const credential = await requireCustomCredential(context, service);
+    return createQdrantContext(credential.values, fetcher, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }) {
+    return validateQdrantCredential(input.values, fetcher, signal);
+  },
+};

--- a/src/providers/qdrant/runtime.test.ts
+++ b/src/providers/qdrant/runtime.test.ts
@@ -1,0 +1,202 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { createQdrantContext, qdrantActionHandlers, validateQdrantCredential } from "./runtime.ts";
+
+const clusterUrl = "https://test-cluster.cloud.qdrant.io:6333";
+const apiKey = "qdrant-secret";
+
+function jsonResponse(result: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ status: "ok", result }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function errorResponse(error: string, status: number): Response {
+  return new Response(JSON.stringify({ status: { error }, result: null }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function setup(response: Response | (() => Response) = jsonResponse({})) {
+  const fetcher = vi.fn<ProviderFetch>(async () => (typeof response === "function" ? response() : response));
+  return {
+    fetcher,
+    context: createQdrantContext({ clusterUrl, apiKey }, fetcher),
+  };
+}
+
+function requestOf(fetcher: ReturnType<typeof vi.fn<ProviderFetch>>) {
+  const [input, init] = fetcher.mock.calls[0];
+  return {
+    url: String(input),
+    init,
+    headers: new Headers(init?.headers),
+  };
+}
+
+describe("Qdrant runtime", () => {
+  it("validates credentials through the collections endpoint and creates a stable profile", async () => {
+    const { fetcher } = setup(jsonResponse({ collections: [{ name: "documents" }] }));
+
+    const result = await validateQdrantCredential({ clusterUrl, apiKey }, fetcher);
+
+    expect(result.profile).toEqual({
+      accountId: "qdrant:test-cluster.cloud.qdrant.io",
+      displayName: "Qdrant Cloud - test-cluster.cloud.qdrant.io",
+    });
+    expect(result.metadata).toEqual({
+      clusterUrl,
+      validationEndpoint: "/collections",
+      collectionCount: 1,
+    });
+    const request = requestOf(fetcher);
+    expect(request.url).toBe(`${clusterUrl}/collections`);
+    expect(request.init?.method).toBe("GET");
+    expect(request.headers.get("api-key")).toBe(apiKey);
+    expect(request.headers.get("content-type")).toBeNull();
+  });
+
+  it("builds create, upsert, and point requests with encoded paths", async () => {
+    const create = setup(jsonResponse(true));
+    await qdrantActionHandlers.create_collection(
+      { collectionName: "my collection", vectorSize: 3, distance: "Cosine" },
+      create.context,
+    );
+    expect(requestOf(create.fetcher).url).toBe(`${clusterUrl}/collections/my%20collection`);
+    expect(JSON.parse(String(requestOf(create.fetcher).init?.body))).toEqual({
+      vectors: { size: 3, distance: "Cosine" },
+    });
+
+    const upsert = setup(jsonResponse({ operation_id: 12, status: "completed" }));
+    const upsertResult = await qdrantActionHandlers.upsert_points(
+      {
+        collectionName: "my collection",
+        points: [{ id: "550e8400-e29b-41d4-a716-446655440000", vector: [0.1, 0.2, 0.3], payload: { kind: "doc" } }],
+      },
+      upsert.context,
+    );
+    expect(upsertResult).toEqual({ operationId: 12, status: "completed" });
+    expect(requestOf(upsert.fetcher).url).toBe(`${clusterUrl}/collections/my%20collection/points?wait=true`);
+
+    const point = setup(jsonResponse({ id: 42, payload: { kind: "doc" } }));
+    await qdrantActionHandlers.get_point({ collectionName: "my collection", id: 42 }, point.context);
+    expect(requestOf(point.fetcher).url).toBe(`${clusterUrl}/collections/my%20collection/points/42`);
+  });
+
+  it("normalizes a null operation ID and rejects excluded point fields", async () => {
+    const upsert = setup(jsonResponse({ operation_id: null, status: "wait_timeout" }));
+    await expect(
+      qdrantActionHandlers.upsert_points(
+        { collectionName: "documents", points: [{ id: 1, vector: [0.1], payload: { ok: true } }] },
+        upsert.context,
+      ),
+    ).resolves.toEqual({ operationId: null, status: "wait_timeout" });
+
+    const invalid = setup();
+    await expect(
+      qdrantActionHandlers.upsert_points(
+        { collectionName: "documents", points: [{ id: 1, vector: [0.1], sparse_values: { values: [1] } }] },
+        invalid.context,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(invalid.fetcher).not.toHaveBeenCalled();
+  });
+
+  it("maps query and scroll inputs and normalizes the next page offset", async () => {
+    const query = setup(jsonResponse({ points: [{ id: 1, version: 2, score: 0.9 }] }));
+    const queryResult = await qdrantActionHandlers.query_points(
+      {
+        collectionName: "documents",
+        vector: [0.1, 0.2],
+        filter: { must: [{ key: "tenant", match: { value: "acme" } }] },
+        limit: 5,
+        offset: 2,
+        scoreThreshold: 0.5,
+        withPayload: true,
+        withVector: false,
+      },
+      query.context,
+    );
+    expect(queryResult).toEqual({ points: [{ id: 1, version: 2, score: 0.9 }] });
+    expect(JSON.parse(String(requestOf(query.fetcher).init?.body))).toEqual({
+      query: [0.1, 0.2],
+      filter: { must: [{ key: "tenant", match: { value: "acme" } }] },
+      score_threshold: 0.5,
+      limit: 5,
+      offset: 2,
+      with_payload: true,
+      with_vector: false,
+    });
+
+    const scroll = setup(jsonResponse({ points: [{ id: 1 }], next_page_offset: 42 }));
+    await expect(
+      qdrantActionHandlers.scroll_points({ collectionName: "documents", limit: 10 }, scroll.context),
+    ).resolves.toEqual({ points: [{ id: 1 }], nextOffset: 42, complete: false });
+    expect(JSON.parse(String(requestOf(scroll.fetcher).init?.body))).toEqual({ limit: 10 });
+  });
+
+  it("marks a final scroll page complete when Qdrant returns no offset", async () => {
+    const { context } = setup(jsonResponse({ points: [], next_page_offset: null }));
+
+    await expect(qdrantActionHandlers.scroll_points({ collectionName: "documents" }, context)).resolves.toEqual({
+      points: [],
+      nextOffset: null,
+      complete: true,
+    });
+  });
+
+  it("preserves execute-phase permission errors and maps validation permission errors", async () => {
+    const execute = setup(errorResponse("forbidden", 403));
+    await expect(
+      qdrantActionHandlers.get_collection({ collectionName: "documents" }, execute.context),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "forbidden",
+    });
+
+    const validateFetcher = vi.fn<ProviderFetch>(async () => errorResponse("invalid key", 401));
+    await expect(validateQdrantCredential({ clusterUrl, apiKey }, validateFetcher)).rejects.toMatchObject({
+      status: 400,
+      message: "invalid key",
+    });
+  });
+
+  it("rejects unsafe or non-Qdrant Cloud cluster URLs", () => {
+    for (const invalidUrl of [
+      "http://test-cluster.cloud.qdrant.io:6333",
+      "https://test-cluster.example.com:6333",
+      "https://test-cluster.cloud.qdrant.io:443",
+      "https://test-cluster.cloud.qdrant.io:6333/path",
+      "https://test-cluster.cloud.qdrant.io:6333?secret=1",
+      "https://user:pass@test-cluster.cloud.qdrant.io:6333",
+    ]) {
+      expect(() => createQdrantContext({ clusterUrl: invalidUrl, apiKey }, vi.fn() as ProviderFetch)).toThrow();
+    }
+  });
+
+  it("rejects malformed successful envelopes", async () => {
+    const { context } = setup(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+
+    await expect(qdrantActionHandlers.list_collections({}, context)).rejects.toMatchObject({
+      status: 502,
+      message: "Qdrant response is missing result",
+    });
+  });
+
+  it("preserves non-JSON client status and maps server errors to 502", async () => {
+    const rateLimited = setup(new Response("rate limited", { status: 429 }));
+    await expect(qdrantActionHandlers.list_collections({}, rateLimited.context)).rejects.toMatchObject({
+      status: 429,
+      message: "rate limited",
+    });
+
+    const serverError = setup(errorResponse("database unavailable", 503));
+    await expect(qdrantActionHandlers.list_collections({}, serverError.context)).rejects.toMatchObject({
+      status: 502,
+      message: "database unavailable",
+    });
+  });
+});

--- a/src/providers/qdrant/runtime.test.ts
+++ b/src/providers/qdrant/runtime.test.ts
@@ -1,6 +1,8 @@
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { describe, expect, it, vi } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { qdrantActions } from "./actions.ts";
 import { createQdrantContext, qdrantActionHandlers, validateQdrantCredential } from "./runtime.ts";
 
 const clusterUrl = "https://test-cluster.cloud.qdrant.io:6333";
@@ -86,6 +88,51 @@ describe("Qdrant runtime", () => {
     expect(requestOf(point.fetcher).url).toBe(`${clusterUrl}/collections/my%20collection/points/42`);
   });
 
+  it("keeps the public point ID schema aligned with Qdrant UUID forms and safe numeric IDs", async () => {
+    const action = qdrantActions.find((candidate) => candidate.name === "get_point")!;
+    const ids = [
+      "936DA01F9ABD4d9d80C702AF85C822A8",
+      "01890f3e-9c4a-7cc2-b3e4-8fef7d7c9b3a",
+      "urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4",
+      Number.MAX_SAFE_INTEGER,
+    ];
+
+    for (const id of ids) {
+      expect(validateActionInput(action, { collectionName: "documents", id }).valid).toBe(true);
+      const request = setup(jsonResponse({ id }));
+      await expect(
+        qdrantActionHandlers.get_point({ collectionName: "documents", id }, request.context),
+      ).resolves.toEqual({ point: { id } });
+      expect(requestOf(request.fetcher).url).toBe(
+        `${clusterUrl}/collections/documents/points/${encodeURIComponent(String(id))}`,
+      );
+    }
+
+    const unsafeId = Number.MAX_SAFE_INTEGER + 1;
+    expect(validateActionInput(action, { collectionName: "documents", id: unsafeId }).valid).toBe(false);
+    const invalid = setup();
+    await expect(
+      qdrantActionHandlers.get_point({ collectionName: "documents", id: unsafeId }, invalid.context),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(invalid.fetcher).not.toHaveBeenCalled();
+  });
+
+  it("preserves collection name whitespace and rejects dot-segment names", async () => {
+    const spaced = setup(jsonResponse({ status: "green" }));
+    await qdrantActionHandlers.get_collection({ collectionName: " documents " }, spaced.context);
+    expect(requestOf(spaced.fetcher).url).toBe(`${clusterUrl}/collections/%20documents%20`);
+
+    const action = qdrantActions.find((candidate) => candidate.name === "get_collection")!;
+    for (const collectionName of [".", ".."]) {
+      expect(validateActionInput(action, { collectionName }).valid).toBe(false);
+      const invalid = setup();
+      await expect(qdrantActionHandlers.get_collection({ collectionName }, invalid.context)).rejects.toMatchObject({
+        status: 400,
+      });
+      expect(invalid.fetcher).not.toHaveBeenCalled();
+    }
+  });
+
   it("normalizes a null operation ID and rejects excluded point fields", async () => {
     const upsert = setup(jsonResponse({ operation_id: null, status: "wait_timeout" }));
     await expect(
@@ -103,6 +150,35 @@ describe("Qdrant runtime", () => {
       ),
     ).rejects.toMatchObject({ status: 400 });
     expect(invalid.fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects point and operation IDs that cannot be represented without precision loss", async () => {
+    const point = setup(jsonResponse({ id: Number.MAX_SAFE_INTEGER + 1 }));
+    await expect(
+      qdrantActionHandlers.get_point({ collectionName: "documents", id: 1 }, point.context),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Qdrant returned an invalid point ID",
+    });
+
+    const query = setup(jsonResponse({ points: [{ id: Number.MAX_SAFE_INTEGER + 1 }] }));
+    await expect(
+      qdrantActionHandlers.query_points({ collectionName: "documents", vector: [0.1] }, query.context),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Qdrant returned an invalid query point ID",
+    });
+
+    const operation = setup(jsonResponse({ operation_id: Number.MAX_SAFE_INTEGER + 1, status: "completed" }));
+    await expect(
+      qdrantActionHandlers.upsert_points(
+        { collectionName: "documents", points: [{ id: 1, vector: [0.1] }] },
+        operation.context,
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Qdrant returned an invalid operation_id",
+    });
   });
 
   it("maps query and scroll inputs and normalizes the next page offset", async () => {
@@ -148,6 +224,15 @@ describe("Qdrant runtime", () => {
     });
   });
 
+  it("maps invalid response pagination offsets to provider errors", async () => {
+    const { context } = setup(jsonResponse({ points: [], next_page_offset: "not-a-point-id" }));
+
+    await expect(qdrantActionHandlers.scroll_points({ collectionName: "documents" }, context)).rejects.toMatchObject({
+      status: 502,
+      message: "Qdrant returned an invalid next_page_offset",
+    });
+  });
+
   it("preserves execute-phase permission errors and maps validation permission errors", async () => {
     const execute = setup(errorResponse("forbidden", 403));
     await expect(
@@ -165,10 +250,18 @@ describe("Qdrant runtime", () => {
   });
 
   it("rejects unsafe or non-Qdrant Cloud cluster URLs", () => {
+    for (const validUrl of [
+      "https://test-cluster.cloud.qdrant.io",
+      "https://test-cluster.cloud.qdrant.io:443",
+      clusterUrl,
+    ]) {
+      expect(() => createQdrantContext({ clusterUrl: validUrl, apiKey }, vi.fn() as ProviderFetch)).not.toThrow();
+    }
+
     for (const invalidUrl of [
       "http://test-cluster.cloud.qdrant.io:6333",
       "https://test-cluster.example.com:6333",
-      "https://test-cluster.cloud.qdrant.io:443",
+      "https://test-cluster.cloud.qdrant.io:6334",
       "https://test-cluster.cloud.qdrant.io:6333/path",
       "https://test-cluster.cloud.qdrant.io:6333?secret=1",
       "https://user:pass@test-cluster.cloud.qdrant.io:6333",

--- a/src/providers/qdrant/runtime.ts
+++ b/src/providers/qdrant/runtime.ts
@@ -1,0 +1,405 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  isAbortSignalError,
+  parseProviderJsonBodyText,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderTextBody,
+} from "../provider-runtime.ts";
+
+const service = "qdrant";
+const requestTimeoutMs = 30_000;
+const qdrantHostnameSuffix = ".cloud.qdrant.io";
+const qdrantPort = "6333";
+
+type QdrantRequestPhase = "validate" | "execute";
+type QdrantHttpMethod = "GET" | "POST" | "PUT";
+
+export interface QdrantContext {
+  clusterUrl: URL;
+  apiKey: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantContext>> = {
+  async list_collections(_input, context) {
+    const payload = await requestQdrantJson(context, "/collections", "GET", undefined, "execute");
+    const result = requireObjectResult(payload, "Qdrant collections response");
+    const collections = Array.isArray(result.collections) ? result.collections : [];
+    return { collections };
+  },
+
+  async get_collection(input, context) {
+    const collectionName = readCollectionName(input);
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}`,
+      "GET",
+      undefined,
+      "execute",
+    );
+    return { collection: requireObjectResult(payload, "Qdrant collection response") };
+  },
+
+  async create_collection(input, context) {
+    const collectionName = readCollectionName(input);
+    const vectorSize = readRequiredPositiveInteger(input.vectorSize, "vectorSize");
+    const distance = requiredString(input.distance, "distance", providerInputError);
+    if (!isDistance(distance)) {
+      throw providerInputError("distance must be Cosine, Euclid, Dot, or Manhattan");
+    }
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}`,
+      "PUT",
+      { vectors: { size: vectorSize, distance } },
+      "execute",
+    );
+    return { created: readBooleanResult(payload, "create collection") };
+  },
+
+  async upsert_points(input, context) {
+    const collectionName = readCollectionName(input);
+    const points = readPoints(input.points);
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}/points?wait=true`,
+      "PUT",
+      { points },
+      "execute",
+    );
+    const result = requireObjectResult(payload, "Qdrant upsert response");
+    return {
+      operationId: readNullableInteger(result.operation_id, "operation_id"),
+      status: readWriteStatus(result.status),
+    };
+  },
+
+  async get_point(input, context) {
+    const collectionName = readCollectionName(input);
+    const id = readPointId(input.id);
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}/points/${encodeURIComponent(String(id))}`,
+      "GET",
+      undefined,
+      "execute",
+    );
+    return { point: requireObjectResult(payload, "Qdrant point response") };
+  },
+
+  async query_points(input, context) {
+    const collectionName = readCollectionName(input);
+    const body = {
+      query: readVector(input.vector, "vector"),
+      filter: optionalRecord(input.filter),
+      score_threshold: readOptionalNumber(input.scoreThreshold, "scoreThreshold"),
+      limit: readOptionalLimit(input.limit),
+      offset: readOptionalNonNegativeInteger(input.offset, "offset"),
+      with_payload: input.withPayload,
+      with_vector: input.withVector,
+    };
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}/points/query`,
+      "POST",
+      compactObject(body),
+      "execute",
+    );
+    const result = requireObjectResult(payload, "Qdrant query response");
+    return { points: Array.isArray(result.points) ? result.points : [] };
+  },
+
+  async scroll_points(input, context) {
+    const collectionName = readCollectionName(input);
+    const offset = input.offset === undefined ? undefined : readPointId(input.offset);
+    const body = {
+      offset,
+      filter: optionalRecord(input.filter),
+      limit: readOptionalLimit(input.limit),
+      with_payload: input.withPayload,
+      with_vector: input.withVector,
+    };
+    const payload = await requestQdrantJson(
+      context,
+      `/collections/${encodeURIComponent(collectionName)}/points/scroll`,
+      "POST",
+      compactObject(body),
+      "execute",
+    );
+    const result = requireObjectResult(payload, "Qdrant scroll response");
+    const nextOffset = readNullablePointId(result.next_page_offset);
+    return {
+      points: Array.isArray(result.points) ? result.points : [],
+      nextOffset,
+      complete: nextOffset === null,
+    };
+  },
+};
+
+export function createQdrantContext(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): QdrantContext {
+  return {
+    clusterUrl: normalizeQdrantClusterUrl(values.clusterUrl),
+    apiKey: requiredString(values.apiKey, "apiKey", providerInputError),
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateQdrantCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createQdrantContext(values, fetcher, signal);
+  const payload = await requestQdrantJson(context, "/collections", "GET", undefined, "validate");
+  const result = requireObjectResult(payload, "Qdrant collections response");
+  const collections = Array.isArray(result.collections) ? result.collections : [];
+
+  return {
+    profile: {
+      accountId: `${service}:${context.clusterUrl.hostname}`,
+      displayName: `Qdrant Cloud - ${context.clusterUrl.hostname}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      clusterUrl: context.clusterUrl.origin,
+      validationEndpoint: "/collections",
+      collectionCount: collections.length,
+    },
+  };
+}
+
+async function requestQdrantJson(
+  context: QdrantContext,
+  path: string,
+  method: QdrantHttpMethod,
+  body: object | undefined,
+  phase: QdrantRequestPhase,
+): Promise<unknown> {
+  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  try {
+    const response = await context.fetcher(new URL(path, `${context.clusterUrl.origin}/`), {
+      method,
+      headers: {
+        accept: "application/json",
+        "api-key": context.apiKey,
+        "user-agent": providerUserAgent,
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: timeout.signal,
+    });
+    const text = await readProviderTextBody(response, "Qdrant response");
+    const payload = parseProviderJsonBodyText(text, {
+      emptyBody: response.ok ? undefined : {},
+      invalidJsonMessage: "Qdrant returned invalid JSON",
+      invalidJsonFallback: response.ok ? undefined : (bodyText) => ({ error: bodyText }),
+    });
+    if (!response.ok) {
+      throw createQdrantError(response.status, payload, phase);
+    }
+    return readQdrantEnvelope(payload);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "Qdrant request timed out", error);
+    }
+    if (isAbortSignalError(context.signal, error)) {
+      throw new ProviderRequestError(499, "Qdrant request was cancelled", error);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Qdrant request failed: ${error.message}` : "Qdrant request failed",
+      error,
+    );
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function normalizeQdrantClusterUrl(value: string | undefined): URL {
+  const url = assertPublicHttpUrl(requiredString(value, "clusterUrl", providerInputError), {
+    fieldName: "clusterUrl",
+    createError: providerInputError,
+  });
+  if (url.protocol !== "https:") {
+    throw providerInputError("clusterUrl must use https");
+  }
+  if (url.username || url.password) {
+    throw providerInputError("clusterUrl must not include credentials");
+  }
+  if (url.port !== qdrantPort) {
+    throw providerInputError("clusterUrl must use port 6333");
+  }
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw providerInputError("clusterUrl must not include a path, query, or fragment");
+  }
+  if (!url.hostname.endsWith(qdrantHostnameSuffix) || url.hostname === qdrantHostnameSuffix.slice(1)) {
+    throw providerInputError("clusterUrl must use an official cloud.qdrant.io endpoint");
+  }
+  return url;
+}
+
+function readQdrantEnvelope(payload: unknown): unknown {
+  const record = optionalRecord(payload);
+  if (!record) {
+    throw providerResponseError("Qdrant response must be an object");
+  }
+  const status = optionalRecord(record.status);
+  const error = optionalString(status?.error) ?? optionalString(record.error);
+  if (error !== undefined) {
+    throw providerResponseError(error);
+  }
+  if (!Object.hasOwn(record, "result")) {
+    throw providerResponseError("Qdrant response is missing result");
+  }
+  return record.result;
+}
+
+function createQdrantError(status: number, payload: unknown, phase: QdrantRequestPhase): ProviderRequestError {
+  const record = optionalRecord(payload);
+  const errorStatus = optionalRecord(record?.status);
+  const message =
+    optionalString(errorStatus?.error) ??
+    optionalString(record?.error) ??
+    optionalString(record?.message) ??
+    `Qdrant request failed with status ${status}`;
+  if ((status === 401 || status === 403) && phase === "validate") {
+    return new ProviderRequestError(400, message);
+  }
+  return new ProviderRequestError(status >= 500 ? 502 : status || 502, message);
+}
+
+function readCollectionName(input: Record<string, unknown>): string {
+  return requiredString(input.collectionName, "collectionName", providerInputError);
+}
+
+function readPoints(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 1000) {
+    throw providerInputError("points must contain between 1 and 1000 points");
+  }
+  return value.map((point) => {
+    const record = optionalRecord(point);
+    if (!record) {
+      throw providerInputError("each point must be an object");
+    }
+    const unsupportedFields = Object.keys(record).filter(
+      (key) => key !== "id" && key !== "vector" && key !== "payload",
+    );
+    if (unsupportedFields.length > 0) {
+      throw providerInputError(`point contains unsupported fields: ${unsupportedFields.join(", ")}`);
+    }
+    const payload = record.payload;
+    if (payload !== undefined && !optionalRecord(payload)) {
+      throw providerInputError("point.payload must be a JSON object");
+    }
+    return compactObject({
+      id: readPointId(record.id),
+      vector: readVector(record.vector, "point.vector"),
+      payload,
+    });
+  });
+}
+
+function readPointId(value: unknown): number | string {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string" && uuidPattern.test(value)) {
+    return value;
+  }
+  throw providerInputError("id must be a non-negative integer or UUID");
+}
+
+function readNullablePointId(value: unknown): number | string | null {
+  return value === null || value === undefined ? null : readPointId(value);
+}
+
+function readVector(value: unknown, fieldName: string): number[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((component) => typeof component !== "number" || !Number.isFinite(component))
+  ) {
+    throw providerInputError(`${fieldName} must be a non-empty numeric array`);
+  }
+  return value as number[];
+}
+
+function readRequiredPositiveInteger(value: unknown, fieldName: string): number {
+  const integer = optionalInteger(value);
+  if (integer === undefined || integer < 1) {
+    throw providerInputError(`${fieldName} must be a positive integer`);
+  }
+  return integer;
+}
+
+function readOptionalLimit(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const limit = readRequiredPositiveInteger(value, "limit");
+  if (limit > 1000) throw providerInputError("limit must be between 1 and 1000");
+  return limit;
+}
+
+function readOptionalNonNegativeInteger(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) return undefined;
+  const integer = optionalInteger(value);
+  if (integer === undefined || integer < 0) throw providerInputError(`${fieldName} must be non-negative`);
+  return integer;
+}
+
+function readOptionalNumber(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) throw providerInputError(`${fieldName} must be a number`);
+  return value;
+}
+
+function readNullableInteger(value: unknown, fieldName: string): number | null {
+  if (value === null || value === undefined) return null;
+  const integer = optionalInteger(value);
+  if (integer === undefined || integer < 0) throw providerResponseError(`Qdrant returned an invalid ${fieldName}`);
+  return integer;
+}
+
+function readBooleanResult(payload: unknown, operation: string): boolean {
+  if (typeof payload !== "boolean") throw providerResponseError(`Qdrant returned an invalid ${operation} result`);
+  return payload;
+}
+
+function readWriteStatus(value: unknown): "acknowledged" | "completed" | "wait_timeout" {
+  if (value === "acknowledged" || value === "completed" || value === "wait_timeout") return value;
+  throw providerResponseError("Qdrant returned an invalid write status");
+}
+
+function requireObjectResult(payload: unknown, label: string): Record<string, unknown> {
+  const record = optionalRecord(payload);
+  if (!record) throw providerResponseError(`${label} must be an object`);
+  return record;
+}
+
+function isDistance(value: string): value is "Cosine" | "Euclid" | "Dot" | "Manhattan" {
+  return value === "Cosine" || value === "Euclid" || value === "Dot" || value === "Manhattan";
+}
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/qdrant/runtime.ts
+++ b/src/providers/qdrant/runtime.ts
@@ -1,8 +1,15 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
-import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import {
+  compactObject,
+  optionalInteger,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl, encodePathSegment } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortSignalError,
@@ -11,11 +18,11 @@ import {
   providerUserAgent,
   readProviderTextBody,
 } from "../provider-runtime.ts";
+import { qdrantUuidPattern } from "./actions.ts";
 
 const service = "qdrant";
 const requestTimeoutMs = 30_000;
 const qdrantHostnameSuffix = ".cloud.qdrant.io";
-const qdrantPort = "6333";
 
 type QdrantRequestPhase = "validate" | "execute";
 type QdrantHttpMethod = "GET" | "POST" | "PUT";
@@ -39,7 +46,7 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     const collectionName = readCollectionName(input);
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}`,
+      `/collections/${encodePathSegment(collectionName)}`,
       "GET",
       undefined,
       "execute",
@@ -56,7 +63,7 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     }
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}`,
+      `/collections/${encodePathSegment(collectionName)}`,
       "PUT",
       { vectors: { size: vectorSize, distance } },
       "execute",
@@ -69,7 +76,7 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     const points = readPoints(input.points);
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}/points?wait=true`,
+      `/collections/${encodePathSegment(collectionName)}/points?wait=true`,
       "PUT",
       { points },
       "execute",
@@ -86,12 +93,16 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     const id = readPointId(input.id);
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}/points/${encodeURIComponent(String(id))}`,
+      `/collections/${encodePathSegment(collectionName)}/points/${encodePathSegment(id)}`,
       "GET",
       undefined,
       "execute",
     );
-    return { point: requireObjectResult(payload, "Qdrant point response") };
+    const point = requireObjectResult(payload, "Qdrant point response");
+    if (!isPointId(point.id)) {
+      throw providerResponseError("Qdrant returned an invalid point ID");
+    }
+    return { point };
   },
 
   async query_points(input, context) {
@@ -107,13 +118,13 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     };
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}/points/query`,
+      `/collections/${encodePathSegment(collectionName)}/points/query`,
       "POST",
       compactObject(body),
       "execute",
     );
     const result = requireObjectResult(payload, "Qdrant query response");
-    return { points: Array.isArray(result.points) ? result.points : [] };
+    return { points: readPointRecords(result.points, "query") };
   },
 
   async scroll_points(input, context) {
@@ -128,7 +139,7 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     };
     const payload = await requestQdrantJson(
       context,
-      `/collections/${encodeURIComponent(collectionName)}/points/scroll`,
+      `/collections/${encodePathSegment(collectionName)}/points/scroll`,
       "POST",
       compactObject(body),
       "execute",
@@ -136,7 +147,7 @@ export const qdrantActionHandlers: Record<string, ProviderRuntimeHandler<QdrantC
     const result = requireObjectResult(payload, "Qdrant scroll response");
     const nextOffset = readNullablePointId(result.next_page_offset);
     return {
-      points: Array.isArray(result.points) ? result.points : [],
+      points: readPointRecords(result.points, "scroll"),
       nextOffset,
       complete: nextOffset === null,
     };
@@ -241,8 +252,8 @@ function normalizeQdrantClusterUrl(value: string | undefined): URL {
   if (url.username || url.password) {
     throw providerInputError("clusterUrl must not include credentials");
   }
-  if (url.port !== qdrantPort) {
-    throw providerInputError("clusterUrl must use port 6333");
+  if (url.port !== "" && url.port !== "6333") {
+    throw providerInputError("clusterUrl must use port 443 or 6333");
   }
   if (url.pathname !== "/" || url.search || url.hash) {
     throw providerInputError("clusterUrl must not include a path, query, or fragment");
@@ -284,7 +295,14 @@ function createQdrantError(status: number, payload: unknown, phase: QdrantReques
 }
 
 function readCollectionName(input: Record<string, unknown>): string {
-  return requiredString(input.collectionName, "collectionName", providerInputError);
+  const collectionName = optionalRawString(input.collectionName);
+  if (collectionName === undefined || collectionName.length === 0) {
+    throw providerInputError("collectionName is required");
+  }
+  if (collectionName === "." || collectionName === "..") {
+    throw providerInputError("collectionName must not be . or ..");
+  }
+  return collectionName;
 }
 
 function readPoints(value: unknown): Record<string, unknown>[] {
@@ -315,17 +333,35 @@ function readPoints(value: unknown): Record<string, unknown>[] {
 }
 
 function readPointId(value: unknown): number | string {
-  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+  if (isPointId(value)) {
     return value;
   }
-  if (typeof value === "string" && uuidPattern.test(value)) {
-    return value;
-  }
-  throw providerInputError("id must be a non-negative integer or UUID");
+  throw providerInputError("id must be a non-negative safe integer or UUID");
 }
 
 function readNullablePointId(value: unknown): number | string | null {
-  return value === null || value === undefined ? null : readPointId(value);
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (isPointId(value)) {
+    return value;
+  }
+  throw providerResponseError("Qdrant returned an invalid next_page_offset");
+}
+
+function isPointId(value: unknown): value is number | string {
+  return (
+    (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) ||
+    (typeof value === "string" && uuidPattern.test(value))
+  );
+}
+
+function readPointRecords(value: unknown, operation: string): unknown[] {
+  const points = Array.isArray(value) ? value : [];
+  if (points.some((point) => !isPointId(optionalRecord(point)?.id))) {
+    throw providerResponseError(`Qdrant returned an invalid ${operation} point ID`);
+  }
+  return points;
 }
 
 function readVector(value: unknown, fieldName: string): number[] {
@@ -370,7 +406,9 @@ function readOptionalNumber(value: unknown, fieldName: string): number | undefin
 function readNullableInteger(value: unknown, fieldName: string): number | null {
   if (value === null || value === undefined) return null;
   const integer = optionalInteger(value);
-  if (integer === undefined || integer < 0) throw providerResponseError(`Qdrant returned an invalid ${fieldName}`);
+  if (integer === undefined || !Number.isSafeInteger(integer) || integer < 0) {
+    throw providerResponseError(`Qdrant returned an invalid ${fieldName}`);
+  }
   return integer;
 }
 
@@ -394,7 +432,7 @@ function isDistance(value: string): value is "Cosine" | "Euclid" | "Dot" | "Manh
   return value === "Cosine" || value === "Euclid" || value === "Dot" || value === "Manhattan";
 }
 
-const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const uuidPattern = new RegExp(qdrantUuidPattern);
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);


### PR DESCRIPTION
## 中文

### 概要

新增 Qdrant Cloud Provider，通过官方 REST API 提供 7 个可本地执行的向量数据库 Action：

- `qdrant.list_collections`
- `qdrant.get_collection`
- `qdrant.create_collection`
- `qdrant.upsert_points`
- `qdrant.get_point`
- `qdrant.query_points`
- `qdrant.scroll_points`

### 主要变更

- 使用 `custom_credential`，支持 Qdrant Cloud `clusterUrl` 和 `apiKey`。
- Credential Validator 通过 `GET /collections` 验证数据库访问权限。
- 仅支持 HTTPS、官方 `*.cloud.qdrant.io` 主机和 `6333` 端口。
- 所有请求使用共享 SSRF 防护 Fetch，不启用私网访问或 DNS 校验绕过。
- 支持 unnamed dense vectors、JSON payload、基础 Qdrant filter 和单页 scroll 分页。
- Upsert 使用单次 `PUT .../points?wait=true` 请求，避免写入与可见性之间的竞态。
- 统一处理 Qdrant 响应包络、超时、取消、非 JSON 响应和 HTTP 错误。
- 严格拒绝 named/sparse vector 字段，保持首版能力边界清晰。
- 未增加 npm 依赖、共享运行时改动或 Provider Proxy。

### 验证

- Qdrant 定向测试：9/9 通过。
- 完整测试：58 个文件、557 个测试全部通过。
- TypeScript 检查通过。
- oxlint 通过。
- oxfmt 格式检查通过。
- Catalog 已生成并包含 7 个 Qdrant Action；生成文件未提交。

## English

### Summary

Add a locally executable Qdrant Cloud Provider backed by the official REST API with seven vector-database actions:

- `qdrant.list_collections`
- `qdrant.get_collection`
- `qdrant.create_collection`
- `qdrant.upsert_points`
- `qdrant.get_point`
- `qdrant.query_points`
- `qdrant.scroll_points`

### Changes

- Add `custom_credential` authentication with Qdrant Cloud `clusterUrl` and `apiKey`.
- Validate credentials through `GET /collections` to verify database access.
- Restrict URLs to HTTPS, official `*.cloud.qdrant.io` hosts, and port `6333`.
- Route every request through the shared SSRF-protected Fetch without private-network access or DNS-validation bypasses.
- Support unnamed dense vectors, JSON payloads, basic Qdrant filters, and single-page scroll pagination.
- Use one `PUT .../points?wait=true` request for upserts to provide write visibility without a separate race-prone request.
- Normalize Qdrant response envelopes and handle timeouts, cancellation, non-JSON responses, and HTTP errors consistently.
- Reject named/sparse vector fields explicitly to keep the initial capability boundary clear.
- Add no npm dependencies, shared runtime changes, or Provider Proxy.

### Verification

- Qdrant focused tests: 9/9 passed.
- Full test suite: 58 files, 557 tests passed.
- TypeScript check passed.
- oxlint passed.
- oxfmt check passed.
- Catalog generation includes all seven Qdrant actions; generated files are not committed.

## Scope Notes

This initial provider intentionally excludes self-hosted Qdrant, gRPC, named/sparse/multivectors, deletion operations, aliases, snapshots, payload indexes, and arbitrary endpoint proxying.