### PR TITLE
feat: sync private provider updates (batch 2)

### DIFF
--- a/src/providers/keepa/actions.ts
+++ b/src/providers/keepa/actions.ts
@@ -1,0 +1,616 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "keepa";
+
+export const keepaMarketplaces = ["US", "GB", "DE", "FR", "JP", "CA", "IT", "ES", "IN", "MX", "BR"] as const;
+
+export const keepaHistoryTypes = [
+  "AMAZON",
+  "NEW",
+  "USED",
+  "SALES",
+  "LISTPRICE",
+  "COLLECTIBLE",
+  "REFURBISHED",
+  "NEW_FBM_SHIPPING",
+  "LIGHTNING_DEAL",
+  "WAREHOUSE",
+  "NEW_FBA",
+  "COUNT_NEW",
+  "COUNT_USED",
+  "COUNT_REFURBISHED",
+  "COUNT_COLLECTIBLE",
+  "EXTRA_INFO_UPDATES",
+  "RATING",
+  "COUNT_REVIEWS",
+  "BUY_BOX_SHIPPING",
+  "USED_NEW_SHIPPING",
+  "USED_VERY_GOOD_SHIPPING",
+  "USED_GOOD_SHIPPING",
+  "USED_ACCEPTABLE_SHIPPING",
+  "COLLECTIBLE_NEW_SHIPPING",
+  "COLLECTIBLE_VERY_GOOD_SHIPPING",
+  "COLLECTIBLE_GOOD_SHIPPING",
+  "COLLECTIBLE_ACCEPTABLE_SHIPPING",
+  "REFURBISHED_SHIPPING",
+  "EBAY_NEW_SHIPPING",
+  "EBAY_USED_SHIPPING",
+  "TRADE_IN",
+  "RENT",
+  "BUY_BOX_USED_SHIPPING",
+  "PRIME_EXCL",
+  "COUNT_NEW_FBA",
+  "COUNT_NEW_FBM",
+] as const;
+
+export const keepaDealPriceTypes = [
+  "AMAZON",
+  "NEW",
+  "USED",
+  "SALES",
+  "COLLECTIBLE",
+  "REFURBISHED",
+  "NEW_FBM_SHIPPING",
+  "LIGHTNING_DEAL",
+  "WAREHOUSE",
+  "NEW_FBA",
+  "USED_NEW_SHIPPING",
+  "USED_VERY_GOOD_SHIPPING",
+  "USED_GOOD_SHIPPING",
+  "USED_ACCEPTABLE_SHIPPING",
+  "COLLECTIBLE_NEW_SHIPPING",
+  "COLLECTIBLE_VERY_GOOD_SHIPPING",
+  "COLLECTIBLE_GOOD_SHIPPING",
+  "COLLECTIBLE_ACCEPTABLE_SHIPPING",
+  "REFURBISHED_SHIPPING",
+  "BUY_BOX_USED_SHIPPING",
+  "PRIME_EXCL",
+] as const;
+
+const marketplaceSchema = s.stringEnum(
+  "Amazon marketplace code using Keepa's official AmazonLocale names.",
+  keepaMarketplaces,
+);
+
+const asinSchema = s.stringPattern("^[A-Za-z0-9]{10}$", {
+  description: "A 10-character Amazon ASIN containing only ASCII letters or digits.",
+});
+
+const asinsSchema = s.array("Amazon ASINs to request.", asinSchema, {
+  minItems: 1,
+  maxItems: 100,
+});
+
+const productRequestOptionalFields: Record<string, JsonSchema> = {
+  statsDays: s.positiveInteger("Number of recent days used for Keepa summary statistics at no additional token cost."),
+  updateHours: s.nonNegativeInteger(
+    "Refresh data when Keepa's stored product data is older than this many hours; zero may consume an extra token per product.",
+  ),
+  offers: s.integer(
+    "Number of marketplace offers to include; values from 20 through 100 may increase token cost and limit the request to 20 ASINs.",
+    {
+      minimum: 20,
+      maximum: 100,
+    },
+  ),
+  onlyLiveOffers: s.boolean("Whether to omit historical offers when offers are requested, reducing response size."),
+  includeBuyBox: s.boolean(
+    "Whether to include Keepa buy box data; this may consume two additional tokens per product when offers are not requested.",
+  ),
+  includeRating: s.boolean("Whether to include existing rating and review-count history in the product payload."),
+};
+
+const responseMetaSchema = s.object("Keepa request and token-budget metadata.", {
+  timestamp: s.nullableInteger("Keepa server response time in Unix epoch milliseconds."),
+  tokensLeft: s.nullableInteger("Tokens remaining after this request."),
+  refillInMs: s.nullableInteger("Milliseconds until Keepa next refills tokens."),
+  refillRatePerMinute: s.nullableInteger("Number of Keepa tokens refilled per minute."),
+  tokensConsumed: s.nullableInteger("Tokens consumed by this request."),
+  processingTimeMs: s.nullableInteger("Server-side processing time in milliseconds."),
+});
+
+const namedIntegerValuesSchema = s.record(
+  "Values keyed by official Keepa Product.CsvType name.",
+  s.nullable(
+    s.integer(
+      "A Keepa price, rank, count, rating, or metadata value; price values use the marketplace's smallest currency unit.",
+    ),
+  ),
+);
+
+const namedBooleanValuesSchema = s.record(
+  "Boolean values keyed by official Keepa Product.CsvType name.",
+  s.boolean("A Keepa statistic flag."),
+);
+
+const productStatsSchema = s.object("Named Keepa product statistics.", {
+  current: namedIntegerValuesSchema,
+  average: namedIntegerValuesSchema,
+  average30Days: namedIntegerValuesSchema,
+  average90Days: namedIntegerValuesSchema,
+  average180Days: namedIntegerValuesSchema,
+  average365Days: namedIntegerValuesSchema,
+  atIntervalStart: namedIntegerValuesSchema,
+  isLowestEver: namedBooleanValuesSchema,
+  isLowest90Days: namedBooleanValuesSchema,
+  raw: s.looseObject("The complete Keepa stats object."),
+});
+
+const productSnapshotSchema = s.object("A normalized Keepa product snapshot.", {
+  asin: s.string("Amazon ASIN."),
+  domainId: s.nullableInteger("Keepa Amazon locale identifier."),
+  title: s.nullableString("Amazon product title."),
+  brand: s.nullableString("Product brand."),
+  manufacturer: s.nullableString("Product manufacturer."),
+  productGroup: s.nullableString("Amazon product group."),
+  parentAsin: s.nullableString("Parent ASIN when this product is a variation."),
+  rootCategory: s.nullableInteger("Root Amazon category node identifier."),
+  categories: s.array(
+    "Amazon category node identifiers assigned to the product.",
+    s.integer("One Amazon category node identifier."),
+  ),
+  imageUrls: s.array(
+    "Resolved Amazon image URLs derived from Keepa image metadata.",
+    s.string("One Amazon media image URL."),
+  ),
+  monthlySold: s.nullableInteger("Estimated monthly sold count when available."),
+  lastUpdate: s.nullableInteger("Last product update in Keepa Time minutes."),
+  stats: s.nullable(productStatsSchema),
+  raw: s.looseObject("The complete Keepa product object."),
+});
+
+const productSnapshotOutputSchema = s.actionOutput(
+  {
+    marketplace: marketplaceSchema,
+    priceValuesUseMinorUnits: s.literal(true, {
+      description: "Whether price integers remain in the marketplace's smallest currency unit.",
+    }),
+    products: s.array("Products returned by Keepa.", productSnapshotSchema),
+    meta: responseMetaSchema,
+  },
+  "Keepa product snapshot response.",
+);
+
+const historyPointSchema = s.object("One normalized Keepa history data point.", {
+  keepaTime: s.integer("Original Keepa Time value in minutes."),
+  timestamp: s.dateTime("UTC timestamp converted from Keepa Time."),
+  value: s.integer(
+    "History value; price values use the marketplace's smallest currency unit and -1 represents no offer.",
+  ),
+  shipping: s.nullableInteger(
+    "Shipping amount in the marketplace's smallest currency unit when this history type records it separately.",
+  ),
+});
+
+const historySeriesSchema = s.object("One named Keepa product history series.", {
+  type: s.stringEnum("Official Keepa Product.CsvType name.", keepaHistoryTypes),
+  index: s.integer("Official Keepa Product.CsvType array index."),
+  unit: s.stringEnum("Unit interpretation for values in this series.", [
+    "minor_currency_unit",
+    "sales_rank",
+    "count",
+    "rating_tenths",
+    "metadata",
+  ]),
+  includesShipping: s.boolean("Whether each raw point contains a separate shipping value after the main value."),
+  points: s.array("Chronological history points.", historyPointSchema),
+});
+
+const productHistorySchema = s.object("Normalized Keepa history for one product.", {
+  asin: s.string("Amazon ASIN."),
+  title: s.nullableString("Amazon product title."),
+  brand: s.nullableString("Product brand."),
+  series: s.array("Named Keepa history series.", historySeriesSchema),
+  raw: s.looseObject("The complete Keepa product object including raw history arrays."),
+});
+
+const productHistoryOutputSchema = s.actionOutput(
+  {
+    marketplace: marketplaceSchema,
+    priceValuesUseMinorUnits: s.literal(true, {
+      description: "Whether price integers remain in the marketplace's smallest currency unit.",
+    }),
+    products: s.array("Products and normalized histories returned by Keepa.", productHistorySchema),
+    meta: responseMetaSchema,
+  },
+  "Keepa product history response.",
+);
+
+const productFinderSortRuleSchema: JsonSchema = {
+  type: "array",
+  prefixItems: [
+    s.nonEmptyString("Official Product Finder field name used for sorting."),
+    s.stringEnum("Sort direction.", ["asc", "desc"]),
+  ],
+  items: false,
+  minItems: 2,
+  maxItems: 2,
+  description: "One official Keepa Product Finder sort rule.",
+};
+
+const productFinderSortSchema = s.array("Product Finder sort rules in priority order.", productFinderSortRuleSchema, {
+  minItems: 1,
+});
+
+const productFinderFiltersSchema = s.looseObject(
+  "Official Keepa ProductFinderRequest fields. Unknown official fields are preserved for forward compatibility.",
+  {
+    title: s.nonEmptyString("Case-insensitive product title search text."),
+    brand: s.stringArray("Brands to include.", {
+      minItems: 1,
+      itemDescription: "One brand name.",
+    }),
+    manufacturer: s.stringArray("Manufacturers to include.", {
+      minItems: 1,
+      itemDescription: "One manufacturer name.",
+    }),
+    categories_include: s.array("Amazon category node IDs to include.", s.integer("One category node ID."), {
+      minItems: 1,
+    }),
+    categories_exclude: s.array("Amazon category node IDs to exclude.", s.integer("One category node ID."), {
+      minItems: 1,
+    }),
+    buyBoxSellerId: s.stringArray("Buy Box seller IDs to include.", {
+      minItems: 1,
+      itemDescription: "One Amazon seller ID.",
+    }),
+    current_AMAZON_gte: s.integer("Minimum current Amazon price in the marketplace's smallest currency unit."),
+    current_AMAZON_lte: s.integer("Maximum current Amazon price in the marketplace's smallest currency unit."),
+    current_NEW_gte: s.integer("Minimum current Marketplace New price in the marketplace's smallest currency unit."),
+    current_NEW_lte: s.integer("Maximum current Marketplace New price in the marketplace's smallest currency unit."),
+    current_BUY_BOX_SHIPPING_gte: s.integer(
+      "Minimum current New Buy Box price including shipping in the marketplace's smallest currency unit.",
+    ),
+    current_BUY_BOX_SHIPPING_lte: s.integer(
+      "Maximum current New Buy Box price including shipping in the marketplace's smallest currency unit.",
+    ),
+    current_SALES_gte: s.integer("Minimum current sales rank."),
+    current_SALES_lte: s.integer("Maximum current sales rank."),
+    current_RATING_gte: s.integer("Minimum product rating multiplied by 10.", {
+      minimum: 0,
+      maximum: 50,
+    }),
+    current_RATING_lte: s.integer("Maximum product rating multiplied by 10.", {
+      minimum: 0,
+      maximum: 50,
+    }),
+    current_COUNT_REVIEWS_gte: s.nonNegativeInteger("Minimum current review count."),
+    current_COUNT_REVIEWS_lte: s.nonNegativeInteger("Maximum current review count."),
+    monthlySold_gte: s.nonNegativeInteger("Minimum estimated monthly sold count."),
+    monthlySold_lte: s.nonNegativeInteger("Maximum estimated monthly sold count."),
+    totalOfferCount_gte: s.nonNegativeInteger("Minimum total offer count."),
+    totalOfferCount_lte: s.nonNegativeInteger("Maximum total offer count."),
+    hasReviews: s.boolean("Whether products must have review data."),
+    isLowest_AMAZON: s.boolean("Whether the current Amazon price must be the lowest value since tracking began."),
+    isLowest_NEW: s.boolean("Whether the current Marketplace New price must be the lowest value since tracking began."),
+    isPrimeExclusive: s.boolean("Whether to include only Prime Exclusive products."),
+    hasAPlus: s.boolean("Whether products must include A+ content."),
+    hasMainVideo: s.boolean("Whether products must include a main video."),
+    sort: productFinderSortSchema,
+    page: s.nonNegativeInteger("Zero-based Product Finder result page."),
+    perPage: s.integer("Number of ASINs requested per Product Finder page.", {
+      minimum: 1,
+    }),
+  },
+);
+
+const categorySchema = s.looseObject("One category object returned by Keepa.", {
+  catId: s.nullableInteger("Amazon category node identifier."),
+  domainId: s.nullableInteger("Keepa Amazon locale identifier."),
+  name: s.nullableString("Amazon category name."),
+  parent: s.nullableInteger("Parent category node identifier."),
+  children: s.nullable(s.array("Child category node identifiers.", s.integer("One child category node identifier."))),
+  productCount: s.nullableInteger("Estimated product count."),
+  sellerCount: s.nullableInteger("Estimated distinct seller count."),
+});
+
+const dealRangeSchema: JsonSchema = {
+  type: "array",
+  prefixItems: [
+    s.integer("Range lower bound."),
+    s.integer("Range upper bound; some Keepa ranges accept -1 as an open upper bound."),
+  ],
+  items: false,
+  minItems: 2,
+  maxItems: 2,
+  description: "Inclusive two-value range.",
+};
+
+const getTokenStatusAction = defineProviderAction(service, {
+  name: "get_token_status",
+  description: "Retrieve Keepa token availability and refill information without consuming tokens.",
+  requiredScopes: [],
+  inputSchema: s.actionInput({}, [], "Input for retrieving Keepa token status."),
+  outputSchema: s.actionOutput(
+    {
+      meta: responseMetaSchema,
+    },
+    "Current Keepa token status.",
+  ),
+});
+
+const getProductSnapshotAction = defineProviderAction(service, {
+  name: "get_product_snapshot",
+  description: "Retrieve current Keepa product metadata and named statistics for one or more Amazon ASINs.",
+  requiredScopes: [],
+  inputSchema: withProductRequestRules(
+    s.actionInput(
+      {
+        marketplace: marketplaceSchema,
+        asins: asinsSchema,
+        ...productRequestOptionalFields,
+      },
+      ["marketplace", "asins"],
+      "Input for retrieving Keepa product snapshots.",
+    ),
+  ),
+  outputSchema: productSnapshotOutputSchema,
+});
+
+const getProductHistoryAction = defineProviderAction(service, {
+  name: "get_product_history",
+  description:
+    "Retrieve named, timestamped Keepa price, rank, offer-count, rating, and review history for Amazon ASINs.",
+  requiredScopes: [],
+  inputSchema: withProductRequestRules(
+    s.actionInput(
+      {
+        marketplace: marketplaceSchema,
+        asins: asinsSchema,
+        days: s.positiveInteger("Limit all returned history to the most recent number of 24-hour periods."),
+        historyTypes: s.array(
+          "Keepa history series to include in the normalized output.",
+          s.stringEnum("One official Keepa Product.CsvType name.", keepaHistoryTypes),
+          { minItems: 1 },
+        ),
+        ...productRequestOptionalFields,
+      },
+      ["marketplace", "asins"],
+      "Input for retrieving Keepa product history.",
+    ),
+  ),
+  outputSchema: productHistoryOutputSchema,
+});
+
+const findProductsAction = defineProviderAction(service, {
+  name: "find_products",
+  description: "Find Amazon ASINs with Keepa Product Finder filters using official ProductFinderRequest field names.",
+  requiredScopes: [],
+  inputSchema: s.actionInput(
+    {
+      marketplace: marketplaceSchema,
+      filters: productFinderFiltersSchema,
+    },
+    ["marketplace", "filters"],
+    "Input for finding products in the Keepa catalog.",
+  ),
+  outputSchema: s.actionOutput(
+    {
+      marketplace: marketplaceSchema,
+      asins: s.array("Matching Amazon ASINs.", s.string("One Amazon ASIN.")),
+      totalResults: s.nullableInteger("Estimated total number of matching products."),
+      meta: responseMetaSchema,
+    },
+    "Keepa Product Finder results.",
+  ),
+});
+
+const searchCategoriesAction = defineProviderAction(service, {
+  name: "search_categories",
+  description: "Search Keepa Amazon categories by name so category IDs can be used in product and best-seller queries.",
+  requiredScopes: [],
+  inputSchema: s.actionInput(
+    {
+      marketplace: marketplaceSchema,
+      term: s.nonEmptyString("Space-separated category keywords; each keyword must contain at least three characters."),
+      includeParents: s.boolean("Whether Keepa should include the parent tree for each category."),
+    },
+    ["marketplace", "term"],
+    "Input for searching Keepa categories.",
+  ),
+  outputSchema: s.actionOutput(
+    {
+      marketplace: marketplaceSchema,
+      categories: s.array("Matching categories.", categorySchema),
+      categoryParents: s.array("Parent categories returned when requested.", categorySchema),
+      meta: responseMetaSchema,
+    },
+    "Keepa category search results.",
+  ),
+});
+
+const getBestSellersAction = defineProviderAction(service, {
+  name: "get_best_sellers",
+  description: "Retrieve Keepa's ordered Amazon best-seller ASIN list for a category node or website display group.",
+  requiredScopes: [],
+  inputSchema: s.actionInput(
+    {
+      marketplace: marketplaceSchema,
+      category: s.anyOf("Amazon category node ID or Keepa website display group name.", [
+        s.nonNegativeInteger("Amazon category node ID."),
+        s.nonEmptyString("Keepa website display group name."),
+      ]),
+    },
+    ["marketplace", "category"],
+    "Input for retrieving Keepa best sellers.",
+  ),
+  outputSchema: s.actionOutput(
+    {
+      marketplace: marketplaceSchema,
+      categoryId: s.nullableInteger("Amazon category node ID resolved by Keepa."),
+      lastUpdate: s.nullableInteger("Best-seller list update time in Keepa Time minutes."),
+      asins: s.array(
+        "Ordered Amazon ASINs, starting with the product having the lowest sales rank.",
+        s.string("One Amazon ASIN."),
+      ),
+      raw: s.looseObject("The complete Keepa bestSellersList object."),
+      meta: responseMetaSchema,
+    },
+    "Keepa best-seller results.",
+  ),
+});
+
+const findDealsAction = defineProviderAction(service, {
+  name: "find_deals",
+  description: "Find recently changed Amazon products with Keepa deal filters and bounded pagination.",
+  requiredScopes: [],
+  inputSchema: s.actionInput(
+    {
+      marketplace: marketplaceSchema,
+      priceType: s.stringEnum("Keepa price or rank type whose change defines the deal.", keepaDealPriceTypes),
+      page: s.nonNegativeInteger("Zero-based deal result page; each page contains at most 150 deals."),
+      dateRange: s.integer("Change interval: 0 for one day, 1 for one week, 2 for one month, or 3 for 90 days.", {
+        minimum: 0,
+        maximum: 3,
+      }),
+      includeCategories: s.array("Amazon category node IDs to include.", s.integer("One category node ID."), {
+        minItems: 1,
+      }),
+      excludeCategories: s.array("Amazon category node IDs to exclude.", s.integer("One category node ID."), {
+        minItems: 1,
+      }),
+      currentRange: dealRangeSchema,
+      deltaRange: dealRangeSchema,
+      deltaPercentRange: dealRangeSchema,
+      salesRankRange: dealRangeSchema,
+      titleSearch: s.nonEmptyString("Case-insensitive title keywords that must all appear in the product title."),
+      minimumRating: s.integer("Minimum product rating multiplied by 10.", {
+        minimum: 0,
+        maximum: 50,
+      }),
+      sortBy: s.stringEnum("Deal result sorting rule.", ["newest", "absolute_delta", "sales_rank", "percentage_delta"]),
+      invertSort: s.boolean("Whether to invert Keepa's default sort direction; newest cannot be inverted."),
+      isLowestEver: s.boolean("Whether the selected price must be the lowest value since tracking began."),
+      isLowest90Days: s.boolean("Whether the selected price must be the lowest value in the past 90 days."),
+      isLowestOffer: s.boolean("Whether the selected price must be the lowest of all New offers."),
+      isBackInStock: s.boolean("Whether to include only products that returned to stock in the past 24 hours."),
+      isOutOfStock: s.boolean("Whether to include only products that went out of stock in the past 24 hours."),
+      hasReviews: s.boolean("Whether to exclude products without reviews."),
+      isPrimeExclusive: s.boolean("Whether to include only Prime Exclusive products."),
+      mustHaveAmazonOffer: s.boolean("Whether products must have an offer sold and fulfilled by Amazon."),
+      mustNotHaveAmazonOffer: s.boolean("Whether products must not have an offer sold and fulfilled by Amazon."),
+    },
+    ["marketplace", "priceType"],
+    "Input for finding Keepa deals.",
+  ),
+  outputSchema: s.actionOutput(
+    {
+      marketplace: marketplaceSchema,
+      deals: s.array(
+        "Deal records returned by Keepa.",
+        s.looseObject("One Keepa deal record.", {
+          asin: s.nullableString("Amazon ASIN."),
+          title: s.nullableString("Amazon product title."),
+        }),
+      ),
+      categoryIds: s.array("Root category IDs represented in the results.", s.integer("One root category ID.")),
+      categoryNames: s.array("Root category names represented in the results.", s.string("One root category name.")),
+      categoryCount: s.array(
+        "Deal counts aligned with categoryIds and categoryNames.",
+        s.integer("Deal count for one root category."),
+      ),
+      raw: s.looseObject("The complete Keepa deals response object."),
+      meta: responseMetaSchema,
+    },
+    "Keepa deal search results.",
+  ),
+});
+
+const getSellerSnapshotAction = defineProviderAction(service, {
+  name: "get_seller_snapshot",
+  description:
+    "Retrieve compact Keepa marketplace seller profiles, ratings, category statistics, brands, and competitors.",
+  requiredScopes: [],
+  inputSchema: s.actionInput(
+    {
+      marketplace: marketplaceSchema,
+      sellerIds: s.array("Amazon marketplace seller IDs.", s.nonEmptyString("One Amazon seller ID."), {
+        minItems: 1,
+        maxItems: 100,
+      }),
+    },
+    ["marketplace", "sellerIds"],
+    "Input for retrieving Keepa seller snapshots.",
+  ),
+  outputSchema: s.actionOutput(
+    {
+      marketplace: marketplaceSchema,
+      sellers: s.array(
+        "Seller profiles returned by Keepa.",
+        s.looseObject("One normalized Keepa seller profile.", {
+          sellerId: s.string("Amazon seller ID."),
+          sellerName: s.nullableString("Amazon seller display name."),
+          currentRating: s.nullableInteger("Current seller rating percentage."),
+          ratingCount: s.nullable(
+            s.array(
+              "Rating counts for the last 30, 90, and 365 days and lifetime.",
+              s.integer("One seller rating count."),
+            ),
+          ),
+          hasFba: s.nullableBoolean("Whether Keepa has observed current FBA listings."),
+          shipsFromChina: s.nullableBoolean("Whether Keepa identifies the seller as shipping from China."),
+          raw: s.looseObject("The complete Keepa seller object."),
+        }),
+      ),
+      meta: responseMetaSchema,
+    },
+    "Keepa seller snapshot results.",
+  ),
+});
+
+export type KeepaActionName =
+  | "get_token_status"
+  | "get_product_snapshot"
+  | "get_product_history"
+  | "find_products"
+  | "search_categories"
+  | "get_best_sellers"
+  | "find_deals"
+  | "get_seller_snapshot";
+
+export const keepaActions: ActionDefinition[] = [
+  getTokenStatusAction,
+  getProductSnapshotAction,
+  getProductHistoryAction,
+  findProductsAction,
+  searchCategoriesAction,
+  getBestSellersAction,
+  findDealsAction,
+  getSellerSnapshotAction,
+];
+
+function withProductRequestRules(schema: JsonSchema): JsonSchema {
+  return {
+    ...schema,
+    allOf: [
+      {
+        if: {
+          required: ["offers"],
+        },
+        then: {
+          properties: {
+            asins: {
+              maxItems: 20,
+            },
+          },
+        },
+      },
+      {
+        if: {
+          required: ["onlyLiveOffers"],
+          properties: {
+            onlyLiveOffers: {
+              const: true,
+            },
+          },
+        },
+        then: {
+          required: ["offers"],
+        },
+      },
+    ],
+  };
+}

