### PR TITLE
fix(github): report the raw page length from list_repository_issues

### DIFF
--- a/src/providers/github/actions.ts
+++ b/src/providers/github/actions.ts
@@ -757,7 +757,8 @@ export const githubActions: ActionDefinition[] = [
   }),
   action({
     name: "list_repository_issues",
-    description: "List issues for a GitHub repository. Pull requests are filtered out from the response.",
+    description:
+      "List issues for a GitHub repository. Pull requests are filtered out of the response; pageInfo.fetched reports the raw page length before filtering, so paginating callers must continue while fetched equals the requested page size even when the issues array comes back short or empty.",
     requiredScopes: githubRepoScopes,
     inputSchema: s.object({
       owner: nonEmptyString,
@@ -771,6 +772,16 @@ export const githubActions: ActionDefinition[] = [
     }),
     outputSchema: s.object({
       issues: s.array(githubIssueSchema),
+      pageInfo: s.requiredObject(
+        "Pagination signals from the raw GitHub page, before pull requests are filtered out.",
+        {
+          fetched: s.integer({
+            minimum: 0,
+            description:
+              "Number of items GitHub returned on this page before filtering. Continue paginating while this equals the requested page size.",
+          }),
+        },
+      ),
     }),
   }),
   action({

--- a/src/providers/github/actions.ts
+++ b/src/providers/github/actions.ts
@@ -758,7 +758,7 @@ export const githubActions: ActionDefinition[] = [
   action({
     name: "list_repository_issues",
     description:
-      "List issues for a GitHub repository. Pull requests are filtered out of the response; pageInfo.fetched reports the raw page length before filtering, so paginating callers must continue while fetched equals the requested page size even when the issues array comes back short or empty.",
+      "List issues for a GitHub repository. Pull requests are filtered out of the response; pageInfo.fetched reports the raw page length before filtering, so paginating callers must continue while fetched equals perPage (30 by default) even when the issues array comes back short or empty.",
     requiredScopes: githubRepoScopes,
     inputSchema: s.object({
       owner: nonEmptyString,
@@ -768,7 +768,13 @@ export const githubActions: ActionDefinition[] = [
       sort: s.stringEnum(["created", "updated", "comments"]),
       direction: s.stringEnum(["asc", "desc"]),
       since: s.string(),
-      ...optionalPaginationFields,
+      perPage: s.integer({
+        minimum: 1,
+        maximum: 100,
+        default: 30,
+        description: "Number of results requested per page. Defaults to 30.",
+      }),
+      page: optionalPaginationFields.page,
     }),
     outputSchema: s.object({
       issues: s.array(githubIssueSchema),
@@ -778,7 +784,7 @@ export const githubActions: ActionDefinition[] = [
           fetched: s.integer({
             minimum: 0,
             description:
-              "Number of items GitHub returned on this page before filtering. Continue paginating while this equals the requested page size.",
+              "Number of items GitHub returned on this page before filtering. Continue paginating while this equals perPage, which defaults to 30.",
           }),
         },
       ),

--- a/src/providers/github/runtime-issue.test.ts
+++ b/src/providers/github/runtime-issue.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+import { issueActionHandlers } from "./runtime-issue.ts";
+
+function pageFetcher(items: unknown[]): typeof fetch {
+  return async () =>
+    new Response(JSON.stringify(items), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+}
+
+describe("list_repository_issues pagination signal", () => {
+  it("reports the raw page length before pull requests are filtered out", async () => {
+    // A raw GitHub page of 3 items where one is a pull request. The
+    // filtered `issues` array alone would read as a short page and stop
+    // page-number pagination early; `pageInfo.fetched` preserves the raw
+    // length so callers can keep paginating correctly.
+    const result = (await issueActionHandlers.list_repository_issues(
+      { owner: "acme", repo: "widgets", perPage: 3 },
+      {
+        accessToken: "token",
+        fetcher: pageFetcher([
+          { id: 1, number: 10, title: "real issue" },
+          { id: 2, number: 11, title: "a pull request", pull_request: { url: "https://example.test" } },
+          { id: 3, number: 12, title: "another issue" },
+        ]),
+      },
+    )) as { issues: Array<{ id: number }>; pageInfo: { fetched: number } };
+
+    expect(result.issues.map((issue) => issue.id)).toEqual([1, 3]);
+    expect(result.pageInfo.fetched).toBe(3);
+  });
+
+  it("reports fetched on an all-pull-request page whose issues array is empty", async () => {
+    const result = (await issueActionHandlers.list_repository_issues(
+      { owner: "acme", repo: "widgets", perPage: 2 },
+      {
+        accessToken: "token",
+        fetcher: pageFetcher([
+          { id: 1, pull_request: {} },
+          { id: 2, pull_request: {} },
+        ]),
+      },
+    )) as { issues: unknown[]; pageInfo: { fetched: number } };
+
+    expect(result.issues).toEqual([]);
+    expect(result.pageInfo.fetched).toBe(2);
+  });
+
+  it("declares pageInfo.fetched in the action's output schema", () => {
+    interface ObjectSchema {
+      properties?: Record<string, ObjectSchema>;
+      required?: string[];
+      type?: string;
+    }
+    const action = provider.actions.find((entry) => entry.name === "list_repository_issues");
+    const pageInfo = (action?.outputSchema as ObjectSchema | undefined)?.properties?.pageInfo;
+
+    expect(pageInfo?.properties?.fetched?.type).toBe("integer");
+    expect(pageInfo?.required).toContain("fetched");
+  });
+});

--- a/src/providers/github/runtime-issue.test.ts
+++ b/src/providers/github/runtime-issue.test.ts
@@ -1,13 +1,17 @@
+import type { JsonSchema } from "../../core/types.ts";
+
 import { describe, expect, it } from "vitest";
 import { provider } from "./definition.ts";
 import { issueActionHandlers } from "./runtime-issue.ts";
 
-function pageFetcher(items: unknown[]): typeof fetch {
-  return async () =>
-    new Response(JSON.stringify(items), {
+function pageFetcher(items: unknown[], onRequest?: (url: string) => void): typeof fetch {
+  return async (url) => {
+    onRequest?.(String(url));
+    return new Response(JSON.stringify(items), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
+  };
 }
 
 describe("list_repository_issues pagination signal", () => {
@@ -48,16 +52,31 @@ describe("list_repository_issues pagination signal", () => {
     expect(result.pageInfo.fetched).toBe(2);
   });
 
-  it("declares pageInfo.fetched in the action's output schema", () => {
-    interface ObjectSchema {
-      properties?: Record<string, ObjectSchema>;
-      required?: string[];
-      type?: string;
-    }
-    const action = provider.actions.find((entry) => entry.name === "list_repository_issues");
-    const pageInfo = (action?.outputSchema as ObjectSchema | undefined)?.properties?.pageInfo;
+  it("requests the documented default page size when perPage is omitted", async () => {
+    let requestedUrl = "";
+    await issueActionHandlers.list_repository_issues(
+      { owner: "acme", repo: "widgets" },
+      {
+        accessToken: "token",
+        fetcher: pageFetcher([], (url) => {
+          requestedUrl = url;
+        }),
+      },
+    );
 
-    expect(pageInfo?.properties?.fetched?.type).toBe("integer");
-    expect(pageInfo?.required).toContain("fetched");
+    expect(new URL(requestedUrl).searchParams.get("per_page")).toBe("30");
+  });
+
+  it("declares the pagination contract in the action schemas", () => {
+    const action = provider.actions.find((entry) => entry.name === "list_repository_issues");
+    const inputProperties = action?.inputSchema.properties as Record<string, JsonSchema> | undefined;
+    const outputProperties = action?.outputSchema.properties as Record<string, JsonSchema> | undefined;
+    const perPage = inputProperties?.perPage;
+    const pageInfo = outputProperties?.pageInfo;
+    const pageInfoProperties = pageInfo?.properties as Record<string, JsonSchema> | undefined;
+
+    expect(perPage).toMatchObject({ type: "integer", minimum: 1, maximum: 100, default: 30 });
+    expect(pageInfoProperties?.fetched?.type).toBe("integer");
+    expect(pageInfo?.required as string[] | undefined).toContain("fetched");
   });
 });

--- a/src/providers/github/runtime-issue.ts
+++ b/src/providers/github/runtime-issue.ts
@@ -289,7 +289,13 @@ async function listRepositoryIssues(input: Record<string, unknown>, accessToken:
   });
 
   return {
+    // The raw GitHub page mixes issues and pull requests; filtering PRs out
+    // destroys the only pagination signal page-number callers have (the raw
+    // page length). `pageInfo.fetched` preserves it: a caller must continue
+    // paginating while `fetched` equals the requested page size, even when
+    // `issues` comes back short or empty.
     issues: issues.filter((issue) => issue.pull_request == null),
+    pageInfo: { fetched: issues.length },
   };
 }
 

--- a/src/providers/github/runtime-issue.ts
+++ b/src/providers/github/runtime-issue.ts
@@ -273,6 +273,7 @@ export const issueActionHandlers: Record<string, GitHubActionHandler> = {
 };
 
 async function listRepositoryIssues(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
+  const perPage = optionalInteger(input.perPage) ?? 30;
   const issues = await githubRequestJson<Record<string, unknown>[]>({
     path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/issues`,
     query: compactObject({
@@ -281,7 +282,7 @@ async function listRepositoryIssues(input: Record<string, unknown>, accessToken:
       sort: optionalString(input.sort),
       direction: optionalString(input.direction),
       since: optionalString(input.since),
-      per_page: optionalInteger(input.perPage),
+      per_page: perPage,
       page: optionalInteger(input.page),
     }),
     accessToken,
@@ -292,8 +293,8 @@ async function listRepositoryIssues(input: Record<string, unknown>, accessToken:
     // The raw GitHub page mixes issues and pull requests; filtering PRs out
     // destroys the only pagination signal page-number callers have (the raw
     // page length). `pageInfo.fetched` preserves it: a caller must continue
-    // paginating while `fetched` equals the requested page size, even when
-    // `issues` comes back short or empty.
+    // paginating while `fetched` equals `perPage`, even when `issues` comes
+    // back short or empty.
     issues: issues.filter((issue) => issue.pull_request == null),
     pageInfo: { fetched: issues.length },
   };


### PR DESCRIPTION
Fixes #229.

`list_repository_issues` fetches one GitHub page and filters pull requests out of it, which destroys the only pagination signal page-number callers have: the filtered array's length says nothing about the raw page length. A short page may be a full page with PRs mixed in, and an empty page may be 100 consecutive PRs — so any paginating consumer that stops on a short or empty page silently drops every later issue, and no sound termination rule can be built from the filtered response alone (details in #229).

The response now carries **`pageInfo.fetched`** — the number of items GitHub returned before filtering — declared in the output schema and in the action description: callers must continue paginating while `fetched` equals the requested page size, even when `issues` comes back short or empty. The PR-filtering behavior itself is unchanged.

Tests cover the mixed page (`fetched=3`, filtered ids `[1,3]`), the all-pull-requests page (`fetched=2`, `issues=[]` — the case that defeats every downstream heuristic), and the schema declaration. `npm run typecheck`, oxfmt, and the full vitest suite (557 tests) pass.