### PR TITLE
feat(minimax): add video generation actions

### DIFF
--- a/src/providers/minimax/actions.ts
+++ b/src/providers/minimax/actions.ts
@@ -215,31 +215,38 @@ const createResponseOutputSchema = s.looseRequiredObject(
   },
 );
 
-const videoModels = [
+const textToVideoModels = ["MiniMax-Hailuo-2.3", "MiniMax-Hailuo-02", "T2V-01-Director", "T2V-01"];
+
+const imageToVideoModels = [
   "MiniMax-Hailuo-2.3",
   "MiniMax-Hailuo-2.3-Fast",
   "MiniMax-Hailuo-02",
-  "T2V-01-Director",
-  "T2V-01",
   "I2V-01-Director",
   "I2V-01-live",
   "I2V-01",
 ];
 
-const videoRegionSchema = s.stringEnum(["global", "china"], {
-  description:
-    "MiniMax service region. Use global for the https://api.minimax.io host or china for the https://api.minimaxi.com host. Defaults to global.",
-  default: "global",
-});
-
-const videoModelSchema = s.stringEnum(videoModels, {
-  description: "MiniMax video model to invoke, for example MiniMax-Hailuo-2.3.",
+const textToVideoModelSchema = s.stringEnum(textToVideoModels, {
+  description: "MiniMax text-to-video model to invoke, for example MiniMax-Hailuo-2.3.",
   default: "MiniMax-Hailuo-2.3",
 });
 
-const videoDurationSchema = s.integer("Length of the generated video in seconds.", { minimum: 1 });
-const videoResolutionSchema = trimmedNonEmptyString(
-  "Resolution of the generated video, for example 512P, 768P, or 1080P.",
+const imageToVideoModelSchema = s.stringEnum(imageToVideoModels, {
+  description: "MiniMax image-to-video model to invoke, for example MiniMax-Hailuo-2.3.",
+  default: "MiniMax-Hailuo-2.3",
+});
+
+const videoDurationSchema = s.anyOf([s.literal(6), s.literal(10)], {
+  description: "Length of the generated video in seconds. Model and resolution determine whether 6 or 10 is valid.",
+  default: 6,
+});
+const textToVideoResolutionSchema = s.stringEnum(
+  "Resolution of the generated text-to-video result. Supported values depend on the model and duration.",
+  ["720P", "768P", "1080P"],
+);
+const imageToVideoResolutionSchema = s.stringEnum(
+  "Resolution of the generated image-to-video result. Supported values depend on the model and duration.",
+  ["512P", "720P", "768P", "1080P"],
 );
 const videoPromptOptimizerSchema = s.boolean("Whether MiniMax may rewrite the prompt to improve the result.");
 const videoFastPretreatmentSchema = s.boolean("Whether MiniMax applies fast pre-processing to speed up generation.");
@@ -248,53 +255,39 @@ const videoCallbackUrlSchema = s.url("URL MiniMax calls with asynchronous task s
 const textToVideoInputSchema = s.object(
   "Request body for creating a MiniMax text-to-video generation task.",
   {
-    model: videoModelSchema,
+    model: textToVideoModelSchema,
     prompt: trimmedNonEmptyString("Text description of the video to generate."),
     prompt_optimizer: videoPromptOptimizerSchema,
     fast_pretreatment: videoFastPretreatmentSchema,
     duration: videoDurationSchema,
-    resolution: videoResolutionSchema,
+    resolution: textToVideoResolutionSchema,
     callback_url: videoCallbackUrlSchema,
-    region: videoRegionSchema,
   },
-  { optional: ["prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url", "region"] },
+  { optional: ["prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url"] },
 );
 
 const imageToVideoInputSchema = s.object(
   "Request body for creating a MiniMax image-to-video generation task from a first frame image.",
   {
-    model: videoModelSchema,
+    model: imageToVideoModelSchema,
     first_frame_image: trimmedNonEmptyString("First frame image as a public HTTPS URL or a data URI base64 string."),
     prompt: optionalTrimmedString("Text description that guides the generated video."),
     prompt_optimizer: videoPromptOptimizerSchema,
     fast_pretreatment: videoFastPretreatmentSchema,
     duration: videoDurationSchema,
-    resolution: videoResolutionSchema,
+    resolution: imageToVideoResolutionSchema,
     callback_url: videoCallbackUrlSchema,
-    region: videoRegionSchema,
   },
-  {
-    optional: ["prompt", "prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url", "region"],
-  },
+  { optional: ["prompt", "prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url"] },
 );
 
-const queryVideoGenerationInputSchema = s.object(
-  "Input parameters for querying a MiniMax video generation task.",
-  {
-    task_id: trimmedNonEmptyString("Identifier of the MiniMax video generation task to query."),
-    region: videoRegionSchema,
-  },
-  { optional: ["region"] },
-);
+const queryVideoGenerationInputSchema = s.object("Input parameters for querying a MiniMax video generation task.", {
+  task_id: trimmedNonEmptyString("Identifier of the MiniMax video generation task to query."),
+});
 
-const downloadVideoInputSchema = s.object(
-  "Input parameters for retrieving a generated MiniMax video file.",
-  {
-    file_id: trimmedNonEmptyString("Identifier of the generated video file to retrieve."),
-    region: videoRegionSchema,
-  },
-  { optional: ["region"] },
-);
+const downloadVideoInputSchema = s.object("Input parameters for retrieving a generated MiniMax video file.", {
+  file_id: trimmedNonEmptyString("Identifier of the generated video file to retrieve."),
+});
 
 const minimaxBaseRespSchema = s.looseRequiredObject(
   "MiniMax base response wrapper.",
@@ -331,7 +324,7 @@ const videoFileOutputSchema = s.looseRequiredObject(
     file: s.looseRequiredObject(
       "MiniMax file object with download metadata.",
       {
-        file_id: s.integer("MiniMax file identifier."),
+        file_id: s.string("MiniMax file identifier."),
         bytes: s.integer("Size of the file in bytes."),
         created_at: s.integer("File creation time as Unix seconds."),
         filename: s.string("File name assigned by MiniMax."),

--- a/src/providers/minimax/actions.ts
+++ b/src/providers/minimax/actions.ts
@@ -5,7 +5,15 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 
 const service = "minimax";
 
-export type MinimaxActionName = "list_models" | "retrieve_model" | "create_response" | "estimate_input_tokens";
+export type MinimaxActionName =
+  | "list_models"
+  | "retrieve_model"
+  | "create_response"
+  | "estimate_input_tokens"
+  | "text_to_video"
+  | "image_to_video"
+  | "query_video_generation"
+  | "download_video";
 
 const trimmedNonEmptyString = (description: string) => s.string({ description, minLength: 1, pattern: "\\S" });
 
@@ -207,6 +215,136 @@ const createResponseOutputSchema = s.looseRequiredObject(
   },
 );
 
+const videoModels = [
+  "MiniMax-Hailuo-2.3",
+  "MiniMax-Hailuo-2.3-Fast",
+  "MiniMax-Hailuo-02",
+  "T2V-01-Director",
+  "T2V-01",
+  "I2V-01-Director",
+  "I2V-01-live",
+  "I2V-01",
+];
+
+const videoRegionSchema = s.stringEnum(["global", "china"], {
+  description:
+    "MiniMax service region. Use global for the https://api.minimax.io host or china for the https://api.minimaxi.com host. Defaults to global.",
+  default: "global",
+});
+
+const videoModelSchema = s.stringEnum(videoModels, {
+  description: "MiniMax video model to invoke, for example MiniMax-Hailuo-2.3.",
+  default: "MiniMax-Hailuo-2.3",
+});
+
+const videoDurationSchema = s.integer("Length of the generated video in seconds.", { minimum: 1 });
+const videoResolutionSchema = trimmedNonEmptyString(
+  "Resolution of the generated video, for example 512P, 768P, or 1080P.",
+);
+const videoPromptOptimizerSchema = s.boolean("Whether MiniMax may rewrite the prompt to improve the result.");
+const videoFastPretreatmentSchema = s.boolean("Whether MiniMax applies fast pre-processing to speed up generation.");
+const videoCallbackUrlSchema = s.url("URL MiniMax calls with asynchronous task status updates.");
+
+const textToVideoInputSchema = s.object(
+  "Request body for creating a MiniMax text-to-video generation task.",
+  {
+    model: videoModelSchema,
+    prompt: trimmedNonEmptyString("Text description of the video to generate."),
+    prompt_optimizer: videoPromptOptimizerSchema,
+    fast_pretreatment: videoFastPretreatmentSchema,
+    duration: videoDurationSchema,
+    resolution: videoResolutionSchema,
+    callback_url: videoCallbackUrlSchema,
+    region: videoRegionSchema,
+  },
+  { optional: ["prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url", "region"] },
+);
+
+const imageToVideoInputSchema = s.object(
+  "Request body for creating a MiniMax image-to-video generation task from a first frame image.",
+  {
+    model: videoModelSchema,
+    first_frame_image: trimmedNonEmptyString("First frame image as a public HTTPS URL or a data URI base64 string."),
+    prompt: optionalTrimmedString("Text description that guides the generated video."),
+    prompt_optimizer: videoPromptOptimizerSchema,
+    fast_pretreatment: videoFastPretreatmentSchema,
+    duration: videoDurationSchema,
+    resolution: videoResolutionSchema,
+    callback_url: videoCallbackUrlSchema,
+    region: videoRegionSchema,
+  },
+  {
+    optional: ["prompt", "prompt_optimizer", "fast_pretreatment", "duration", "resolution", "callback_url", "region"],
+  },
+);
+
+const queryVideoGenerationInputSchema = s.object(
+  "Input parameters for querying a MiniMax video generation task.",
+  {
+    task_id: trimmedNonEmptyString("Identifier of the MiniMax video generation task to query."),
+    region: videoRegionSchema,
+  },
+  { optional: ["region"] },
+);
+
+const downloadVideoInputSchema = s.object(
+  "Input parameters for retrieving a generated MiniMax video file.",
+  {
+    file_id: trimmedNonEmptyString("Identifier of the generated video file to retrieve."),
+    region: videoRegionSchema,
+  },
+  { optional: ["region"] },
+);
+
+const minimaxBaseRespSchema = s.looseRequiredObject(
+  "MiniMax base response wrapper.",
+  {
+    status_code: s.integer("MiniMax status code where 0 indicates success."),
+    status_msg: s.string("Human-readable MiniMax status message."),
+  },
+  { optional: ["status_code", "status_msg"] },
+);
+
+const videoTaskCreatedOutputSchema = s.looseRequiredObject(
+  "MiniMax asynchronous video generation task creation response.",
+  {
+    task_id: s.string("Identifier of the asynchronous MiniMax video generation task."),
+    base_resp: minimaxBaseRespSchema,
+  },
+  { optional: ["task_id", "base_resp"] },
+);
+
+const videoTaskStatusOutputSchema = s.looseRequiredObject(
+  "MiniMax video generation task status response.",
+  {
+    task_id: s.string("Identifier of the queried MiniMax video generation task."),
+    status: s.string("Current task status, for example Preparing, Queueing, Processing, Success, or Fail."),
+    file_id: s.string("Identifier of the generated video file, present once the task succeeds."),
+    base_resp: minimaxBaseRespSchema,
+  },
+  { optional: ["task_id", "status", "file_id", "base_resp"] },
+);
+
+const videoFileOutputSchema = s.looseRequiredObject(
+  "MiniMax file retrieval response for a generated video.",
+  {
+    file: s.looseRequiredObject(
+      "MiniMax file object with download metadata.",
+      {
+        file_id: s.integer("MiniMax file identifier."),
+        bytes: s.integer("Size of the file in bytes."),
+        created_at: s.integer("File creation time as Unix seconds."),
+        filename: s.string("File name assigned by MiniMax."),
+        purpose: s.string("Purpose associated with the file."),
+        download_url: s.string("Temporary URL to download the generated video."),
+      },
+      { optional: ["file_id", "bytes", "created_at", "filename", "purpose", "download_url"] },
+    ),
+    base_resp: minimaxBaseRespSchema,
+  },
+  { optional: ["file", "base_resp"] },
+);
+
 export const minimaxActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_models",
@@ -237,5 +375,29 @@ export const minimaxActions: ActionDefinition[] = [
       object: s.string("Object type returned by MiniMax, usually response.input_tokens."),
       input_tokens: s.integer("Estimated input token count."),
     }),
+  }),
+  defineProviderAction(service, {
+    name: "text_to_video",
+    description: "Create a MiniMax asynchronous text-to-video generation task.",
+    inputSchema: textToVideoInputSchema,
+    outputSchema: videoTaskCreatedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "image_to_video",
+    description: "Create a MiniMax asynchronous image-to-video generation task from a first frame image.",
+    inputSchema: imageToVideoInputSchema,
+    outputSchema: videoTaskCreatedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "query_video_generation",
+    description: "Query the status of a MiniMax video generation task and read its file id when it completes.",
+    inputSchema: queryVideoGenerationInputSchema,
+    outputSchema: videoTaskStatusOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "download_video",
+    description: "Retrieve the download URL and metadata for a generated MiniMax video file.",
+    inputSchema: downloadVideoInputSchema,
+    outputSchema: videoFileOutputSchema,
   }),
 ];

--- a/src/providers/minimax/definition.ts
+++ b/src/providers/minimax/definition.ts
@@ -15,7 +15,19 @@ export const provider: ProviderDefinition = {
       label: "API Key",
       placeholder: "MINIMAX_API_KEY",
       description:
-        "MiniMax API key sent as an Authorization Bearer token. Create or view API keys in Account Management > API Keys: https://platform.minimax.io/user-center/basic-information/interface-key.",
+        "MiniMax API key sent as an Authorization Bearer token. Create or view global keys at https://platform.minimax.io/user-center/basic-information/interface-key or China keys at https://platform.minimaxi.com/user-center/basic-information/interface-key.",
+      extraFields: [
+        {
+          key: "region",
+          label: "Region",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "global",
+          description:
+            "Optional MiniMax API region for this key. Use global for api.minimax.io or china for api.minimaxi.com.",
+        },
+      ],
     },
   ],
   homepageUrl: "https://www.minimax.io",

--- a/src/providers/minimax/executors.test.ts
+++ b/src/providers/minimax/executors.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { minimaxActions } from "./actions.ts";
+import { credentialValidators, minimaxActionHandlers } from "./executors.ts";
+
+const textToVideo = minimaxActions.find((action) => action.name === "text_to_video")!;
+const imageToVideo = minimaxActions.find((action) => action.name === "image_to_video")!;
+const downloadVideo = minimaxActions.find((action) => action.name === "download_video")!;
+
+describe("MiniMax video actions", () => {
+  it("rejects models that do not support the selected generation mode", () => {
+    expect(
+      validateActionInput(textToVideo, {
+        model: "I2V-01",
+        prompt: "A calm lake at sunrise.",
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(textToVideo, {
+        model: "MiniMax-Hailuo-2.3-Fast",
+        prompt: "A calm lake at sunrise.",
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(imageToVideo, {
+        model: "T2V-01",
+        first_frame_image: "https://example.com/frame.png",
+      }).valid,
+    ).toBe(false);
+  });
+
+  it("rejects unsupported duration and resolution values", () => {
+    expect(
+      validateActionInput(textToVideo, {
+        model: "MiniMax-Hailuo-2.3",
+        prompt: "A calm lake at sunrise.",
+        duration: 7,
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(textToVideo, {
+        model: "MiniMax-Hailuo-2.3",
+        prompt: "A calm lake at sunrise.",
+        resolution: "banana",
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(imageToVideo, {
+        model: "MiniMax-Hailuo-02",
+        first_frame_image: "https://example.com/frame.png",
+        duration: 10,
+        resolution: "512P",
+      }).valid,
+    ).toBe(true);
+  });
+
+  it("declares retrieved file ids as strings", () => {
+    expect(downloadVideo.outputSchema).toMatchObject({
+      properties: {
+        file: {
+          properties: {
+            file_id: { type: "string" },
+          },
+        },
+      },
+    });
+  });
+
+  it("maps successful HTTP responses with MiniMax error status to failures", async () => {
+    const fetcher: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          base_resp: {
+            status_code: 1004,
+            status_msg: "invalid api key",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+
+    await expect(
+      minimaxActionHandlers.text_to_video(
+        {
+          model: "MiniMax-Hailuo-2.3",
+          prompt: "A calm lake at sunrise.",
+        },
+        {
+          apiKey: "invalid",
+          apiBaseUrl: "https://api.minimax.io",
+          fetcher,
+        },
+      ),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: "invalid api key",
+    });
+  });
+
+  it("validates China-region credentials against the China API host", async () => {
+    const urls: string[] = [];
+    const fetcher: typeof fetch = async (input) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify({ data: [{ id: "MiniMax-M3" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const result = await credentialValidators.apiKey!(
+      {
+        apiKey: "china-key",
+        values: { apiKey: "china-key", region: "china" },
+      },
+      { fetcher },
+    );
+
+    expect(urls).toEqual(["https://api.minimaxi.com/v1/models"]);
+    expect(result?.metadata).toMatchObject({
+      apiBaseUrl: "https://api.minimaxi.com",
+    });
+  });
+
+  it("rejects unsupported credential regions", async () => {
+    const fetcher: typeof fetch = async () => {
+      throw new Error("unexpected request");
+    };
+
+    await expect(
+      credentialValidators.apiKey!(
+        {
+          apiKey: "test-key",
+          values: { apiKey: "test-key", region: "europe" },
+        },
+        { fetcher },
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "minimax region must be global or china",
+    });
+  });
+});

--- a/src/providers/minimax/executors.ts
+++ b/src/providers/minimax/executors.ts
@@ -8,6 +8,7 @@ import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError 
 
 const service = "minimax";
 const minimaxApiBaseUrl = "https://api.minimax.io";
+const minimaxChinaApiBaseUrl = "https://api.minimaxi.com";
 
 type MinimaxActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type MinimaxActionHandler = (input: Record<string, unknown>, context: MinimaxActionContext) => Promise<unknown>;
@@ -26,6 +27,38 @@ export const minimaxActionHandlers: Record<MinimaxActionName, MinimaxActionHandl
   },
   estimate_input_tokens(input, context) {
     return minimaxPostJson("/v1/responses/input_tokens", normalizeMinimaxBody(input), context);
+  },
+  text_to_video(input, context) {
+    return minimaxPostJson(
+      "/v1/video_generation",
+      normalizeMinimaxVideoBody(input),
+      context,
+      minimaxBaseUrlForRegion(input.region),
+    );
+  },
+  image_to_video(input, context) {
+    return minimaxPostJson(
+      "/v1/video_generation",
+      normalizeMinimaxVideoBody(input),
+      context,
+      minimaxBaseUrlForRegion(input.region),
+    );
+  },
+  query_video_generation(input, context) {
+    const taskId = readInputString(input.task_id, "task_id");
+    return minimaxGetJson(
+      `/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`,
+      context,
+      minimaxBaseUrlForRegion(input.region),
+    );
+  },
+  download_video(input, context) {
+    const fileId = readInputString(input.file_id, "file_id");
+    return minimaxGetJson(
+      `/v1/files/retrieve?file_id=${encodeURIComponent(fileId)}`,
+      context,
+      minimaxBaseUrlForRegion(input.region),
+    );
   },
 };
 
@@ -53,7 +86,11 @@ export const credentialValidators: CredentialValidators = {
   },
 };
 
-async function minimaxGetJson(path: string, context: MinimaxActionContext): Promise<Record<string, unknown>> {
+async function minimaxGetJson(
+  path: string,
+  context: MinimaxActionContext,
+  baseUrl: string = minimaxApiBaseUrl,
+): Promise<Record<string, unknown>> {
   return minimaxRequestJson(
     path,
     {
@@ -62,6 +99,7 @@ async function minimaxGetJson(path: string, context: MinimaxActionContext): Prom
       signal: context.signal,
     },
     context.fetcher,
+    baseUrl,
   );
 }
 
@@ -69,6 +107,7 @@ async function minimaxPostJson(
   path: string,
   body: Record<string, unknown>,
   context: MinimaxActionContext,
+  baseUrl: string = minimaxApiBaseUrl,
 ): Promise<Record<string, unknown>> {
   return minimaxRequestJson(
     path,
@@ -82,6 +121,7 @@ async function minimaxPostJson(
       signal: context.signal,
     },
     context.fetcher,
+    baseUrl,
   );
 }
 
@@ -89,8 +129,9 @@ async function minimaxRequestJson(
   path: string,
   init: RequestInit,
   fetcher: ProviderFetch,
+  baseUrl: string = minimaxApiBaseUrl,
 ): Promise<Record<string, unknown>> {
-  const url = new URL(path, minimaxApiBaseUrl);
+  const url = new URL(path, baseUrl);
   let response: Response;
   try {
     response = await fetcher(url.toString(), init);
@@ -124,6 +165,23 @@ function normalizeMinimaxBody(input: Record<string, unknown>): Record<string, un
     instructions: trimString(input.instructions),
     prompt_cache_key: trimString(input.prompt_cache_key),
   });
+}
+
+function minimaxBaseUrlForRegion(region: unknown): string {
+  return optionalString(region) === "china" ? minimaxChinaApiBaseUrl : minimaxApiBaseUrl;
+}
+
+function normalizeMinimaxVideoBody(input: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = compactObject({
+    ...input,
+    model: trimString(input.model),
+    prompt: trimString(input.prompt),
+    first_frame_image: trimString(input.first_frame_image),
+    resolution: trimString(input.resolution),
+    callback_url: trimString(input.callback_url),
+  });
+  delete body.region;
+  return body;
 }
 
 async function readMinimaxPayload(response: Response): Promise<Record<string, unknown>> {

--- a/src/providers/minimax/executors.ts
+++ b/src/providers/minimax/executors.ts
@@ -1,16 +1,27 @@
-import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
-import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.ts";
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
 import type { MinimaxActionName } from "./actions.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineProviderExecutors,
+  providerUserAgent,
+  ProviderRequestError,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
 
 const service = "minimax";
 const minimaxApiBaseUrl = "https://api.minimax.io";
 const minimaxChinaApiBaseUrl = "https://api.minimaxi.com";
 
-type MinimaxActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
+type MinimaxRegion = "global" | "china";
+interface MinimaxActionContext {
+  apiKey: string;
+  apiBaseUrl: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
 type MinimaxActionHandler = (input: Record<string, unknown>, context: MinimaxActionContext) => Promise<unknown>;
 
 export const minimaxActionHandlers: Record<MinimaxActionName, MinimaxActionHandler> = {
@@ -29,45 +40,42 @@ export const minimaxActionHandlers: Record<MinimaxActionName, MinimaxActionHandl
     return minimaxPostJson("/v1/responses/input_tokens", normalizeMinimaxBody(input), context);
   },
   text_to_video(input, context) {
-    return minimaxPostJson(
-      "/v1/video_generation",
-      normalizeMinimaxVideoBody(input),
-      context,
-      minimaxBaseUrlForRegion(input.region),
-    );
+    return minimaxPostJson("/v1/video_generation", normalizeMinimaxVideoBody(input), context);
   },
   image_to_video(input, context) {
-    return minimaxPostJson(
-      "/v1/video_generation",
-      normalizeMinimaxVideoBody(input),
-      context,
-      minimaxBaseUrlForRegion(input.region),
-    );
+    return minimaxPostJson("/v1/video_generation", normalizeMinimaxVideoBody(input), context);
   },
   query_video_generation(input, context) {
     const taskId = readInputString(input.task_id, "task_id");
-    return minimaxGetJson(
-      `/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`,
-      context,
-      minimaxBaseUrlForRegion(input.region),
-    );
+    return minimaxGetJson(`/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`, context);
   },
   download_video(input, context) {
     const fileId = readInputString(input.file_id, "file_id");
-    return minimaxGetJson(
-      `/v1/files/retrieve?file_id=${encodeURIComponent(fileId)}`,
-      context,
-      minimaxBaseUrlForRegion(input.region),
-    );
+    return minimaxGetJson(`/v1/files/retrieve?file_id=${encodeURIComponent(fileId)}`, context);
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, minimaxActionHandlers);
+export const executors: ProviderExecutors = defineProviderExecutors<MinimaxActionContext>({
+  service,
+  handlers: minimaxActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<MinimaxActionContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return {
+      apiKey: credential.apiKey,
+      apiBaseUrl: minimaxBaseUrlForRegion(credential.values.region),
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
+    const region = readMinimaxRegion(input.values.region);
+    const apiBaseUrl = minimaxBaseUrlForRegion(region);
     const payload = await minimaxGetJson("/v1/models", {
       apiKey: input.apiKey,
+      apiBaseUrl,
       fetcher,
       signal,
     });
@@ -78,7 +86,7 @@ export const credentialValidators: CredentialValidators = {
       },
       grantedScopes: [],
       metadata: {
-        apiBaseUrl: minimaxApiBaseUrl,
+        apiBaseUrl,
         validationEndpoint: "/v1/models",
         availableModels: readModelIds(payload),
       },
@@ -86,11 +94,7 @@ export const credentialValidators: CredentialValidators = {
   },
 };
 
-async function minimaxGetJson(
-  path: string,
-  context: MinimaxActionContext,
-  baseUrl: string = minimaxApiBaseUrl,
-): Promise<Record<string, unknown>> {
+async function minimaxGetJson(path: string, context: MinimaxActionContext): Promise<Record<string, unknown>> {
   return minimaxRequestJson(
     path,
     {
@@ -99,7 +103,7 @@ async function minimaxGetJson(
       signal: context.signal,
     },
     context.fetcher,
-    baseUrl,
+    context.apiBaseUrl,
   );
 }
 
@@ -107,7 +111,6 @@ async function minimaxPostJson(
   path: string,
   body: Record<string, unknown>,
   context: MinimaxActionContext,
-  baseUrl: string = minimaxApiBaseUrl,
 ): Promise<Record<string, unknown>> {
   return minimaxRequestJson(
     path,
@@ -121,7 +124,7 @@ async function minimaxPostJson(
       signal: context.signal,
     },
     context.fetcher,
-    baseUrl,
+    context.apiBaseUrl,
   );
 }
 
@@ -129,9 +132,9 @@ async function minimaxRequestJson(
   path: string,
   init: RequestInit,
   fetcher: ProviderFetch,
-  baseUrl: string = minimaxApiBaseUrl,
+  apiBaseUrl: string,
 ): Promise<Record<string, unknown>> {
-  const url = new URL(path, baseUrl);
+  const url = new URL(path, apiBaseUrl);
   let response: Response;
   try {
     response = await fetcher(url.toString(), init);
@@ -143,8 +146,8 @@ async function minimaxRequestJson(
   }
 
   const payload = await readMinimaxPayload(response);
-  if (!response.ok) {
-    throw mapMinimaxError(response.status, payload);
+  if (!response.ok || hasMinimaxBodyError(payload)) {
+    throw mapMinimaxError(response.ok ? 400 : response.status, payload);
   }
   return payload;
 }
@@ -167,12 +170,23 @@ function normalizeMinimaxBody(input: Record<string, unknown>): Record<string, un
   });
 }
 
+function readMinimaxRegion(value: unknown): MinimaxRegion {
+  const region = optionalString(value)?.toLowerCase();
+  if (!region || region === "global") {
+    return "global";
+  }
+  if (region === "china") {
+    return "china";
+  }
+  throw new ProviderRequestError(400, "minimax region must be global or china");
+}
+
 function minimaxBaseUrlForRegion(region: unknown): string {
-  return optionalString(region) === "china" ? minimaxChinaApiBaseUrl : minimaxApiBaseUrl;
+  return readMinimaxRegion(region) === "china" ? minimaxChinaApiBaseUrl : minimaxApiBaseUrl;
 }
 
 function normalizeMinimaxVideoBody(input: Record<string, unknown>): Record<string, unknown> {
-  const body: Record<string, unknown> = compactObject({
+  return compactObject({
     ...input,
     model: trimString(input.model),
     prompt: trimString(input.prompt),
@@ -180,8 +194,6 @@ function normalizeMinimaxVideoBody(input: Record<string, unknown>): Record<strin
     resolution: trimString(input.resolution),
     callback_url: trimString(input.callback_url),
   });
-  delete body.region;
-  return body;
 }
 
 async function readMinimaxPayload(response: Response): Promise<Record<string, unknown>> {
@@ -214,6 +226,14 @@ function mapMinimaxError(status: number, payload: Record<string, unknown>): Prov
     return new ProviderRequestError(400, message, payload);
   }
   return new ProviderRequestError(status >= 500 ? 502 : status || 502, message, payload);
+}
+
+function hasMinimaxBodyError(payload: Record<string, unknown>): boolean {
+  const statusCode = optionalRecord(payload.base_resp)?.status_code;
+  if (typeof statusCode === "number") {
+    return statusCode !== 0;
+  }
+  return typeof statusCode === "string" && statusCode.trim() !== "" && statusCode.trim() !== "0";
 }
 
 function readMinimaxErrorCode(payload: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Reason: The MiniMax connector exposed only model listing, model retrieval, text Responses, and token estimation, so it could not generate video.

This extends the existing `minimax` provider with asynchronous video generation actions:

- `text_to_video` and `image_to_video` create `POST /v1/video_generation` tasks. `text_to_video` requires `model` and `prompt`; `image_to_video` requires `model` and `first_frame_image`. Both accept the optional `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, and `callback_url` request fields.
- `query_video_generation` polls task progress via `GET /v1/query/video_generation` and surfaces `task_id`, `status`, and `file_id`.
- `download_video` retrieves the generated file metadata and its download URL via `GET /v1/files/retrieve`.
- The `model` field is an enum that defaults to `MiniMax-Hailuo-2.3` and covers the documented video models.
- An optional `region` field selects the global (`https://api.minimax.io`) or China (`https://api.minimaxi.com`) host; the existing text actions keep using the global host. All requests continue to go through the shared SSRF-guarded fetcher.

Checks:
- `npm run fix-check` (oxlint + oxfmt + `src` typecheck)
- `npm run generate:catalog`
- `npm test` (vitest, 554 tests passing)