--- a/src/providers/keepa/definition.ts
+++ b/src/providers/keepa/definition.ts
@@ -1,0 +1,23 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { keepaActions } from "./actions.ts";
+
+const service = "keepa";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Keepa",
+  categories: ["Data", "Marketing"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Access Key",
+      placeholder: "KEEPA_API_KEY",
+      description:
+        "Private Keepa API access key passed as the key query parameter. Subscribe to Keepa Data Access and view your key at https://keepa.com/#!api.",
+    },
+  ],
+  homepageUrl: "https://keepa.com",
+  actions: keepaActions,
+};

--- a/src/providers/keepa/executors.ts
+++ b/src/providers/keepa/executors.ts
@@ -1,0 +1,26 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+
+import { defineApiKeyProviderExecutors, defineProviderProxy } from "../provider-runtime.ts";
+import { keepaActionHandlers, keepaApiBaseUrl, validateKeepaCredential } from "./runtime.ts";
+
+const service = "keepa";
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, keepaActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: keepaApiBaseUrl,
+  auth: { type: "api_key_query", name: "key" },
+  customizeRequest({ headers }) {
+    headers.set("accept", "application/json");
+  },
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validateKeepaCredential(input.apiKey, fetcher, signal);
+  },
+};

--- a/src/providers/keepa/runtime.ts
+++ b/src/providers/keepa/runtime.ts
@@ -1,0 +1,796 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { KeepaActionName, keepaDealPriceTypes, keepaHistoryTypes, keepaMarketplaces } from "./actions.ts";
+
+import { compactObject, optionalRawString, optionalRecord, requiredString } from "../../core/cast.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
+import { keepaDealPriceTypes as dealPriceTypes, keepaHistoryTypes as historyTypes } from "./actions.ts";
+
+export const keepaApiBaseUrl = "https://api.keepa.com";
+
+type KeepaMarketplace = (typeof keepaMarketplaces)[number];
+type KeepaHistoryType = (typeof keepaHistoryTypes)[number];
+type KeepaDealPriceType = (typeof keepaDealPriceTypes)[number];
+type KeepaPhase = "validate" | "execute";
+type KeepaActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
+
+interface KeepaRequest {
+  path: string;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: Record<string, unknown>;
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
+  phase: KeepaPhase;
+}
+
+interface KeepaMetricDefinition {
+  type: KeepaHistoryType;
+  index: number;
+  isPrice: boolean;
+  includesShipping: boolean;
+  unit: "minor_currency_unit" | "sales_rank" | "count" | "rating_tenths" | "metadata";
+}
+
+const keepaTimeStartMinutes = 21_564_000;
+const keepaDefaultTimeoutMs = 120_000;
+
+const marketplaceDomainIdByCode: Record<KeepaMarketplace, number> = {
+  US: 1,
+  GB: 2,
+  DE: 3,
+  FR: 4,
+  JP: 5,
+  CA: 6,
+  IT: 8,
+  ES: 9,
+  IN: 10,
+  MX: 11,
+  BR: 12,
+};
+
+const keepaMetrics: KeepaMetricDefinition[] = [
+  metric("AMAZON", 0, true),
+  metric("NEW", 1, true),
+  metric("USED", 2, true),
+  metric("SALES", 3, false, false, "sales_rank"),
+  metric("LISTPRICE", 4, true),
+  metric("COLLECTIBLE", 5, true),
+  metric("REFURBISHED", 6, true),
+  metric("NEW_FBM_SHIPPING", 7, true, true),
+  metric("LIGHTNING_DEAL", 8, true),
+  metric("WAREHOUSE", 9, true),
+  metric("NEW_FBA", 10, true),
+  metric("COUNT_NEW", 11, false, false, "count"),
+  metric("COUNT_USED", 12, false, false, "count"),
+  metric("COUNT_REFURBISHED", 13, false, false, "count"),
+  metric("COUNT_COLLECTIBLE", 14, false, false, "count"),
+  metric("EXTRA_INFO_UPDATES", 15, false, false, "metadata"),
+  metric("RATING", 16, false, false, "rating_tenths"),
+  metric("COUNT_REVIEWS", 17, false, false, "count"),
+  metric("BUY_BOX_SHIPPING", 18, true, true),
+  metric("USED_NEW_SHIPPING", 19, true, true),
+  metric("USED_VERY_GOOD_SHIPPING", 20, true, true),
+  metric("USED_GOOD_SHIPPING", 21, true, true),
+  metric("USED_ACCEPTABLE_SHIPPING", 22, true, true),
+  metric("COLLECTIBLE_NEW_SHIPPING", 23, true, true),
+  metric("COLLECTIBLE_VERY_GOOD_SHIPPING", 24, true, true),
+  metric("COLLECTIBLE_GOOD_SHIPPING", 25, true, true),
+  metric("COLLECTIBLE_ACCEPTABLE_SHIPPING", 26, true, true),
+  metric("REFURBISHED_SHIPPING", 27, true, true),
+  metric("EBAY_NEW_SHIPPING", 28, true, true),
+  metric("EBAY_USED_SHIPPING", 29, true, true),
+  metric("TRADE_IN", 30, true),
+  metric("RENT", 31, true),
+  metric("BUY_BOX_USED_SHIPPING", 32, true, true),
+  metric("PRIME_EXCL", 33, true),
+  metric("COUNT_NEW_FBA", 34, false, false, "count"),
+  metric("COUNT_NEW_FBM", 35, false, false, "count"),
+];
+
+const keepaMetricByType = new Map(keepaMetrics.map((item) => [item.type, item]));
+const keepaHistoryTypeSet = new Set<KeepaHistoryType>(historyTypes);
+const keepaDealPriceTypeSet = new Set<KeepaDealPriceType>(dealPriceTypes);
+
+const dealSortTypeByName = {
+  newest: 1,
+  absolute_delta: 2,
+  sales_rank: 3,
+  percentage_delta: 4,
+} as const;
+
+export const keepaActionHandlers: Record<KeepaActionName, KeepaActionHandler> = {
+  async get_token_status(_input, context) {
+    const payload = await requestKeepa({
+      path: "/token",
+      context,
+      phase: "execute",
+    });
+    return { meta: normalizeMeta(payload) };
+  },
+
+  async get_product_snapshot(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const payload = await requestKeepa({
+      path: "/product",
+      query: buildProductQuery(input, marketplace, false),
+      context,
+      phase: "execute",
+    });
+    return {
+      marketplace,
+      priceValuesUseMinorUnits: true,
+      products: readObjectArray(payload.products).map(normalizeProductSnapshot),
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async get_product_history(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const requestedTypes = readRequestedHistoryTypes(input.historyTypes);
+    const payload = await requestKeepa({
+      path: "/product",
+      query: {
+        ...buildProductQuery(input, marketplace, true),
+        ...(typeof input.days === "number" ? { days: input.days } : {}),
+      },
+      context,
+      phase: "execute",
+    });
+    return {
+      marketplace,
+      priceValuesUseMinorUnits: true,
+      products: readObjectArray(payload.products).map((product) => normalizeProductHistory(product, requestedTypes)),
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async find_products(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const filters = requireInputObject(input.filters, "filters");
+    const payload = await requestKeepa({
+      path: "/query",
+      query: {
+        domain: marketplaceDomainIdByCode[marketplace],
+        selection: JSON.stringify(filters),
+      },
+      context,
+      phase: "execute",
+    });
+    return {
+      marketplace,
+      asins: readStringArray(payload.asinList),
+      totalResults: asNullableInteger(payload.totalResults),
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async search_categories(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const term = readRequiredInputString(input.term, "term");
+    validateCategorySearchTerm(term);
+    const payload = await requestKeepa({
+      path: "/search",
+      query: {
+        domain: marketplaceDomainIdByCode[marketplace],
+        type: "category",
+        term,
+        ...(input.includeParents === true ? { parents: 1 } : {}),
+      },
+      context,
+      phase: "execute",
+    });
+    return {
+      marketplace,
+      categories: objectMapValues(payload.categories),
+      categoryParents: objectMapValues(payload.categoryParents),
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async get_best_sellers(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const category = input.category;
+    if (typeof category !== "string" && typeof category !== "number") {
+      throw new ProviderRequestError(400, "category is required");
+    }
+    const payload = await requestKeepa({
+      path: "/bestsellers",
+      query: {
+        domain: marketplaceDomainIdByCode[marketplace],
+        category,
+      },
+      context,
+      phase: "execute",
+    });
+    const bestSellers = optionalRecord(payload.bestSellersList) ?? {};
+    return {
+      marketplace,
+      categoryId: asNullableInteger(bestSellers.categoryId),
+      lastUpdate: asNullableInteger(bestSellers.lastUpdate),
+      asins: readStringArray(bestSellers.asinList),
+      raw: bestSellers,
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async find_deals(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const priceType = requireDealPriceType(input.priceType);
+    const payload = await requestKeepa({
+      path: "/deal",
+      body: buildDealRequest(input, marketplace, priceType),
+      context,
+      phase: "execute",
+    });
+    const deals = optionalRecord(payload.deals) ?? {};
+    return {
+      marketplace,
+      deals: readObjectArray(deals.dr),
+      categoryIds: readIntegerArray(deals.categoryIds),
+      categoryNames: readStringArray(deals.categoryNames),
+      categoryCount: readIntegerArray(deals.categoryCount),
+      raw: deals,
+      meta: normalizeMeta(payload),
+    };
+  },
+
+  async get_seller_snapshot(input, context) {
+    const marketplace = requireMarketplace(input.marketplace);
+    const sellerIds = readStringArray(input.sellerIds);
+    const payload = await requestKeepa({
+      path: "/seller",
+      query: {
+        domain: marketplaceDomainIdByCode[marketplace],
+        seller: sellerIds.join(","),
+      },
+      context,
+      phase: "execute",
+    });
+    return {
+      marketplace,
+      sellers: objectMapEntries(payload.sellers).map(([sellerId, raw]) => normalizeSeller(sellerId, raw)),
+      meta: normalizeMeta(payload),
+    };
+  },
+};
+
+export async function validateKeepaCredential(
+  apiKey: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const payload = await requestKeepa({
+    path: "/token",
+    context: { apiKey, fetcher, signal },
+    phase: "validate",
+  });
+  const meta = normalizeMeta(payload);
+  return {
+    profile: {
+      accountId: "keepa-api-key",
+      displayName: "Keepa API Key",
+    },
+    grantedScopes: [],
+    metadata: {
+      apiBaseUrl: keepaApiBaseUrl,
+      validationEndpoint: "/token",
+      tokenStatus: meta,
+    },
+  };
+}
+
+function buildProductQuery(
+  input: Record<string, unknown>,
+  marketplace: KeepaMarketplace,
+  history: boolean,
+): Record<string, string | number> {
+  const asins = readAsinArray(input.asins);
+  assertProductRequestRules(input, asins);
+  return {
+    asin: asins.join(","),
+    domain: marketplaceDomainIdByCode[marketplace],
+    history: history ? 1 : 0,
+    ...(typeof input.statsDays === "number" ? { stats: input.statsDays } : {}),
+    ...(typeof input.updateHours === "number" ? { update: input.updateHours } : {}),
+    ...(typeof input.offers === "number" ? { offers: input.offers } : {}),
+    ...(input.onlyLiveOffers === true ? { "only-live-offers": 1 } : {}),
+    ...(input.includeBuyBox === true ? { buybox: 1 } : {}),
+    ...(input.includeRating === true ? { rating: 1 } : {}),
+  };
+}
+
+function buildDealRequest(
+  input: Record<string, unknown>,
+  marketplace: KeepaMarketplace,
+  priceType: KeepaDealPriceType,
+): Record<string, unknown> {
+  const metricDefinition = keepaMetricByType.get(priceType);
+  if (!metricDefinition) {
+    throw new ProviderRequestError(400, `unsupported deal price type: ${priceType}`);
+  }
+  const sortName =
+    typeof input.sortBy === "string" && input.sortBy in dealSortTypeByName
+      ? (input.sortBy as keyof typeof dealSortTypeByName)
+      : "newest";
+  const sortType = dealSortTypeByName[sortName];
+  if (sortType === 1 && input.invertSort === true) {
+    throw new ProviderRequestError(400, "newest deal sorting cannot be inverted");
+  }
+  const ranges = {
+    currentRange: readOptionalIntegerArray(input.currentRange),
+    deltaRange: readOptionalIntegerArray(input.deltaRange),
+    deltaPercentRange: readOptionalIntegerArray(input.deltaPercentRange),
+    salesRankRange: readOptionalIntegerArray(input.salesRankRange),
+  };
+  return compactObject({
+    page: typeof input.page === "number" ? input.page : 0,
+    domainId: marketplaceDomainIdByCode[marketplace],
+    priceTypes: [metricDefinition.index],
+    dateRange: typeof input.dateRange === "number" ? input.dateRange : 0,
+    sortType: input.invertSort === true ? -sortType : sortType,
+    isLowest: input.isLowestEver === true,
+    isLowest90: input.isLowest90Days === true,
+    isLowestOffer: input.isLowestOffer === true,
+    isBackInStock: input.isBackInStock === true,
+    isOutOfStock: input.isOutOfStock === true,
+    hasReviews: input.hasReviews === true,
+    isPrimeExclusive: input.isPrimeExclusive === true,
+    mustHaveAmazonOffer: input.mustHaveAmazonOffer === true,
+    mustNotHaveAmazonOffer: input.mustNotHaveAmazonOffer === true,
+    filterErotic: true,
+    isRangeEnabled: Object.values(ranges).some((value) => value !== undefined),
+    isFilterEnabled: [
+      input.isLowestEver,
+      input.isLowest90Days,
+      input.isLowestOffer,
+      input.isBackInStock,
+      input.isOutOfStock,
+      input.hasReviews,
+      input.isPrimeExclusive,
+      input.mustHaveAmazonOffer,
+      input.mustNotHaveAmazonOffer,
+      input.minimumRating,
+      input.titleSearch,
+    ].some((value) => value !== undefined && value !== false),
+    includeCategories: readOptionalIntegerArray(input.includeCategories),
+    excludeCategories: readOptionalIntegerArray(input.excludeCategories),
+    titleSearch: optionalRawString(input.titleSearch),
+    minRating: typeof input.minimumRating === "number" ? input.minimumRating : undefined,
+    ...ranges,
+  });
+}
+
+async function requestKeepa(input: KeepaRequest): Promise<Record<string, unknown>> {
+  const url = new URL(input.path, keepaApiBaseUrl);
+  url.searchParams.set("key", input.context.apiKey);
+  for (const [name, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(name, String(value));
+    }
+  }
+
+  const timeoutHandle = createProviderTimeout(input.context.signal, keepaDefaultTimeoutMs);
+  let response: Response;
+  let payload: unknown;
+  try {
+    response = await input.context.fetcher(url, {
+      method: input.body ? "POST" : "GET",
+      headers: {
+        accept: "application/json",
+        ...(input.body ? { "content-type": "application/json;charset=UTF-8" } : {}),
+        "user-agent": providerUserAgent,
+      },
+      ...(input.body ? { body: JSON.stringify(input.body) } : {}),
+      signal: timeoutHandle.signal,
+    });
+    payload = await readJsonPayload(response);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, "Keepa request timed out");
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `Keepa request failed: ${error.message}` : "Keepa request failed",
+    );
+  } finally {
+    timeoutHandle.cleanup();
+  }
+
+  const envelope = optionalRecord(payload);
+  if (!envelope) {
+    throw new ProviderRequestError(502, "Keepa returned an invalid response envelope", payload);
+  }
+  if (!response.ok || envelope.error) {
+    throw createKeepaError(response.status, envelope, input.phase);
+  }
+  return envelope;
+}
+
+async function readJsonPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.trim() === "") {
+    throw new ProviderRequestError(502, "Keepa returned an empty response");
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new ProviderRequestError(502, "Keepa returned invalid JSON");
+  }
+}
+
+function createKeepaError(status: number, envelope: Record<string, unknown>, phase: KeepaPhase): ProviderRequestError {
+  const error = optionalRecord(envelope.error);
+  const providerType = optionalRawString(error?.type);
+  const details = optionalRawString(error?.details);
+  const message =
+    optionalRawString(error?.message) ??
+    details ??
+    (providerType ? `Keepa request failed with ${providerType}` : `Keepa request failed (${status})`);
+  const data = {
+    providerType: providerType ?? null,
+    details: details ?? null,
+    tokensLeft: asNullableInteger(envelope.tokensLeft),
+    refillInMs: asNullableInteger(envelope.refillIn),
+  };
+
+  if (status === 429) {
+    return new ProviderRequestError(429, message, {
+      ...data,
+      reason: "token_budget_exhausted",
+    });
+  }
+  if (status === 503) {
+    return new ProviderRequestError(503, message, {
+      ...data,
+      reason: "service_unavailable",
+    });
+  }
+  if (status === 401 || status === 403 || status === 402) {
+    if (phase === "validate") {
+      return new ProviderRequestError(400, message, data);
+    }
+    return new ProviderRequestError(status === 402 ? 403 : status, message, {
+      ...data,
+      providerStatus: status,
+    });
+  }
+  if (status === 400 || status === 405) {
+    return new ProviderRequestError(400, message, data);
+  }
+  return new ProviderRequestError(status >= 500 ? status : 502, message, data);
+}
+
+function normalizeMeta(payload: Record<string, unknown>): Record<string, number | null> {
+  return {
+    timestamp: asNullableInteger(payload.timestamp),
+    tokensLeft: asNullableInteger(payload.tokensLeft),
+    refillInMs: asNullableInteger(payload.refillIn),
+    refillRatePerMinute: asNullableInteger(payload.refillRate),
+    tokensConsumed: asNullableInteger(payload.tokensConsumed),
+    processingTimeMs: asNullableInteger(payload.processingTimeInMs),
+  };
+}
+
+function normalizeProductSnapshot(product: Record<string, unknown>): Record<string, unknown> {
+  const asin = requireUpstreamString(product.asin, "product.asin");
+  const stats = optionalRecord(product.stats);
+  return {
+    asin,
+    domainId: asNullableInteger(product.domainId),
+    title: asNullableString(product.title),
+    brand: asNullableString(product.brand),
+    manufacturer: asNullableString(product.manufacturer),
+    productGroup: asNullableString(product.productGroup),
+    parentAsin: asNullableString(product.parentAsin),
+    rootCategory: asNullableInteger(product.rootCategory),
+    categories: readIntegerArray(product.categories),
+    imageUrls: collectImageUrls(product),
+    monthlySold: asNullableInteger(product.monthlySold),
+    lastUpdate: asNullableInteger(product.lastUpdate),
+    stats: stats ? normalizeStats(stats) : null,
+    raw: product,
+  };
+}
+
+function normalizeStats(stats: Record<string, unknown>): Record<string, unknown> {
+  return {
+    current: normalizeMetricIntegerArray(stats.current),
+    average: normalizeMetricIntegerArray(stats.avg),
+    average30Days: normalizeMetricIntegerArray(stats.avg30),
+    average90Days: normalizeMetricIntegerArray(stats.avg90),
+    average180Days: normalizeMetricIntegerArray(stats.avg180),
+    average365Days: normalizeMetricIntegerArray(stats.avg365),
+    atIntervalStart: normalizeMetricIntegerArray(stats.atIntervalStart),
+    isLowestEver: normalizeMetricBooleanArray(stats.isLowest),
+    isLowest90Days: normalizeMetricBooleanArray(stats.isLowest90),
+    raw: stats,
+  };
+}
+
+function normalizeMetricIntegerArray(value: unknown): Record<string, number | null> {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    keepaMetrics
+      .filter((item) => item.index < value.length)
+      .map((item) => [item.type, asNullableInteger(value[item.index])]),
+  );
+}
+
+function normalizeMetricBooleanArray(value: unknown): Record<string, boolean> {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    keepaMetrics
+      .filter((item) => item.index < value.length && typeof value[item.index] === "boolean")
+      .map((item) => [item.type, value[item.index] as boolean]),
+  );
+}
+
+function normalizeProductHistory(
+  product: Record<string, unknown>,
+  requestedTypes: Set<KeepaHistoryType> | undefined,
+): Record<string, unknown> {
+  const csv = Array.isArray(product.csv) ? product.csv : [];
+  return {
+    asin: requireUpstreamString(product.asin, "product.asin"),
+    title: asNullableString(product.title),
+    brand: asNullableString(product.brand),
+    series: keepaMetrics
+      .filter((definition) => !requestedTypes || requestedTypes.has(definition.type))
+      .flatMap((definition) => {
+        const rawSeries = csv[definition.index];
+        if (!Array.isArray(rawSeries)) {
+          return [];
+        }
+        return [
+          {
+            type: definition.type,
+            index: definition.index,
+            unit: definition.unit,
+            includesShipping: definition.includesShipping,
+            points: normalizeHistoryPoints(rawSeries, definition.includesShipping),
+          },
+        ];
+      }),
+    raw: product,
+  };
+}
+
+function normalizeHistoryPoints(
+  value: unknown[],
+  includesShipping: boolean,
+): Array<{
+  keepaTime: number;
+  timestamp: string;
+  value: number;
+  shipping: number | null;
+}> {
+  const stride = includesShipping ? 3 : 2;
+  const points: Array<{
+    keepaTime: number;
+    timestamp: string;
+    value: number;
+    shipping: number | null;
+  }> = [];
+  for (let index = 0; index + stride - 1 < value.length; index += stride) {
+    const keepaTime = value[index];
+    const historyValue = value[index + 1];
+    const shipping = includesShipping ? value[index + 2] : null;
+    if (
+      typeof keepaTime !== "number" ||
+      !Number.isInteger(keepaTime) ||
+      typeof historyValue !== "number" ||
+      !Number.isInteger(historyValue) ||
+      (shipping !== null && (typeof shipping !== "number" || !Number.isInteger(shipping)))
+    ) {
+      continue;
+    }
+    points.push({
+      keepaTime,
+      timestamp: keepaTimeToIso(keepaTime),
+      value: historyValue,
+      shipping,
+    });
+  }
+  return points;
+}
+
+function collectImageUrls(product: Record<string, unknown>): string[] {
+  const imageNames: string[] = [];
+  if (Array.isArray(product.images)) {
+    for (const item of product.images) {
+      const image = optionalRecord(item);
+      const name = optionalRawString(image?.l) ?? optionalRawString(image?.m);
+      if (name) {
+        imageNames.push(name);
+      }
+    }
+  }
+  const legacyImages = optionalRawString(product.imagesCSV);
+  if (legacyImages) {
+    imageNames.push(...legacyImages.split(",").map((value) => value.trim()));
+  }
+  return [...new Set(imageNames.filter(Boolean))].map((name) => `https://m.media-amazon.com/images/I/${name}`);
+}
+
+function normalizeSeller(sellerId: string, raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    sellerId: optionalRawString(raw.sellerId) ?? sellerId,
+    sellerName: asNullableString(raw.sellerName),
+    currentRating: asNullableInteger(raw.currentRating),
+    ratingCount: Array.isArray(raw.ratingCount) ? readIntegerArray(raw.ratingCount) : null,
+    hasFba: typeof raw.hasFBA === "boolean" ? raw.hasFBA : null,
+    shipsFromChina: typeof raw.shipsFromChina === "boolean" ? raw.shipsFromChina : null,
+    raw,
+  };
+}
+
+function keepaTimeToIso(keepaTime: number): string {
+  return new Date((keepaTime + keepaTimeStartMinutes) * 60_000).toISOString();
+}
+
+function requireMarketplace(value: unknown): KeepaMarketplace {
+  if (typeof value !== "string" || !Object.prototype.hasOwnProperty.call(marketplaceDomainIdByCode, value)) {
+    throw new ProviderRequestError(400, "unsupported Keepa marketplace");
+  }
+  return value as KeepaMarketplace;
+}
+
+function requireDealPriceType(value: unknown): KeepaDealPriceType {
+  if (typeof value !== "string" || !keepaDealPriceTypeSet.has(value as KeepaDealPriceType)) {
+    throw new ProviderRequestError(400, "unsupported Keepa deal price type");
+  }
+  return value as KeepaDealPriceType;
+}
+
+function readRequestedHistoryTypes(value: unknown): Set<KeepaHistoryType> | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const types = value.filter(
+    (item): item is KeepaHistoryType => typeof item === "string" && keepaHistoryTypeSet.has(item as KeepaHistoryType),
+  );
+  return new Set(types);
+}
+
+function validateCategorySearchTerm(term: string): void {
+  const keywords = term.split(" ").filter(Boolean);
+  if (keywords.length === 0 || keywords.some((keyword) => keyword.length < 3)) {
+    throw new ProviderRequestError(400, "each category search keyword must contain at least three characters");
+  }
+}
+
+function assertProductRequestRules(input: Record<string, unknown>, asins: string[]): void {
+  if (typeof input.offers === "number" && asins.length > 20) {
+    throw new ProviderRequestError(400, "offers can only be requested for up to 20 ASINs");
+  }
+  if (input.onlyLiveOffers === true && typeof input.offers !== "number") {
+    throw new ProviderRequestError(400, "onlyLiveOffers requires offers");
+  }
+}
+
+function requireInputObject(value: unknown, fieldName: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (!object) {
+    throw new ProviderRequestError(400, `${fieldName} must be an object`);
+  }
+  return object;
+}
+
+function readRequiredInputString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function requireUpstreamString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value === "") {
+    throw new ProviderRequestError(502, `Keepa response is missing ${fieldName}`);
+  }
+  return value;
+}
+
+function readObjectArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    const object = optionalRecord(item);
+    return object ? [object] : [];
+  });
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function readAsinArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(400, "asins must be an array");
+  }
+  return value.map(normalizeAsin);
+}
+
+function normalizeAsin(value: unknown): string {
+  if (typeof value !== "string" || value.length !== 10) {
+    throw new ProviderRequestError(400, "ASIN must contain 10 ASCII letters or digits");
+  }
+  const asin = value.toUpperCase();
+  for (const character of asin) {
+    const code = character.charCodeAt(0);
+    const isDigit = code >= 48 && code <= 57;
+    const isUppercaseLetter = code >= 65 && code <= 90;
+    if (!isDigit && !isUppercaseLetter) {
+      throw new ProviderRequestError(400, "ASIN must contain 10 ASCII letters or digits");
+    }
+  }
+  return asin;
+}
+
+function readIntegerArray(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is number => typeof item === "number" && Number.isInteger(item));
+}
+
+function readOptionalIntegerArray(value: unknown): number[] | undefined {
+  return Array.isArray(value) ? readIntegerArray(value) : undefined;
+}
+
+function objectMapValues(value: unknown): Array<Record<string, unknown>> {
+  const object = optionalRecord(value);
+  if (!object) {
+    return [];
+  }
+  return Object.values(object).flatMap((item) => {
+    const child = optionalRecord(item);
+    return child ? [child] : [];
+  });
+}
+
+function objectMapEntries(value: unknown): Array<[string, Record<string, unknown>]> {
+  const object = optionalRecord(value);
+  if (!object) {
+    return [];
+  }
+  return Object.entries(object).flatMap(([key, item]) => {
+    const child = optionalRecord(item);
+    return child ? [[key, child] as [string, Record<string, unknown>]] : [];
+  });
+}
+
+function asNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNullableInteger(value: unknown): number | null {
+  return Number.isInteger(value) ? (value as number) : null;
+}
+
+function metric(
+  type: KeepaHistoryType,
+  index: number,
+  isPrice: boolean,
+  includesShipping = false,
+  unit: KeepaMetricDefinition["unit"] = "minor_currency_unit",
+): KeepaMetricDefinition {
+  return {
+    type,
+    index,
+    isPrice,
+    includesShipping,
+    unit: isPrice ? "minor_currency_unit" : unit,
+  };
+}

