### PR TITLE
fix(providers): bound transit response buffering

### DIFF
--- a/src/providers/agenty/runtime.ts
+++ b/src/providers/agenty/runtime.ts
@@ -3,6 +3,7 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 import type { AgentyActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const agentyApiBaseUrl = "https://api.agenty.com/v2";
@@ -581,7 +582,12 @@ async function uploadAgentyTransitFile(context: AgentyRuntimeContext, response: 
   }
 
   const mimeType = response.headers.get("content-type") ?? "application/octet-stream";
-  const upload = await context.transitFiles.create(new File([await response.arrayBuffer()], name, { type: mimeType }));
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Agenty file output",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
   return {
     name,
     mimetype: mimeType,

--- a/src/providers/docsend_2_pdf/executors.ts
+++ b/src/providers/docsend_2_pdf/executors.ts
@@ -8,7 +8,7 @@ import type { Docsend2PdfActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   defineProviderExecutors,
   defineProviderProxy,
@@ -53,7 +53,8 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
 
 async function convert(input: Record<string, unknown>, context: Docsend2PdfContext): Promise<unknown> {
   const returnPdfBase64 = optionalBoolean(input.returnPdfBase64) ?? false;
-  if (!returnPdfBase64 && !context.transitFiles) {
+  const transitFiles = context.transitFiles;
+  if (!returnPdfBase64 && !transitFiles) {
     throw new ProviderRequestError(
       400,
       "Transit file storage is not enabled; set returnPdfBase64=true to return PDF bytes inline.",
@@ -77,7 +78,21 @@ async function convert(input: Record<string, unknown>, context: Docsend2PdfConte
     throw new ProviderRequestError(502, `Docsend2pdf convert returned unexpected content type ${contentType}`);
   }
 
-  const bytes = Buffer.from(await response.arrayBuffer());
+  let bytes: Buffer;
+  if (returnPdfBase64) {
+    bytes = Buffer.from(await response.arrayBuffer());
+  } else {
+    if (!transitFiles) {
+      throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+    }
+    bytes = Buffer.from(
+      await readBoundedResponseBytes(response, {
+        maxBytes: transitFiles.maxBytes,
+        fieldName: "Docsend2pdf converted PDF",
+        createError: (message) => new ProviderRequestError(413, message),
+      }),
+    );
+  }
   const outputName = normalizePdfName(optionalString(input.outputName) ?? readFilename(response));
   const pdf = returnPdfBase64
     ? {

--- a/src/providers/elevenlabs/executors.ts
+++ b/src/providers/elevenlabs/executors.ts
@@ -16,6 +16,7 @@ import {
   optionalString,
   requiredRecord,
 } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
@@ -341,7 +342,16 @@ async function elevenlabsTextToSpeech(input: Record<string, unknown>, context: E
     throw await createElevenlabsError(response, "execute");
   }
 
-  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "text_to_speech requires transit file storage");
+  }
+  const bytes = Buffer.from(
+    await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "ElevenLabs text-to-speech audio",
+      createError: (message) => new ProviderRequestError(413, message),
+    }),
+  );
   const contentType = response.headers.get("content-type") ?? "application/octet-stream";
   const extension = inferElevenlabsAudioExtension(contentType, outputFormat);
   const name = `elevenlabs-tts-${String(input.voiceId)}.${extension}`;
@@ -356,6 +366,10 @@ async function elevenlabsTextToSpeech(input: Record<string, unknown>, context: E
 }
 
 async function elevenlabsTextToSpeechWithTimestamps(input: Record<string, unknown>, context: ElevenlabsRuntimeContext) {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "text_to_speech_with_timestamps requires transit file storage");
+  }
+
   const requestPayload = buildTextToSpeechBody(input);
   const outputFormat = optionalString(input.outputFormat) ?? "mp3_44100_128";
   const modelId = optionalString(input.modelId);
@@ -369,6 +383,7 @@ async function elevenlabsTextToSpeechWithTimestamps(input: Record<string, unknow
         optimize_streaming_latency: numberQueryValue(input.optimizeStreamingLatency),
       }),
       body: requestPayload,
+      maxResponseBytes: Math.ceil((context.transitFiles.maxBytes * 4) / 3) + 4 * 1024 * 1024,
     },
     context.apiKey,
     context.fetcher,
@@ -378,15 +393,16 @@ async function elevenlabsTextToSpeechWithTimestamps(input: Record<string, unknow
   const contentType = inferElevenlabsContentType(outputFormat);
   const extension = inferElevenlabsAudioExtension(contentType, outputFormat);
   const name = `elevenlabs-tts-timestamps-${String(input.voiceId)}.${extension}`;
+  const audioBytes = decodeRequiredBase64(payload.audio_base64, "audio_base64");
+  if (audioBytes.byteLength > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(
+      413,
+      `ElevenLabs text-to-speech audio exceeds ${context.transitFiles.maxBytes} bytes`,
+    );
+  }
 
   return compactObject({
-    file: await storeElevenlabsFile(
-      context,
-      name,
-      contentType,
-      decodeRequiredBase64(payload.audio_base64, "audio_base64"),
-      "text_to_speech_with_timestamps",
-    ),
+    file: await storeElevenlabsFile(context, name, contentType, audioBytes, "text_to_speech_with_timestamps"),
     alignment: normalizeCharacterAlignment(payload.alignment),
     normalizedAlignment: normalizeCharacterAlignment(payload.normalized_alignment),
     voiceId: String(input.voiceId),
@@ -414,7 +430,16 @@ async function createElevenlabsSoundEffect(input: Record<string, unknown>, conte
     throw await createElevenlabsError(response, "execute");
   }
 
-  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "create_sound_effect requires transit file storage");
+  }
+  const bytes = Buffer.from(
+    await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "ElevenLabs sound effect audio",
+      createError: (message) => new ProviderRequestError(413, message),
+    }),
+  );
   const contentType = response.headers.get("content-type") ?? inferElevenlabsContentType(outputFormat);
   const extension = inferElevenlabsAudioExtension(contentType, outputFormat);
   const name = `elevenlabs-sound-effect.${extension}`;
