### PR TITLE
feat(home-assistant): add WebSocket-only registry and automation actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@
 - User-supplied content/download URLs (e.g. `fileUrl`, `sourceUrl`, `imageUrl`) must ALWAYS be validated public-only — call `assertPublicHttpUrl` without `allowPrivateNetwork` and download them with the public-only `providerFetch`, never a private-aware `context.fetcher`. The private-network opt-in covers only the trusted instance host.
 - Prefer the shared `assertPublicHttpUrl` / `isBlockedIpAddress` over a bespoke per-provider hostname guard; bespoke guards have missed the cloud-metadata blocklist and bracketed-IPv6 forms.
 - Gotcha: a provider that branches on `fetcher === fetch` (e.g. to gate rate limiting to production) must compare against `providerFetch`, since that is the fetcher the runtime now injects — not the global `fetch`.
+- Non-fetch egress is held to the same policy. A provider that opens a WebSocket must use `openGuardedWebSocket` from `src/core/guarded-websocket.ts`, never `new WebSocket(...)` directly: it validates the target with the same `assertGuardedEgressUrl` hop check the guarded fetch uses (URL literal plus DNS resolved addresses), accepts the same `allowPrivateNetwork` / `skipDnsValidation` options, and maps `ws`/`wss` onto the `http`/`https` form the guard understands. It works on Node and on workerd, which both expose a client `WebSocket` constructor. Any future non-HTTP transport should reuse `assertGuardedEgressUrl` rather than growing a second, drifting host check.
+- The private-network opt-in only means the guard permits the target — it does not make it reachable. Cloudflare Workers cannot route to private addresses at all, so a self-hosted provider pointed at a LAN instance works on Node/Docker/Fly deployments only, regardless of `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`.
 
 ## TypeScript And Tooling
 

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -183,11 +183,8 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
       : options.lookup === undefined
         ? await resolveDefaultLookup()
         : options.lookup;
-    const guardHop = async (value: string, fieldName: string): Promise<URL> => {
-      const url = assertPublicHttpUrl(value, { fieldName, createError, allowPrivateNetwork });
-      await assertResolvedAddressesAllowed(url.hostname, fieldName, { allowPrivateNetwork, createError, lookup });
-      return url;
-    };
+    const guardHop = (value: string, fieldName: string): Promise<URL> =>
+      assertGuardedEgressUrl(value, { fieldName, createError, allowPrivateNetwork, lookup });
 
     const request = input instanceof Request ? input : undefined;
     let url = await guardHop(request?.url ?? (input instanceof URL ? input.href : String(input)), "request URL");
@@ -263,6 +260,47 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
 
   guardedFetchBases.set(guardedFetch, baseFetch);
   return guardedFetch;