--- a/src/providers/lingxing/actions.ts
+++ b/src/providers/lingxing/actions.ts
@@ -1,0 +1,54 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "lingxing";
+
+const mcpToolSummarySchema = s.object(
+  "A tool currently exposed by the connected Lingxing MCP server.",
+  {
+    name: s.nonEmptyString("The exact MCP tool name to pass to call_tool."),
+    description: s.string("The current tool description supplied by Lingxing MCP."),
+    inputSchema: s.looseObject("The current JSON Schema for the tool arguments, supplied by Lingxing MCP."),
+  },
+  { optional: ["description"] },
+);
+
+export const lingxingActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_tools",
+    description:
+      "Discover the current Lingxing ERP MCP tools and their live input schemas before choosing a tool to call.",
+    inputSchema: s.actionInput({}, [], "No input is required."),
+    outputSchema: s.actionOutput(
+      {
+        tools: s.array("Tools currently exposed to the connected Lingxing account.", mcpToolSummarySchema),
+      },
+      "The current Lingxing MCP tool catalog.",
+    ),
+    followUpActions: ["lingxing.call_tool"],
+  }),
+  defineProviderAction(service, {
+    name: "call_tool",
+    description:
+      "Call a current Lingxing ERP MCP tool with JSON arguments. Discover the tool first and confirm the user's intent because some Lingxing tools create or update ERP data.",
+    inputSchema: s.object(
+      "Input for invoking one current Lingxing MCP tool.",
+      {
+        toolName: s.nonEmptyString("The exact tool name returned by list_tools."),
+        arguments: s.looseObject("JSON arguments matching the inputSchema returned for the selected tool."),
+      },
+      { optional: ["arguments"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        result: s.unknown(
+          "The tool result. Structured MCP content is returned directly; otherwise the MCP content envelope is preserved.",
+        ),
+      },
+      "The normalized result returned by the Lingxing MCP tool.",
+    ),
+    followUpActions: ["lingxing.list_tools"],
+  }),
+];

--- a/src/providers/lingxing/definition.ts
+++ b/src/providers/lingxing/definition.ts
@@ -1,0 +1,46 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { lingxingActions } from "./actions.ts";
+
+const service = "lingxing";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Lingxing",
+  description: "Discover and call live Lingxing ERP tools through the official Lingxing Streamable HTTP MCP service.",
+  categories: ["Productivity", "Data", "Marketing"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "serverUrl",
+          label: "MCP Server URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://openmcp.lingxing.com/mcp-servers/lingxing-mcp",
+          description:
+            "The official Lingxing MCP Server URL for your current ERP account. Copy it from AI Assistant > Manage MCP as described at https://www.lingxing.com/help/article/mcp. Only openmcp.lingxing.com is accepted.",
+        },
+        {
+          key: "mcpKey",
+          label: "X-Mcp-Key",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Paste your Lingxing X-Mcp-Key",
+          description:
+            "The X-Mcp-Key bound to your current Lingxing ERP account. Copy or regenerate it from AI Assistant > Manage MCP as described at https://www.lingxing.com/help/article/mcp.",
+        },
+      ],
+      testAction: {
+        actionName: "list_tools",
+        input: {},
+      },
+    },
+  ],
+  homepageUrl: "https://www.lingxing.com",
+  actions: lingxingActions,
+};

--- a/src/providers/lingxing/executors.ts
+++ b/src/providers/lingxing/executors.ts
@@ -1,0 +1,23 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { createProviderFetch, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createLingxingContext, lingxingActionHandlers, validateLingxingCredential } from "./runtime.ts";
+
+const service = "lingxing";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: lingxingActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch) {
+    const credential = await requireCustomCredential(context, service);
+    return createLingxingContext(credential.values, fetcher, context.signal);
+  },
+  fallbackMessage: "Lingxing MCP request failed",
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({ fetch: fetcher });
+    return validateLingxingCredential(input.values, guardedFetcher, signal);
+  },
+};

--- a/src/providers/lingxing/runtime.ts
+++ b/src/providers/lingxing/runtime.ts
@@ -1,0 +1,399 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { createHash } from "node:crypto";
+import { optionalRecord, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+const lingxingMcpHost = "openmcp.lingxing.com";
+const lingxingRequestTimeoutMs = 30_000;
+const lingxingToolIntervalMs = 1_000;
+const maximumTrackedRateLimitKeys = 1_024;
+
+interface LingxingCredential {
+  endpoint: URL;
+  mcpKey: string;
+}
+
+export interface LingxingContext extends LingxingCredential {
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+interface LingxingToolRateLimiterOptions {
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface LingxingToolRateLimiter {
+  run<T>(key: string, task: () => Promise<T>): Promise<T>;
+}
+
+type LingxingRequestPhase = "validate" | "execute";
+type LingxingMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+class InMemoryLingxingToolRateLimiter implements LingxingToolRateLimiter {
+  private readonly nextStartByKey = new Map<string, number>();
+  private readonly tails = new Map<string, Promise<unknown>>();
+  private readonly now: () => number;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+
+  constructor(options: LingxingToolRateLimiterOptions) {
+    this.now = options.now ?? Date.now;
+    this.sleep =
+      options.sleep ?? ((milliseconds) => new Promise<void>((resolve) => globalThis.setTimeout(resolve, milliseconds)));
+  }
+
+  async run<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(async () => {
+        const now = this.now();
+        this.pruneExpiredKeys(now);
+        const waitMs = Math.max(0, (this.nextStartByKey.get(key) ?? now) - now);
+        if (waitMs > 0) {
+          await this.sleep(waitMs);
+        }
+        this.nextStartByKey.set(key, this.now() + lingxingToolIntervalMs);
+        return await task();
+      });
+    this.tails.set(key, current);
+
+    try {
+      return (await current) as T;
+    } finally {
+      if (this.tails.get(key) === current) {
+        this.tails.delete(key);
+      }
+    }
+  }
+
+  private pruneExpiredKeys(now: number): void {
+    if (this.nextStartByKey.size < maximumTrackedRateLimitKeys) {
+      return;
+    }
+    for (const [key, nextStart] of this.nextStartByKey) {
+      if (nextStart <= now) {
+        this.nextStartByKey.delete(key);
+      }
+    }
+  }
+}
+
+const lingxingToolRateLimiter = createLingxingToolRateLimiter();
+
+export const lingxingActionHandlers: Record<string, ProviderRuntimeHandler<LingxingContext>> = {
+  list_tools(_input, context) {
+    return listLingxingTools(context);
+  },
+  call_tool(input, context) {
+    return callLingxingTool(context, input);
+  },
+};
+
+export function createLingxingToolRateLimiter(options: LingxingToolRateLimiterOptions = {}): LingxingToolRateLimiter {
+  return new InMemoryLingxingToolRateLimiter(options);
+}
+
+export function createLingxingContext(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): LingxingContext {
+  const credential = readLingxingCredential(values);
+  return {
+    ...credential,
+    fetcher,
+    signal,
+  };
+}
+
+export function normalizeLingxingMcpEndpoint(value: unknown): URL {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ProviderRequestError(400, "Lingxing MCP Server URL is required");
+  }
+
+  let endpoint: URL;
+  try {
+    endpoint = new URL(value.trim());
+  } catch {
+    throw new ProviderRequestError(400, "Lingxing MCP Server URL must be a valid URL");
+  }
+
+  if (
+    endpoint.protocol !== "https:" ||
+    endpoint.hostname !== lingxingMcpHost ||
+    (endpoint.port !== "" && endpoint.port !== "443")
+  ) {
+    throw new ProviderRequestError(400, `Lingxing MCP Server URL must use https://${lingxingMcpHost}`);
+  }
+  if (endpoint.username || endpoint.password) {
+    throw new ProviderRequestError(400, "Lingxing MCP Server URL must not include username or password");
+  }
+
+  endpoint = assertPublicHttpUrl(endpoint.toString(), {
+    fieldName: "serverUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+  });
+  endpoint.hash = "";
+  return endpoint;
+}
+
+export async function validateLingxingCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createLingxingContext(values, fetcher, signal);
+  const tools = await runLingxingMcp("validate", () => discoverLingxingTools(context));
+  if (tools.length === 0) {
+    throw new ProviderRequestError(502, "Lingxing MCP did not expose any tools for this account");
+  }
+
+  const credentialHash = hashLingxingCredential(context);
+  return {
+    profile: {
+      accountId: `lingxing:mcp:${credentialHash}`,
+      displayName: `Lingxing MCP · ${credentialHash.slice(-6)}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpHost: context.endpoint.hostname,
+      discoveredToolCount: tools.length,
+    },
+  };
+}
+
+export async function listLingxingTools(context: LingxingContext): Promise<{
+  tools: Array<{
+    name: string;
+    description?: string;
+    inputSchema: Record<string, unknown>;
+  }>;
+}> {
+  return {
+    tools: await runLingxingMcp("execute", () => discoverLingxingTools(context)),
+  };
+}
+
+export async function callLingxingTool(
+  context: LingxingContext,
+  input: Record<string, unknown>,
+): Promise<{ result: unknown }> {
+  const toolName = requiredString(input.toolName, "toolName", (message) => new ProviderRequestError(400, message));
+  const argumentsValue = readToolArguments(input.arguments);
+  const rateLimitKey = hashLingxingRateLimitKey(context, toolName);
+  const result = await lingxingToolRateLimiter.run(rateLimitKey, () =>
+    runLingxingMcp("execute", () =>
+      withLingxingMcpClient(context, async (client) => {
+        const toolResult = await client.callTool(
+          {
+            name: toolName,
+            arguments: argumentsValue,
+          },
+          undefined,
+          {
+            timeout: lingxingRequestTimeoutMs,
+            signal: context.signal,
+          },
+        );
+        return normalizeLingxingMcpToolResult(toolName, toolResult);
+      }),
+    ),
+  );
+  return { result };
+}
+
+async function discoverLingxingTools(context: LingxingContext): Promise<
+  Array<{
+    name: string;
+    description?: string;
+    inputSchema: Record<string, unknown>;
+  }>
+> {
+  return withLingxingMcpClient(context, async (client) => {
+    const result = await client.listTools(
+      {},
+      {
+        timeout: lingxingRequestTimeoutMs,
+        signal: context.signal,
+      },
+    );
+    return result.tools.map((tool) => {
+      const summary: {
+        name: string;
+        description?: string;
+        inputSchema: Record<string, unknown>;
+      } = {
+        name: tool.name,
+        inputSchema: tool.inputSchema,
+      };
+      if (tool.description) {
+        summary.description = tool.description;
+      }
+      return summary;
+    });
+  });
+}
+
+async function withLingxingMcpClient<T>(context: LingxingContext, run: (client: Client) => Promise<T>): Promise<T> {
+  const headers = new Headers();
+  headers.set("X-Mcp-Key", context.mcpKey);
+  headers.set("user-agent", providerUserAgent);
+  const transport = new StreamableHTTPClientTransport(context.endpoint, {
+    fetch: context.fetcher,
+    requestInit: {
+      headers,
+      redirect: "error",
+      signal: context.signal,
+    },
+  });
+  const client = new Client({
+    name: "oomol-connect-lingxing",
+    version: "1.0.0",
+  });
+
+  try {
+    await client.connect(transport, {
+      timeout: lingxingRequestTimeoutMs,
+      signal: context.signal,
+    });
+    return await run(client);
+  } catch (error) {
+    throw mapLingxingMcpError(error);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function readLingxingCredential(values: Record<string, string>): LingxingCredential {
+  const mcpKey = values.mcpKey?.trim();
+  if (!mcpKey) {
+    throw new ProviderRequestError(400, "Lingxing X-Mcp-Key is required");
+  }
+  return {
+    endpoint: normalizeLingxingMcpEndpoint(values.serverUrl),
+    mcpKey,
+  };
+}
+
+function readToolArguments(value: unknown): Record<string, unknown> {
+  if (value === undefined) {
+    return {};
+  }
+  const argumentsValue = optionalRecord(value);
+  if (!argumentsValue) {
+    throw new ProviderRequestError(400, "arguments must be a JSON object");
+  }
+  return argumentsValue;
+}
+
+function normalizeLingxingMcpToolResult(toolName: string, result: LingxingMcpToolResult): unknown {
+  if ("content" in result && result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `Lingxing MCP tool ${toolName} returned an error: ${formatLingxingMcpToolContent(result)}`,
+      result,
+    );
+  }
+  if ("toolResult" in result) {
+    return result;
+  }
+  return result.structuredContent ?? result;
+}
+
+function formatLingxingMcpToolContent(result: LingxingMcpToolResult): string {
+  const content = "content" in result && Array.isArray(result.content) ? result.content : [];
+  const text = content
+    .map((item) => {
+      if (item.type === "text") {
+        return item.text;
+      }
+      if (item.type === "resource") {
+        return "text" in item.resource ? item.resource.text : item.resource.uri;
+      }
+      if (item.type === "resource_link") {
+        return item.uri;
+      }
+      return item.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+
+  return text.slice(0, 300) || "empty error content";
+}
+
+function mapLingxingMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) {
+    return error;
+  }
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "Lingxing MCP token is invalid or expired", error);
+  }
+  if (error instanceof StreamableHTTPError) {
+    const status = error.code;
+    return new ProviderRequestError(
+      status === 401 || status === 403
+        ? 401
+        : status === 429
+          ? 429
+          : status && status >= 400 && status < 500
+            ? 400
+            : 502,
+      `Lingxing MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof McpError) {
+    return error.code === ErrorCode.RequestTimeout
+      ? new ProviderRequestError(504, "Lingxing MCP request timed out", error)
+      : new ProviderRequestError(502, `Lingxing MCP request failed: ${error.message}`, error);
+  }
+  if (isAbortError(error)) {
+    return new ProviderRequestError(504, "Lingxing MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `Lingxing MCP request failed: ${error.message}` : "Lingxing MCP request failed",
+    error,
+  );
+}
+
+async function runLingxingMcp<T>(phase: LingxingRequestPhase, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof ProviderRequestError && error.status === 401) {
+      throw new ProviderRequestError(
+        phase === "validate" ? 400 : 401,
+        "Lingxing MCP Server URL or X-Mcp-Key is invalid",
+        error,
+      );
+    }
+    throw error;
+  }
+}
+
+function hashLingxingCredential(credential: Pick<LingxingCredential, "endpoint">): string {
+  return createHash("sha256").update(credential.endpoint.toString()).digest("hex").slice(0, 16);
+}
+
+function hashLingxingRateLimitKey(credential: LingxingCredential, toolName: string): string {
+  return createHash("sha256")
+    .update(credential.endpoint.toString())
+    .update("\0")
+    .update(credential.mcpKey)
+    .update("\0")
+    .update(toolName)
+    .digest("hex");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}

--- a/src/providers/photoroom/actions.ts
+++ b/src/providers/photoroom/actions.ts
@@ -1,0 +1,220 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "photoroom";
+
+const keepBackgroundSchema: JsonSchema = {
+  ...s.object(
+    "Keep the source background, optionally blurring it.",
+    {
+      type: s.literal("keep", { description: "The background strategy." }),
+      blurMode: s.stringEnum("The blur style applied to the retained background.", ["gaussian", "bokeh"]),
+      blurRadius: s.number("The background blur radius above 0 and up to 0.05.", {
+        exclusiveMinimum: 0,
+        maximum: 0.05,
+      }),
+    },
+    { optional: ["blurMode", "blurRadius"] },
+  ),
+  allOf: [
+    {
+      if: { required: ["blurRadius"] },
+      then: { required: ["blurMode"] },
+    },
+  ],
+};
+
+const colorBackgroundSchema = s.requiredObject("Replace the source background with a solid color.", {
+  type: s.literal("color", { description: "The background strategy." }),
+  color: s.nonEmptyString(
+    "A hexadecimal color without a leading hash, such as FFFFFF or FF0000EE, or a supported color name.",
+  ),
+});
+
+const imageBackgroundSchema = s.object(
+  "Replace the source background with an image that Photoroom can fetch.",
+  {
+    type: s.literal("image", { description: "The background strategy." }),
+    imageUrl: s.string({
+      format: "uri",
+      minLength: 1,
+      description: "The publicly reachable URL of the replacement background image.",
+    }),
+    scaling: s.stringEnum("How the replacement background should fit the output canvas.", ["fit", "fill"]),
+  },
+  { optional: ["scaling"] },
+);
+
+const aiBackgroundSchema = s.object(
+  "Generate a product-scene background from a controlled prompt.",
+  {
+    type: s.literal("ai", { description: "The background strategy." }),
+    prompt: s.nonEmptyString("A description of the product scene to generate around the existing subject."),
+    seed: s.positiveInteger("A fixed generation seed for producing similar backgrounds from the same prompt."),
+    expandPromptMode: s.stringEnum("Whether Photoroom should automatically expand a short background prompt.", [
+      "ai.auto",
+      "ai.never",
+    ]),
+  },
+  { optional: ["seed", "expandPromptMode"] },
+);
+
+const backgroundSchema = s.oneOf(
+  [keepBackgroundSchema, colorBackgroundSchema, imageBackgroundSchema, aiBackgroundSchema],
+  { description: "The background treatment applied to the product image." },
+);
+
+const outlineSchema = s.object(
+  "A colored outline drawn around the detected product subject.",
+  {
+    color: s.nonEmptyString("A hexadecimal color without a leading hash or a supported color name."),
+    width: s.number("The outline width as a ratio of the result image size.", {
+      minimum: 0,
+      maximum: 0.1,
+    }),
+    blurRadius: s.number("The outline blur radius as a ratio of the result image size.", {
+      minimum: 0,
+      maximum: 0.025,
+    }),
+  },
+  { optional: ["width", "blurRadius"] },
+);
+
+const canvasSchema: JsonSchema = {
+  ...s.object(
+    "Output canvas sizing and subject positioning controls.",
+    {
+      width: s.positiveInteger("The output canvas width in pixels. Provide height with this field."),
+      height: s.positiveInteger("The output canvas height in pixels. Provide width with this field."),
+      padding: {
+        ...s.number("The fractional padding on every side of the subject, from 0 up to but excluding 0.5.", {
+          minimum: 0,
+        }),
+        exclusiveMaximum: 0.5,
+      },
+      scaling: s.stringEnum("Whether the subject should fit or fill the available canvas.", ["fit", "fill"]),
+      horizontalAlignment: s.stringEnum("The horizontal subject alignment.", ["left", "center", "right"]),
+      verticalAlignment: s.stringEnum("The vertical subject alignment.", ["top", "center", "bottom"]),
+    },
+    {
+      optional: ["width", "height", "padding", "scaling", "horizontalAlignment", "verticalAlignment"],
+    },
+  ),
+  allOf: [
+    {
+      if: { required: ["width"] },
+      then: { required: ["height"] },
+    },
+    {
+      if: { required: ["height"] },
+      then: { required: ["width"] },
+    },
+  ],
+};
+
+const editProductImageInputSchema: JsonSchema = {
+  ...s.object(
+    "A URL-based Photoroom product image edit with controlled composable options.",
+    {
+      imageUrl: s.string({
+        format: "uri",
+        minLength: 1,
+        description: "The publicly reachable source product image URL that Photoroom should edit.",
+      }),
+      background: backgroundSchema,
+      shadowStyle: s.stringEnum(
+        "The current Photoroom AI shadow style generated around the detected product subject.",
+        ["auto", "soft", "hard"],
+      ),
+      lightingMode: s.stringEnum(
+        "The relighting mode. Preserve hue and saturation when product color accuracy matters.",
+        ["ai.auto", "ai.preserve-hue-and-saturation"],
+      ),
+      textRemovalMode: s.stringEnum(
+        "The class of text to remove. This can change product details and requires human review.",
+        ["ai.artificial", "ai.natural", "ai.all"],
+      ),
+      beautifyMode: s.stringEnum(
+        "The product-specific AI beautification mode. This can alter the subject and requires human review.",
+        ["ai.auto", "ai.food", "ai.car"],
+      ),
+      beautifySeed: s.positiveInteger(
+        "A fixed seed for producing similar beautification results. Requires beautifyMode.",
+      ),
+      outline: outlineSchema,
+      canvas: canvasSchema,
+      outputFormat: s.stringEnum("The encoded format of the edited result image.", ["png", "jpeg", "webp"]),
+      outputDpi: s.integer("The output pixel density in dots per inch.", {
+        minimum: 72,
+        maximum: 1200,
+      }),
+    },
+    {
+      optional: [
+        "shadowStyle",
+        "lightingMode",
+        "textRemovalMode",
+        "beautifyMode",
+        "beautifySeed",
+        "outline",
+        "canvas",
+        "outputFormat",
+        "outputDpi",
+      ],
+    },
+  ),
+  allOf: [
+    {
+      if: {
+        properties: {
+          background: {
+            properties: { type: { const: "ai" } },
+            required: ["type"],
+          },
+        },
+        required: ["background"],
+      },
+      then: { not: { required: ["shadowStyle"] } },
+    },
+    {
+      if: {
+        properties: {
+          background: {
+            properties: { type: { const: "keep" } },
+            required: ["type"],
+          },
+        },
+        required: ["background"],
+      },
+      then: { not: { required: ["beautifyMode"] } },
+    },
+    {
+      if: { required: ["beautifySeed"] },
+      then: { required: ["beautifyMode"] },
+    },
+  ],
+};
+
+export const photoroomActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "edit_product_image",
+    description:
+      "Apply a controlled combination of Photoroom product-image edits to an imageUrl, upload the binary result to local transit storage, and return resultUrl. This action is for composed ecommerce edits rather than simple background removal; outputs that use relighting, text removal, or beautification should be reviewed by a human before publishing.",
+    inputSchema: editProductImageInputSchema,
+    outputSchema: s.requiredObject("The edited product image stored in local transit storage.", {
+      resultUrl: s.url("The local transit URL used to download the edited image."),
+      fileName: s.nonEmptyString("The generated filename stored in transit."),
+      contentType: s.stringEnum("The MIME type detected from the edited image bytes.", [
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+      ]),
+      contentLength: s.nonNegativeInteger("The edited image size in bytes."),
+      humanReviewRecommended: s.boolean(
+        "Whether selected AI edits can alter product appearance or text and should be reviewed before publishing.",
+      ),
+    }),
+  }),
+];