@@ -438,7 +463,16 @@ async function getElevenlabsAudioFromHistoryItem(input: Record<string, unknown>,
     throw await createElevenlabsError(response, "execute");
   }
 
-  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "get_audio_from_history_item requires transit file storage");
+  }
+  const bytes = Buffer.from(
+    await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "ElevenLabs history audio",
+      createError: (message) => new ProviderRequestError(413, message),
+    }),
+  );
   const contentType = response.headers.get("content-type") ?? "audio/mpeg";
   const extension = inferElevenlabsAudioExtension(contentType, "mp3_44100_128");
   const name = `elevenlabs-history-${historyItemId}.${extension}`;
@@ -514,6 +548,7 @@ type ElevenlabsRequestInput = {
   query?: Record<string, string | string[] | undefined>;
   body?: Record<string, unknown>;
   mode?: "validate" | "execute";
+  maxResponseBytes?: number;
 };
 
 async function requestElevenlabsJson<T>(
@@ -533,7 +568,7 @@ async function requestElevenlabsJson<T>(
     throw await createElevenlabsError(response, input.mode ?? "execute");
   }
 
-  return readElevenlabsJson<T>(response);
+  return readElevenlabsJson<T>(response, input.maxResponseBytes);
 }
 
 function buildElevenlabsUrl(
@@ -586,10 +621,21 @@ function elevenlabsBinaryJsonHeaders(apiKey: string) {
   };
 }
 
