### PR TITLE
fix: reduce executable registry size

### DIFF
--- a/scripts/generate-provider-registry.ts
+++ b/scripts/generate-provider-registry.ts
@@ -29,12 +29,6 @@ function propertyName(service: string): string {
 
 async function writeRegistry(filename: string, sources: ProviderSource[]): Promise<void> {
   const services = sources.map((source) => source.service);
-  const executableActionIds = new Map<string, string[]>(
-    sources.map((source) => [
-      source.service,
-      source.definition.actions.map((action) => action.id).sort((a, b) => a.localeCompare(b)),
-    ]),
-  );
   const lines = [
     'import type { ExecutorModule } from "./provider-loader.ts";',
     "",
@@ -43,15 +37,6 @@ async function writeRegistry(filename: string, sources: ProviderSource[]): Promi
     ...services.map(
       (service) => `  ${propertyName(service)}: (): Promise<ExecutorModule> => import("./${service}/executors.ts"),`,
     ),
-    "};",
-    "",
-    "/** Generated local executable action ids by provider. Do not hand-edit. */",
-    "export const executableActionIds: Record<string, string[]> = {",
-    ...services.flatMap((service) => [
-      `  ${propertyName(service)}: [`,
-      ...(executableActionIds.get(service) ?? []).map((actionId) => `    ${JSON.stringify(actionId)},`),
-      "  ],",
-    ]),
     "};",
   ];
 

--- a/src/catalog-store.test.ts
+++ b/src/catalog-store.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderDefinition } from "./core/types.ts";
 
 import { describe, expect, it } from "vitest";
-import { createCatalogStore } from "./catalog-store.ts";
+import { createCatalogStore, resolveExecutableActionIds } from "./catalog-store.ts";
 
 describe("catalog store", () => {
   it("preserves optional provider descriptions without defaulting missing ones", () => {
@@ -72,4 +72,38 @@ describe("catalog store", () => {
       properties: { message: { type: "string" } },
     });
   });
+
+  it("resolves every action from executable services alongside explicit action ids", () => {
+    const providers = [providerFixture("example", ["ping", "pong"]), providerFixture("remote", ["ping"])];
+
+    const catalog = createCatalogStore(providers, {
+      executableActionIds: resolveExecutableActionIds(providers, {
+        executableServices: ["example"],
+        executableActionIds: ["remote.ping"],
+      }),
+    });
+
+    expect(catalog.executableActionIds).toEqual(new Set(["example.ping", "example.pong", "remote.ping"]));
+    expect(catalog.actionsById.get("example.pong")?.execution.locallyExecutable).toBe(true);
+  });
 });
+
+function providerFixture(service: string, actionNames: string[]): ProviderDefinition {
+  return {
+    service,
+    displayName: service,
+    categories: ["Developer Tools"],
+    authTypes: ["no_auth"],
+    auth: [{ type: "no_auth" }],
+    actions: actionNames.map((name) => ({
+      id: `${service}.${name}`,
+      service,
+      name,
+      description: `${name} action.`,
+      requiredScopes: [],
+      providerPermissions: [],
+      inputSchema: {},
+      outputSchema: {},
+    })),
+  };
+}

--- a/src/catalog-store.ts
+++ b/src/catalog-store.ts
@@ -69,11 +69,19 @@ export type CatalogStore = {
   executableActionIds: Set<string>;
 };
 
-export interface LoadCatalogOptions {
+export interface CreateCatalogStoreOptions {
   executableActionIds?: Iterable<string>;
 }
 
-export function createCatalogStore(providers: ProviderDefinition[], options: LoadCatalogOptions = {}): CatalogStore {
+export interface LoadCatalogOptions extends CreateCatalogStoreOptions {
+  /** Mark every catalog action owned by these locally loaded provider services as executable. */
+  executableServices?: Iterable<string>;
+}
+
+export function createCatalogStore(
+  providers: ProviderDefinition[],
+  options: CreateCatalogStoreOptions = {},
+): CatalogStore {
   const sortedProviders = sortProviders(providers);
   const executableActions = new Set(options.executableActionIds ?? []);
   const runtimeProviders = sortedProviders.map((provider): RuntimeProviderDefinition => {
@@ -148,7 +156,26 @@ export async function loadCatalog(
         return JSON.parse(content) as ProviderDefinition;
       }),
   );
-  return createCatalogStore(providers, options);
+  return createCatalogStore(providers, {
+    executableActionIds: resolveExecutableActionIds(providers, options),
+  });
+}
+
+/** Resolve provider-level executable services into the exact action ids present in a loaded catalog. */
+export function resolveExecutableActionIds(
+  providers: ProviderDefinition[],
+  options: LoadCatalogOptions = {},
+): Set<string> {
+  const actionIds = new Set(options.executableActionIds ?? []);
+  const services = new Set(options.executableServices ?? []);
+  for (const provider of providers) {
+    if (services.has(provider.service)) {
+      for (const action of provider.actions) {
+        actionIds.add(action.id);
+      }
+    }
+  }
+  return actionIds;
 }
 
 function createActionExecutionStatus(

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -8,7 +8,7 @@ import type { ISecretCodec } from "./secrets/secret-codec-core.ts";
 import { ActionPolicyService, parseActionPolicyList } from "../core/action-policy.ts";
 import { parsePrivateNetworkAccessFlag, setPrivateNetworkAccessAllowed } from "../core/request.ts";
 import { ProviderLoader } from "../providers/provider-loader.ts";
-import { executableActionIds, executorModules } from "../providers/registry.cloudflare.generated.ts";
+import { executorModules } from "../providers/registry.cloudflare.generated.ts";
 import { isConsoleShellPath } from "./api/console-paths.ts";
 import { loadCatalogFromAssets } from "./cloudflare/catalog-assets.ts";
 import { readPositiveInteger, resolvePublicOrigin } from "./cloudflare/cloudflare-env.ts";
@@ -120,7 +120,7 @@ function writeWorkerLog(level: "error" | "info" | "warn"): (fields: unknown, mes
 
 function loadCatalogOnce(assets: AssetsBinding): Promise<CatalogStore> {
   catalogPromise ??= loadCatalogFromAssets(assets, {
-    executableActionIds: Object.values(executableActionIds).flat(),
+    executableServices: Object.keys(executorModules),
   });
   return catalogPromise;
 }

--- a/src/server/cloudflare/catalog-assets.ts
+++ b/src/server/cloudflare/catalog-assets.ts
@@ -2,7 +2,7 @@ import type { CatalogStore, LoadCatalogOptions } from "../../catalog-store.ts";
 import type { ProviderDefinition } from "../../core/types.ts";
 import type { AssetsBinding } from "./cloudflare-bindings.ts";
 
-import { createCatalogStore } from "../../catalog-store.ts";
+import { createCatalogStore, resolveExecutableActionIds } from "../../catalog-store.ts";
 
 const catalogAssetPath = "/catalog/apps.json";
 
@@ -11,7 +11,9 @@ export async function loadCatalogFromAssets(
   options: LoadCatalogOptions = {},
 ): Promise<CatalogStore> {
   const providers = (await readJsonAsset(assets, catalogAssetPath)) as ProviderDefinition[];
-  return createCatalogStore(providers, options);
+  return createCatalogStore(providers, {
+    executableActionIds: resolveExecutableActionIds(providers, options),
+  });
 }
 
 async function readJsonAsset(assets: AssetsBinding, path: string): Promise<unknown> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ import { loadCatalog } from "../catalog-store.ts";
 import { ActionPolicyService, parseActionPolicyList } from "../core/action-policy.ts";
 import { parsePrivateNetworkAccessFlag, setPrivateNetworkAccessAllowed } from "../core/request.ts";
 import { ProviderLoader } from "../providers/provider-loader.ts";
-import { executableActionIds, executorModules } from "../providers/registry.generated.ts";
+import { executorModules } from "../providers/registry.generated.ts";
 import { createRuntimeJwtVerifier } from "./api/runtime-jwt.ts";
 import { registerStaticRoutes } from "./api/static-routes.ts";
 import { createConnectApp } from "./connect-app.ts";
@@ -41,7 +41,7 @@ const builtRoot = join(process.cwd(), "dist/web");
 const staticRoot = await resolveStaticRoot(builtRoot);
 await mkdir(dataDir, { recursive: true });
 const catalog = await loadCatalog(undefined, {
-  executableActionIds: Object.values(executableActionIds).flat(),
+  executableServices: Object.keys(executorModules),
 });
 const providerLoader = new ProviderLoader(executorModules);
 const runtimeDatabase = new SqliteRuntimeDatabase(join(dataDir, "connect.sqlite"), {


### PR DESCRIPTION
## Summary

- stop generating full executable action ID arrays in the Node and Cloudflare provider registries
- use the loaded executor module service keys to identify locally executable providers
- resolve those services to the exact action IDs present in the loaded catalog before creating `CatalogStore`
- preserve explicit `executableActionIds`, runtime execution metadata, and public response shapes

This is the first of the two changes discussed in #235. Catalog asset chunking will follow in a separate PR.

## Why

The generated Cloudflare registry repeated all 12,743 executable action IDs even though each included provider already has a lazy executor module entry. The existing generator marks every action from an included provider executable, so the executor module service keys carry the same information more compactly.

## Wrangler size comparison

Measured from `v1.3.3` and this branch with Wrangler 4.115.0, the same Cloudflare bindings/configuration, `--dry-run`, and `--minify`:

| Build | Minified upload | Gzip |
| --- | ---: | ---: |
| `v1.3.3` baseline | 11,935.15 KiB | 2,854.70 KiB |
| This PR | 11,566.36 KiB | 2,777.99 KiB |
| Reduction | **368.79 KiB** | **76.71 KiB** |

The emitted `cloudflare.js` decreased from 12,221,596 to 11,843,955 bytes, a reduction of 377,641 bytes.

## Validation

- generated both provider registries for 1,194 total / 1,192 Cloudflare providers
- `oxlint . --fix`
- `oxfmt .`
- `node scripts/typecheck.ts src scripts-all examples`
- `vitest run` — 61 test files and 591 tests passed
- Wrangler dry-run builds for both baseline and optimized revisions

Refs #235