+}
+
+export interface GuardedEgressUrlOptions {
+  /** Field name used in guard violation messages, e.g. `"request URL"`. */
+  fieldName: string;
+  /** Error factory for guard violations. */
+  createError: (message: string) => Error;
+  /** Allow RFC 1918 and other private targets while retaining reserved-target guards. */
+  allowPrivateNetwork?: boolean;
+  /**
+   * DNS lookup used to validate resolved addresses: `null` disables the check,
+   * `undefined` uses the module default (`node:dns` where available).
+   */
+  lookup?: GuardedFetchDnsLookup | null;
+}
+
+/**
+ * Apply the shared SSRF egress policy to one URL: validate the literal with
+ * {@link assertPublicHttpUrl}, then validate the addresses its hostname
+ * resolves to, and return the normalized URL.
+ *
+ * This is the single hop check behind {@link createGuardedFetch} (which applies
+ * it to the request URL and every redirect `Location`). It is exported so
+ * non-fetch egress transports that cannot reuse the fetch wrapper — currently
+ * {@link ../core/guarded-websocket.ts openGuardedWebSocket} — enforce exactly
+ * the same policy instead of growing a second, drifting implementation.
+ */
+export async function assertGuardedEgressUrl(value: string, options: GuardedEgressUrlOptions): Promise<URL> {
+  const allowPrivateNetwork = options.allowPrivateNetwork === true;
+  const lookup = options.lookup === undefined ? await resolveDefaultLookup() : options.lookup;
+  const url = assertPublicHttpUrl(value, {
+    fieldName: options.fieldName,
+    createError: options.createError,
+    allowPrivateNetwork,
+  });
+  await assertResolvedAddressesAllowed(url.hostname, options.fieldName, {
+    allowPrivateNetwork,
+    createError: options.createError,
+    lookup,
+  });
+  return url;
 }
 
 interface ResolvedAddressPolicy {

--- a/src/core/guarded-websocket.test.ts
+++ b/src/core/guarded-websocket.test.ts
@@ -1,0 +1,296 @@
+import type { GuardedFetchDnsLookup, ResolvedAddress } from "./guarded-fetch.ts";
+import type { GuardedWebSocketFailure, WebSocketConstructor } from "./guarded-websocket.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { openGuardedWebSocket } from "./guarded-websocket.ts";
+
+type Listener = (event: unknown) => void;
+
+class FakeSocket {
+  static opened: FakeSocket[] = [];
+
+  readonly url: string;
+  closed = false;
+  private readonly listeners = new Map<string, Listener[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeSocket.opened.push(this);
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.closed = true;
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const existing = this.listeners.get(type);
+    if (existing) {
+      existing.push(listener);
+      return;
+    }
+    this.listeners.set(type, [listener]);
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+/** Constructor that reports the socket back so the test can drive its events. */
+function fakeConstructor(onCreate?: (socket: FakeSocket) => void): WebSocketConstructor {
+  return function FakeWebSocket(url: string) {
+    const socket = new FakeSocket(url);
+    // Open on the next tick so the caller has attached its handshake listeners.
+    globalThis.setTimeout(() => onCreate?.(socket), 0);
+    return socket;
+  } as unknown as WebSocketConstructor;
+}
+
+/** Constructor whose sockets open immediately after listeners are attached. */
+function openingConstructor(): WebSocketConstructor {
+  return fakeConstructor((socket) => socket.emit("open"));
+}
+
+function lookupTable(entries: Record<string, ResolvedAddress[]>): GuardedFetchDnsLookup {
+  return async (hostname: string) => {
+    const result = entries[hostname];
+    if (!result) {
+      throw new Error(`no lookup entry for ${hostname}`);
+    }
+    return result;
+  };
+}
+
+/** Records which failure kind the guard reported, so tests assert on the kind and not only the message. */
+interface FailureRecorder {
+  createFailure: (kind: GuardedWebSocketFailure, message: string) => Error;
+  kinds: GuardedWebSocketFailure[];
+}
+
+function failureKinds(): FailureRecorder {
+  const kinds: GuardedWebSocketFailure[] = [];
+  return {
+    createFailure: (kind, message) => {
+      kinds.push(kind);
+      return new Error(message);
+    },
+    kinds,
+  };
+}
+
+describe("openGuardedWebSocket URL guard", () => {
+  it("rejects a literal loopback target before constructing a socket", async () => {
+    FakeSocket.opened = [];
+    await expect(
+      openGuardedWebSocket("ws://127.0.0.1:8123/api/websocket", { webSocketConstructor: openingConstructor() }),
+    ).rejects.toThrow(/private or reserved IP addresses/);
+    expect(FakeSocket.opened).toHaveLength(0);
+  });
+
+  it("rejects a cloud metadata target", async () => {
+    await expect(
+      openGuardedWebSocket("ws://169.254.169.254/api/websocket", { webSocketConstructor: openingConstructor() }),
+    ).rejects.toThrow(/private or reserved IP addresses/);
+  });
+
+  it("rejects a hostname that resolves into a private range", async () => {
+    FakeSocket.opened = [];
+    await expect(
+      openGuardedWebSocket("ws://homeassistant.example.com/api/websocket", {
+        webSocketConstructor: openingConstructor(),
+        lookup: lookupTable({ "homeassistant.example.com": [{ address: "192.168.1.10", family: 4 }] }),
+      }),
+    ).rejects.toThrow(/must not resolve to private or reserved IP addresses/);
+    expect(FakeSocket.opened).toHaveLength(0);
+  });
+
+  it("allows a private-resolving hostname when private network access is opted in", async () => {
+    const socket = await openGuardedWebSocket("ws://homeassistant.example.com/api/websocket", {
+      webSocketConstructor: openingConstructor(),
+      allowPrivateNetwork: true,
+      lookup: lookupTable({ "homeassistant.example.com": [{ address: "192.168.1.10", family: 4 }] }),
+    });
+    expect(socket).toBeInstanceOf(FakeSocket);
+  });
+
+  it("re-evaluates a function-valued private network flag on every call", async () => {
+    let allowed = false;
+    const options = {
+      webSocketConstructor: openingConstructor(),
+      allowPrivateNetwork: (): boolean => allowed,
+      lookup: lookupTable({ "ha.example.com": [{ address: "10.0.0.5", family: 4 }] }),
+    };
+    await expect(openGuardedWebSocket("ws://ha.example.com/api/websocket", options)).rejects.toThrow(
+      /must not resolve to private/,
+    );
+    allowed = true;
+    await expect(openGuardedWebSocket("ws://ha.example.com/api/websocket", options)).resolves.toBeInstanceOf(
+      FakeSocket,
+    );
+  });
+
+  it("fails closed when the lookup cannot resolve the hostname", async () => {
+    await expect(
+      openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+        webSocketConstructor: openingConstructor(),
+        lookup: lookupTable({}),
+      }),
+    ).rejects.toThrow(/could not be resolved for validation/);
+  });
+
+  it("skips resolved-address validation when skipDnsValidation is set", async () => {
+    await expect(
+      openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+        webSocketConstructor: openingConstructor(),
+        skipDnsValidation: true,
+        lookup: lookupTable({}),
+      }),
+    ).resolves.toBeInstanceOf(FakeSocket);
+  });
+
+  it("rejects a non-http scheme", async () => {
+    await expect(
+      openGuardedWebSocket("ftp://ha.example.com/api/websocket", { webSocketConstructor: openingConstructor() }),
+    ).rejects.toThrow(/must use http or https/);
+  });
+
+  it("uses the caller's guard error factory and field name", async () => {
+    class GuardError extends Error {}
+    await expect(
+      openGuardedWebSocket("ws://127.0.0.1/api/websocket", {
+        webSocketConstructor: openingConstructor(),
+        createError: (message) => new GuardError(message),
+        fieldName: "Home Assistant base URL",
+      }),
+    ).rejects.toThrow(/^Home Assistant base URL/);
+  });
+});
+
+describe("openGuardedWebSocket scheme mapping", () => {
+  it("connects over wss when the validated URL is https", async () => {
+    FakeSocket.opened = [];
+    await openGuardedWebSocket("https://ha.example.com/api/websocket", {
+      webSocketConstructor: openingConstructor(),
+    });
+    expect(FakeSocket.opened[0]?.url).toBe("wss://ha.example.com/api/websocket");
+  });
+
+  it("connects over ws when the validated URL is http", async () => {
+    FakeSocket.opened = [];
+    await openGuardedWebSocket("http://ha.example.com:8123/api/websocket", {
+      webSocketConstructor: openingConstructor(),
+    });
+    expect(FakeSocket.opened[0]?.url).toBe("ws://ha.example.com:8123/api/websocket");
+  });
+
+  it("preserves a wss input and its query string", async () => {
+    FakeSocket.opened = [];
+    await openGuardedWebSocket("wss://ha.example.com/api/websocket?v=1", {
+      webSocketConstructor: openingConstructor(),
+    });
+    expect(FakeSocket.opened[0]?.url).toBe("wss://ha.example.com/api/websocket?v=1");
+  });
+
+  it("normalizes the hostname before connecting", async () => {
+    FakeSocket.opened = [];
+    await openGuardedWebSocket("wss://HA.Example.COM./api/websocket", {
+      webSocketConstructor: openingConstructor(),
+    });
+    expect(FakeSocket.opened[0]?.url).toBe("wss://ha.example.com/api/websocket");
+  });
+});
+
+describe("openGuardedWebSocket failures", () => {
+  it("reports an unsupported runtime when the global constructor is missing", async () => {
+    const { createFailure, kinds } = failureKinds();
+    vi.stubGlobal("WebSocket", undefined);
+    try {
+      await expect(openGuardedWebSocket("wss://ha.example.com/api/websocket", { createFailure })).rejects.toThrow(
+        /WebSocket is unavailable in this runtime/,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(kinds).toEqual(["unsupported"]);
+  });
+
+  it("falls back to the global constructor when none is injected", async () => {
+    const created: string[] = [];
+    vi.stubGlobal(
+      "WebSocket",
+      fakeConstructor((socket) => {
+        created.push(socket.url);
+        socket.emit("open");
+      }),
+    );
+    try {
+      await expect(openGuardedWebSocket("wss://ha.example.com/api/websocket")).resolves.toBeInstanceOf(FakeSocket);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(created).toEqual(["wss://ha.example.com/api/websocket"]);
+  });
+
+  it("reports a connect failure when the socket errors before opening", async () => {
+    const { createFailure, kinds } = failureKinds();
+    await expect(
+      openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+        webSocketConstructor: fakeConstructor((socket) => socket.emit("error")),
+        createFailure,
+      }),
+    ).rejects.toThrow(/WebSocket connection failed/);
+    expect(kinds).toEqual(["connect"]);
+  });
+
+  it("reports a connect failure when the peer closes before opening", async () => {
+    const { createFailure, kinds } = failureKinds();
+    await expect(
+      openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+        webSocketConstructor: fakeConstructor((socket) => socket.emit("close", { code: 1006 })),
+        createFailure,
+      }),
+    ).rejects.toThrow(/closed before the connection opened/);
+    expect(kinds).toEqual(["connect"]);
+  });
+
+  it("times out and closes a socket that never opens", async () => {
+    const { createFailure, kinds } = failureKinds();
+    FakeSocket.opened = [];
+    await expect(
+      openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+        webSocketConstructor: fakeConstructor(),
+        connectTimeoutMs: 5,
+        createFailure,
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(kinds).toEqual(["timeout"]);
+    expect(FakeSocket.opened[0]?.closed).toBe(true);
+  });
+
+  it("aborts a pending connection when the signal fires", async () => {
+    const controller = new AbortController();
+    const pending = openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+      webSocketConstructor: fakeConstructor(),
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/);
+  });
+
+  it("ignores a late close event after the socket opened", async () => {
+    let opened: FakeSocket | undefined;
+    const socket = await openGuardedWebSocket("wss://ha.example.com/api/websocket", {
+      webSocketConstructor: fakeConstructor((created) => {
+        opened = created;
+        created.emit("open");
+      }),
+    });
+    expect(socket).toBe(opened);
+    // Post-handshake events belong to the caller; they must not reject retroactively.
+    expect(() => opened?.emit("close", { code: 1000 })).not.toThrow();
+  });
+});