--- a/src/providers/photoroom/definition.ts
+++ b/src/providers/photoroom/definition.ts
@@ -1,0 +1,25 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { photoroomActions } from "./actions.ts";
+
+const service = "photoroom";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Photoroom",
+  description:
+    "Apply controlled ecommerce image edits with Photoroom and store the generated result in local transit storage.",
+  categories: ["AI", "Design & Media"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "PHOTOROOM_API_KEY",
+      description:
+        "Photoroom API key sent with the x-api-key header. Activate the API and create or manage keys in the Photoroom API dashboard: https://app.photoroom.com/api-dashboard.",
+    },
+  ],
+  homepageUrl: "https://www.photoroom.com",
+  actions: photoroomActions,
+};

--- a/src/providers/photoroom/executors.ts
+++ b/src/providers/photoroom/executors.ts
@@ -1,0 +1,20 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+
+import { createProviderFetch, defineApiKeyProviderExecutors } from "../provider-runtime.ts";
+import { photoroomActionHandlers, validatePhotoroomCredential } from "./runtime.ts";
+
+const service = "photoroom";
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, photoroomActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({
+      fetch: fetcher,
+      skipDnsValidation: true,
+    });
+    return validatePhotoroomCredential(input.apiKey, guardedFetcher, signal);
+  },
+};

--- a/src/providers/photoroom/runtime.ts
+++ b/src/providers/photoroom/runtime.ts
@@ -1,0 +1,362 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { compactObject, optionalNumber, optionalRawString, optionalRecord } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+export const photoroomApiBaseUrl = "https://image-api.photoroom.com";
+const photoroomAccountUrl = `${photoroomApiBaseUrl}/v2/account`;
+const photoroomEditUrl = `${photoroomApiBaseUrl}/v2/edit`;
+const photoroomAiShadowsModelVersion = "2026-04-15";
+const photoroomShadowModeByStyle: Record<string, string> = {
+  auto: "ai.auto-with-overrides",
+  soft: "ai.preset-soft",
+  hard: "ai.preset-hard",
+};
+
+type PhotoroomRequestPhase = "validate" | "execute";
+
+export const photoroomActionHandlers: Record<string, ProviderRuntimeHandler<ApiKeyProviderContext>> = {
+  edit_product_image(input, context) {
+    return editPhotoroomProductImage(input, context);
+  },
+};
+
+export async function validatePhotoroomCredential(
+  apiKey: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const response = await fetchPhotoroom(
+    photoroomAccountUrl,
+    {
+      headers: photoroomHeaders(apiKey, "application/json"),
+      signal,
+    },
+    fetcher,
+  );
+  const payload = await readPhotoroomJson(response);
+  if (!response.ok) {
+    throw createPhotoroomError(response, payload, "validate");
+  }
+
+  const account = normalizePhotoroomAccount(payload);
+  return {
+    profile: {
+      accountId: "photoroom",
+      displayName: account.plan ? `Photoroom ${account.plan}` : "Photoroom API Key",
+    },
+    grantedScopes: [],
+    metadata: compactObject({
+      apiBaseUrl: photoroomApiBaseUrl,
+      validationEndpoint: "/v2/account",
+      plan: account.plan,
+      images: account.images,
+    }),
+  };
+}
+
+async function editPhotoroomProductImage(
+  input: Record<string, unknown>,
+  context: ApiKeyProviderContext,
+): Promise<unknown> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+  }
+
+  const response = await fetchPhotoroom(
+    buildPhotoroomEditUrl(input),
+    {
+      headers: photoroomHeaders(
+        context.apiKey,
+        "image/png, image/jpeg, image/webp, application/json",
+        input.shadowStyle !== undefined,
+      ),
+      signal: context.signal,
+    },
+    context.fetcher,
+  );
+
+  if (!response.ok) {
+    throw createPhotoroomError(response, await readPhotoroomJson(response), "execute");
+  }
+
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Photoroom edited image",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  if (bytes.byteLength === 0) {
+    throw new ProviderRequestError(502, "Photoroom response did not include edited image bytes");
+  }
+
+  const contentType = detectPhotoroomImageMimeType(bytes);
+  if (!contentType) {
+    throw new ProviderRequestError(502, "Photoroom response was not a supported PNG, JPEG, or WebP image");
+  }
+
+  const fileName = `photoroom-product-image.${extensionForMimeType(contentType)}`;
+  let resultUrl: string;
+  try {
+    const stored = await context.transitFiles.create(
+      new File([Uint8Array.from(bytes)], fileName, { type: contentType }),
+    );
+    resultUrl = stored.downloadUrl;
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    throw new ProviderRequestError(500, error instanceof Error ? error.message : "Unknown file transit error", error);
+  }
+
+  return {
+    resultUrl,
+    fileName,
+    contentType,
+    contentLength: bytes.byteLength,
+    humanReviewRecommended:
+      input.lightingMode !== undefined || input.textRemovalMode !== undefined || input.beautifyMode !== undefined,
+  };
+}
+
+export function buildPhotoroomEditUrl(input: Record<string, unknown>): URL {
+  const url = new URL(photoroomEditUrl);
+  url.searchParams.set("imageUrl", requireTrimmedInputString(input.imageUrl, "imageUrl"));
+
+  const background = requireInputObject(input.background, "background");
+  const backgroundType = requireInputString(background.type, "background.type");
+  if (backgroundType === "keep") {
+    url.searchParams.set("removeBackground", "false");
+    setOptionalString(url, "background.blur.mode", background.blurMode);
+    setOptionalNumber(url, "background.blur.radius", background.blurRadius);
+  } else if (backgroundType === "color") {
+    url.searchParams.set("removeBackground", "true");
+    url.searchParams.set("background.color", requireTrimmedInputString(background.color, "background.color"));
+  } else if (backgroundType === "image") {
+    url.searchParams.set("removeBackground", "true");
+    url.searchParams.set("background.imageUrl", requireTrimmedInputString(background.imageUrl, "background.imageUrl"));
+    setOptionalString(url, "background.scaling", background.scaling);
+  } else if (backgroundType === "ai") {
+    url.searchParams.set("removeBackground", "true");
+    url.searchParams.set("background.prompt", requireTrimmedInputString(background.prompt, "background.prompt"));
+    setOptionalNumber(url, "background.seed", background.seed);
+    setOptionalString(url, "background.expandPrompt.mode", background.expandPromptMode);
+  } else {
+    throw new ProviderRequestError(400, `unsupported photoroom background type: ${backgroundType}`);
+  }
+
+  const shadowStyle = optionalRawString(input.shadowStyle);
+  if (shadowStyle !== undefined) {
+    const shadowMode = photoroomShadowModeByStyle[shadowStyle];
+    if (!shadowMode) {
+      throw new ProviderRequestError(400, `unsupported photoroom shadow style: ${shadowStyle}`);
+    }
+    url.searchParams.set("shadow.mode", shadowMode);
+  }
+  setOptionalString(url, "lighting.mode", input.lightingMode);
+  setOptionalString(url, "textRemoval.mode", input.textRemovalMode);
+  setOptionalString(url, "beautify.mode", input.beautifyMode);
+  setOptionalNumber(url, "beautify.seed", input.beautifySeed);
+
+  const outline = optionalRecord(input.outline);
+  if (outline) {
+    url.searchParams.set("outline.color", requireTrimmedInputString(outline.color, "outline.color"));
+    setOptionalNumber(url, "outline.width", outline.width);
+    setOptionalNumber(url, "outline.blurRadius", outline.blurRadius);
+  }
+
+  const canvas = optionalRecord(input.canvas);
+  if (canvas) {
+    if (typeof canvas.width === "number" && typeof canvas.height === "number") {
+      url.searchParams.set("outputSize", `${canvas.width}x${canvas.height}`);
+    }
+    setOptionalNumber(url, "padding", canvas.padding);
+    setOptionalString(url, "scaling", canvas.scaling);
+    setOptionalString(url, "horizontalAlignment", canvas.horizontalAlignment);
+    setOptionalString(url, "verticalAlignment", canvas.verticalAlignment);
+  }
+
+  setOptionalString(url, "export.format", input.outputFormat);
+  setOptionalNumber(url, "export.dpi", input.outputDpi);
+  return url;
+}
+
+async function fetchPhotoroom(input: string | URL, init: RequestInit, fetcher: ProviderFetch): Promise<Response> {
+  try {
+    return await fetcher(input, init);
+  } catch (error) {
+    throw new ProviderRequestError(502, error instanceof Error ? error.message : "Photoroom request failed", error);
+  }
+}
+
+async function readPhotoroomJson(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+  if (contentType === "application/json") {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function createPhotoroomError(
+  response: Response,
+  payload: unknown,
+  phase: PhotoroomRequestPhase,
+): ProviderRequestError {
+  const message = extractPhotoroomErrorMessage(payload) ?? `Photoroom request failed with status ${response.status}`;
+
+  if (response.status === 429) {
+    return new ProviderRequestError(429, message, payload);
+  }
+  if (response.status === 401 || response.status === 403) {
+    return new ProviderRequestError(phase === "validate" ? 400 : 401, message, payload);
+  }
+  if (response.status === 402) {
+    return new ProviderRequestError(502, message, {
+      status: response.status,
+      payload,
+    });
+  }
+  if (response.status >= 400 && response.status < 500) {
+    return new ProviderRequestError(400, message, payload);
+  }
+  return new ProviderRequestError(502, message, {
+    status: response.status,
+    payload,
+  });
+}
+
+function extractPhotoroomErrorMessage(payload: unknown): string | undefined {
+  if (typeof payload === "string") {
+    return payload.trim() || undefined;
+  }
+  const record = optionalRecord(payload);
+  const error = optionalRecord(record?.error);
+  return (
+    optionalRawString(error?.message) ??
+    optionalRawString(error?.detail) ??
+    optionalRawString(record?.message) ??
+    optionalRawString(record?.error)
+  );
+}
+
+function normalizePhotoroomAccount(payload: unknown): {
+  plan: string | undefined;
+  images: {
+    available: number;
+    subscription: number;
+  };
+} {
+  const account = optionalRecord(payload);
+  if (!account) {
+    throw new ProviderRequestError(502, "Photoroom account response was not an object");
+  }
+  const images = optionalRecord(account.images);
+  const available = optionalNumber(images?.available);
+  const subscription = optionalNumber(images?.subscription);
+  const plan = optionalRawString(account.plan);
+
+  if (!images || available === undefined || subscription === undefined) {
+    throw new ProviderRequestError(502, "Photoroom account response did not include image quota details");
+  }
+
+  return {
+    plan,
+    images: {
+      available,
+      subscription,
+    },
+  };
+}
+
+function photoroomHeaders(apiKey: string, accept: string, usesAiShadows = false): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept,
+    "user-agent": providerUserAgent,
+    "x-api-key": apiKey,
+  };
+  if (usesAiShadows) {
+    headers["pr-ai-shadows-model-version"] = photoroomAiShadowsModelVersion;
+  }
+  return headers;
+}
+
+function requireInputString(value: unknown, fieldName: string): string {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  throw new ProviderRequestError(400, `${fieldName} is required`);
+}
+
+function requireTrimmedInputString(value: unknown, fieldName: string): string {
+  if (typeof value === "string" && value.trim() !== "") {
+    return value.trim();
+  }
+  throw new ProviderRequestError(400, `${fieldName} is required`);
+}
+
+function requireInputObject(value: unknown, fieldName: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (object) {
+    return object;
+  }
+  throw new ProviderRequestError(400, `${fieldName} is required`);
+}
+
+function setOptionalString(url: URL, key: string, value: unknown): void {
+  if (typeof value === "string") {
+    url.searchParams.set(key, value);
+  }
+}
+
+function setOptionalNumber(url: URL, key: string, value: unknown): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    url.searchParams.set(key, String(value));
+  }
+}
+
+function detectPhotoroomImageMimeType(bytes: Uint8Array): "image/png" | "image/jpeg" | "image/webp" | undefined {
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) {
+    return "image/jpeg";
+  }
+  if (
+    startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return undefined;
+}
+
+function startsWith(bytes: Uint8Array, signature: readonly number[]): boolean {
+  return bytes.byteLength >= signature.length && signature.every((value, index) => bytes[index] === value);
+}
+
+function extensionForMimeType(mimeType: "image/png" | "image/jpeg" | "image/webp"): string {
+  if (mimeType === "image/png") {
+    return "png";
+  }
+  if (mimeType === "image/jpeg") {
+    return "jpg";
+  }
+  return "webp";
+}

