### PR TITLE
fix(cloudflare): use Worker-safe validation for MCP

### DIFF
--- a/src/providers/cloudflare_mcp/executors.test.ts
+++ b/src/providers/cloudflare_mcp/executors.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cloudflareMcpActionHandlers, credentialValidators } from "./executors.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Cloudflare MCP executors", () => {
   it("sends bearer auth and maps search to the official MCP tool", async () => {
@@ -37,6 +41,16 @@ describe("Cloudflare MCP executors", () => {
 
     expect(apiKeyResult?.metadata?.mcpTools).toEqual(["docs", "execute", "search"]);
     expect(oauthResult?.metadata?.mcpTools).toEqual(["docs", "execute", "search"]);
+  });
+
+  it("validates MCP tool schemas when string code generation is unavailable", async () => {
+    vi.stubGlobal("Function", function disabledFunctionConstructor() {
+      throw new EvalError("Code generation from strings disallowed for this context");
+    });
+
+    await expect(
+      credentialValidators.apiKey!({ apiKey: "api-token", values: {} }, { fetcher: createMcpFetch([], "api-token") }),
+    ).resolves.toMatchObject({ metadata: { mcpTools: ["docs", "execute", "search"] } });
   });
 
   it("does not start MCP traffic after the execution is cancelled", async () => {
@@ -78,6 +92,7 @@ function createMcpFetch(calls: Array<Record<string, unknown>>, expectedToken: st
               tools: ["docs", "execute", "search"].map((name) => ({
                 name,
                 inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
               })),
             }
           : { content: [{ type: "text", text: '["workers"]' }] };

--- a/src/providers/cloudflare_mcp/executors.ts
+++ b/src/providers/cloudflare_mcp/executors.ts
@@ -5,6 +5,7 @@ import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import { createHash } from "node:crypto";
 import { defineBearerProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
@@ -12,6 +13,7 @@ const service = "cloudflare_mcp";
 const cloudflareMcpEndpoint = "https://mcp.cloudflare.com/mcp";
 const cloudflareMcpRequestTimeoutMs = 60_000;
 const expectedTools = ["docs", "execute", "search"];
+const cloudflareMcpJsonSchemaValidator = new CfWorkerJsonSchemaValidator();
 
 type CloudflareMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
@@ -102,7 +104,10 @@ async function withCloudflareMcpClient<T>(
     fetch: input.fetcher,
     requestInit: { headers },
   });
-  const client = new Client({ name: "oomol-connect-cloudflare-mcp", version: "1.0.0" });
+  const client = new Client(
+    { name: "oomol-connect-cloudflare-mcp", version: "1.0.0" },
+    { jsonSchemaValidator: cloudflareMcpJsonSchemaValidator },
+  );
 
   try {
     await client.connect(transport, {


### PR DESCRIPTION
## Summary

- configure the Cloudflare MCP client to use the MCP SDK's `CfWorkerJsonSchemaValidator`
- add a regression test that disables string-based code generation while validating advertised MCP tool output schemas

## Root cause

The MCP SDK client defaults to AJV for JSON Schema validation. When Cloudflare's MCP server advertises tool `outputSchema` values, AJV compiles them with `new Function(...)`. Cloudflare Workers disallow runtime code generation from strings, so credential validation and MCP requests fail with:

```text
Cloudflare MCP request failed: Code generation from strings disallowed for this context
```

The SDK's Cloudflare-specific validator uses `@cfworker/json-schema` and performs validation without `eval` or `new Function`.

## Impact

Cloudflare-hosted Open Connector deployments can validate Cloudflare MCP credentials and invoke its tools. Node deployments retain the same behavior.

Because the provider is currently broken on Cloudflare in v1.3.3, could this be included in a patch release after review?

## Validation

- `node scripts/typecheck.ts src scripts-all examples`
- `vitest run` (61 files, 590 tests)
- dedicated regression test with `Function` disabled and MCP `outputSchema` values present
