### PR TITLE
fix(home-assistant): respect OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK

### DIFF
--- a/src/providers/home_assistant/executors.ts
+++ b/src/providers/home_assistant/executors.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
 import type { HomeAssistantActionContext } from "./runtime.ts";
 
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
 import {
   homeAssistantActionHandlers,
@@ -13,6 +14,7 @@ const service = "home_assistant";
 export const executors: ProviderExecutors = defineProviderExecutors<HomeAssistantActionContext>({
   service,
   handlers: homeAssistantActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HomeAssistantActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setPrivateNetworkAccessAllowed } from "../core/request.ts";
+import { isPrivateNetworkAccessAllowed, setPrivateNetworkAccessAllowed } from "../core/request.ts";
 import {
   createProviderTimeout,
   defineProviderExecutors,
@@ -135,6 +135,68 @@ describe("provider egress SSRF guard", () => {
 
     expect(response.status).toBe(302);
     expect(calls).toHaveLength(1);
+  });
+
+  it("blocks private targets for executors that do not opt in", async () => {
+    const calls = stubFetchSequence([new Response("{}", { status: 200 })]);
+    const executors = defineProviderExecutors<{ fetcher: typeof fetch }>({
+      service: "test_service",
+      handlers: {
+        async probe(_input, context) {
+          return { status: (await context.fetcher("http://10.0.0.5:8123/api/")).status };
+        },
+      },
+      createContext: (_context, fetcher) => ({ fetcher }),
+    });
+    setPrivateNetworkAccessAllowed(true);
+
+    const result = await executors["test_service.probe"]!({}, executionContext);
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("must not target private or reserved IP addresses");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("reaches private targets for opted-in executors once the deployment enables the flag", async () => {
+    const calls = stubFetchSequence([new Response("{}", { status: 200 })]);
+    const executors = defineProviderExecutors<{ fetcher: typeof fetch }>({
+      service: "test_service",
+      handlers: {
+        async probe(_input, context) {
+          return { status: (await context.fetcher("http://10.0.0.5:8123/api/")).status };
+        },
+      },
+      createContext: (_context, fetcher) => ({ fetcher }),
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+    setPrivateNetworkAccessAllowed(true);
+
+    const result = await executors["test_service.probe"]!({}, executionContext);
+
+    expect(result.ok).toBe(true);
+    expect(calls.map((call) => call.url)).toEqual(["http://10.0.0.5:8123/api/"]);
+  });
+
+  it("keeps the opt-in gated on the deployment flag and never unblocks loopback", async () => {
+    const executors = defineProviderExecutors<{ fetcher: typeof fetch }>({
+      service: "test_service",
+      handlers: {
+        async probe(_input, context) {
+          return { status: (await context.fetcher(_input.url as string)).status };
+        },
+      },
+      createContext: (_context, fetcher) => ({ fetcher }),
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+
+    const calls = stubFetchSequence([]);
+    const disabled = await executors["test_service.probe"]!({ url: "http://10.0.0.5:8123/api/" }, executionContext);
+    setPrivateNetworkAccessAllowed(true);
+    const loopback = await executors["test_service.probe"]!({ url: "http://127.0.0.1:8123/api/" }, executionContext);
+
+    expect(disabled.ok).toBe(false);
+    expect(loopback.ok).toBe(false);
+    expect(calls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary
 
  - Home Assistant connections to a LAN instance fail with `request URL must not target private or reserved IP addresses`, even when the deployment sets
  `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`.
  - `src/providers/home_assistant/executors.ts` never passed `allowPrivateNetwork` to `defineProviderExecutors`, so the flag had no effect for this
  provider.
  - Adds the one-line opt-in, matching the 26 other providers that already wire it.

  ## Problem
 
  `defineProviderExecutors` builds a private-network-aware egress fetch only when a provider opts in; otherwise it falls back to the public-only  `providerFetch`. Home Assistant took that fallback, so the flag could never reach a `192.168.x.x` or `10.x.x.x` instance — the self-hosted case it  exists for. `homeassistant.local:8123`, the placeholder shown in the connection form, was unreachable for the same reason.
 
  Default behavior is unchanged: with the flag unset, private targets stay blocked. Loopback, link-local, and cloud-metadata targets stay blocked either  way.

  ## Scope

  Only the executor needed wiring. Home Assistant has no `assertPublicHttpUrl` call site to thread the flag into `resolveHomeAssistantBaseUrl` and  `validateHomeAssistantCredential` both route through the provider-local `normalizeBaseUrl` — and no `proxy.registry.ts` entry. Migrating  `normalizeBaseUrl` onto the shared `assertPublicHttpUrl` is a separate change, not attempted here.  
  
  ## Tests

  Added to `src/providers/provider-runtime.test.ts` rather than a provider-local file, per AGENTS.md: "Keep open-source-only shared-infrastructure tests  beside the shared module rather than inside a provider directory." Three cases cover the shared opt-in path: default blocks a private target, an  opted-in executor reaches it once the flag is enabled, and loopback stays blocked even then.

  ## Verification

  `npm run fix-check` (clean) and `npm test` — 57 files, 566 tests passing.