--- a/src/core/guarded-websocket.ts
+++ b/src/core/guarded-websocket.ts
@@ -1,0 +1,220 @@
+import type { GuardedFetchDnsLookup } from "./guarded-fetch.ts";
+
+import { assertGuardedEgressUrl } from "./guarded-fetch.ts";
+
+/** Payload delivered by a WebSocket `message` event. */
+export interface WebSocketMessageEvent {
+  data: unknown;
+}
+
+/** Detail delivered by a WebSocket `close` event. */
+export interface WebSocketCloseEvent {
+  code?: number;
+  reason?: string;
+}
+
+/**
+ * Structural view of a client WebSocket, covering only what provider egress
+ * uses. Declared locally because `src` builds without the DOM lib, and because
+ * the Node and workerd globals differ in details this layer does not depend on.
+ */
+export interface WebSocketLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "message", listener: (event: WebSocketMessageEvent) => void): void;
+  addEventListener(type: "error", listener: (event: unknown) => void): void;
+  addEventListener(type: "close", listener: (event: WebSocketCloseEvent) => void): void;
+}
+
+/** Constructor shape used to open a client WebSocket. */
+export type WebSocketConstructor = new (url: string) => WebSocketLike;
+
+/**
+ * Why {@link openGuardedWebSocket} failed after the URL passed the egress guard.
+ *
+ * - `unsupported`: the runtime has no client WebSocket constructor.
+ * - `connect`: the handshake failed or the peer closed before the socket opened.
+ * - `timeout`: the connection did not open within the deadline, or was aborted.
+ */
+export type GuardedWebSocketFailure = "unsupported" | "connect" | "timeout";
+
+export interface GuardedWebSocketOptions {
+  /**
+   * Allow RFC 1918, shared-address-space, and private targets while retaining
+   * reserved/loopback/link-local/metadata guards. A function is re-evaluated on
+   * every call so deployment flags configured after module load are honored.
+   */
+  allowPrivateNetwork?: boolean | (() => boolean);
+  /** Error factory for egress guard violations. Defaults to TypeError. */
+  createError?: (message: string) => Error;
+  /** Error factory for runtime failures. Defaults to {@link GuardedWebSocketOptions.createError}. */
+  createFailure?: (kind: GuardedWebSocketFailure, message: string) => Error;
+  /**
+   * DNS lookup override: `null` disables resolved-address validation for this
+   * connection, `undefined` uses the module default (`node:dns` when available).
+   */
+  lookup?: GuardedFetchDnsLookup | null;
+  /**
+   * Skip the DNS resolved-address check (the URL literal guard still runs).
+   * Only safe when the host is a hardcoded literal fully controlled by the code,
+   * never when it comes from credential or user input.
+   */
+  skipDnsValidation?: boolean;
+  /** Deadline for the opening handshake. Defaults to 15s. */
+  connectTimeoutMs?: number;
+  /** Abort the pending connection. */
+  signal?: AbortSignal;
+  /** Field name used in guard violation messages. Defaults to `"WebSocket URL"`. */
+  fieldName?: string;
+  /** Constructor override, for tests. Defaults to `globalThis.WebSocket`. */
+  webSocketConstructor?: WebSocketConstructor;
+}
+
+const defaultConnectTimeoutMs = 15_000;
+
+/**
+ * Open a client WebSocket to a user- or credential-supplied host under the same
+ * SSRF policy as guarded provider fetches.
+ *
+ * The target is validated with {@link assertGuardedEgressUrl} — literal
+ * hostname/IP checks plus DNS resolved-address checks — before the socket is
+ * constructed, so a name that resolves into loopback, link-local, cloud
+ * metadata, or (unless opted in) private ranges is rejected without a
+ * connection attempt. `ws://` and `wss://` inputs are validated as their
+ * `http://` / `https://` equivalents; the socket then connects to the
+ * normalized `ws` form of the validated URL.
+ *
+ * Two limits are inherent to the transport rather than to this wrapper, and
+ * match what {@link createGuardedFetch} can offer:
+ *
+ * - The constructor re-resolves the hostname itself, so a low-TTL rebinding
+ *   record can still move the connection after validation. Pinning a resolved
+ *   address is not expressible over the WebSocket API.
+ * - Redirects are not part of the WebSocket handshake, so there is no
+ *   per-hop revalidation to perform.
+ *
+ * Resolves once the socket is open. The returned socket has no listeners
+ * attached beyond the ones used for the handshake, and those are inert after
+ * this promise settles: the caller owns `message`/`error`/`close` handling and
+ * must close the socket when finished.
+ */
+export async function openGuardedWebSocket(url: string, options: GuardedWebSocketOptions = {}): Promise<WebSocketLike> {
+  const createError = options.createError ?? ((message: string): Error => new TypeError(message));
+  const createFailure =
+    options.createFailure ?? ((_kind: GuardedWebSocketFailure, message: string): Error => createError(message));
+  const allowPrivateNetwork =
+    typeof options.allowPrivateNetwork === "function"
+      ? options.allowPrivateNetwork()
+      : options.allowPrivateNetwork === true;
+
+  const validated = await assertGuardedEgressUrl(toHttpEquivalent(url), {
+    fieldName: options.fieldName ?? "WebSocket URL",
+    createError,
+    allowPrivateNetwork,
+    lookup: options.skipDnsValidation ? null : options.lookup,
+  });
+
+  const constructor = options.webSocketConstructor ?? globalWebSocketConstructor();
+  if (!constructor) {
+    throw createFailure("unsupported", "WebSocket is unavailable in this runtime");
+  }
+
+  const target = `${validated.protocol === "https:" ? "wss:" : "ws:"}//${validated.host}${validated.pathname}${validated.search}`;
+  return openSocket(constructor, target, options, createFailure);
+}
+
+function openSocket(
+  constructor: WebSocketConstructor,
+  target: string,
+  options: GuardedWebSocketOptions,
+  createFailure: (kind: GuardedWebSocketFailure, message: string) => Error,
+): Promise<WebSocketLike> {
+  return new Promise<WebSocketLike>((resolve, reject) => {
+    let socket: WebSocketLike;
+    try {
+      socket = new constructor(target);
+    } catch (error) {
+      reject(createFailure("connect", `WebSocket connection failed: ${describeError(error)}`));
+      return;
+    }
+
+    let settled = false;
+    const timer = globalThis.setTimeout(() => {
+      fail(createFailure("timeout", "WebSocket connection timed out"));
+    }, options.connectTimeoutMs ?? defaultConnectTimeoutMs);
+    const onAbort = (): void => {
+      fail(createFailure("timeout", "WebSocket connection was aborted"));
+    };
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    function cleanup(): void {
+      globalThis.clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+    }
+
+    function fail(error: Error): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      closeQuietly(socket);
+      reject(error);
+    }
+
+    socket.addEventListener("open", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(socket);
+    });
+    socket.addEventListener("error", () => {
+      fail(createFailure("connect", "WebSocket connection failed"));
+    });
+    socket.addEventListener("close", () => {
+      fail(createFailure("connect", "WebSocket closed before the connection opened"));
+    });
+
+    if (options.signal?.aborted) {
+      onAbort();
+    }
+  });
+}
+
+/**
+ * Map a `ws`/`wss` URL onto the `http`/`https` form the shared egress guard
+ * validates. Anything else is passed through so the guard reports its own
+ * scheme error rather than a rewritten one.
+ */
+function toHttpEquivalent(value: string): string {
+  if (/^wss:\/\//i.test(value)) {
+    return `https://${value.slice("wss://".length)}`;
+  }
+  if (/^ws:\/\//i.test(value)) {
+    return `http://${value.slice("ws://".length)}`;
+  }
+  return value;
+}
+
+function globalWebSocketConstructor(): WebSocketConstructor | undefined {
+  const candidate = (globalThis as { WebSocket?: unknown }).WebSocket;
+  // Node 22+ and workerd both expose a client constructor; the shapes differ in
+  // details (listener overloads, close-frame handling) that WebSocketLike does
+  // not depend on, so narrow structurally rather than to a lib-specific type.
+  return typeof candidate === "function" ? (candidate as WebSocketConstructor) : undefined;
+}
+
+function closeQuietly(socket: WebSocketLike): void {
+  try {
+    socket.close();
+  } catch {
+    // A socket that never opened may reject close(); the failure is already reported.
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}

--- a/src/providers/home_assistant/actions.ts
+++ b/src/providers/home_assistant/actions.ts
@@ -1,4 +1,4 @@
-import type { ActionDefinition } from "../../core/types.ts";
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
@@ -32,6 +32,42 @@ const entityInputSchema = s.actionInput(
   ["entityId"],
   "Input parameters for selecting one Home Assistant entity.",
 );
+
+/** Output field for one registry that only the Home Assistant WebSocket API serves. */
+export type HomeAssistantRegistryName = "entities" | "devices" | "areas" | "floors" | "labels";
+
+/** Every registry `get_registries` can fetch, in output-field order. */
+export const homeAssistantRegistryNames: HomeAssistantRegistryName[] = [
+  "entities",
+  "devices",
+  "areas",
+  "floors",
+  "labels",
+];
+
+const registryNames: string[] = homeAssistantRegistryNames;
+
+// Home Assistant's search ItemType enum; the values it accepts as a search origin.
+const searchItemTypes: string[] = [
+  "area",
+  "automation",
+  "automation_blueprint",
+  "config_entry",
+  "device",
+  "entity",
+  "floor",
+  "group",
+  "integration",
+  "label",
+  "person",
+  "scene",
+  "script",
+  "script_blueprint",
+];
+
+function registryListSchema(description: string): JsonSchema {
+  return s.nullable(s.array(description, s.looseObject("One Home Assistant registry entry.")));
+}
 
 export const homeAssistantActions: ActionDefinition[] = [
   defineProviderAction(service, {
@@ -141,9 +177,125 @@ export const homeAssistantActions: ActionDefinition[] = [
       "The rendered Home Assistant template response.",
     ),
   }),
+  defineProviderAction(service, {
+    name: "get_registries",
+    description:
+      "List the Home Assistant entity, device, area, floor, and label registries in one call. These registries expose the device and room structure behind entity ids, which the REST API does not serve.",
+    inputSchema: s.actionInput(
+      {
+        include: s.array(
+          "The registries to fetch. Defaults to all five when omitted or empty.",
+          s.stringEnum("One Home Assistant registry name.", registryNames),
+        ),
+      },
+      [],
+      "Input parameters for selecting which Home Assistant registries to fetch.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        entities: registryListSchema(
+          "The entity registry entries, including the device and area each entity belongs to.",
+        ),
+        devices: registryListSchema("The device registry entries, including manufacturer, model, and area."),
+        areas: registryListSchema("The area registry entries."),
+        floors: registryListSchema("The floor registry entries."),
+        labels: registryListSchema("The label registry entries."),
+      },
+      "The requested Home Assistant registries. Registries excluded from the request are null.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "search_related",
+    description:
+      "Find the Home Assistant items related to one entity, device, area, automation, or config entry, such as the automations that reference a given light.",
+    inputSchema: s.actionInput(
+      {
+        itemType: s.stringEnum("The Home Assistant item type to search from.", searchItemTypes),
+        itemId: s.nonEmptyString(
+          "The identifier of the item to search from, for example light.living_room for an entity.",
+        ),
+      },
+      ["itemType", "itemId"],
+      "Input parameters for one Home Assistant related-items search.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        related: s.looseObject("The related Home Assistant item identifiers, keyed by item type."),
+      },
+      "The Home Assistant items related to the requested item.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_device_automations",
+    description:
+      "List the triggers, conditions, and actions one Home Assistant device supports, for building automations against that device.",
+    inputSchema: s.actionInput(
+      {
+        deviceId: s.nonEmptyString("The Home Assistant device registry identifier."),
+      },
+      ["deviceId"],
+      "Input parameters for listing one Home Assistant device's automation capabilities.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        triggers: s.array("The device triggers.", s.looseObject("One Home Assistant device trigger.")),
+        conditions: s.array("The device conditions.", s.looseObject("One Home Assistant device condition.")),
+        actions: s.array("The device actions.", s.looseObject("One Home Assistant device action.")),
+      },
+      "The automation capabilities for the requested Home Assistant device.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "execute_script",
+    description:
+      "Run a Home Assistant script sequence, which can chain several service calls, delays, and conditions in one request instead of one service call at a time.",
+    inputSchema: s.actionInput(
+      {
+        sequence: s.array(
+          "The Home Assistant script steps to run, in the same format as a script's sequence.",
+          s.looseObject("One Home Assistant script step."),
+        ),
+        variables: s.looseObject("Optional variables made available to the script sequence."),
+      },
+      ["sequence"],
+      "Input parameters for running one Home Assistant script sequence.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        context: s.nullable(s.looseObject("The Home Assistant context for the script run.")),
+        response: s.nullable(s.looseObject("The optional script response variable returned by Home Assistant.")),
+      },
+      "The Home Assistant script execution result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "validate_config",
+    description:
+      "Validate Home Assistant trigger, condition, and action configurations before storing them in an automation.",
+    inputSchema: s.actionInput(
+      {
+        triggers: s.array("The trigger configurations to validate.", s.looseObject("One Home Assistant trigger.")),
+        conditions: s.array(
+          "The condition configurations to validate.",
+          s.looseObject("One Home Assistant condition."),
+        ),
+        actions: s.array("The action configurations to validate.", s.looseObject("One Home Assistant action.")),
+      },
+      [],
+      "Input parameters for validating Home Assistant automation configuration. At least one list is required.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        validation: s.looseObject(
+          "The validation result keyed by triggers, conditions, and actions, each with valid and error fields.",
+        ),
+      },
+      "The Home Assistant configuration validation result.",
+    ),
+  }),
 ];
 