--- a/src/providers/sellersprite/actions.ts
+++ b/src/providers/sellersprite/actions.ts
@@ -1,0 +1,467 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "sellersprite";
+
+const marketplaceSchema = s.stringEnum("Amazon marketplace code supported by SellerSprite.", [
+  "US",
+  "JP",
+  "UK",
+  "DE",
+  "FR",
+  "IT",
+  "ES",
+  "CA",
+  "IN",
+]);
+
+function monthSchema(description: string) {
+  return s.string(description, {
+    pattern: "^\\s*[0-9]{4}(0[1-9]|1[0-2])\\s*$",
+  });
+}
+
+function asinSchema(description: string) {
+  return s.string(description, {
+    pattern: "^\\s*[A-Za-z0-9]{10}\\s*$",
+  });
+}
+
+const pageSchema = s.positiveInteger("One-based page number.");
+const pageSizeSchema = s.integer("Number of results per page, up to 100.", {
+  minimum: 1,
+  maximum: 100,
+});
+const matchTypeSchema = s.integer("Keyword match type: 1 for phrase, 2 for broad, or 3 for exact.", {
+  minimum: 1,
+  maximum: 3,
+});
+const variationSchema = s.stringEnum("Variation handling: N includes variation ASINs and Y excludes them.", ["N", "Y"]);
+const yesSchema = s.stringEnum("Whether the filter is enabled.", ["Y"]);
+const sortSchema = s.object(
+  "SellerSprite sort settings.",
+  {
+    field: s.nonWhitespaceString("SellerSprite field name used to sort the results."),
+    desc: s.boolean("Whether results are sorted in descending order."),
+  },
+  { required: [] },
+);
+
+const badgeOutputSchema = s.nullable(
+  s.looseObject("SellerSprite badges associated with the product.", {
+    bestSeller: s.nullableString("Best Seller badge value."),
+    amazonChoice: s.nullableString("Amazon's Choice badge value."),
+    newRelease: s.nullableString("New Release badge value."),
+    ebc: s.nullableString("Whether the product has A+ content."),
+    video: s.nullableString("Whether the product has a video."),
+  }),
+);
+
+const subcategoryOutputSchema = s.looseObject("Amazon subcategory rank returned by SellerSprite.", {
+  code: s.nullableString("Amazon subcategory code."),
+  rank: s.nullableInteger("Product rank in the subcategory."),
+  label: s.nullableString("Amazon subcategory label."),
+});
+
+const productOutputSchema = s.looseObject("Product research record returned by SellerSprite.", {
+  asin: s.nullableString("Amazon ASIN."),
+  brand: s.nullableString("Product brand."),
+  brandUrl: s.nullableString("Amazon brand URL."),
+  imageUrl: s.nullableString("Product image URL."),
+  title: s.nullableString("Amazon product title."),
+  parent: s.nullableString("Parent ASIN."),
+  nodeId: s.nullable(
+    s.anyOf("Amazon category node identifier.", [
+      s.integer("Numeric Amazon category node identifier."),
+      s.string("String Amazon category node identifier."),
+    ]),
+  ),
+  nodeIdPath: s.nullableString("Amazon category node path."),
+  nodeLabelPath: s.nullableString("Amazon category label path."),
+  bsrId: s.nullableString("Amazon BSR category identifier."),
+  bsr: s.nullableInteger("Amazon Best Sellers Rank."),
+  bsrCr: s.nullableNumber("BSR growth rate."),
+  bsrCv: s.nullableInteger("BSR growth amount."),
+  units: s.nullableInteger("Estimated monthly parent-product sales volume."),
+  unitsGr: s.nullableNumber("Estimated monthly sales growth rate."),
+  amzUnit: s.nullableInteger("Estimated recent child-ASIN sales volume."),
+  amzSales: s.nullableNumber("Estimated child-ASIN sales revenue."),
+  amzUnitDate: s.nullableInteger("Child-ASIN estimate update time in epoch milliseconds."),
+  revenue: s.nullableNumber("Estimated monthly parent-product revenue."),
+  price: s.nullableNumber("Current product price."),
+  averagePrice: s.nullableNumber("Average product price."),
+  primePrice: s.nullableNumber("Prime price, or -1 when unavailable."),
+  profit: s.nullableNumber("Estimated gross margin percentage."),
+  fba: s.nullableNumber("Estimated FBA fee."),
+  ratings: s.nullableInteger("Product rating count."),
+  ratingsRate: s.nullableNumber("Estimated review rate."),
+  rating: s.nullableNumber("Average product rating."),
+  ratingsCv: s.nullableInteger("Monthly rating-count growth."),
+  ratingDelta: s.nullableInteger("New ratings in the recent period."),
+  lqs: s.nullableNumber("SellerSprite listing quality score."),
+  availableDate: s.nullableInteger("Listing date in epoch milliseconds."),
+  fulfillment: s.nullableString("Fulfillment method."),
+  variations: s.nullableInteger("Variation count."),
+  sellers: s.nullableInteger("Seller count."),
+  sellerId: s.nullableString("Buy Box seller identifier."),
+  sellerName: s.nullableString("Buy Box seller name."),
+  sellerNation: s.nullableString("Buy Box seller country code."),
+  weight: s.nullableString("Product weight text."),
+  dimension: s.nullableString("Product dimensions text."),
+  dimensionsType: s.nullableString("SellerSprite dimension type."),
+  pkgDimensions: s.nullableString("Package dimensions text."),
+  pkgDimensionType: s.nullableString("SellerSprite package dimension type."),
+  pkgWeight: s.nullableString("Package weight text."),
+  sku: s.nullableString("Variation attribute text."),
+  deliveryPrice: s.nullableNumber("Seller delivery fee, or -1 when unavailable."),
+  badge: badgeOutputSchema,
+  subcategories: s.nullable(s.array("Amazon subcategory ranks.", subcategoryOutputSchema)),
+});
+
+const paginatedProductOutputSchema = s.object(
+  "Paginated product research results returned by SellerSprite.",
+  {
+    pages: s.integer("Total number of result pages."),
+    page: s.integer("Current result page."),
+    size: s.integer("Number of requested results per page."),
+    total: s.integer("Total number of matching results."),
+    took: s.nullableInteger("SellerSprite query duration in milliseconds."),
+    order: s.nullable(s.looseObject("Sort settings echoed by SellerSprite.")),
+    items: s.array("Products returned on this page.", productOutputSchema),
+  },
+  {
+    required: ["pages", "page", "size", "total", "items"],
+    additionalProperties: true,
+  },
+);
+
+const usageOutputSchema = s.actionOutput(
+  {
+    usage: s.unknown(
+      "Raw current-month per-module usage payload returned by SellerSprite because the provider does not publish a stable nested schema.",
+    ),
+  },
+  "Current SellerSprite API usage information.",
+);
+
+const asinDetailOptionalFields = {
+  asinUrl: s.nullableString("Amazon product URL."),
+  availableDate: s.nullableInteger("Listing date in epoch milliseconds."),
+  badge: badgeOutputSchema,
+  brand: s.nullableString("Product brand."),
+  brandUrl: s.nullableString("Amazon brand URL."),
+  bsrId: s.nullableString("Amazon BSR category identifier."),
+  bsrLabel: s.nullableString("Amazon BSR category label."),
+  bsrRank: s.nullableInteger("Amazon Best Sellers Rank."),
+  createdTime: s.nullableInteger("SellerSprite record creation time in epoch milliseconds."),
+  dimensions: s.nullableString("Product dimensions text."),
+  firstRatingDate: s.nullableInteger("First rating date in epoch milliseconds."),
+  imageUrl: s.nullableString("Product image URL."),
+  lqs: s.nullableInteger("SellerSprite listing quality score."),
+  nodeId: s.nullable(
+    s.anyOf("Amazon category node identifier.", [
+      s.integer("Numeric Amazon category node identifier."),
+      s.string("String Amazon category node identifier."),
+    ]),
+  ),
+  nodeIdPath: s.nullableString("Amazon category node path."),
+  nodeLabelPath: s.nullableString("Amazon category label path."),
+  nodeLabelPathLocale: s.nullableString("Localized Amazon category label path."),
+  parent: s.nullableString("Parent ASIN."),
+  price: s.nullableNumber("Current product price."),
+  primePrice: s.nullableNumber("Prime price, or -1 when unavailable."),
+  deliveryPrice: s.nullableNumber("Seller delivery fee, or -1 when unavailable."),
+  coupon: s.nullableString("Current coupon text."),
+  questions: s.nullableInteger("Customer question count."),
+  rating: s.nullableNumber("Average product rating."),
+  ratings: s.nullableInteger("Product rating count."),
+  reviews: s.nullableInteger("Product review count."),
+  variantRatings: s.nullableInteger("Variation rating count."),
+  variantReviews: s.nullableInteger("Variation review count."),
+  sellerId: s.nullableString("Buy Box seller identifier."),
+  sellerName: s.nullableString("Buy Box seller name."),
+  fulfillment: s.nullableString("Fulfillment method."),
+  sellers: s.nullableInteger("Seller count."),
+  skuList: s.nullable(s.array("Variation attribute strings.", s.string("One variation attribute string."))),
+  marketplace: s.nullableString("Amazon marketplace code."),
+  title: s.nullableString("Amazon product title."),
+  features: s.nullable(s.array("Amazon feature bullets.", s.string("One Amazon feature bullet."))),
+  overviews: s.nullableString("JSON-formatted product overview text."),
+  updatedTime: s.nullableInteger("SellerSprite update time in epoch milliseconds."),
+  variationList: s.nullable(
+    s.array(
+      "Product variations returned by SellerSprite.",
+      s.looseObject("One product variation.", {
+        asin: s.nullableString("Variation ASIN."),
+        attribute: s.nullableString("Variation attribute text."),
+      }),
+    ),
+  ),
+  variations: s.nullableInteger("Variation count."),
+  weight: s.nullableString("Product weight text."),
+  zoomImageUrl: s.nullableString("Large product image URL."),
+  subcategories: s.nullable(s.array("Amazon subcategory ranks.", subcategoryOutputSchema)),
+};
+
+const asinDetailOutputSchema = s.object(
+  "SellerSprite ASIN details with stable documented fields and additional upstream fields preserved.",
+  {
+    asin: s.string("Amazon ASIN returned by SellerSprite."),
+    ...asinDetailOptionalFields,
+  },
+  {
+    required: ["asin"],
+    additionalProperties: true,
+  },
+);
+
+const competitorOptionalFields = {
+  month: monthSchema("Historical month in YYYYMM format."),
+  brand: s.nonWhitespaceString("Brand name used to filter competitor products."),
+  sellerName: s.nonWhitespaceString("Seller name used to filter competitor products."),
+  asins: s.array("ASINs used to select competitor products.", asinSchema("One Amazon ASIN."), {
+    minItems: 1,
+    maxItems: 40,
+  }),
+  nodeIdPath: s.nonWhitespaceString("Amazon category node path used to filter products."),
+  nodeIdPathEqual: s.boolean("Whether nodeIdPath is matched exactly instead of including descendant categories."),
+  keyword: s.nonWhitespaceString("Keyword used to filter competitor products."),
+  matchType: matchTypeSchema,
+  variation: variationSchema,
+  page: pageSchema,
+  size: pageSizeSchema,
+  order: sortSchema,
+};
+
+const competitorInputSchema = s.actionInput(
+  {
+    marketplace: marketplaceSchema,
+    ...competitorOptionalFields,
+  },
+  ["marketplace"],
+  "Filters for the SellerSprite competitor lookup.",
+);
+
+const productResearchOptionalFields = {
+  month: monthSchema("Historical month in YYYYMM format."),
+  keyword: s.nonWhitespaceString("Keyword used to filter products."),
+  includeSellers: s.nonWhitespaceString("Seller names to include."),
+  excludeSellers: s.nonWhitespaceString("Seller names to exclude."),
+  matchType: matchTypeSchema,
+  excludeKeywords: s.nonWhitespaceString("Keywords to exclude."),
+  minPrice: s.number("Minimum product price."),
+  maxPrice: s.number("Maximum product price."),
+  minRating: s.number("Minimum average rating."),
+  maxRating: s.number("Maximum average rating."),
+  minRatings: s.integer("Minimum rating count."),
+  maxRatings: s.integer("Maximum rating count."),
+  minRatingsCv: s.integer("Minimum monthly rating-count growth."),
+  maxRatingsCv: s.integer("Maximum monthly rating-count growth."),
+  minSellers: s.integer("Minimum seller count."),
+  maxSellers: s.integer("Maximum seller count."),
+  minProfit: s.number("Minimum estimated gross margin percentage."),
+  maxProfit: s.number("Maximum estimated gross margin percentage."),
+  minBsr: s.integer("Minimum BSR filter value."),
+  maxBsr: s.integer("Maximum BSR filter value."),
+  minBsrCv: s.integer("Minimum BSR growth amount."),
+  maxBsrCv: s.integer("Maximum BSR growth amount."),
+  minBsrCr: s.number("Minimum BSR growth rate."),
+  maxBsrCr: s.number("Maximum BSR growth rate."),
+  minUnits: s.integer("Minimum estimated monthly parent-product sales volume."),
+  maxUnits: s.integer("Maximum estimated monthly parent-product sales volume."),
+  minAmzUnit: s.integer("Minimum estimated monthly child-ASIN sales volume."),
+  maxAmzUnit: s.integer("Maximum estimated monthly child-ASIN sales volume."),
+  minRevenue: s.number("Minimum estimated monthly revenue."),
+  maxRevenue: s.number("Maximum estimated monthly revenue."),
+  minRevenueCr: s.number("Minimum estimated monthly revenue growth rate."),
+  maxRevenueCr: s.number("Maximum estimated monthly revenue growth rate."),
+  minUnitsCr: s.number("Minimum estimated monthly sales growth rate."),
+  maxUnitsCr: s.number("Maximum estimated monthly sales growth rate."),
+  weightUnit: s.nonWhitespaceString("Weight unit used by minWeights and maxWeights."),
+  minWeights: s.number("Minimum product weight."),
+  maxWeights: s.number("Maximum product weight."),
+  minVariations: s.integer("Minimum variation count."),
+  maxVariations: s.integer("Maximum variation count."),
+  filterSub: yesSchema,
+  minSubBsrRank: s.integer("Minimum subcategory BSR used when filterSub is Y."),
+  maxSubBsrRank: s.integer("Maximum subcategory BSR used when filterSub is Y."),
+  includeBrands: s.nonWhitespaceString("Brand names to include."),
+  excludeBrands: s.nonWhitespaceString("Brand names to exclude."),
+  nodeIdPaths: s.array(
+    "Amazon category node paths used to filter products.",
+    s.nonWhitespaceString("One Amazon category node path."),
+    {
+      minItems: 1,
+    },
+  ),
+  nodeIdPathEqual: s.boolean("Whether category paths are matched exactly instead of including descendants."),
+  availableMonth: s.anyOf("Listing age bucket in months.", [
+    s.literal(1, { description: "Listings from the last month." }),
+    s.literal(3, { description: "Listings from the last three months." }),
+    s.literal(6, { description: "Listings from the last six months." }),
+    s.literal(12, { description: "Listings from the last year." }),
+    s.literal(24, { description: "Listings from the last two years." }),
+  ]),
+  dimensionType: s.nonWhitespaceString("Comma-separated SellerSprite product dimension type codes."),
+  minFba: s.number("Minimum estimated FBA fee."),
+  maxFba: s.number("Maximum estimated FBA fee."),
+  minLqs: s.number("Minimum SellerSprite listing quality score."),
+  maxLqs: s.number("Maximum SellerSprite listing quality score."),
+  sellerNation: s.nonWhitespaceString("Comma-separated seller country codes."),
+  badgeBS: yesSchema,
+  badgeAC: yesSchema,
+  badgeNR: yesSchema,
+  fulfillment: s.nonWhitespaceString("Comma-separated fulfillment methods such as AMZ, FBA, or FBM."),
+  variation: variationSchema,
+  page: pageSchema,
+  size: pageSizeSchema,
+  order: sortSchema,
+};
+
+const productResearchInputSchema = s.actionInput(
+  {
+    marketplace: marketplaceSchema,
+    ...productResearchOptionalFields,
+  },
+  ["marketplace"],
+  "Filters for SellerSprite product research.",
+);
+
+const rankPositionOutputSchema = s.nullable(
+  s.looseObject("Natural or advertising search position.", {
+    page: s.nullableInteger("Search results page."),
+    pageSize: s.nullableInteger("Number of results on the search page."),
+    index: s.nullableInteger("Position within the search page."),
+    position: s.nullableInteger("Overall position in the search results."),
+    updatedTime: s.nullableInteger("Ranking update time in epoch milliseconds."),
+  }),
+);
+
+const keywordOutputSchema = s.looseObject("Reverse-ASIN traffic keyword returned by SellerSprite.", {
+  keyword: s.nullableString("Traffic keyword."),
+  keywordCn: s.nullableString("Chinese keyword translation."),
+  searches: s.nullableInteger("Estimated monthly Amazon search volume."),
+  products: s.nullableInteger("Number of products in the keyword results."),
+  purchases: s.nullableInteger("Estimated monthly purchase count."),
+  purchaseRate: s.nullableNumber("Estimated purchase rate."),
+  bid: s.nullableNumber("Suggested phrase-match PPC bid."),
+  bidMax: s.nullableNumber("Maximum suggested PPC bid."),
+  bidMin: s.nullableNumber("Minimum suggested PPC bid."),
+  badges: s.nullable(s.array("Search exposure position types.", s.string("One exposure position type."))),
+  rankPosition: rankPositionOutputSchema,
+  adPosition: rankPositionOutputSchema,
+  searchesRank: s.nullableInteger("Amazon ABA search frequency rank."),
+  searchesRankTimeFrom: s.nullableInteger("ABA rank period start in epoch milliseconds."),
+  searchesRankTimeTo: s.nullableInteger("ABA rank period end in epoch milliseconds."),
+  latest1daysAds: s.nullableInteger("Advertising competitors seen in the last day."),
+  latest7daysAds: s.nullableInteger("Advertising competitors seen in the last seven days."),
+  latest30daysAds: s.nullableInteger("Advertising competitors seen in the last thirty days."),
+  supplyDemandRatio: s.nullableNumber("Estimated search-volume-to-product ratio."),
+  trafficPercentage: s.nullableNumber("Estimated share of product exposure from the keyword."),
+  trafficKeywordType: s.nullableString("SellerSprite traffic-share classification."),
+  conversionKeywordType: s.nullableString("SellerSprite conversion classification."),
+  calculatedWeeklySearches: s.nullableNumber("Estimated weekly product exposure from the keyword."),
+  impressions: s.nullableInteger("Total keyword search-result impressions."),
+  clicks: s.nullableInteger("Total keyword search-result clicks."),
+  naturalRatio: s.nullableNumber("Natural traffic share."),
+  adRatio: s.nullableNumber("Advertising traffic share."),
+  updatedTime: s.nullableInteger("Keyword update time in epoch milliseconds."),
+});
+
+const keywordStatOutputSchema = s.looseObject("High-frequency word statistic.", {
+  keywords: s.nullableString("High-frequency word."),
+  total: s.nullableInteger("Number of matching keywords."),
+});
+
+const reverseKeywordOptionalFields = {
+  keyword: s.nonWhitespaceString("Keyword text used to filter the reverse-ASIN results."),
+  month: monthSchema("Historical month in YYYYMM format; omit for the latest 30 days."),
+  badges: s.array(
+    "SellerSprite exposure-position types used to filter results.",
+    s.nonWhitespaceString("One SellerSprite exposure-position type."),
+    { minItems: 1 },
+  ),
+  trafficKeywordTypes: s.array(
+    "SellerSprite traffic-share classifications used to filter results.",
+    s.nonWhitespaceString("One SellerSprite traffic-share classification."),
+    { minItems: 1 },
+  ),
+  conversionKeywordTypes: s.array(
+    "SellerSprite conversion classifications used to filter results.",
+    s.nonWhitespaceString("One SellerSprite conversion classification."),
+    { minItems: 1 },
+  ),
+  page: pageSchema,
+  size: pageSizeSchema,
+  order: sortSchema,
+};
+
+const reverseKeywordInputSchema = s.actionInput(
+  {
+    marketplace: marketplaceSchema,
+    asin: asinSchema("Amazon ASIN to reverse-search."),
+    ...reverseKeywordOptionalFields,
+  },
+  ["marketplace", "asin"],
+  "Filters for SellerSprite reverse-ASIN traffic keyword research.",
+);
+
+const reverseKeywordOutputSchema = s.object(
+  "Reverse-ASIN traffic keyword results returned by SellerSprite.",
+  {
+    marketplace: s.string("Amazon marketplace code."),
+    asin: s.string("Amazon ASIN."),
+    total: s.integer("Total number of matching traffic keywords."),
+    items: s.array("Traffic keywords returned on this page.", keywordOutputSchema),
+    stats: s.array("High-frequency word statistics.", keywordStatOutputSchema),
+  },
+  {
+    required: ["marketplace", "asin", "total", "items"],
+    additionalProperties: true,
+  },
+);
+
+export const sellerspriteActions: ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_api_usage",
+    description: "Retrieve current-month SellerSprite API usage for initialized purchased modules.",
+    inputSchema: s.actionInput({}, [], "Input for retrieving SellerSprite API usage."),
+    outputSchema: usageOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_asin_detail",
+    description:
+      "Retrieve SellerSprite product, listing, category, rating, seller, and variation details for an Amazon ASIN.",
+    inputSchema: s.actionInput(
+      {
+        marketplace: marketplaceSchema,
+        asin: asinSchema("Amazon ASIN to retrieve."),
+      },
+      ["marketplace", "asin"],
+      "Input for retrieving SellerSprite ASIN details.",
+    ),
+    outputSchema: asinDetailOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "lookup_competitors",
+    description: "Query SellerSprite competitor products with sales, revenue, ranking, pricing, and seller estimates.",
+    inputSchema: competitorInputSchema,
+    outputSchema: paginatedProductOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "research_products",
+    description:
+      "Research Amazon products in SellerSprite using product, sales, revenue, ranking, review, category, and seller filters.",
+    inputSchema: productResearchInputSchema,
+    outputSchema: paginatedProductOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "reverse_asin_keywords",
+    description:
+      "Find Amazon search traffic keywords, natural ranks, advertising ranks, and traffic estimates for an ASIN with SellerSprite.",
+    inputSchema: reverseKeywordInputSchema,
+    outputSchema: reverseKeywordOutputSchema,
+  }),
+];