-async function readElevenlabsJson<T>(response: Response) {
+async function readElevenlabsJson<T>(response: Response, maxBytes?: number) {
   try {
-    return (await response.json()) as T;
-  } catch {
+    if (maxBytes === undefined) {
+      return (await response.json()) as T;
+    }
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes,
+      fieldName: "ElevenLabs JSON response",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
     throw new ProviderRequestError(502, "elevenlabs returned invalid JSON");
   }
 }

--- a/src/providers/feishu_app_bot/executors.ts
+++ b/src/providers/feishu_app_bot/executors.ts
@@ -9,7 +9,7 @@ import type { FeishuActionRuntimeContext } from "../feishu/shared/client.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalBoolean, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import { createFeishuApplicationActionHandlers } from "../feishu/shared/application-runtime.ts";
 import { createFeishuBaseAdvancedActionHandlers } from "../feishu/shared/base-advanced-runtime.ts";
 import { createFeishuBaseActionHandlers } from "../feishu/shared/base-runtime.ts";
@@ -1142,8 +1142,13 @@ async function uploadFeishuMediaTransitFile(input: {
 
     const mimeType = normalizeMimeType(response.headers.get("content-type")) ?? "application/octet-stream";
     const fileName = input.preferredFileName ?? buildFeishuTransitFileName(input.idValue, mimeType);
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: input.context.transitFiles.maxBytes,
+      fieldName: `Feishu ${input.actionName} output`,
+      createError: (message) => new ProviderRequestError(413, message),
+    });
     const upload = await input.context.transitFiles.create(
-      new File([await response.arrayBuffer()], fileName, { type: mimeType }),
+      new File([Uint8Array.from(bytes)], fileName, { type: mimeType }),
     );
 
     return {

--- a/src/providers/fuxin/executors.ts
+++ b/src/providers/fuxin/executors.ts
@@ -20,7 +20,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   defineProviderExecutors,
   normalizeProviderProxyEndpoint,
@@ -354,13 +354,19 @@ async function fuxinDownloadFile(input: Record<string, unknown>, context: FuxinA
     signal: context.signal,
   });
 
-  const bytes = await response.arrayBuffer();
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Foxit file download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
   const mimeType = normalizeMimeType(response.headers.get("content-type")) ?? fuxinBinaryMimeTypeFallback;
   const resolvedFileName =
     fileName ??
     readDispositionFileName(response.headers.get("content-disposition")) ??
     buildDefaultFileName("foxit-download", mimeType);
-  const upload = await context.transitFiles.create(new File([bytes], resolvedFileName, { type: mimeType }));
+  const upload = await context.transitFiles.create(
+    new File([Uint8Array.from(bytes)], resolvedFileName, { type: mimeType }),
+  );
 
   return {
     file: {

--- a/src/providers/gemini/runtime.ts
+++ b/src/providers/gemini/runtime.ts
@@ -1,7 +1,7 @@
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { jsonObject } from "../../core/request.ts";
+import { jsonObject, readBoundedResponseBytes } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const geminiApiBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
@@ -642,8 +642,12 @@ async function fetchGemini(
 
 async function downloadMediaBytes(
   url: string,
-  context: Pick<GeminiRuntimeContext, "apiKey" | "fetcher" | "signal">,
+  context: Pick<GeminiRuntimeContext, "apiKey" | "fetcher" | "signal" | "transitFiles">,
 ): Promise<GeminiDownloadedMedia> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(502, "gemini media actions require server-side file transit");
+  }
+
   const headers: Record<string, string> = {
     "user-agent": providerUserAgent,
   };
@@ -667,7 +671,11 @@ async function downloadMediaBytes(
   }
 
   return {
-    bytes: new Uint8Array(await response.arrayBuffer()),
+    bytes: await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "Gemini media download",
+      createError: (message) => new ProviderRequestError(413, message),
+    }),
     mimeType: response.headers.get("content-type") ?? undefined,
   };
 }