-export type HomeAssistantActionName =
+export type HomeAssistantRestActionName =
   | "get_config"
   | "list_states"
   | "get_state"
@@ -152,3 +304,10 @@ export type HomeAssistantActionName =
   | "list_events"
   | "fire_event"
   | "render_template";
+
+export type HomeAssistantWebSocketActionName =
+  | "get_registries"
+  | "search_related"
+  | "list_device_automations"
+  | "execute_script"
+  | "validate_config";

--- a/src/providers/home_assistant/executors.ts
+++ b/src/providers/home_assistant/executors.ts
@@ -3,6 +3,7 @@ import type { HomeAssistantActionContext } from "./runtime.ts";
 
 import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
+import { homeAssistantWebSocketActionHandlers } from "./runtime-ws.ts";
 import {
   homeAssistantActionHandlers,
   resolveHomeAssistantBaseUrl,
@@ -13,7 +14,7 @@ const service = "home_assistant";
 
 export const executors: ProviderExecutors = defineProviderExecutors<HomeAssistantActionContext>({
   service,
-  handlers: homeAssistantActionHandlers,
+  handlers: { ...homeAssistantActionHandlers, ...homeAssistantWebSocketActionHandlers },
   allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HomeAssistantActionContext> {
     const credential = await requireApiKeyCredential(context, service);

--- a/src/providers/home_assistant/runtime-ws.ts
+++ b/src/providers/home_assistant/runtime-ws.ts
@@ -1,0 +1,368 @@
+import type { GuardedWebSocketFailure, WebSocketLike } from "../../core/guarded-websocket.ts";
+import type { HomeAssistantRegistryName, HomeAssistantWebSocketActionName } from "./actions.ts";
+import type { HomeAssistantActionContext, HomeAssistantActionHandler } from "./runtime.ts";
+
+import { compactObject, objectArray, optionalRecord, optionalString } from "../../core/cast.ts";
+import { openGuardedWebSocket } from "../../core/guarded-websocket.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { homeAssistantRegistryNames } from "./actions.ts";
+import { readInputString } from "./runtime.ts";
+
+/**
+ * Deadline covering the whole session: handshake, authentication, and every
+ * command in the batch. Matches the REST action timeout.
+ */
+const homeAssistantWebSocketTimeoutMs = 30_000;
+
+const registryCommandTypes: Record<HomeAssistantRegistryName, string> = {
+  entities: "config/entity_registry/list",
+  devices: "config/device_registry/list",
+  areas: "config/area_registry/list",
+  floors: "config/floor_registry/list",
+  labels: "config/label_registry/list",
+};
+
+/** One Home Assistant WebSocket command, without the connection-assigned `id`. */
+interface HomeAssistantCommand {
+  type: string;
+  [key: string]: unknown;
+}
+
+export const homeAssistantWebSocketActionHandlers: Record<
+  HomeAssistantWebSocketActionName,
+  HomeAssistantActionHandler
+> = {
+  async get_registries(input, context) {
+    const requested = readRegistryNames(input.include);
+    const results = await runHomeAssistantCommands(
+      context,
+      requested.map((name) => ({ type: registryCommandTypes[name] })),
+    );
+
+    // Registries the caller did not ask for stay null so an omitted registry is
+    // distinguishable from one the instance genuinely has no entries for.
+    const output: Record<HomeAssistantRegistryName, unknown> = {
+      entities: null,
+      devices: null,
+      areas: null,
+      floors: null,
+      labels: null,
+    };
+    requested.forEach((name, index) => {
+      output[name] = results[index] ?? [];
+    });
+    return output;
+  },
+  async search_related(input, context) {
+    const [related] = await runHomeAssistantCommands(context, [
+      {
+        type: "search/related",
+        item_type: readInputString(input.itemType, "itemType"),
+        item_id: readInputString(input.itemId, "itemId"),
+      },
+    ]);
+    return { related: optionalRecord(related) ?? {} };
+  },
+  async list_device_automations(input, context) {
+    const deviceId = readInputString(input.deviceId, "deviceId");
+    const [triggers, conditions, actions] = await runHomeAssistantCommands(context, [
+      { type: "device_automation/trigger/list", device_id: deviceId },
+      { type: "device_automation/condition/list", device_id: deviceId },
+      { type: "device_automation/action/list", device_id: deviceId },
+    ]);
+    return { triggers: triggers ?? [], conditions: conditions ?? [], actions: actions ?? [] };
+  },
+  async execute_script(input, context) {
+    const [payload] = await runHomeAssistantCommands(context, [
+      {
+        type: "execute_script",
+        sequence: objectArray(input.sequence, "sequence", (message) => new ProviderRequestError(400, message)),
+        ...compactObject({ variables: optionalRecord(input.variables) }),
+      },
+    ]);
+    const record = optionalRecord(payload) ?? {};
+    return {
+      context: optionalRecord(record.context) ?? null,
+      response: optionalRecord(record.response) ?? null,
+    };
+  },
+  async validate_config(input, context) {
+    const triggers = readOptionalConfigList(input.triggers, "triggers");
+    const conditions = readOptionalConfigList(input.conditions, "conditions");
+    const actions = readOptionalConfigList(input.actions, "actions");
+    if (!triggers && !conditions && !actions) {
+      throw new ProviderRequestError(400, "At least one of triggers, conditions, or actions is required");
+    }
+
+    const [payload] = await runHomeAssistantCommands(context, [
+      { type: "validate_config", ...compactObject({ triggers, conditions, actions }) },
+    ]);
+    return { validation: optionalRecord(payload) ?? {} };
+  },
+};
+
+/**
+ * Open one authenticated Home Assistant WebSocket session, run every command in
+ * the batch concurrently over it, and return their results in input order.
+ *
+ * Commands share a connection because the handshake costs two round trips
+ * before any command can be sent; batching keeps a multi-registry action at one
+ * handshake instead of one per registry.
+ */
+async function runHomeAssistantCommands(
+  context: HomeAssistantActionContext,
+  commands: HomeAssistantCommand[],
+): Promise<unknown[]> {
+  const socket = await openGuardedWebSocket(buildWebSocketUrl(context.baseUrl), {
+    allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    createError: (message) => new ProviderRequestError(400, message),
+    createFailure: createConnectionError,
+    connectTimeoutMs: homeAssistantWebSocketTimeoutMs,
+    signal: context.signal,
+    fieldName: "Home Assistant base URL",
+  });
+
+  const inbox = createMessageInbox(socket);
+  const timer = globalThis.setTimeout(() => {
+    inbox.fail(new ProviderRequestError(504, "Home Assistant WebSocket request timed out"));
+  }, homeAssistantWebSocketTimeoutMs);
+  const onAbort = (): void => {
+    inbox.fail(new ProviderRequestError(504, "Home Assistant WebSocket request was aborted"));
+  };
+  context.signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    await authenticate(socket, inbox, context.apiKey);
+    return await sendCommands(socket, inbox, commands);
+  } finally {
+    globalThis.clearTimeout(timer);
+    context.signal?.removeEventListener("abort", onAbort);
+    closeQuietly(socket);
+  }
+}
+
+/** Messages arrive unsolicited, so buffer them and hand them out in arrival order. */
+interface MessageInbox {
+  next(): Promise<Record<string, unknown>>;
+  fail(error: Error): void;
+}
+
+/** A caller parked in {@link MessageInbox.next} until a message or failure arrives. */
+interface PendingReader {
+  resolve: (message: Record<string, unknown>) => void;
+  reject: (error: Error) => void;
+}
+
+function createMessageInbox(socket: WebSocketLike): MessageInbox {
+  const buffered: Array<Record<string, unknown>> = [];
+  const waiting: PendingReader[] = [];
+  let failure: Error | undefined;
+
+  function fail(error: Error): void {
+    if (failure) {
+      return;
+    }
+    failure = error;
+    while (waiting.length > 0) {
+      waiting.shift()?.reject(error);
+    }
+  }
+
+  function push(message: Record<string, unknown>): void {
+    const waiter = waiting.shift();
+    if (waiter) {
+      waiter.resolve(message);
+      return;
+    }
+    buffered.push(message);
+  }
+
+  socket.addEventListener("message", (event) => {
+    const message = parseMessage(event.data);
+    if (!message) {
+      fail(new ProviderRequestError(502, "Home Assistant sent an unreadable WebSocket message"));
+      return;
+    }
+    push(message);
+  });
+  socket.addEventListener("error", () => {
+    fail(new ProviderRequestError(502, "Home Assistant WebSocket connection failed"));
+  });
+  socket.addEventListener("close", () => {
+    fail(new ProviderRequestError(502, "Home Assistant closed the WebSocket connection"));
+  });
+
+  return {
+    next(): Promise<Record<string, unknown>> {
+      const buffer = buffered.shift();
+      if (buffer) {
+        return Promise.resolve(buffer);
+      }
+      if (failure) {
+        return Promise.reject(failure);
+      }
+      return new Promise((resolve, reject) => {
+        waiting.push({ resolve, reject });
+      });
+    },
+    fail,
+  };
+}
+
+/**
+ * Home Assistant authenticates in-band: the server opens with `auth_required`
+ * and the token travels as a message rather than a header, which is what lets
+ * the same code path work on runtimes whose WebSocket constructor cannot set
+ * request headers.
+ */
+async function authenticate(socket: WebSocketLike, inbox: MessageInbox, apiKey: string): Promise<void> {
+  const greeting = await inbox.next();
+  if (greeting.type === "auth_ok") {
+    return;
+  }
+  if (greeting.type !== "auth_required") {
+    throw new ProviderRequestError(502, "Home Assistant sent an unexpected WebSocket handshake message");
+  }
+
+  socket.send(JSON.stringify({ type: "auth", access_token: apiKey }));
+  const result = await inbox.next();
+  if (result.type === "auth_ok") {
+    return;
+  }
+  if (result.type === "auth_invalid") {
+    throw new ProviderRequestError(401, optionalString(result.message) ?? "Home Assistant rejected the access token");
+  }
+  throw new ProviderRequestError(502, "Home Assistant sent an unexpected WebSocket authentication response");
+}
+
+async function sendCommands(
+  socket: WebSocketLike,
+  inbox: MessageInbox,
+  commands: HomeAssistantCommand[],
+): Promise<unknown[]> {
+  const results: unknown[] = new Array<unknown>(commands.length);
+  // Home Assistant requires ids that are positive and increasing per connection.
+  const pending = new Map<number, number>();
+  commands.forEach((command, index) => {
+    const id = index + 1;
+    pending.set(id, index);
+    socket.send(JSON.stringify({ ...command, id }));
+  });
+
+  while (pending.size > 0) {
+    const message = await inbox.next();
+    if (message.type !== "result") {
+      continue;
+    }
+    const id = typeof message.id === "number" ? message.id : undefined;
+    const index = id === undefined ? undefined : pending.get(id);
+    if (id === undefined || index === undefined) {
+      continue;
+    }
+    pending.delete(id);
+    if (message.success !== true) {
+      throw createCommandError(message.error, commands[index].type);
+    }
+    results[index] = message.result;
+  }
+
+  return results;
+}
+
+function buildWebSocketUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/api/websocket`;
+  return url.toString();
+}
+
+function parseMessage(data: unknown): Record<string, unknown> | undefined {
+  const text = typeof data === "string" ? data : decodeBinaryMessage(data);
+  if (text === undefined) {
+    return undefined;
+  }
+  try {
+    return optionalRecord(JSON.parse(text));
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBinaryMessage(data: unknown): string | undefined {
+  if (data instanceof Uint8Array) {
+    return new TextDecoder().decode(data);
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+  return undefined;
+}
+
+function createConnectionError(kind: GuardedWebSocketFailure, message: string): ProviderRequestError {
+  if (kind === "unsupported") {
+    return new ProviderRequestError(501, "Home Assistant WebSocket actions require a runtime with a WebSocket client");
+  }
+  if (kind === "timeout") {
+    return new ProviderRequestError(504, "Home Assistant WebSocket connection timed out");
+  }
+  return new ProviderRequestError(502, message);
+}
+
+/**
+ * Map a Home Assistant command error onto the runtime status codes callers
+ * already see from the REST actions.
+ */
+function createCommandError(error: unknown, commandType: string): ProviderRequestError {
+  const record = optionalRecord(error);
+  const code = optionalString(record?.code);
+  const message = optionalString(record?.message) ?? `Home Assistant rejected the ${commandType} command`;
+  if (code === "unauthorized") {
+    return new ProviderRequestError(403, message);
+  }
+  if (code === "not_found" || code === "unknown_command") {
+    return new ProviderRequestError(404, message);
+  }
+  if (code === "invalid_format" || code === "id_reuse") {
+    return new ProviderRequestError(400, message);
+  }
+  return new ProviderRequestError(502, message);
+}
+
+function readRegistryNames(value: unknown): HomeAssistantRegistryName[] {
+  if (value === undefined || value === null) {
+    return homeAssistantRegistryNames;
+  }
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(400, "include must be an array of registry names");
+  }
+  if (value.length === 0) {
+    return homeAssistantRegistryNames;
+  }
+
+  const selected: HomeAssistantRegistryName[] = [];
+  for (const entry of value) {
+    const name = homeAssistantRegistryNames.find((candidate) => candidate === entry);
+    if (!name) {
+      throw new ProviderRequestError(400, `include must only contain ${homeAssistantRegistryNames.join(", ")}`);
+    }
+    if (!selected.includes(name)) {
+      selected.push(name);
+    }
+  }
+  return selected;
+}
+
+function readOptionalConfigList(value: unknown, fieldName: string): Array<Record<string, unknown>> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return objectArray(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function closeQuietly(socket: WebSocketLike): void {
+  try {
+    socket.close();
+  } catch {
+    // The socket may already be closed; the action result is unaffected.
+  }
+}

--- a/src/providers/home_assistant/runtime-ws.ts
+++ b/src/providers/home_assistant/runtime-ws.ts
@@ -114,6 +114,10 @@ async function runHomeAssistantCommands(
   context: HomeAssistantActionContext,
   commands: HomeAssistantCommand[],
 ): Promise<unknown[]> {
+  // One deadline for the whole session. The handshake may use all of it, and the
+  // command phase then gets whatever is left, so a slow instance cannot spend the
+  // budget twice.
+  const deadline = Date.now() + homeAssistantWebSocketTimeoutMs;
   const socket = await openGuardedWebSocket(buildWebSocketUrl(context.baseUrl), {
     allowPrivateNetwork: isPrivateNetworkAccessAllowed,
     createError: (message) => new ProviderRequestError(400, message),
@@ -124,13 +128,22 @@ async function runHomeAssistantCommands(
   });
 
   const inbox = createMessageInbox(socket);
-  const timer = globalThis.setTimeout(() => {
-    inbox.fail(new ProviderRequestError(504, "Home Assistant WebSocket request timed out"));
-  }, homeAssistantWebSocketTimeoutMs);
+  const timer = globalThis.setTimeout(
+    () => {
+      inbox.fail(new ProviderRequestError(504, "Home Assistant WebSocket request timed out"));
+    },
+    Math.max(0, deadline - Date.now()),
+  );
   const onAbort = (): void => {
     inbox.fail(new ProviderRequestError(504, "Home Assistant WebSocket request was aborted"));
   };
   context.signal?.addEventListener("abort", onAbort, { once: true });
+  // The signal can fire between the socket opening and this listener attaching;
+  // recheck so that abort is not missed until the deadline, matching what
+  // openGuardedWebSocket does after attaching its own handshake listeners.
+  if (context.signal?.aborted) {
+    onAbort();
+  }
 
   try {
     await authenticate(socket, inbox, context.apiKey);

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -1,4 +1,4 @@
-import type { HomeAssistantActionName } from "./actions.ts";
+import type { HomeAssistantRestActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
@@ -17,12 +17,12 @@ export interface HomeAssistantActionContext {
   signal?: AbortSignal;
 }
 
-type HomeAssistantActionHandler = (
+export type HomeAssistantActionHandler = (
   input: Record<string, unknown>,
   context: HomeAssistantActionContext,
 ) => Promise<unknown>;
 
-export const homeAssistantActionHandlers: Record<HomeAssistantActionName, HomeAssistantActionHandler> = {
+export const homeAssistantActionHandlers: Record<HomeAssistantRestActionName, HomeAssistantActionHandler> = {
   async get_config(_input, context) {
     return {
       config: await requestHomeAssistantJson({
@@ -296,6 +296,7 @@ function normalizeBaseUrl(value: unknown): string {
   return url.pathname === "/" ? url.origin : `${url.origin}${url.pathname}`;
 }
 
-function readInputString(value: unknown, fieldName: string): string {
+/** Read a required string action input, reported as a 400 like the other input guards. */
+export function readInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
 }


### PR DESCRIPTION
## Summary

- add `openGuardedWebSocket` in `src/core/guarded-websocket.ts`, so provider egress that is not a fetch is held to the same SSRF policy
- extract the per-hop check behind `createGuardedFetch` as `assertGuardedEgressUrl`, and make both transports use it
- add five Home Assistant actions that the REST API cannot serve: registries, related-item search, device automation capabilities, script execution, and config validation
- document the WebSocket egress rule in AGENTS.md

## Problem

The Home Assistant provider exposes entity states but not the structure behind them. `/api/states` returns `light.living_room` and nothing that says which device, area, or floor it belongs to, so "turn off the lights downstairs" is a string-matching guess rather than a query.

Those registries are only reachable over Home Assistant's WebSocket API. So are related-item search, per-device automation capabilities, multi-step script execution, and trigger/condition/action validation. None of them have a REST equivalent.

## Egress guard

This is the part worth review attention.

Every non-fetch egress in this repository so far targets a host fixed in code: the IMAP/SMTP runtime resolves its hosts from a per-provider allowlist (`netease_mail`) or a literal (`qq_mail`), and the Pushover realtime socket uses a constant `wss://` URL. None of them needed a guard, which is why `src/core` did not have one.

A self-hosted Home Assistant is the first case where a non-fetch transport connects to a **credential-supplied host**, which is exactly the case AGENTS.md says the DNS resolved-address check must cover.

Rather than add a second, narrower check for WebSockets, this extracts the hop check that `createGuardedFetch` already performs — `assertPublicHttpUrl` on the literal, then resolved-address validation — into `assertGuardedEgressUrl`, and has both transports call it. `ws`/`wss` targets are validated as their `http`/`https` equivalents and then connected over the normalized `ws` form. `allowPrivateNetwork` and `skipDnsValidation` behave as they do for fetch.

Two limits are inherent to the transport and match what the fetch guard can offer: the constructor re-resolves the hostname itself, so low-TTL rebinding remains possible, and WebSocket handshakes have no redirects to revalidate. Both are stated in the JSDoc.

## Runtime support

Node 22+ and workerd both expose a client `WebSocket` constructor, so this is one code path rather than a Node-only capability. Verified on workerd with `wrangler dev` and the repository's compatibility settings rather than from documentation:

```json
{ "hasConstructor": "function", "constructed": true, "readyState": 0,
  "hasAddEventListener": "function", "hasSend": "function",
  "hasClose": "function", "hasNodeDns": "function" }
```

`node:dns` being present under `nodejs_compat` means the resolved-address check applies on Cloudflare too, consistent with the note added in #135.

The provider is therefore **not** marked `nodeOnly`; doing so would also drop the eight REST actions that work on Cloudflare today. Home Assistant authenticates in-band, with the token in a message rather than a header, so nothing here needs a constructor that can set request headers.

Reachability is a separate matter from the guard: Workers cannot route to private addresses, so a LAN instance remains a Node/Docker/Fly deployment concern regardless of `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK`. AGENTS.md now says so.

## Actions

| Action | WebSocket commands |
| --- | --- |
| `get_registries` | `config/{entity,device,area,floor,label}_registry/list` |
| `search_related` | `search/related` |
| `list_device_automations` | `device_automation/{trigger,condition,action}/list` |
| `execute_script` | `execute_script` |
| `validate_config` | `validate_config` |

All five are one-shot commands, so they map onto the existing request/response executor model unchanged.

Subscription commands are deliberately excluded. The action model has no streaming, and every Home Assistant subscription that carries an initial snapshot already has a one-shot equivalent — `render_template` is a subscription whose first message equals `POST /api/template`, and `subscribe_entities` starts from what `/api/states` already returns. What remains is increment-only (`subscribe_events`, `subscribe_trigger`, `logbook/event_stream`), which a bounded listen window would serve badly. That needs a webhook design, not an action.

`get_registries` sends all five registry commands over one connection. The handshake costs two round trips before any command can be sent, so batching matters more here than it would over HTTP.

Reference: https://developers.home-assistant.io/docs/api/websocket

## Verification

- `npm run fix-check`, `npm test` (574 passing, 20 new)
- workerd probe above, via `wrangler dev`
- end-to-end against a real Home Assistant instance: `get_registries` returned 160 devices and 7 areas over a single connection with ids 1–5; `search_related` resolved a device to its area, config entry, integration, and three entities; auth failure mapped to 401; a loopback base URL stayed blocked with the private-network flag enabled