--- a/src/providers/sellersprite/definition.ts
+++ b/src/providers/sellersprite/definition.ts
@@ -1,0 +1,26 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { sellerspriteActions } from "./actions.ts";
+
+const service = "sellersprite";
+
+/**
+ * SellerSprite provider backed by the SellerSprite Open API.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "SellerSprite",
+  categories: ["Data", "Marketing"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "Secret Key",
+      placeholder: "sellersprite_secret_key",
+      description:
+        "SellerSprite Open API secret key sent with the secret-key header. Create or view API keys at https://open.sellersprite.com/app/list.",
+    },
+  ],
+  homepageUrl: "https://www.sellersprite.com/",
+  actions: sellerspriteActions,
+};

--- a/src/providers/sellersprite/executors.ts
+++ b/src/providers/sellersprite/executors.ts
@@ -1,0 +1,67 @@
+import type {
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import { createProviderFetch, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import {
+  sellerSpriteActionHandlers,
+  sellerSpriteApiBaseUrl,
+  toSellerSpriteExecutionError,
+  validateSellerSpriteCredential,
+} from "./runtime.ts";
+
+const service = "sellersprite";
+const sellerSpriteFetch = createProviderFetch({ skipDnsValidation: true });
+
+export const executors: ProviderExecutors = defineSellerSpriteExecutors();
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: sellerSpriteApiBaseUrl,
+  auth: { type: "api_key_header", name: "secret-key" },
+  skipDnsValidation: true,
+  customizeRequest({ headers }) {
+    if (!headers.has("accept")) {
+      headers.set("accept", "application/json");
+    }
+    if (!headers.has("content-type")) {
+      headers.set("content-type", "application/json;charset=UTF-8");
+    }
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validateSellerSpriteCredential(input.apiKey, fetcher, signal);
+  },
+};
+
+function defineSellerSpriteExecutors(): ProviderExecutors {
+  const output: ProviderExecutors = {};
+  for (const [name, handler] of Object.entries(sellerSpriteActionHandlers)) {
+    output[`${service}.${name}`] = async (input, context: ExecutionContext) => {
+      try {
+        const credential = await requireApiKeyCredential(context, service);
+        const providerContext: ApiKeyProviderContext = {
+          apiKey: credential.apiKey,
+          fetcher: sellerSpriteFetch,
+          signal: context.signal,
+        };
+        if (context.transitFiles) {
+          providerContext.transitFiles = context.transitFiles;
+        }
+        return {
+          ok: true,
+          output: await handler(input as Record<string, unknown>, providerContext),
+        };
+      } catch (error) {
+        return toSellerSpriteExecutionError(error);
+      }
+    };
+  }
+  return output;
+}

--- a/src/providers/sellersprite/runtime.ts
+++ b/src/providers/sellersprite/runtime.ts
@@ -1,0 +1,515 @@
+import type { CredentialValidationResult, ExecutionResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { compactObject, optionalRecord, optionalString, requiredString, requiredStringArray } from "../../core/cast.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+  readProviderJsonBody,
+  toProviderExecutionError,
+} from "../provider-runtime.ts";
+
+export const sellerSpriteApiBaseUrl = "https://api.sellersprite.com";
+
+const sellerSpriteValidationPath = "/v1/visits";
+const sellerSpriteRequestTimeoutMs = 30_000;
+const sellerSpriteMarketplaces = new Set(["US", "JP", "UK", "DE", "FR", "IT", "ES", "CA", "IN"]);
+const competitorStringFields: readonly string[] = ["brand", "sellerName", "nodeIdPath", "keyword"];
+const researchStringFields: readonly string[] = [
+  "keyword",
+  "includeSellers",
+  "excludeSellers",
+  "excludeKeywords",
+  "weightUnit",
+  "includeBrands",
+  "excludeBrands",
+  "dimensionType",
+  "sellerNation",
+  "fulfillment",
+];
+const reverseKeywordArrayFields: readonly string[] = ["badges", "trafficKeywordTypes", "conversionKeywordTypes"];
+const emptySellerSpriteBody = Symbol("empty SellerSprite response");
+
+type SellerSpritePhase = "validate" | "execute";
+
+interface SellerSpriteRequest {
+  path: string;
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
+  phase: SellerSpritePhase;
+  method?: "GET" | "POST";
+  body?: Record<string, unknown>;
+}
+
+interface SellerSpriteEnvelope {
+  code?: unknown;
+  message?: unknown;
+  data?: unknown;
+}
+
+interface SellerSpriteErrorInput {
+  status: number;
+  code?: string;
+  message?: string;
+  retryAfter: string | null;
+  phase: SellerSpritePhase;
+}
+
+class SellerSpriteRequestError extends ProviderRequestError {
+  readonly code: string;
+
+  constructor(code: string, status: number, message: string, details?: unknown) {
+    super(status, message, details);
+    this.code = code;
+  }
+}
+
+export const sellerSpriteActionHandlers: Record<string, ProviderRuntimeHandler<ApiKeyProviderContext>> = {
+  async get_api_usage(_input, context): Promise<unknown> {
+    const data = await requestSellerSpriteData({
+      path: sellerSpriteValidationPath,
+      context,
+      phase: "execute",
+    });
+    return { usage: data };
+  },
+  async get_asin_detail(input, context): Promise<unknown> {
+    const marketplace = requireMarketplace(input.marketplace);
+    const asin = requireAsin(input.asin, "asin");
+    const data = await requestSellerSpriteData({
+      path: `/v1/asin/${encodeURIComponent(marketplace)}/${encodeURIComponent(asin)}`,
+      context,
+      phase: "execute",
+    });
+    const detail = requireResponseObject(data, "SellerSprite ASIN detail");
+    requireResponseString(detail.asin, "data.asin");
+    return detail;
+  },
+  async lookup_competitors(input, context): Promise<unknown> {
+    const data = await requestSellerSpriteData({
+      path: "/v1/product/competitor-lookup",
+      method: "POST",
+      body: normalizeCompetitorInput(input),
+      context,
+      phase: "execute",
+    });
+    return normalizeProductPage(data);
+  },
+  async research_products(input, context): Promise<unknown> {
+    const data = await requestSellerSpriteData({
+      path: "/v1/product/research",
+      method: "POST",
+      body: normalizeResearchInput(input),
+      context,
+      phase: "execute",
+    });
+    return normalizeProductPage(data);
+  },
+  async reverse_asin_keywords(input, context): Promise<unknown> {
+    const data = await requestSellerSpriteData({
+      path: "/v1/traffic/keyword",
+      method: "POST",
+      body: normalizeReverseKeywordInput(input),
+      context,
+      phase: "execute",
+    });
+    return normalizeReverseKeywords(data);
+  },
+};
+
+export async function validateSellerSpriteCredential(
+  apiKey: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const usage = await requestSellerSpriteData({
+    path: sellerSpriteValidationPath,
+    context: { apiKey, fetcher, signal },
+    phase: "validate",
+  });
+
+  return {
+    profile: {
+      accountId: "sellersprite",
+      displayName: "SellerSprite API Key",
+    },
+    grantedScopes: [],
+    metadata: {
+      apiBaseUrl: sellerSpriteApiBaseUrl,
+      validationEndpoint: sellerSpriteValidationPath,
+      usage,
+    },
+  };
+}
+
+export function toSellerSpriteExecutionError(error: unknown): ExecutionResult {
+  if (error instanceof SellerSpriteRequestError) {
+    return {
+      ok: false,
+      error: {
+        code: error.code,
+        message: error.message,
+        details: {
+          status: error.status,
+          details: error.details,
+        },
+      },
+    };
+  }
+  return toProviderExecutionError(error, "SellerSprite request failed");
+}
+
+async function requestSellerSpriteData(input: SellerSpriteRequest): Promise<unknown> {
+  const timeout = createProviderTimeout(input.context.signal, sellerSpriteRequestTimeoutMs);
+  let response: Response;
+  let payload: unknown;
+
+  try {
+    response = await input.context.fetcher(new URL(input.path, sellerSpriteApiBaseUrl), {
+      method: input.method ?? "GET",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json;charset=UTF-8",
+        "secret-key": input.context.apiKey,
+        "user-agent": providerUserAgent,
+        "x-request-id": randomUuidV7(),
+      },
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal: timeout.signal,
+    });
+    payload = await readProviderJsonBody(response, {
+      emptyBody: emptySellerSpriteBody,
+      invalidJsonMessage: "SellerSprite returned invalid JSON",
+    });
+    if (payload === emptySellerSpriteBody) {
+      throw new ProviderRequestError(502, "SellerSprite returned an empty response");
+    }
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, "SellerSprite request timed out");
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `SellerSprite request failed: ${error.message}` : "SellerSprite request failed",
+    );
+  } finally {
+    timeout.cleanup();
+  }
+
+  const envelope = asSellerSpriteEnvelope(payload);
+  const code = optionalString(envelope.code);
+  const message = optionalString(envelope.message);
+
+  if (!response.ok || code !== "OK") {
+    throw createSellerSpriteError({
+      status: response.status,
+      code,
+      message,
+      retryAfter: response.headers.get("retry-after"),
+      phase: input.phase,
+    });
+  }
+
+  return envelope.data;
+}
+
+function normalizeCompetitorInput(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    ...input,
+    marketplace: requireMarketplace(input.marketplace),
+    month: normalizeOptionalMonth(input.month),
+    asins: normalizeOptionalAsins(input.asins),
+    order: normalizeOptionalOrder(input.order),
+  };
+  normalizeOptionalStrings(output, input, competitorStringFields);
+  return compactObject(output);
+}
+
+function normalizeResearchInput(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    ...input,
+    marketplace: requireMarketplace(input.marketplace),
+    month: normalizeOptionalMonth(input.month),
+    nodeIdPaths: normalizeOptionalStringArray(input.nodeIdPaths, "nodeIdPaths"),
+    order: normalizeOptionalOrder(input.order),
+  };
+  normalizeOptionalStrings(output, input, researchStringFields);
+  return compactObject(output);
+}
+
+function normalizeReverseKeywordInput(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    ...input,
+    marketplace: requireMarketplace(input.marketplace),
+    asin: requireAsin(input.asin, "asin"),
+    keyword: normalizeOptionalString(input.keyword, "keyword"),
+    month: normalizeOptionalMonth(input.month),
+    order: normalizeOptionalOrder(input.order),
+  };
+  for (const fieldName of reverseKeywordArrayFields) {
+    output[fieldName] = normalizeOptionalStringArray(input[fieldName], fieldName);
+  }
+  return compactObject(output);
+}
+
+function normalizeOptionalStrings(
+  output: Record<string, unknown>,
+  input: Record<string, unknown>,
+  fieldNames: readonly string[],
+): void {
+  for (const fieldName of fieldNames) {
+    output[fieldName] = normalizeOptionalString(input[fieldName], fieldName);
+  }
+}
+
+function normalizeOptionalString(value: unknown, fieldName: string): string | undefined {
+  return value === undefined ? undefined : requireInputString(value, fieldName);
+}
+
+function normalizeOptionalStringArray(value: unknown, fieldName: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requiredStringArray(value, fieldName, requestError).map((item, index) =>
+    requireInputString(item, `${fieldName}[${index}]`),
+  );
+}
+
+function normalizeOptionalAsins(value: unknown): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requiredStringArray(value, "asins", requestError).map((item, index) => requireAsin(item, `asins[${index}]`));
+}
+
+function normalizeOptionalMonth(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const month = requireInputString(value, "month");
+  if (!isValidMonth(month)) {
+    throw new ProviderRequestError(400, "month must use YYYYMM format");
+  }
+  return month;
+}
+
+function normalizeOptionalOrder(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const order = optionalRecord(value);
+  if (!order) {
+    throw new ProviderRequestError(400, "order must be an object");
+  }
+  const normalized: Record<string, unknown> = {
+    ...order,
+    field: normalizeOptionalString(order.field, "order.field"),
+  };
+  if (order.desc !== undefined && typeof order.desc !== "boolean") {
+    throw new ProviderRequestError(400, "order.desc must be a boolean");
+  }
+  return compactObject(normalized);
+}
+
+function requireMarketplace(value: unknown): string {
+  const marketplace = requireInputString(value, "marketplace");
+  if (!sellerSpriteMarketplaces.has(marketplace)) {
+    throw new ProviderRequestError(400, "marketplace is not supported by SellerSprite");
+  }
+  return marketplace;
+}
+
+function requireAsin(value: unknown, fieldName: string): string {
+  const asin = requireInputString(value, fieldName).toUpperCase();
+  if (!isAsin(asin)) {
+    throw new ProviderRequestError(400, `${fieldName} must contain 10 ASCII letters or digits`);
+  }
+  return asin;
+}
+
+function requireInputString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, requestError);
+}
+
+function requestError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function asSellerSpriteEnvelope(value: unknown): SellerSpriteEnvelope {
+  const envelope = optionalRecord(value);
+  if (!envelope) {
+    throw new ProviderRequestError(502, "SellerSprite returned an invalid response envelope");
+  }
+  return envelope;
+}
+
+function createSellerSpriteError(input: SellerSpriteErrorInput): ProviderRequestError {
+  const message =
+    input.message ||
+    (input.code
+      ? `SellerSprite request failed with ${input.code}`
+      : `SellerSprite request failed with status ${input.status || 500}`);
+  const details = {
+    providerCode: input.code ?? null,
+    retryAfter: input.retryAfter,
+  };
+
+  if (input.status === 429 || input.code === "ERROR_VISIT_MAX" || isRateLimitMessage(message)) {
+    return new SellerSpriteRequestError("rate_limited", 429, message, {
+      ...details,
+      reason: input.code === "ERROR_VISIT_MAX" ? "quota_exhausted" : "rate_limit",
+    });
+  }
+
+  if (input.code === "ERROR_SECRET_KEY_OVERDUE") {
+    return new SellerSpriteRequestError("credential_expired", 401, message, details);
+  }
+
+  if (input.code === "ERROR_SECRET_KEY" || input.code === "ERROR_SECRET_KEY_INVALID" || input.status === 401) {
+    return new SellerSpriteRequestError(
+      input.phase === "validate" ? "invalid_input" : "credential_expired",
+      input.phase === "validate" ? 400 : 401,
+      message,
+      details,
+    );
+  }
+
+  if (input.code === "ERROR_AUTH_ERROR" || input.status === 403 || isModuleAccessMessage(message)) {
+    return new SellerSpriteRequestError(
+      input.phase === "validate" ? "invalid_input" : "scope_missing",
+      input.phase === "validate" ? 400 : 403,
+      message,
+      {
+        ...details,
+        reason: "module_not_purchased_or_unavailable",
+      },
+    );
+  }
+
+  if (input.code === "ERROR_PARAM" || (input.status >= 400 && input.status < 500)) {
+    return new SellerSpriteRequestError("invalid_input", 400, message, details);
+  }
+
+  return new SellerSpriteRequestError("provider_error", input.status >= 500 ? input.status : 502, message, details);
+}
+
+function isRateLimitMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    message.includes("频繁") ||
+    message.includes("限流") ||
+    message.includes("访问次数已达上限") ||
+    lower.includes("too many requests") ||
+    lower.includes("rate limit")
+  );
+}
+
+function isModuleAccessMessage(message: string): boolean {
+  return (
+    message.includes("未购买") ||
+    message.includes("未订阅") ||
+    message.includes("未开通") ||
+    message.includes("无权限") ||
+    (message.includes("没有") && message.includes("权限"))
+  );
+}
+
+function normalizeProductPage(value: unknown): Record<string, unknown> {
+  const data = requireResponseObject(value, "SellerSprite product page");
+  return {
+    ...data,
+    pages: requireResponseInteger(data.pages, "data.pages"),
+    page: requireResponseInteger(data.page, "data.page"),
+    size: requireResponseInteger(data.size, "data.size"),
+    total: requireResponseInteger(data.total, "data.total"),
+    items: requireResponseObjectArray(data.items, "data.items"),
+  };
+}
+
+function normalizeReverseKeywords(value: unknown): Record<string, unknown> {
+  const data = requireResponseObject(value, "SellerSprite reverse keyword page");
+  return {
+    ...data,
+    marketplace: requireResponseString(data.marketplace, "data.marketplace"),
+    asin: requireResponseString(data.asin, "data.asin"),
+    total: requireResponseInteger(data.total, "data.total"),
+    items: requireResponseObjectArray(data.items, "data.items"),
+    stats: data.stats === undefined || data.stats === null ? [] : requireResponseObjectArray(data.stats, "data.stats"),
+  };
+}
+
+function requireResponseObject(value: unknown, fieldName: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (!object) {
+    throw new ProviderRequestError(502, `${fieldName} must be an object`);
+  }
+  return object;
+}
+
+function requireResponseObjectArray(value: unknown, fieldName: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, `${fieldName} must be an array`);
+  }
+  return value.map((item, index) => requireResponseObject(item, `${fieldName}[${index}]`));
+}
+
+function requireResponseString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ProviderRequestError(502, `${fieldName} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireResponseInteger(value: unknown, fieldName: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new ProviderRequestError(502, `${fieldName} must be an integer`);
+  }
+  return value;
+}
+
+function isValidMonth(value: string): boolean {
+  if (value.length !== 6) {
+    return false;
+  }
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+  const month = Number(value.slice(4));
+  return month >= 1 && month <= 12;
+}
+
+function isAsin(value: string): boolean {
+  if (value.length !== 10) {
+    return false;
+  }
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    const isUppercaseLetter = code >= 65 && code <= 90;
+    const isDigit = code >= 48 && code <= 57;
+    if (!isUppercaseLetter && !isDigit) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function randomUuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  let timestamp = Date.now();
+  for (let index = 5; index >= 0; index -= 1) {
+    bytes[index] = timestamp % 256;
+    timestamp = Math.floor(timestamp / 256);
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/providers/shopify_admin/actions.ts
+++ b/src/providers/shopify_admin/actions.ts
@@ -66,6 +66,7 @@ const variant = s.requiredObject("A normalized Shopify product variant.", {
   sku: s.nullableString("The variant SKU when returned by Shopify."),
   price: s.nullableString("The variant price as a decimal string when returned by Shopify."),
   inventoryQuantity: s.nullable(s.integer({ description: "The tracked inventory quantity when returned by Shopify." })),
+  inventoryItemId: s.nullableString("The inventory item ID associated with the variant when returned by Shopify."),
   productId: s.nullableString("The parent product ID when returned by Shopify."),
   productTitle: s.nullableString("The parent product title when returned by Shopify."),
   cursor: s.nullable(cursor),
@@ -184,6 +185,454 @@ const collectionDetail = s.requiredObject("A normalized Shopify collection detai
   raw: rawObject,
 });
 
+const inventoryQuantity = s.requiredObject("One Shopify inventory quantity state.", {
+  name: s.string("The inventory quantity state name."),
+  quantity: s.integer("The quantity recorded for this state."),
+});
+
+const inventoryLevel = s.requiredObject("A normalized Shopify inventory level for one item at one location.", {
+  id: gid,
+  isActive: s.boolean("Whether the inventory level is active."),
+  inventoryItemId: gid,
+  inventoryItemSku: s.nullableString("The inventory item SKU when returned by Shopify."),
+  locationId: gid,
+  locationName: s.string("The location name."),
+  quantities: s.array("The requested inventory quantity states returned by Shopify.", inventoryQuantity),
+  raw: rawObject,
+});
+
+const productStatus = s.stringEnum("The Shopify product status.", ["ACTIVE", "ARCHIVED", "DRAFT", "UNLISTED"]);
+
+const metafieldInput = s.object(
+  "A Shopify metafield to create or update on the product.",
+  {
+    id: gid,
+    namespace: s.nonEmptyString("The metafield namespace."),
+    key: s.nonEmptyString("The metafield key."),
+    type: s.nonEmptyString("The Shopify metafield type."),
+    value: s.string("The metafield value encoded as a string."),
+  },
+  { optional: ["id", "namespace", "key", "type", "value"] },
+);
+
+const seoInput = s.object(
+  "Search engine optimization fields for the product.",
+  {
+    title: s.string("The SEO title."),
+    description: s.string("The SEO description."),
+  },
+  { optional: ["title", "description"] },
+);
+
+const productOptionValueInput = s.object(
+  "A value to define for a product option.",
+  {
+    name: s.nonEmptyString("The product option value name."),
+    linkedMetafieldValue: s.string("The metafield value linked to this option value."),
+  },
+  { optional: ["name", "linkedMetafieldValue"] },
+);
+
+const linkedMetafieldCreateInput = s.object(
+  "A metafield definition linked to a product option.",
+  {
+    namespace: s.nonEmptyString("The namespace of the linked metafield definition."),
+    key: s.nonEmptyString("The key of the linked metafield definition."),
+    values: s.array(
+      "The linked metafield values used to populate the product option.",
+      s.string("A linked metafield value."),
+    ),
+  },
+  { optional: ["values"] },
+);
+
+const productOptionInput = s.object(
+  "A product option and its possible values.",
+  {
+    name: s.nonEmptyString("The product option name."),
+    position: s.integer("The product option position."),
+    linkedMetafield: linkedMetafieldCreateInput,
+    values: s.array("Values associated with this product option.", productOptionValueInput, { minItems: 1 }),
+  },
+  { optional: ["name", "position", "linkedMetafield", "values"] },
+);
+
+const createMediaInput = s.object(
+  "A media object to add to a Shopify product.",
+  {
+    mediaContentType: s.stringEnum("The Shopify media content type.", ["EXTERNAL_VIDEO", "IMAGE", "MODEL_3D", "VIDEO"]),
+    originalSource: s.nonEmptyString("The external source URL or Shopify staged upload URL for the media."),
+    alt: s.string("Alternative text for the media."),
+  },
+  { optional: ["alt"] },
+);
+
+const productCreateInput = s.object(
+  "The typed Shopify ProductCreateInput fields supported by this action.",
+  {
+    category: gid,
+    claimOwnership: s.object(
+      "Product feature ownership claimed by the connected Shopify app.",
+      {
+        bundles: s.boolean("Whether the app claims ownership of bundle configuration for this product."),
+      },
+      { optional: ["bundles"] },
+    ),
+    collectionsToJoin: s.array("Collection IDs to associate with the new product.", gid),
+    combinedListingRole: s.stringEnum("The product role in a combined listing.", ["CHILD", "PARENT"]),
+    descriptionHtml: s.string("The product description with HTML tags."),
+    giftCard: s.boolean("Whether the product is a gift card."),
+    giftCardTemplateSuffix: s.string("The theme template suffix for a gift card product."),
+    handle: s.nonEmptyString("The unique human-readable product URL handle."),
+    metafields: s.array("Metafields to associate with the product.", metafieldInput),
+    productOptions: s.array("Product options and values for the initial product variant.", productOptionInput, {
+      maxItems: 3,
+    }),
+    productType: s.string("The merchant-defined product type."),
+    requiresSellingPlan: s.boolean("Whether the product can only be purchased with a selling plan."),
+    seo: seoInput,
+    status: productStatus,
+    tags: s.array("Searchable product tags.", s.string("A product tag.")),
+    templateSuffix: s.string("The theme template suffix for the product."),
+    title: s.string("The product title displayed to customers."),
+    vendor: s.string("The product vendor name."),
+  },
+  {
+    optional: [
+      "category",
+      "claimOwnership",
+      "collectionsToJoin",
+      "combinedListingRole",
+      "descriptionHtml",
+      "giftCard",
+      "giftCardTemplateSuffix",
+      "handle",
+      "metafields",
+      "productOptions",
+      "productType",
+      "requiresSellingPlan",
+      "seo",
+      "status",
+      "tags",
+      "templateSuffix",
+      "title",
+      "vendor",
+    ],
+  },
+);
+
+const productUpdateInput = s.object(
+  "The typed Shopify ProductUpdateInput fields supported by this action.",
+  {
+    id: gid,
+    category: gid,
+    collectionsToJoin: s.array("Collection IDs to associate with the product.", gid),
+    collectionsToLeave: s.array("Collection IDs to disassociate from the product.", gid),
+    deleteConflictingConstrainedMetafields: s.boolean(
+      "Whether to delete metafields whose constraints conflict with the updated category.",
+    ),
+    descriptionHtml: s.string("The product description with HTML tags."),
+    giftCardTemplateSuffix: s.string("The theme template suffix for a gift card product."),
+    handle: s.nonEmptyString("The unique human-readable product URL handle."),
+    metafields: s.array("Metafields to create or update on the product.", metafieldInput),
+    productType: s.string("The merchant-defined product type."),
+    redirectNewHandle: s.boolean("Whether Shopify should redirect the previous handle to the new handle."),
+    requiresSellingPlan: s.boolean("Whether the product can only be purchased with a selling plan."),
+    seo: seoInput,
+    status: productStatus,
+    tags: s.array("The complete replacement list of searchable product tags.", s.string("A product tag.")),
+    templateSuffix: s.string("The theme template suffix for the product."),
+    title: s.string("The product title displayed to customers."),
+    vendor: s.string("The product vendor name."),
+  },
+  {
+    optional: [
+      "category",
+      "collectionsToJoin",
+      "collectionsToLeave",
+      "deleteConflictingConstrainedMetafields",
+      "descriptionHtml",
+      "giftCardTemplateSuffix",
+      "handle",
+      "metafields",
+      "productType",
+      "redirectNewHandle",
+      "requiresSellingPlan",
+      "seo",
+      "status",
+      "tags",
+      "templateSuffix",
+      "title",
+      "vendor",
+    ],
+  },
+);
+
+const inventoryQuantityInput = s.requiredObject("An absolute inventory quantity to set for one item at one location.", {
+  inventoryItemId: gid,
+  locationId: gid,
+  quantity: s.integer("The absolute quantity to set."),
+  changeFromQuantity: s.nullable(
+    s.integer("The expected current quantity for compare-and-swap, or null to explicitly skip the check."),
+  ),
+});
+
+const inventoryAdjustmentInput = s.object(
+  "An incremental inventory quantity change for one item at one location.",
+  {
+    inventoryItemId: gid,
+    locationId: gid,
+    delta: s.integer("The amount by which Shopify should change the inventory quantity."),
+    changeFromQuantity: s.nullable(
+      s.integer("The expected current quantity for compare-and-swap, or null to explicitly skip the check."),
+    ),
+    ledgerDocumentUri: s.nonEmptyString(
+      "A non-Shopify URI identifying the exact inventory transaction or ledger entry.",
+    ),
+  },
+  { required: ["inventoryItemId", "locationId", "delta", "changeFromQuantity"] },
+);
+
+const inventoryAdjustmentReason = s.stringEnum("The Shopify reason for changing inventory quantities.", [
+  "correction",
+  "cycle_count_available",
+  "damaged",
+  "movement_created",
+  "movement_updated",
+  "movement_received",
+  "movement_canceled",
+  "other",
+  "promotion",
+  "quality_control",
+  "received",
+  "reservation_created",
+  "reservation_deleted",
+  "reservation_updated",
+  "restock",
+  "safety_stock",
+  "shrinkage",
+]);
+
+const inventoryAdjustQuantitiesInput: JsonSchema = {
+  ...s.actionInput(
+    {
+      idempotencyKey: s.nonEmptyString(
+        "A caller-stable idempotency key reused when retrying the same inventory adjustment.",
+      ),
+      name: s.nonEmptyString("The inventory quantity state to adjust."),
+      reason: inventoryAdjustmentReason,
+      referenceDocumentUri: s.nonEmptyString(
+        "A URI identifying the business reason or source document for the adjustment group.",
+      ),
+      changes: s.array("Incremental inventory quantity changes to apply.", inventoryAdjustmentInput, {
+        minItems: 1,
+      }),
+    },
+    ["idempotencyKey", "name", "reason", "changes"],
+    "The typed Shopify inventoryAdjustQuantities mutation input.",
+  ),
+  allOf: [
+    {
+      if: { properties: { name: { const: "available" } }, required: ["name"] },
+      then: {
+        properties: {
+          changes: {
+            items: { not: { required: ["ledgerDocumentUri"] } },
+          },
+        },
+      },
+      else: {
+        properties: {
+          changes: {
+            items: { required: ["ledgerDocumentUri"] },
+          },
+        },
+      },
+    },
+  ],
+};
+
+const inventoryChange = s.requiredObject("A normalized inventory quantity change.", {
+  name: s.string("The inventory quantity state that changed."),
+  delta: s.integer("The amount by which the inventory quantity changed."),
+  quantityAfterChange: s.nullable(s.integer("The resulting quantity after the change when returned by Shopify.")),
+  raw: rawObject,
+});
+
+const inventoryAdjustmentGroup = s.requiredObject("A normalized Shopify inventory adjustment group.", {
+  id: gid,
+  createdAt: s.string("The timestamp when Shopify created the adjustment group."),
+  reason: s.string("The reason for the inventory changes."),
+  referenceDocumentUri: s.nullableString("The audit trail reference URI when returned by Shopify."),
+  changes: s.array("Inventory changes made by the operation.", inventoryChange),
+  raw: rawObject,
+});
+
+const fulfillmentOrderLineItemInput = s.requiredObject("A fulfillment order line item and quantity to fulfill.", {
+  id: gid,
+  quantity: s.positiveInteger("The quantity of this fulfillment order line item to fulfill."),
+});
+
+const fulfillmentOrderInput = s.object(
+  "A fulfillment order and the optional subset of its line items to fulfill.",
+  {
+    fulfillmentOrderId: gid,
+    fulfillmentOrderLineItems: s.array(
+      "The fulfillment order line items to fulfill; omit this field to fulfill all line items.",
+      fulfillmentOrderLineItemInput,
+      { minItems: 1, maxItems: 512 },
+    ),
+  },
+  { required: ["fulfillmentOrderId"] },
+);
+
+const fulfillmentOrderLineItem = s.requiredObject("A normalized Shopify fulfillment order line item.", {
+  id: gid,
+  totalQuantity: s.integer("The total quantity included in the fulfillment order."),
+  remainingQuantity: s.integer("The quantity that remains to be fulfilled."),
+  inventoryItemId: s.nullableString("The inventory item ID associated with the line item when returned by Shopify."),
+  sku: s.nullableString("The variant SKU when returned by Shopify."),
+  productTitle: s.string("The product title."),
+  variantTitle: s.nullableString("The variant title when returned by Shopify."),
+  requiresShipping: s.boolean("Whether the line item requires physical shipping."),
+  raw: rawObject,
+});
+
+const fulfillmentOrderSupportedAction = s.requiredObject(
+  "An action supported by the fulfillment order in its current state.",
+  {
+    action: s.string("The Shopify fulfillment order action."),
+    externalUrl: s.nullable(s.url("The external URL for an EXTERNAL action when returned by Shopify.")),
+  },
+);
+
+const fulfillmentOrder = s.requiredObject("A normalized Shopify fulfillment order.", {
+  id: gid,
+  orderId: gid,
+  orderName: s.string("The merchant-facing order name."),
+  status: s.string("The fulfillment order status."),
+  requestStatus: s.string("The fulfillment request status."),
+  assignedLocationId: s.nullableString("The assigned Shopify location ID when returned by Shopify."),
+  assignedLocationName: s.string("The assigned fulfillment location name."),
+  supportedActions: s.array("Actions currently supported by the fulfillment order.", fulfillmentOrderSupportedAction),
+  lineItems: s.array("Fulfillment order line items returned by Shopify.", fulfillmentOrderLineItem),
+  lineItemsPageInfo: pageInfo,
+  updatedAt: s.string("The fulfillment order update timestamp."),
+  cursor: s.nullable(cursor),
+  raw: rawObject,
+});
+
+const orderFulfillmentOrders = s.requiredObject("An order and its normalized fulfillment orders.", {
+  id: gid,
+  name: s.string("The merchant-facing Shopify order name."),
+  fulfillmentOrders: s.array("Fulfillment orders associated with the order.", fulfillmentOrder),
+  pageInfo,
+  raw: rawObject,
+});
+
+const fulfillmentOriginAddressInput = s.object(
+  "The full origin address used for fulfillment tax calculations.",
+  {
+    countryCode: s.nonEmptyString("The country code of the fulfillment location."),
+    address1: s.string("The first street address line."),
+    address2: s.string("The second street address line."),
+    city: s.string("The city of the fulfillment location."),
+    provinceCode: s.string("The province or state code of the fulfillment location."),
+    zip: s.string("The postal code of the fulfillment location."),
+  },
+  { required: ["countryCode"] },
+);
+
+const fulfillmentTrackingInput: JsonSchema = {
+  ...s.object(
+    "Tracking information for the fulfillment.",
+    {
+      company: s.string("The tracking company name, using Shopify's exact capitalization."),
+      number: s.nonEmptyString("The single tracking number."),
+      numbers: s.stringArray("One or more tracking numbers for a multi-package fulfillment.", {
+        minItems: 1,
+        itemDescription: "A tracking number.",
+      }),
+      url: s.url("The URL for the single tracking number."),
+      urls: s.array("Tracking URLs corresponding by position to the tracking numbers.", s.url("A tracking URL."), {
+        minItems: 1,
+      }),
+    },
+    { optional: ["company", "number", "numbers", "url", "urls"] },
+  ),
+  allOf: [
+    { not: { required: ["number", "numbers"] } },
+    { not: { required: ["url", "urls"] } },
+    { if: { required: ["url"] }, then: { required: ["number"] } },
+    { if: { required: ["urls"] }, then: { required: ["numbers"] } },
+  ],
+};
+
+const fulfillment = s.requiredObject("A normalized Shopify fulfillment.", {
+  id: gid,
+  name: s.string("The merchant-facing fulfillment name."),
+  status: s.stringEnum("The Shopify fulfillment status.", [
+    "CANCELLED",
+    "ERROR",
+    "FAILURE",
+    "SUCCESS",
+    "OPEN",
+    "PENDING",
+  ]),
+  totalQuantity: s.integer("The total fulfilled line item quantity."),
+  createdAt: s.string("The fulfillment creation timestamp."),
+  orderId: s.string("The fulfilled order ID."),
+  orderName: s.string("The merchant-facing fulfilled order name."),
+  trackingInfo: s.array(
+    "Tracking information returned for the fulfillment.",
+    s.requiredObject("One normalized tracking record.", {
+      company: s.nullableString("The tracking company when returned by Shopify."),
+      number: s.nullableString("The tracking number when returned by Shopify."),
+      url: s.nullable(s.url("The tracking URL when returned by Shopify.")),
+      raw: rawObject,
+    }),
+  ),
+  raw: rawObject,
+});
+
+const bulkOperation = s.requiredObject("A normalized Shopify bulk operation.", {
+  id: gid,
+  status: s.stringEnum("The Shopify bulk operation status.", [
+    "CANCELED",
+    "CANCELING",
+    "COMPLETED",
+    "CREATED",
+    "EXPIRED",
+    "FAILED",
+    "RUNNING",
+  ]),
+  type: s.stringEnum("The Shopify bulk operation type.", ["MUTATION", "QUERY"]),
+  createdAt: s.string("The bulk operation creation timestamp."),
+  completedAt: s.nullableString("The successful completion timestamp when returned by Shopify."),
+  errorCode: s.nullable(
+    s.stringEnum("The Shopify bulk operation failure error code.", [
+      "ACCESS_DENIED",
+      "INTERNAL_SERVER_ERROR",
+      "TIMEOUT",
+    ]),
+  ),
+  objectCount: s.string("The running object count encoded as an unsigned 64-bit integer string."),
+  rootObjectCount: s.string("The running root object count encoded as an unsigned 64-bit integer string."),
+  fileSize: s.nullableString("The result file size in bytes encoded as an unsigned 64-bit integer string."),
+  url: s.nullable(s.url("The completed JSONL result URL when returned by Shopify.")),
+  partialDataUrl: s.nullable(s.url("The partial JSONL result URL for a failed operation when returned by Shopify.")),
+  query: s.string("The GraphQL query executed by the bulk operation."),
+  raw: rawObject,
+});
+
+const transitFileOutput = s.requiredObject("A file stored in local connector transit storage.", {
+  fileId: s.nonEmptyString("The local transit file identifier."),
+  downloadUrl: s.url("The local URL for downloading the transit file."),
+  sizeBytes: s.nonNegativeInteger("The transit file size in bytes."),
+  name: s.nonEmptyString("The file name stored in transit storage."),
+  mimeType: s.nonEmptyString("The MIME type stored in transit storage."),
+});
+
 const connectionInput = s.actionInput(
   {
     first,
@@ -211,16 +660,27 @@ export type ShopifyAdminActionName =
   | "list_products"
   | "get_product"
   | "list_product_variants"
+  | "list_order_fulfillment_orders"
+  | "get_fulfillment_order"
   | "list_orders"
   | "get_order"
   | "list_customers"
   | "get_customer"
   | "list_inventory_items"
   | "get_inventory_item"
+  | "get_inventory_quantities"
   | "list_locations"
   | "get_location"
   | "list_collections"
   | "get_collection"
+  | "create_product"
+  | "update_product"
+  | "adjust_inventory_quantities"
+  | "set_inventory_quantities"
+  | "create_fulfillment"
+  | "submit_bulk_query"
+  | "get_bulk_operation"
+  | "download_bulk_result"
   | "execute_graphql";
 
 export const shopifyAdminActions: ActionDefinition[] = [
@@ -259,6 +719,52 @@ export const shopifyAdminActions: ActionDefinition[] = [
       },
       "The normalized Shopify product variant list response.",
     ),
+  ),
+  action(
+    "list_order_fulfillment_orders",
+    "List fulfillment orders and fulfillable line items for one Shopify order.",
+    s.actionInput(
+      {
+        orderId: gid,
+        first,
+        after: cursor,
+        displayable: s.boolean("Whether to exclude fulfillment orders that Shopify normally hides from merchants."),
+      },
+      ["orderId"],
+      "The Shopify order fulfillment order connection input.",
+    ),
+    s.actionOutput({ order: s.nullable(orderFulfillmentOrders) }, "The Shopify order fulfillment order response."),
+    {
+      providerPermissions: [
+        "read_assigned_fulfillment_orders",
+        "read_merchant_managed_fulfillment_orders",
+        "read_third_party_fulfillment_orders",
+      ],
+    },
+  ),
+  action(
+    "get_fulfillment_order",
+    "Retrieve one Shopify fulfillment order with independently paginated line items.",
+    s.actionInput(
+      {
+        id: gid,
+        lineItemsFirst: first,
+        lineItemsAfter: cursor,
+      },
+      ["id"],
+      "The Shopify fulfillment order lookup input.",
+    ),
+    s.actionOutput(
+      { fulfillmentOrder: s.nullable(fulfillmentOrder) },
+      "The normalized Shopify fulfillment order response.",
+    ),
+    {
+      providerPermissions: [
+        "read_assigned_fulfillment_orders",
+        "read_merchant_managed_fulfillment_orders",
+        "read_third_party_fulfillment_orders",
+      ],
+    },
   ),
   action(
     "list_orders",
@@ -318,6 +824,25 @@ export const shopifyAdminActions: ActionDefinition[] = [
     ),
   ),
   action(
+    "get_inventory_quantities",
+    "Retrieve selected inventory quantity states for one Shopify inventory item at one location.",
+    s.actionInput(
+      {
+        inventoryItemId: gid,
+        locationId: gid,
+        names: s.stringArray("Inventory quantity state names to retrieve.", {
+          minItems: 1,
+          itemDescription: "An inventory quantity state name.",
+          default: ["available", "on_hand"],
+        }),
+        includeInactive: s.boolean("Whether Shopify should return the inventory level when it is inactive."),
+      },
+      ["inventoryItemId", "locationId"],
+      "The Shopify inventory level lookup input.",
+    ),
+    s.actionOutput({ inventoryLevel: s.nullable(inventoryLevel) }, "The normalized Shopify inventory level response."),
+  ),
+  action(
     "list_locations",
     "List Shopify inventory locations with optional filters and cursor pagination.",
     locationConnectionInput,
@@ -354,6 +879,146 @@ export const shopifyAdminActions: ActionDefinition[] = [
     s.actionOutput({ collection: s.nullable(collectionDetail) }, "The normalized Shopify collection response."),
   ),
   action(
+    "create_product",
+    "Create one Shopify product with typed product attributes and optional media sources.",
+    s.actionInput(
+      {
+        product: productCreateInput,
+        media: s.array("Media sources to add to the new product.", createMediaInput),
+      },
+      ["product"],
+      "The typed Shopify productCreate mutation input.",
+    ),
+    s.actionOutput({ product: productDetail }, "The normalized created Shopify product."),
+    { providerPermissions: ["write_products"] },
+  ),
+  action(
+    "update_product",
+    "Update one Shopify product by GraphQL global ID with typed attributes and optional new media.",
+    s.actionInput(
+      {
+        product: productUpdateInput,
+        media: s.array("New media sources to add to the product.", createMediaInput),
+      },
+      ["product"],
+      "The typed Shopify productUpdate mutation input.",
+    ),
+    s.actionOutput({ product: productDetail }, "The normalized updated Shopify product."),
+    { providerPermissions: ["write_products"] },
+  ),
+  action(
+    "adjust_inventory_quantities",
+    "Apply incremental Shopify inventory quantity changes with required idempotency and explicit compare-and-swap values.",
+    inventoryAdjustQuantitiesInput,
+    s.actionOutput({ inventoryAdjustmentGroup }, "The normalized Shopify inventory adjustment response."),
+    { providerPermissions: ["write_inventory"] },
+  ),
+  action(
+    "set_inventory_quantities",
+    "Set absolute Shopify inventory quantities with required idempotency and explicit compare-and-swap values.",
+    s.actionInput(
+      {
+        idempotencyKey: s.nonEmptyString(
+          "A caller-stable idempotency key reused when retrying the same inventory write.",
+        ),
+        name: s.stringEnum("The inventory quantity state to set.", ["available", "on_hand"]),
+        reason: inventoryAdjustmentReason,
+        referenceDocumentUri: s.nonEmptyString(
+          "A URI identifying the source document or system event for the inventory audit trail.",
+        ),
+        quantities: s.array("Absolute inventory quantities to set.", inventoryQuantityInput, {
+          minItems: 1,
+        }),
+      },
+      ["idempotencyKey", "name", "reason", "quantities"],
+      "The typed Shopify inventorySetQuantities mutation input.",
+    ),
+    s.actionOutput({ inventoryAdjustmentGroup }, "The normalized Shopify inventory adjustment response."),
+    { providerPermissions: ["write_inventory"] },
+  ),
+  action(
+    "create_fulfillment",
+    "Create a Shopify fulfillment for one or more fulfillment orders with optional tracking and customer notification.",
+    s.actionInput(
+      {
+        fulfillment: s.object(
+          "The fulfillment orders, notification preference, origin address, and tracking information.",
+          {
+            lineItemsByFulfillmentOrder: s.array(
+              "Fulfillment orders and optional line item subsets to fulfill.",
+              fulfillmentOrderInput,
+              { minItems: 1 },
+            ),
+            notifyCustomer: s.boolean("Whether Shopify should notify the customer about the fulfillment."),
+            originAddress: fulfillmentOriginAddressInput,
+            trackingInfo: fulfillmentTrackingInput,
+          },
+          { required: ["lineItemsByFulfillmentOrder"] },
+        ),
+        message: s.string("An optional message for the fulfillment request."),
+      },
+      ["fulfillment"],
+      "The typed Shopify fulfillmentCreate mutation input.",
+    ),
+    s.actionOutput({ fulfillment }, "The normalized created Shopify fulfillment."),
+    {
+      providerPermissions: [
+        "write_assigned_fulfillment_orders",
+        "write_merchant_managed_fulfillment_orders",
+        "write_third_party_fulfillment_orders",
+      ],
+    },
+  ),
+  action(
+    "submit_bulk_query",
+    "Submit a Shopify Admin GraphQL bulk query and return an operation ID for asynchronous polling.",
+    s.actionInput(
+      {
+        query: s.nonEmptyString("The bulk GraphQL query document containing at least one supported connection."),
+        groupObjects: s.boolean({
+          default: false,
+          description: "Whether Shopify should group child objects under parents in JSONL; grouping is slower.",
+        }),
+      },
+      ["query"],
+      "The Shopify bulkOperationRunQuery mutation input.",
+    ),
+    s.actionOutput({ operation: bulkOperation }, "The submitted Shopify bulk query operation."),
+    {
+      followUpActions: ["shopify_admin.get_bulk_operation"],
+      asyncLifecycle: {
+        startActionId: "shopify_admin.submit_bulk_query",
+        statusActionId: "shopify_admin.get_bulk_operation",
+      },
+    },
+  ),
+  action(
+    "get_bulk_operation",
+    "Retrieve one Shopify bulk operation by ID for progress polling and result URL discovery.",
+    s.actionInput({ id: gid }, ["id"], "The Shopify bulk operation lookup input."),
+    s.actionOutput({ operation: s.nullable(bulkOperation) }, "The Shopify bulk operation lookup response."),
+    {
+      followUpActions: ["shopify_admin.download_bulk_result"],
+      asyncLifecycle: {
+        startActionId: "shopify_admin.submit_bulk_query",
+        statusActionId: "shopify_admin.get_bulk_operation",
+      },
+    },
+  ),
+  action(
+    "download_bulk_result",
+    "Download a completed or partial Shopify bulk JSONL result into local connector transit storage.",
+    s.actionInput(
+      {
+        url: s.url("The expiring Shopify bulk operation URL or partialDataUrl."),
+        fileName: s.nonEmptyString("An optional file name for the transit object."),
+      },
+      ["url"],
+      "The Shopify bulk result download input.",
+    ),
+    s.actionOutput({ file: transitFileOutput }, "The downloaded Shopify bulk result."),
+  ),
+  action(
     "execute_graphql",
     "Execute a JSON-friendly Shopify Admin GraphQL query or mutation against the connected shop.",
     s.actionInput(
@@ -382,6 +1047,7 @@ function action(
   description: string,
   inputSchema: JsonSchema,
   outputSchema: JsonSchema,
+  metadata: Partial<Pick<ActionDefinition, "providerPermissions" | "followUpActions" | "asyncLifecycle">> = {},
 ): ActionDefinition {
   return defineProviderAction(service, {
     name,
@@ -389,5 +1055,6 @@ function action(
     requiredScopes: [],
     inputSchema,
     outputSchema,
+    ...metadata,
   });
 }

--- a/src/providers/shopify_admin/executors.ts
+++ b/src/providers/shopify_admin/executors.ts
@@ -31,6 +31,7 @@ export const executors: ProviderExecutors = defineProviderExecutors({
       apiKey: credential.apiKey,
       shopDomain,
       fetcher,
+      transitFiles: context.transitFiles,
       signal: context.signal,
     };
   },

--- a/src/providers/shopify_admin/runtime.ts
+++ b/src/providers/shopify_admin/runtime.ts
@@ -1091,11 +1091,9 @@ async function downloadShopifyAdminBulkResult(
       signal: timeout.signal,
     });
     if (!response.ok) {
-      throw new ProviderRequestError(
-        502,
-        `shopify_admin bulk result download failed with HTTP ${response.status}`,
-        { providerStatus: response.status },
-      );
+      throw new ProviderRequestError(502, `shopify_admin bulk result download failed with HTTP ${response.status}`, {
+        providerStatus: response.status,
+      });
     }
 
     const name = optionalString(input.fileName) ?? "shopify-bulk-operation-result.jsonl";

--- a/src/providers/shopify_admin/runtime.ts
+++ b/src/providers/shopify_admin/runtime.ts
@@ -11,10 +11,11 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { readBoundedResponseBytes } from "../../core/request.ts";
-import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const shopifyAdminApiVersion = "2026-04";
 
+const bulkResultDownloadTimeoutMs = 300_000;
 const credentialHelpUrl = "https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens";
 const currentShopQuery =
   "query ShopifyAdminCurrentShop { shop { id name myshopifyDomain primaryDomain { url host } } }";
@@ -868,7 +869,7 @@ export const shopifyAdminActionHandlers: Record<ShopifyAdminActionName, ShopifyA
       query: createFulfillmentMutation,
       variables: compactObject({
         fulfillment: readObject(input.fulfillment, "fulfillment"),
-        message: optionalString(input.message),
+        message: typeof input.message === "string" ? input.message : undefined,
       }),
     });
     const result = readMutationResult(payload, "fulfillmentCreate");
@@ -1045,11 +1046,10 @@ function readMutationResult(payload: ShopifyAdminGraphQLResponse, fieldName: str
   const result = readObject(readObject(payload.data, "data")[fieldName], fieldName);
   const errors = readMutationUserErrors(result.userErrors);
   if (errors.length > 0) {
-    throw new ProviderRequestError(
-      422,
-      `shopify_admin ${fieldName} user error: ${errors.join("; ")}`,
-      result.userErrors,
-    );
+    throw new ProviderRequestError(502, `shopify_admin ${fieldName} user error: ${errors.join("; ")}`, {
+      providerStatus: 422,
+      userErrors: result.userErrors,
+    });
   }
   return result;
 }
@@ -1080,26 +1080,27 @@ async function downloadShopifyAdminBulkResult(
   }
 
   const url = requiredString(input.url, "url", providerInputError);
-  const response = await context.fetcher(url, {
-    headers: {
-      accept: "application/jsonl, application/x-ndjson, application/json, text/plain",
-      "user-agent": providerUserAgent,
-    },
-    signal: context.signal,
-  });
-  if (!response.ok) {
-    await cancelUnreadResponseBody(response);
-    throw new ProviderRequestError(
-      response.status,
-      `shopify_admin bulk result download failed with HTTP ${response.status}`,
-    );
-  }
-
-  const name = optionalString(input.fileName) ?? "shopify-bulk-operation-result.jsonl";
-  const mimeType =
-    optionalString(response.headers.get("content-type"))?.split(";")[0]?.trim() || "application/x-ndjson";
-
+  const timeout = createProviderTimeout(context.signal, bulkResultDownloadTimeoutMs);
+  let response: Response | undefined;
   try {
+    response = await context.fetcher(url, {
+      headers: {
+        accept: "application/jsonl, application/x-ndjson, application/json, text/plain",
+        "user-agent": providerUserAgent,
+      },
+      signal: timeout.signal,
+    });
+    if (!response.ok) {
+      throw new ProviderRequestError(
+        502,
+        `shopify_admin bulk result download failed with HTTP ${response.status}`,
+        { providerStatus: response.status },
+      );
+    }
+
+    const name = optionalString(input.fileName) ?? "shopify-bulk-operation-result.jsonl";
+    const mimeType =
+      optionalString(response.headers.get("content-type"))?.split(";")[0]?.trim() || "application/x-ndjson";
     const bytes = await readBoundedResponseBytes(response, {
       maxBytes: context.transitFiles.maxBytes,
       fieldName: "Shopify bulk result",
@@ -1116,7 +1117,12 @@ async function downloadShopifyAdminBulkResult(
       },
     };
   } catch (error) {
-    await cancelUnreadResponseBody(response);
+    if (response) {
+      await cancelUnreadResponseBody(response);
+    }
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "shopify_admin bulk result download timed out");
+    }
     if (error instanceof ProviderRequestError) {
       throw error;
     }
@@ -1124,6 +1130,8 @@ async function downloadShopifyAdminBulkResult(
       502,
       error instanceof Error ? error.message : "shopify_admin bulk result transit upload failed",
     );
+  } finally {
+    timeout.cleanup();
   }
 }
 

--- a/src/providers/shopify_admin/runtime.ts
+++ b/src/providers/shopify_admin/runtime.ts
@@ -1,3 +1,4 @@
+import type { TransitFileWriter } from "../../core/types.ts";
 import type { ShopifyAdminActionName } from "./actions.ts";
 
 import {
@@ -9,6 +10,7 @@ import {
   requiredRecord,
   requiredString,
 } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const shopifyAdminApiVersion = "2026-04";
@@ -65,6 +67,9 @@ const listProductVariantsQuery = `query ShopifyAdminListProductVariants($first: 
         sku
         price
         inventoryQuantity
+        inventoryItem {
+          id
+        }
         product {
           id
           title
@@ -79,6 +84,84 @@ const listProductVariantsQuery = `query ShopifyAdminListProductVariants($first: 
     }
   }
 }`;
+const fulfillmentOrderFieldsFragment = `fragment ShopifyAdminFulfillmentOrderFields on FulfillmentOrder {
+  id
+  orderId
+  orderName
+  status
+  requestStatus
+  assignedLocation {
+    name
+    location {
+      id
+    }
+  }
+  supportedActions {
+    action
+    externalUrl
+  }
+  lineItems(first: $lineItemsFirst, after: $lineItemsAfter) {
+    edges {
+      node {
+        id
+        totalQuantity
+        remainingQuantity
+        inventoryItemId
+        sku
+        productTitle
+        variantTitle
+        requiresShipping
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+  updatedAt
+}`;
+const listOrderFulfillmentOrdersQuery = `query ShopifyAdminListOrderFulfillmentOrders(
+  $orderId: ID!,
+  $first: Int,
+  $after: String,
+  $displayable: Boolean,
+  $lineItemsFirst: Int!,
+  $lineItemsAfter: String
+) {
+  order(id: $orderId) {
+    id
+    name
+    fulfillmentOrders(first: $first, after: $after, displayable: $displayable) {
+      edges {
+        cursor
+        node {
+          ...ShopifyAdminFulfillmentOrderFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+
+${fulfillmentOrderFieldsFragment}`;
+const getFulfillmentOrderQuery = `query ShopifyAdminGetFulfillmentOrder(
+  $id: ID!,
+  $lineItemsFirst: Int!,
+  $lineItemsAfter: String
+) {
+  fulfillmentOrder(id: $id) {
+    ...ShopifyAdminFulfillmentOrderFields
+  }
+}
+
+${fulfillmentOrderFieldsFragment}`;
 const listOrdersQuery = `query ShopifyAdminListOrders($first: Int, $after: String, $query: String) {
   orders(first: $first, after: $after, query: $query) {
     edges {
@@ -228,6 +311,31 @@ const getInventoryItemQuery = `query ShopifyAdminGetInventoryItem($id: ID!) {
     updatedAt
   }
 }`;
+const getInventoryQuantitiesQuery = `query ShopifyAdminGetInventoryQuantities(
+  $inventoryItemId: ID!,
+  $locationId: ID!,
+  $names: [String!]!,
+  $includeInactive: Boolean
+) {
+  inventoryItem(id: $inventoryItemId) {
+    inventoryLevel(locationId: $locationId, includeInactive: $includeInactive) {
+      id
+      isActive
+      item {
+        id
+        sku
+      }
+      location {
+        id
+        name
+      }
+      quantities(names: $names) {
+        name
+        quantity
+      }
+    }
+  }
+}`;
 const listLocationsQuery = `query ShopifyAdminListLocations(
   $first: Int,
   $after: String,
@@ -318,6 +426,167 @@ const getCollectionQuery = `query ShopifyAdminGetCollection($id: ID!) {
     }
   }
 }`;
+const createProductMutation = `mutation ShopifyAdminCreateProduct(
+  $product: ProductCreateInput!,
+  $media: [CreateMediaInput!]
+) {
+  productCreate(product: $product, media: $media) {
+    product {
+      id
+      title
+      handle
+      status
+      vendor
+      productType
+      descriptionHtml
+      createdAt
+      updatedAt
+      onlineStoreUrl
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+const updateProductMutation = `mutation ShopifyAdminUpdateProduct(
+  $product: ProductUpdateInput!,
+  $media: [CreateMediaInput!]
+) {
+  productUpdate(product: $product, media: $media) {
+    product {
+      id
+      title
+      handle
+      status
+      vendor
+      productType
+      descriptionHtml
+      createdAt
+      updatedAt
+      onlineStoreUrl
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+const adjustInventoryQuantitiesMutation = `mutation ShopifyAdminAdjustInventoryQuantities(
+  $input: InventoryAdjustQuantitiesInput!,
+  $idempotencyKey: String!
+) {
+  inventoryAdjustQuantities(input: $input) @idempotent(key: $idempotencyKey) {
+    inventoryAdjustmentGroup {
+      id
+      createdAt
+      reason
+      referenceDocumentUri
+      changes {
+        name
+        delta
+        quantityAfterChange
+      }
+    }
+    userErrors {
+      code
+      field
+      message
+    }
+  }
+}`;
+const setInventoryQuantitiesMutation = `mutation ShopifyAdminSetInventoryQuantities(
+  $input: InventorySetQuantitiesInput!,
+  $idempotencyKey: String!
+) {
+  inventorySetQuantities(input: $input) @idempotent(key: $idempotencyKey) {
+    inventoryAdjustmentGroup {
+      id
+      createdAt
+      reason
+      referenceDocumentUri
+      changes {
+        name
+        delta
+        quantityAfterChange
+      }
+    }
+    userErrors {
+      code
+      field
+      message
+    }
+  }
+}`;
+const createFulfillmentMutation = `mutation ShopifyAdminCreateFulfillment(
+  $fulfillment: FulfillmentInput!,
+  $message: String
+) {
+  fulfillmentCreate(fulfillment: $fulfillment, message: $message) {
+    fulfillment {
+      id
+      name
+      status
+      totalQuantity
+      createdAt
+      order {
+        id
+        name
+      }
+      trackingInfo {
+        company
+        number
+        url
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+const submitBulkQueryMutation = `mutation ShopifyAdminSubmitBulkQuery(
+  $query: String!,
+  $groupObjects: Boolean!
+) {
+  bulkOperationRunQuery(query: $query, groupObjects: $groupObjects) {
+    bulkOperation {
+      id
+      status
+      type
+      createdAt
+      completedAt
+      errorCode
+      objectCount
+      rootObjectCount
+      fileSize
+      url
+      partialDataUrl
+      query
+    }
+    userErrors {
+      code
+      field
+      message
+    }
+  }
+}`;
+const getBulkOperationQuery = `query ShopifyAdminGetBulkOperation($id: ID!) {
+  bulkOperation(id: $id) {
+    id
+    status
+    type
+    createdAt
+    completedAt
+    errorCode
+    objectCount
+    rootObjectCount
+    fileSize
+    url
+    partialDataUrl
+    query
+  }
+}`;
 
 type ShopifyAdminActionHandler = (
   input: Record<string, unknown>,
@@ -328,6 +597,7 @@ interface ShopifyAdminActionContext {
   apiKey: string;
   shopDomain: string;
   fetcher: typeof fetch;
+  transitFiles?: TransitFileWriter;
   signal?: AbortSignal;
 }
 
@@ -384,6 +654,34 @@ export const shopifyAdminActionHandlers: Record<ShopifyAdminActionName, ShopifyA
     return {
       variants: readEdges(variants).map((edge) => normalizeVariant(edge)),
       pageInfo: normalizePageInfo(readObject(variants.pageInfo, "pageInfo")),
+    };
+  },
+  async list_order_fulfillment_orders(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: listOrderFulfillmentOrdersQuery,
+      variables: compactObject({
+        orderId: input.orderId,
+        lineItemsFirst: 250,
+        first: optionalInteger(input.first) ?? 50,
+        after: optionalString(input.after),
+        displayable: optionalBoolean(input.displayable),
+      }),
+    });
+    const order = readNullableObject(readObject(payload.data, "data").order, "order");
+    return { order: order ? normalizeOrderFulfillmentOrders(order) : null };
+  },
+  async get_fulfillment_order(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: getFulfillmentOrderQuery,
+      variables: compactObject({
+        id: input.id,
+        lineItemsFirst: optionalInteger(input.lineItemsFirst) ?? 50,
+        lineItemsAfter: optionalString(input.lineItemsAfter),
+      }),
+    });
+    const fulfillmentOrder = readNullableObject(readObject(payload.data, "data").fulfillmentOrder, "fulfillmentOrder");
+    return {
+      fulfillmentOrder: fulfillmentOrder ? normalizeFulfillmentOrder({ node: fulfillmentOrder }) : null,
     };
   },
   async list_orders(input, context) {
@@ -443,6 +741,22 @@ export const shopifyAdminActionHandlers: Record<ShopifyAdminActionName, ShopifyA
     const inventoryItem = readNullableObject(readObject(payload.data, "data").inventoryItem, "inventoryItem");
     return { inventoryItem: inventoryItem ? normalizeInventoryItemDetail(inventoryItem) : null };
   },
+  async get_inventory_quantities(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: getInventoryQuantitiesQuery,
+      variables: compactObject({
+        inventoryItemId: input.inventoryItemId,
+        locationId: input.locationId,
+        names: readNonEmptyStringArray(input.names) ?? ["available", "on_hand"],
+        includeInactive: optionalBoolean(input.includeInactive),
+      }),
+    });
+    const inventoryItem = readNullableObject(readObject(payload.data, "data").inventoryItem, "inventoryItem");
+    const inventoryLevel = inventoryItem ? readNullableObject(inventoryItem.inventoryLevel, "inventoryLevel") : null;
+    return {
+      inventoryLevel: inventoryLevel ? normalizeInventoryLevel(inventoryLevel) : null,
+    };
+  },
   async list_locations(input, context) {
     const payload = await requestShopifyAdminGraphQL(context, {
       query: listLocationsQuery,
@@ -480,6 +794,113 @@ export const shopifyAdminActionHandlers: Record<ShopifyAdminActionName, ShopifyA
     });
     const collection = readNullableObject(readObject(payload.data, "data").collection, "collection");
     return { collection: collection ? normalizeCollectionDetail(collection) : null };
+  },
+  async create_product(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: createProductMutation,
+      variables: compactObject({
+        product: readObject(input.product, "product"),
+        media: Array.isArray(input.media) ? input.media : undefined,
+      }),
+    });
+    const result = readMutationResult(payload, "productCreate");
+    return {
+      product: normalizeProductDetail(readObject(result.product, "product")),
+    };
+  },
+  async update_product(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: updateProductMutation,
+      variables: compactObject({
+        product: readObject(input.product, "product"),
+        media: Array.isArray(input.media) ? input.media : undefined,
+      }),
+    });
+    const result = readMutationResult(payload, "productUpdate");
+    return {
+      product: normalizeProductDetail(readObject(result.product, "product")),
+    };
+  },
+  async adjust_inventory_quantities(input, context) {
+    const { idempotencyKey, name, reason, referenceDocumentUri, changes } = input;
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: adjustInventoryQuantitiesMutation,
+      variables: {
+        idempotencyKey,
+        input: compactObject({
+          name,
+          reason,
+          referenceDocumentUri: typeof referenceDocumentUri === "string" ? referenceDocumentUri : undefined,
+          changes,
+        }),
+      },
+    });
+    const result = readMutationResult(payload, "inventoryAdjustQuantities");
+    return {
+      inventoryAdjustmentGroup: normalizeInventoryAdjustmentGroup(
+        readObject(result.inventoryAdjustmentGroup, "inventoryAdjustmentGroup"),
+      ),
+    };
+  },
+  async set_inventory_quantities(input, context) {
+    const { idempotencyKey, name, reason, referenceDocumentUri, quantities } = input;
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: setInventoryQuantitiesMutation,
+      variables: {
+        idempotencyKey,
+        input: compactObject({
+          name,
+          reason,
+          referenceDocumentUri: typeof referenceDocumentUri === "string" ? referenceDocumentUri : undefined,
+          quantities,
+        }),
+      },
+    });
+    const result = readMutationResult(payload, "inventorySetQuantities");
+    return {
+      inventoryAdjustmentGroup: normalizeInventoryAdjustmentGroup(
+        readObject(result.inventoryAdjustmentGroup, "inventoryAdjustmentGroup"),
+      ),
+    };
+  },
+  async create_fulfillment(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: createFulfillmentMutation,
+      variables: compactObject({
+        fulfillment: readObject(input.fulfillment, "fulfillment"),
+        message: optionalString(input.message),
+      }),
+    });
+    const result = readMutationResult(payload, "fulfillmentCreate");
+    return {
+      fulfillment: normalizeFulfillment(readObject(result.fulfillment, "fulfillment")),
+    };
+  },
+  async submit_bulk_query(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: submitBulkQueryMutation,
+      variables: {
+        query: input.query,
+        groupObjects: optionalBoolean(input.groupObjects) ?? false,
+      },
+    });
+    const result = readMutationResult(payload, "bulkOperationRunQuery");
+    return {
+      operation: normalizeBulkOperation(readObject(result.bulkOperation, "bulkOperation")),
+    };
+  },
+  async get_bulk_operation(input, context) {
+    const payload = await requestShopifyAdminGraphQL(context, {
+      query: getBulkOperationQuery,
+      variables: { id: input.id },
+    });
+    const operation = readNullableObject(readObject(payload.data, "data").bulkOperation, "bulkOperation");
+    return {
+      operation: operation ? normalizeBulkOperation(operation) : null,
+    };
+  },
+  async download_bulk_result(input, context) {
+    return downloadShopifyAdminBulkResult(input, context);
   },
   async execute_graphql(input, context) {
     const payload = await requestShopifyAdminGraphQL(context, {
@@ -620,6 +1041,103 @@ function readGraphQLErrors(value: unknown): string[] {
   return value.map((item) => optionalString(optionalRecord(item)?.message) ?? "unknown GraphQL error");
 }
 
+function readMutationResult(payload: ShopifyAdminGraphQLResponse, fieldName: string): Record<string, unknown> {
+  const result = readObject(readObject(payload.data, "data")[fieldName], fieldName);
+  const errors = readMutationUserErrors(result.userErrors);
+  if (errors.length > 0) {
+    throw new ProviderRequestError(
+      422,
+      `shopify_admin ${fieldName} user error: ${errors.join("; ")}`,
+      result.userErrors,
+    );
+  }
+  return result;
+}
+
+function readMutationUserErrors(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => {
+    const error = optionalRecord(item);
+    const message = optionalString(error?.message) ?? "unknown mutation error";
+    const code = optionalString(error?.code);
+    const field = Array.isArray(error?.field)
+      ? error.field.filter((part): part is string => typeof part === "string").join(".")
+      : undefined;
+    return [field ? `${field}:` : undefined, code ? `[${code}]` : undefined, message]
+      .filter((part): part is string => typeof part === "string")
+      .join(" ");
+  });
+}
+
+async function downloadShopifyAdminBulkResult(
+  input: Record<string, unknown>,
+  context: ShopifyAdminActionContext,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "shopify_admin download_bulk_result requires transit file storage");
+  }
+
+  const url = requiredString(input.url, "url", providerInputError);
+  const response = await context.fetcher(url, {
+    headers: {
+      accept: "application/jsonl, application/x-ndjson, application/json, text/plain",
+      "user-agent": providerUserAgent,
+    },
+    signal: context.signal,
+  });
+  if (!response.ok) {
+    await cancelUnreadResponseBody(response);
+    throw new ProviderRequestError(
+      response.status,
+      `shopify_admin bulk result download failed with HTTP ${response.status}`,
+    );
+  }
+
+  const name = optionalString(input.fileName) ?? "shopify-bulk-operation-result.jsonl";
+  const mimeType =
+    optionalString(response.headers.get("content-type"))?.split(";")[0]?.trim() || "application/x-ndjson";
+
+  try {
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "Shopify bulk result",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    const stored = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+    return {
+      file: {
+        fileId: stored.fileId,
+        downloadUrl: stored.downloadUrl,
+        sizeBytes: stored.sizeBytes,
+        name: stored.name,
+        mimeType: stored.mimeType,
+      },
+    };
+  } catch (error) {
+    await cancelUnreadResponseBody(response);
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? error.message : "shopify_admin bulk result transit upload failed",
+    );
+  }
+}
+
+async function cancelUnreadResponseBody(response: Response): Promise<void> {
+  if (!response.body || response.body.locked) {
+    return;
+  }
+  try {
+    await response.body.cancel();
+  } catch {
+    // 清理是 best-effort，不能覆盖原始下载或存储错误。
+  }
+}
+
 function connectionVariables(input: Record<string, unknown>): Record<string, unknown> {
   return compactObject({
     first: optionalInteger(input.first),
@@ -681,8 +1199,77 @@ function normalizeProductDetail(raw: Record<string, unknown>): Record<string, un
   };
 }
 
+function normalizeInventoryAdjustmentGroup(raw: Record<string, unknown>): Record<string, unknown> {
+  const changes = raw.changes;
+  if (!Array.isArray(changes)) {
+    throw new ProviderRequestError(502, "shopify_admin response is missing inventory adjustment changes");
+  }
+  return {
+    id: readRequiredString(raw, "id"),
+    createdAt: readRequiredString(raw, "createdAt"),
+    reason: readRequiredString(raw, "reason"),
+    referenceDocumentUri: optionalString(raw.referenceDocumentUri) ?? null,
+    changes: changes.map((item) => {
+      const change = readObject(item, "inventory change");
+      return {
+        name: readRequiredString(change, "name"),
+        delta: readRequiredInteger(change, "delta"),
+        quantityAfterChange: optionalInteger(change.quantityAfterChange) ?? null,
+        raw: change,
+      };
+    }),
+    raw,
+  };
+}
+
+function normalizeFulfillment(raw: Record<string, unknown>): Record<string, unknown> {
+  const order = readObject(raw.order, "order");
+  const trackingInfo = raw.trackingInfo;
+  if (!Array.isArray(trackingInfo)) {
+    throw new ProviderRequestError(502, "shopify_admin response is missing fulfillment trackingInfo");
+  }
+  return {
+    id: readRequiredString(raw, "id"),
+    name: readRequiredString(raw, "name"),
+    status: readRequiredString(raw, "status"),
+    totalQuantity: readRequiredInteger(raw, "totalQuantity"),
+    createdAt: readRequiredString(raw, "createdAt"),
+    orderId: readRequiredString(order, "id"),
+    orderName: readRequiredString(order, "name"),
+    trackingInfo: trackingInfo.map((item) => {
+      const tracking = readObject(item, "trackingInfo");
+      return {
+        company: optionalString(tracking.company) ?? null,
+        number: optionalString(tracking.number) ?? null,
+        url: optionalString(tracking.url) ?? null,
+        raw: tracking,
+      };
+    }),
+    raw,
+  };
+}
+
+function normalizeBulkOperation(raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: readRequiredString(raw, "id"),
+    status: readRequiredString(raw, "status"),
+    type: readRequiredString(raw, "type"),
+    createdAt: readRequiredString(raw, "createdAt"),
+    completedAt: optionalString(raw.completedAt) ?? null,
+    errorCode: optionalString(raw.errorCode) ?? null,
+    objectCount: readUnsignedInt64(raw, "objectCount"),
+    rootObjectCount: readUnsignedInt64(raw, "rootObjectCount"),
+    fileSize: readOptionalUnsignedInt64(raw.fileSize),
+    url: optionalString(raw.url) ?? null,
+    partialDataUrl: optionalString(raw.partialDataUrl) ?? null,
+    query: readRequiredString(raw, "query"),
+    raw,
+  };
+}
+
 function normalizeVariant(edge: Record<string, unknown>): Record<string, unknown> {
   const variant = readObject(edge.node, "node");
+  const inventoryItem = optionalRecord(variant.inventoryItem);
   const product = optionalRecord(variant.product);
   return {
     id: readRequiredString(variant, "id"),
@@ -690,10 +1277,67 @@ function normalizeVariant(edge: Record<string, unknown>): Record<string, unknown
     sku: optionalString(variant.sku) ?? null,
     price: optionalString(variant.price) ?? null,
     inventoryQuantity: optionalInteger(variant.inventoryQuantity) ?? null,
+    inventoryItemId: optionalString(inventoryItem?.id) ?? null,
     productId: optionalString(product?.id) ?? null,
     productTitle: optionalString(product?.title) ?? null,
     cursor: optionalString(edge.cursor) ?? null,
     raw: variant,
+  };
+}
+
+function normalizeOrderFulfillmentOrders(raw: Record<string, unknown>): Record<string, unknown> {
+  const connection = readObject(raw.fulfillmentOrders, "fulfillmentOrders");
+  return {
+    id: readRequiredString(raw, "id"),
+    name: readRequiredString(raw, "name"),
+    fulfillmentOrders: readEdges(connection).map((edge) => normalizeFulfillmentOrder(edge)),
+    pageInfo: normalizePageInfo(readObject(connection.pageInfo, "pageInfo")),
+    raw,
+  };
+}
+
+function normalizeFulfillmentOrder(edge: Record<string, unknown>): Record<string, unknown> {
+  const fulfillmentOrder = readObject(edge.node, "node");
+  const assignedLocation = readObject(fulfillmentOrder.assignedLocation, "assignedLocation");
+  const location = optionalRecord(assignedLocation.location);
+  const lineItems = readObject(fulfillmentOrder.lineItems, "lineItems");
+  const supportedActions = fulfillmentOrder.supportedActions;
+  if (!Array.isArray(supportedActions)) {
+    throw new ProviderRequestError(502, "shopify_admin response is missing supportedActions");
+  }
+  return {
+    id: readRequiredString(fulfillmentOrder, "id"),
+    orderId: readRequiredString(fulfillmentOrder, "orderId"),
+    orderName: readRequiredString(fulfillmentOrder, "orderName"),
+    status: readRequiredString(fulfillmentOrder, "status"),
+    requestStatus: readRequiredString(fulfillmentOrder, "requestStatus"),
+    assignedLocationId: optionalString(location?.id) ?? null,
+    assignedLocationName: readRequiredString(assignedLocation, "name"),
+    supportedActions: supportedActions.map((item) => {
+      const supportedAction = readObject(item, "supportedAction");
+      return {
+        action: readRequiredString(supportedAction, "action"),
+        externalUrl: optionalString(supportedAction.externalUrl) ?? null,
+      };
+    }),
+    lineItems: readEdges(lineItems).map((lineItemEdge) => {
+      const lineItem = readObject(lineItemEdge.node, "node");
+      return {
+        id: readRequiredString(lineItem, "id"),
+        totalQuantity: readRequiredInteger(lineItem, "totalQuantity"),
+        remainingQuantity: readRequiredInteger(lineItem, "remainingQuantity"),
+        inventoryItemId: optionalString(lineItem.inventoryItemId) ?? null,
+        sku: optionalString(lineItem.sku) ?? null,
+        productTitle: readRequiredString(lineItem, "productTitle"),
+        variantTitle: optionalString(lineItem.variantTitle) ?? null,
+        requiresShipping: readRequiredBoolean(lineItem, "requiresShipping"),
+        raw: lineItem,
+      };
+    }),
+    lineItemsPageInfo: normalizePageInfo(readObject(lineItems.pageInfo, "pageInfo")),
+    updatedAt: readRequiredString(fulfillmentOrder, "updatedAt"),
+    cursor: optionalString(edge.cursor) ?? null,
+    raw: fulfillmentOrder,
   };
 }
 
@@ -774,6 +1418,31 @@ function normalizeInventoryItemDetail(raw: Record<string, unknown>): Record<stri
     harmonizedSystemCode: optionalString(raw.harmonizedSystemCode) ?? null,
     createdAt: optionalString(raw.createdAt) ?? null,
     updatedAt: optionalString(raw.updatedAt) ?? null,
+    raw,
+  };
+}
+
+function normalizeInventoryLevel(raw: Record<string, unknown>): Record<string, unknown> {
+  const inventoryItem = readObject(raw.item, "item");
+  const location = readObject(raw.location, "location");
+  const quantities = raw.quantities;
+  if (!Array.isArray(quantities)) {
+    throw new ProviderRequestError(502, "shopify_admin response is missing inventory quantities");
+  }
+  return {
+    id: readRequiredString(raw, "id"),
+    isActive: readRequiredBoolean(raw, "isActive"),
+    inventoryItemId: readRequiredString(inventoryItem, "id"),
+    inventoryItemSku: optionalString(inventoryItem.sku) ?? null,
+    locationId: readRequiredString(location, "id"),
+    locationName: readRequiredString(location, "name"),
+    quantities: quantities.map((item) => {
+      const quantity = readObject(item, "inventory quantity");
+      return {
+        name: readRequiredString(quantity, "name"),
+        quantity: readRequiredInteger(quantity, "quantity"),
+      };
+    }),
     raw,
   };
 }
@@ -871,6 +1540,40 @@ function readRequiredString(input: Record<string, unknown>, key: string): string
 
 function readStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function readNonEmptyStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+  return strings.length > 0 ? strings : undefined;
+}
+
+function readRequiredInteger(input: Record<string, unknown>, key: string): number {
+  const value = input[key];
+  if (!Number.isInteger(value)) {
+    throw new ProviderRequestError(502, `shopify_admin response is missing ${key}`);
+  }
+  return value as number;
+}
+
+function readUnsignedInt64(input: Record<string, unknown>, key: string): string {
+  const value = readOptionalUnsignedInt64(input[key]);
+  if (value === null) {
+    throw new ProviderRequestError(502, `shopify_admin response is missing ${key}`);
+  }
+  return value;
+}
+
+function readOptionalUnsignedInt64(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return String(value);
+  }
+  return null;
 }
 
 function readRequiredBoolean(input: Record<string, unknown>, key: string): boolean {


### PR DESCRIPTION
## 概要

同步第二批 5 个 provider：

- 新增 Lingxing MCP、SellerSprite、Photoroom、Keepa
- 为 Shopify Admin 补齐 fulfillment、inventory CAS/idempotency、typed product writes 与 bulk operation/transit 共 11 个 action

## 边界

- Lingxing 的 credential endpoint 与 Shopify shop domain 保留完整 DNS/SSRF 防护
- Photoroom 源图 URL 仅传给第三方，结果写入 OSS `transitFiles`
- Shopify bulk 签名 URL 由 connector 下载，经过默认 guarded fetch、大小限制和本地 transit
- Shopify Admin 继续使用 OSS API-key + shopDomain，不引入私有 OAuth 或 Ali OSS
- 未迁移私有 tests、docs、coverage notes 或商业字段，未修改共享 helper

## 验证

- `npm run generate:catalog`
- `npm run fix-check`
- `npm run build`
- 逐 provider schema/runtime/file-transit/error probes
- `git diff --check origin/main...HEAD`

在包含两批提交的集成分支上执行 `node ../connect-port.ts --force`，两边 missing provider/action 均为 `(none)`。未运行全量测试。