--- a/src/providers/gladia/runtime.ts
+++ b/src/providers/gladia/runtime.ts
@@ -177,8 +177,12 @@ async function downloadTranscriptionAudio(
     optionalString(input.fileName) ??
     readContentDispositionFileName(response.headers.get("content-disposition")) ??
     `gladia-${id}${extensionFromMimeType(mimeType)}`;
-  const body = await response.arrayBuffer();
-  const upload = await context.transitFiles.create(new File([body], name, { type: mimeType }));
+  const body = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Gladia transcription audio",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(body)], name, { type: mimeType }));
 
   return {
     id,

--- a/src/providers/googledrive/executors.ts
+++ b/src/providers/googledrive/executors.ts
@@ -2,6 +2,7 @@ import type { CredentialValidators, ProviderExecutors } from "../../core/types.t
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { randomUUID } from "node:crypto";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 import {
   createComment,
@@ -507,7 +508,12 @@ async function exportFile(input: Record<string, unknown>, context: ActionContext
   const mimeType = response.headers.get("content-type") ?? requestedMimeType;
   const extension = extensionForExportMimeType(mimeType);
   const name = `${fileId}${extension}`;
-  const upload = await context.transitFiles.create(new File([await response.arrayBuffer()], name, { type: mimeType }));
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Google Drive export",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return {
     fileId,

--- a/src/providers/klangio/runtime.ts
+++ b/src/providers/klangio/runtime.ts
@@ -219,14 +219,20 @@ async function downloadKlangioFile(input: {
     throw createKlangioError(response, payload);
   }
 
-  const bytes = await response.arrayBuffer();
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: input.context.transitFiles.maxBytes,
+    fieldName: `Klangio ${input.actionName} file`,
+    createError: (message) => new ProviderRequestError(413, message),
+  });
   if (bytes.byteLength === 0) {
     throw new ProviderRequestError(502, `Klangio ${input.actionName} response did not include file bytes`);
   }
 
   const contentType = normalizeMimeType(response.headers.get("content-type")) ?? input.fallbackMimeType;
   const name = appendExtensionIfMissing(input.fileName, extensionForMimeType(contentType));
-  const upload = await input.context.transitFiles.create(new File([bytes], name, { type: contentType }));
+  const upload = await input.context.transitFiles.create(
+    new File([Uint8Array.from(bytes)], name, { type: contentType }),
+  );
 
   return {
     file: {

--- a/src/providers/kraken_io/executors.ts
+++ b/src/providers/kraken_io/executors.ts
@@ -16,6 +16,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import {
   defineProviderExecutors,
   providerUserAgent,
@@ -143,7 +144,7 @@ async function optimizeKrakenImage(input: Record<string, unknown>, context: Krak
   const fileName = resolveKrakenFileName(payload, krakedUrl);
   const download = await downloadKrakenFile(krakedUrl, fileName, context);
   const upload = await context.transitFiles.create(
-    new File([download.bytes], fileName, { type: download.contentType }),
+    new File([Uint8Array.from(download.bytes)], fileName, { type: download.contentType }),
   );
 
   return compactObject({
@@ -351,8 +352,12 @@ function extractKrakenMessage(payload: unknown): string | undefined {
 async function downloadKrakenFile(
   krakedUrl: string,
   fileName: string,
-  context: Pick<KrakenIoActionContext, "fetcher" | "signal">,
-): Promise<{ bytes: ArrayBuffer; contentType: string }> {
+  context: Pick<KrakenIoActionContext, "fetcher" | "signal" | "transitFiles">,
+): Promise<{ bytes: Uint8Array; contentType: string }> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+  }
+
   let response: Response;
   try {
     response = await context.fetcher(krakedUrl, {
@@ -378,7 +383,11 @@ async function downloadKrakenFile(
     );
   }
 
-  const bytes = await response.arrayBuffer();
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Kraken.io optimized file download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
   if (bytes.byteLength === 0) {
     throw new ProviderRequestError(502, "Kraken.io optimized file download was empty");
   }

--- a/src/providers/remove_bg/executors.ts
+++ b/src/providers/remove_bg/executors.ts
@@ -9,6 +9,7 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { defineApiKeyProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "remove_bg";
@@ -124,10 +125,22 @@ async function removeBgRemoveBackground(
   let payload: unknown;
   let bytes: Uint8Array;
   if (normalizedContentType === "application/json") {
-    payload = await response.json();
+    const jsonBytes = await readBoundedResponseBytes(response, {
+      maxBytes: Math.ceil((context.transitFiles.maxBytes * 4) / 3) + 1024 * 1024,
+      fieldName: "remove.bg JSON result",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    payload = JSON.parse(new TextDecoder().decode(jsonBytes)) as unknown;
     bytes = Buffer.from(extractRemoveBgResultBase64(payload), "base64");
   } else {
-    bytes = new Uint8Array(await response.arrayBuffer());
+    bytes = await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "remove.bg result",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+  }
+  if (bytes.byteLength > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(413, `remove.bg result exceeds ${context.transitFiles.maxBytes} bytes`);
   }
   if (bytes.byteLength === 0) {
     throw new ProviderRequestError(502, "remove.bg response did not include result bytes");

--- a/src/providers/screenshotone/runtime.ts
+++ b/src/providers/screenshotone/runtime.ts
@@ -3,6 +3,7 @@ import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.t
 import type { ScreenshotoneActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const screenshotoneApiBaseUrl = "https://api.screenshotone.com";
@@ -198,10 +199,14 @@ async function uploadScreenshotoneResponse(
     context,
     kind === "animation" ? "take_animated_screenshot" : "take_screenshot",
   );
-  const bytes = await response.arrayBuffer();
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: transitFiles.maxBytes,
+    fieldName: `ScreenshotOne ${kind} output`,
+    createError: (message) => new ProviderRequestError(413, message),
+  });
   const mimeType = response.headers.get("content-type") ?? "application/octet-stream";
   const name = buildScreenshotoneTransitFileName(kind, mimeType);
-  const upload = await transitFiles.create(new File([bytes], name, { type: mimeType }));
+  const upload = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return {
     file: {

--- a/src/providers/stabilityai/executors.ts
+++ b/src/providers/stabilityai/executors.ts
@@ -4,6 +4,7 @@ import type { StabilityAiActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import {
   createProviderTimeout,
   defineApiKeyProviderExecutors,
@@ -90,7 +91,13 @@ async function stabilityAiTextToAudio(input: Record<string, unknown>, context: A
     accept: "audio/*",
   });
 
-  const bytes = Buffer.from(await response.arrayBuffer());
+  const bytes = Buffer.from(
+    await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "Stability AI audio output",
+      createError: (message) => new ProviderRequestError(413, message),
+    }),
+  );
   const contentType = response.headers.get("content-type") ?? inferContentType(outputFormat);
   const extension = inferStabilityAiAudioExtension(contentType, outputFormat);
   const name = `stabilityai-text-to-audio.${extension}`;

--- a/src/providers/tinypng/runtime.ts
+++ b/src/providers/tinypng/runtime.ts
@@ -10,7 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const tinypngApiBaseUrl: string = "https://api.tinify.com";
@@ -134,10 +134,14 @@ async function outputImage(input: Record<string, unknown>, context: ApiKeyProvid
   });
 
   await assertTinypngResponse(response, "execute");
-  const bytes = await response.arrayBuffer();
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "TinyPNG output image",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
   const mimeType = response.headers.get("content-type") ?? "image/png";
   const name = buildTinypngTransitFileName(imageId, mimeType);
-  const upload = await context.transitFiles.create(new File([bytes], name, { type: mimeType }));
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return compactObject({
     imageId,

--- a/src/providers/vimeo/runtime.ts
+++ b/src/providers/vimeo/runtime.ts
@@ -10,7 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { assertPublicHttpUrl, queryParams } from "../../core/request.ts";
+import { assertPublicHttpUrl, queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -258,7 +258,12 @@ async function vimeoDownloadVideoFile(input: Record<string, unknown>, context: V
 
   const mimeType = response.headers.get("content-type") ?? optionalString(selected.type) ?? "application/octet-stream";
   const name = resolveDownloadFileName(input, selected, mimeType);
-  const upload = await context.transitFiles.create(new File([await response.arrayBuffer()], name, { type: mimeType }));
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Vimeo video download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return {
     videoId: input.videoId,

--- a/src/providers/youtube/runtime.ts
+++ b/src/providers/youtube/runtime.ts
@@ -466,9 +466,12 @@ async function downloadCaption(input: Record<string, unknown>, context: YoutubeA
   const mimeType = optionalString(input.mimeType) ?? inferMimeType(response.headers.get("content-type"));
   const fileName =
     optionalString(input.fileName) ?? resolveCaptionFileName(captionId, optionalString(input.tfmt), mimeType);
-  const upload = await context.transitFiles.create(
-    new File([await response.arrayBuffer()], fileName, { type: mimeType }),
-  );
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "YouTube caption download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], fileName, { type: mimeType }));
   return {
     file: {
       id: captionId,


### PR DESCRIPTION
## 概要

批次 provider 自审发现，多个文件输出 action 会先无界读取完整 provider 响应，再由 `transitFiles.create` 检查大小。超大图片、音频、视频或导出文件因此可能在限制生效前放大进程内存。

本 PR 将 16 个 provider 的 response → transit 路径改为复用现有 `readBoundedResponseBytes`，以 `transitFiles.maxBytes` 在读取阶段早停并返回 413：

- Agenty、Docsend2pdf、ElevenLabs、Feishu App Bot、Foxit、Gemini、Gladia、Google Drive
- Klangio、Kraken.io、remove.bg、ScreenshotOne、Stability AI、TinyPNG、Vimeo、YouTube

remove.bg 与 ElevenLabs 的 JSON/base64 文件分支按 base64 膨胀量限制 JSON 响应，并在解码后再次检查实际文件大小。仅返回 inline base64、读取本地 transit file 或已有独立 bounded reader 的路径保持不变。

## 边界

- 不修改共享 helper；沿用 `src/core/request.ts` 已有 bounded reader
- 保留各 provider 的认证、请求、输出和非超限错误语义
- 不混入审计发现的低优先级旧 JSON helper 清理

## 验证

- `npm run fix-check`
- `npm run build`
- `npx vitest run src/core/request.test.ts src/providers/provider-runtime.test.ts`（2 files / 36 tests）
- `git diff --check origin/main..HEAD`

未运行全量测试；本 PR 未改共享 helper，涉及 provider 没有对应的 OSS provider-local tests。
