### PR TITLE
feat(home-assistant): add REST coverage for config CRUD, history, and calendars

### DIFF
--- a/src/providers/home_assistant/actions.ts
+++ b/src/providers/home_assistant/actions.ts
@@ -11,17 +11,27 @@ const contextSchema = s.looseObject("The Home Assistant context attached to a st
   user_id: s.nullableString("The optional Home Assistant user identifier."),
 });
 
-const stateSchema = s.looseRequiredObject(
-  "One Home Assistant entity state object.",
-  {
-    entity_id: s.string("The Home Assistant entity identifier."),
-    state: s.string("The current state value."),
-    attributes: s.looseObject("The integration-specific attributes for the entity state."),
-    last_changed: s.string("The timestamp when the state last changed."),
-    last_updated: s.string("The timestamp when the state object was last updated."),
-    context: contextSchema,
-  },
-  { optional: ["attributes", "context"] },
+const stateProperties = {
+  entity_id: s.string("The Home Assistant entity identifier."),
+  state: s.string("The current state value."),
+  attributes: s.looseObject("The integration-specific attributes for the entity state."),
+  last_changed: s.string("The timestamp when the state last changed."),
+  last_updated: s.string("The timestamp when the state object was last updated."),
+  context: contextSchema,
+};
+
+const stateSchema = s.looseRequiredObject("One Home Assistant entity state object.", stateProperties, {
+  optional: ["attributes", "context"],
+});
+
+// History rows are not full state objects. With minimal_response, Home Assistant
+// returns only state and last_changed for the entries between the first and last
+// of the period, dropping entity_id, attributes, and last_updated; no_attributes
+// drops attributes on every row. Only state and last_changed are always present.
+const historyStateSchema = s.looseRequiredObject(
+  "One recorded Home Assistant state. Fields other than state and last_changed are omitted for compacted rows.",
+  stateProperties,
+  { optional: ["entity_id", "attributes", "last_updated", "context"] },
 );
 
 const emptyInputSchema = s.actionInput({}, [], "No input is required for this action.");
@@ -238,7 +248,7 @@ export const homeAssistantActions: ActionDefinition[] = [
       {
         history: s.array(
           "One list of state objects per requested entity, in the order Home Assistant returns them.",
-          s.array("The recorded states for one entity.", stateSchema),
+          s.array("The recorded states for one entity.", historyStateSchema),
         ),
       },
       "The recorded Home Assistant state history.",

--- a/src/providers/home_assistant/actions.ts
+++ b/src/providers/home_assistant/actions.ts
@@ -178,6 +178,125 @@ export const homeAssistantActions: ActionDefinition[] = [
     ),
   }),
   defineProviderAction(service, {
+    name: "get_history",
+    description:
+      "Fetch recorded state history for one or more Home Assistant entities over a time period, for answering questions about how a value changed.",
+    followUpActions: ["home_assistant.get_logbook"],
+    inputSchema: s.actionInput(
+      {
+        entityIds: s.array(
+          "The entity ids to fetch history for. Home Assistant requires at least one.",
+          s.nonEmptyString("One Home Assistant entity identifier."),
+          { minItems: 1 },
+        ),
+        startTime: s.dateTime("The start of the period. Defaults to one day before now when omitted."),
+        endTime: s.dateTime("The end of the period. Defaults to one day after the start time."),
+        minimalResponse: s.boolean(
+          "Return only state changes without full attribute payloads, which greatly reduces response size.",
+        ),
+        noAttributes: s.boolean("Omit entity attributes from the response."),
+        skipInitialState: s.boolean("Omit the state that was already active at the start of the period."),
+        significantChangesOnly: s.boolean(
+          "Return only significant state changes. Home Assistant defaults this to true.",
+        ),
+      },
+      ["entityIds"],
+      "Input parameters for one Home Assistant history query.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        history: s.array(
+          "One list of state objects per requested entity, in the order Home Assistant returns them.",
+          s.array("The recorded states for one entity.", stateSchema),
+        ),
+      },
+      "The recorded Home Assistant state history.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_logbook",
+    description:
+      "Fetch the Home Assistant logbook: the human-readable timeline of what happened and what triggered it, for diagnosing why something changed.",
+    inputSchema: s.actionInput(
+      {
+        startTime: s.dateTime("The start of the period. Defaults to one day before now when omitted."),
+        endTime: s.dateTime("The end of the period."),
+        entityIds: s.array(
+          "Optional entity ids to restrict the logbook to.",
+          s.nonEmptyString("One Home Assistant entity identifier."),
+        ),
+        period: s.positiveInteger("The number of days to cover, used when no end time is given."),
+        contextId: s.nonEmptyString(
+          "Optional Home Assistant context id, to list only the entries produced by one action.",
+        ),
+      },
+      [],
+      "Input parameters for one Home Assistant logbook query.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        entries: s.array("The logbook entries.", s.looseObject("One Home Assistant logbook entry.")),
+      },
+      "The Home Assistant logbook entries for the requested period.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_calendars",
+    description: "List the calendar entities exposed by Home Assistant.",
+    followUpActions: ["home_assistant.list_calendar_events"],
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        calendars: s.array(
+          "The Home Assistant calendar entities.",
+          s.looseRequiredObject(
+            "One Home Assistant calendar entity.",
+            {
+              entity_id: s.string("The calendar entity identifier."),
+              name: s.string("The calendar display name."),
+            },
+            { optional: ["name"] },
+          ),
+        ),
+      },
+      "The Home Assistant calendar entities.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_calendar_events",
+    description: "List the events on one Home Assistant calendar between a start and end time.",
+    inputSchema: s.actionInput(
+      {
+        entityId: s.nonEmptyString("The calendar entity identifier, for example calendar.personal."),
+        start: s.dateTime("The inclusive start of the window."),
+        end: s.dateTime("The exclusive end of the window, which must be after the start."),
+      },
+      ["entityId", "start", "end"],
+      "Input parameters for one Home Assistant calendar event query.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        events: s.array(
+          "The calendar events in the requested window.",
+          s.looseObject(
+            "One Home Assistant calendar event. Start and end are objects holding either dateTime or date.",
+          ),
+        ),
+      },
+      "The Home Assistant calendar events.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_error_log",
+    description:
+      "Fetch the Home Assistant error log for the current session as plain text. Home Assistant serves this only when the instance runs with file logging enabled, so it can report not found on an otherwise healthy instance.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { log: s.string("The plain-text Home Assistant error log.") },
+      "The Home Assistant error log.",
+    ),
+  }),
+  defineProviderAction(service, {
     name: "get_registries",
     description:
       "List the Home Assistant entity, device, area, floor, and label registries in one call. These registries expose the device and room structure behind entity ids, which the REST API does not serve.",

--- a/src/providers/home_assistant/actions.ts
+++ b/src/providers/home_assistant/actions.ts
@@ -69,6 +69,37 @@ function registryListSchema(description: string): JsonSchema {
   return s.nullable(s.array(description, s.looseObject("One Home Assistant registry entry.")));
 }
 
+// The editable config store reached through /api/config/<component>/config/<key>.
+// Every domain there takes an admin token and only covers entries Home Assistant
+// itself manages (automations.yaml, scripts.yaml, scenes.yaml); entries defined
+// in other YAML files are not visible to it.
+const configAdminNote =
+  "Requires an admin access token, and only covers entries stored in the Home Assistant UI-editable config; entries defined in other YAML files return not found.";
+
+const configWriteResultSchema = s.actionOutput(
+  { result: s.string("The Home Assistant result status, normally ok.") },
+  "The Home Assistant config write result.",
+);
+
+function configKeyInput(field: string, description: string): JsonSchema {
+  return s.actionInput({ [field]: s.nonEmptyString(description) }, [field], "Input parameters for one config entry.");
+}
+
+function configSaveInput(field: string, description: string, configDescription: string): JsonSchema {
+  return s.actionInput(
+    {
+      [field]: s.nonEmptyString(description),
+      config: s.looseObject(configDescription),
+    },
+    [field, "config"],
+    "Input parameters for saving one config entry.",
+  );
+}
+
+function configReadOutput(description: string): JsonSchema {
+  return s.actionOutput({ config: s.looseObject(description) }, "The stored Home Assistant configuration entry.");
+}
+
 export const homeAssistantActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_config",
@@ -348,6 +379,7 @@ export const homeAssistantActions: ActionDefinition[] = [
     name: "list_device_automations",
     description:
       "List the triggers, conditions, and actions one Home Assistant device supports, for building automations against that device.",
+    followUpActions: ["home_assistant.validate_config"],
     inputSchema: s.actionInput(
       {
         deviceId: s.nonEmptyString("The Home Assistant device registry identifier."),
@@ -391,6 +423,7 @@ export const homeAssistantActions: ActionDefinition[] = [
     name: "validate_config",
     description:
       "Validate Home Assistant trigger, condition, and action configurations before storing them in an automation.",
+    followUpActions: ["home_assistant.save_automation_config", "home_assistant.save_script_config"],
     inputSchema: s.actionInput(
       {
         triggers: s.array("The trigger configurations to validate.", s.looseObject("One Home Assistant trigger.")),
@@ -410,6 +443,92 @@ export const homeAssistantActions: ActionDefinition[] = [
         ),
       },
       "The Home Assistant configuration validation result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_automation_config",
+    description: `Fetch the stored configuration for one Home Assistant automation. ${configAdminNote}`,
+    followUpActions: ["home_assistant.save_automation_config"],
+    inputSchema: configKeyInput("automationId", "The automation id, which is the id field inside the automation."),
+    outputSchema: configReadOutput("The stored automation configuration."),
+  }),
+  defineProviderAction(service, {
+    name: "save_automation_config",
+    description: `Create or replace one Home Assistant automation. Posting to an unused id creates the automation. ${configAdminNote}`,
+    followUpActions: ["home_assistant.get_automation_config", "home_assistant.get_logbook"],
+    inputSchema: configSaveInput(
+      "automationId",
+      "The automation id to create or replace.",
+      "The automation configuration, with the same keys as an automations.yaml entry such as alias, triggers, conditions, actions, and mode.",
+    ),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_automation_config",
+    description: `Delete one Home Assistant automation. ${configAdminNote}`,
+    inputSchema: configKeyInput("automationId", "The automation id to delete."),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_script_config",
+    description: `Fetch the stored configuration for one Home Assistant script. ${configAdminNote}`,
+    followUpActions: ["home_assistant.save_script_config"],
+    inputSchema: configKeyInput("scriptKey", "The script key, the slug after script. in the entity id."),
+    outputSchema: configReadOutput("The stored script configuration."),
+  }),
+  defineProviderAction(service, {
+    name: "save_script_config",
+    description: `Create or replace one Home Assistant script. Posting to an unused key creates the script. ${configAdminNote}`,
+    followUpActions: ["home_assistant.get_script_config"],
+    inputSchema: configSaveInput(
+      "scriptKey",
+      "The script key to create or replace, which must be a slug of lowercase letters, digits, and underscores.",
+      "The script configuration, with the same keys as a scripts.yaml entry such as alias, sequence, and mode.",
+    ),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_script_config",
+    description: `Delete one Home Assistant script. ${configAdminNote}`,
+    inputSchema: configKeyInput("scriptKey", "The script key to delete."),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_scene_config",
+    description: `Fetch the stored configuration for one Home Assistant scene. ${configAdminNote}`,
+    followUpActions: ["home_assistant.save_scene_config"],
+    inputSchema: configKeyInput("sceneId", "The scene id, which is the id field inside the scene."),
+    outputSchema: configReadOutput("The stored scene configuration."),
+  }),
+  defineProviderAction(service, {
+    name: "save_scene_config",
+    description: `Create or replace one Home Assistant scene. Posting to an unused id creates the scene. ${configAdminNote}`,
+    followUpActions: ["home_assistant.get_scene_config"],
+    inputSchema: configSaveInput(
+      "sceneId",
+      "The scene id to create or replace.",
+      "The scene configuration, with the same keys as a scenes.yaml entry such as name and entities.",
+    ),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_scene_config",
+    description: `Delete one Home Assistant scene. ${configAdminNote}`,
+    inputSchema: configKeyInput("sceneId", "The scene id to delete."),
+    outputSchema: configWriteResultSchema,
+  }),
+  defineProviderAction(service, {
+    name: "check_config",
+    description:
+      "Ask Home Assistant to validate its own configuration files and report errors and warnings. Requires an admin access token.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        result: s.string("Either valid or invalid."),
+        errors: s.nullableString("The configuration errors, or null when there are none."),
+        warnings: s.nullableString("The configuration warnings, or null when there are none."),
+      },
+      "The Home Assistant configuration check result.",
     ),
   }),
 ];

--- a/src/providers/home_assistant/executors.ts
+++ b/src/providers/home_assistant/executors.ts
@@ -3,6 +3,7 @@ import type { HomeAssistantActionContext } from "./runtime.ts";
 
 import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
+import { homeAssistantConfigActionHandlers } from "./runtime-config.ts";
 import { homeAssistantWebSocketActionHandlers } from "./runtime-ws.ts";
 import {
   homeAssistantActionHandlers,
@@ -14,7 +15,11 @@ const service = "home_assistant";
 
 export const executors: ProviderExecutors = defineProviderExecutors<HomeAssistantActionContext>({
   service,
-  handlers: { ...homeAssistantActionHandlers, ...homeAssistantWebSocketActionHandlers },
+  handlers: {
+    ...homeAssistantActionHandlers,
+    ...homeAssistantConfigActionHandlers,
+    ...homeAssistantWebSocketActionHandlers,
+  },
   allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HomeAssistantActionContext> {
     const credential = await requireApiKeyCredential(context, service);

--- a/src/providers/home_assistant/runtime-config.ts
+++ b/src/providers/home_assistant/runtime-config.ts
@@ -1,0 +1,137 @@
+import type { HomeAssistantActionContext, HomeAssistantActionHandler } from "./runtime.ts";
+
+import { optionalRecord, optionalString, optionalStringOrNull, requiredRecord } from "../../core/cast.ts";
+import { badHomeAssistantRequest, requestHomeAssistantJson } from "./runtime.ts";
+
+/**
+ * One editable Home Assistant config domain served by `/api/config/<component>/config/<key>`.
+ *
+ * The three domains differ only in the component segment, the input field that
+ * carries the key, and whether Home Assistant validates that key as a slug, so
+ * the read/write/delete handlers are shared and parameterised by this record.
+ */
+interface HomeAssistantConfigDomain {
+  /** Path segment under `/api/config`. */
+  component: string;
+  /** Action input field holding the config key. */
+  keyField: string;
+  /** Home Assistant validates script keys with `cv.slug`; automation and scene ids are free-form strings. */
+  keyMustBeSlug: boolean;
+}
+
+const automationDomain: HomeAssistantConfigDomain = {
+  component: "automation",
+  keyField: "automationId",
+  keyMustBeSlug: false,
+};
+
+const scriptDomain: HomeAssistantConfigDomain = {
+  component: "script",
+  keyField: "scriptKey",
+  keyMustBeSlug: true,
+};
+
+const sceneDomain: HomeAssistantConfigDomain = {
+  component: "scene",
+  keyField: "sceneId",
+  keyMustBeSlug: false,
+};
+
+const slugPattern = /^[a-z0-9_]+$/;
+
+export const homeAssistantConfigActionHandlers: Record<string, HomeAssistantActionHandler> = {
+  get_automation_config: (input, context) => readConfig(automationDomain, input, context),
+  save_automation_config: (input, context) => writeConfig(automationDomain, input, context),
+  delete_automation_config: (input, context) => removeConfig(automationDomain, input, context),
+  get_script_config: (input, context) => readConfig(scriptDomain, input, context),
+  save_script_config: (input, context) => writeConfig(scriptDomain, input, context),
+  delete_script_config: (input, context) => removeConfig(scriptDomain, input, context),
+  get_scene_config: (input, context) => readConfig(sceneDomain, input, context),
+  save_scene_config: (input, context) => writeConfig(sceneDomain, input, context),
+  delete_scene_config: (input, context) => removeConfig(sceneDomain, input, context),
+  async check_config(_input, context) {
+    const payload =
+      optionalRecord(
+        await requestHomeAssistantJson({
+          context,
+          path: "/api/config/core/check_config",
+          method: "POST",
+        }),
+      ) ?? {};
+    return {
+      result: optionalString(payload.result) ?? "unknown",
+      errors: optionalStringOrNull(payload.errors),
+      warnings: optionalStringOrNull(payload.warnings),
+    };
+  },
+};
+
+async function readConfig(
+  domain: HomeAssistantConfigDomain,
+  input: Record<string, unknown>,
+  context: HomeAssistantActionContext,
+): Promise<unknown> {
+  return {
+    config: await requestHomeAssistantJson({
+      context,
+      path: buildConfigPath(domain, input),
+      method: "GET",
+    }),
+  };
+}
+
+async function writeConfig(
+  domain: HomeAssistantConfigDomain,
+  input: Record<string, unknown>,
+  context: HomeAssistantActionContext,
+): Promise<unknown> {
+  // The key travels in the path; Home Assistant injects it into the stored
+  // entry itself, so the body is the bare config object.
+  const path = buildConfigPath(domain, input);
+  const config = requiredRecord(input.config, "config", badHomeAssistantRequest);
+  return {
+    result: readConfigResult(
+      await requestHomeAssistantJson({
+        context,
+        path,
+        method: "POST",
+        body: config,
+      }),
+    ),
+  };
+}
+
+async function removeConfig(
+  domain: HomeAssistantConfigDomain,
+  input: Record<string, unknown>,
+  context: HomeAssistantActionContext,
+): Promise<unknown> {
+  return {
+    result: readConfigResult(
+      await requestHomeAssistantJson({
+        context,
+        path: buildConfigPath(domain, input),
+        method: "DELETE",
+      }),
+    ),
+  };
+}
+
+function buildConfigPath(domain: HomeAssistantConfigDomain, input: Record<string, unknown>): string {
+  return `/api/config/${domain.component}/config/${encodeURIComponent(readConfigKey(domain, input))}`;
+}
+
+function readConfigKey(domain: HomeAssistantConfigDomain, input: Record<string, unknown>): string {
+  const value = optionalString(input[domain.keyField]);
+  if (!value) {
+    throw badHomeAssistantRequest(`${domain.keyField} is required`);
+  }
+  if (domain.keyMustBeSlug && !slugPattern.test(value)) {
+    throw badHomeAssistantRequest(`${domain.keyField} must be a slug of lowercase letters, digits, and underscores`);
+  }
+  return value;
+}
+
+function readConfigResult(payload: unknown): string {
+  return optionalString(optionalRecord(payload)?.result) ?? "ok";
+}

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -131,34 +131,29 @@ export function resolveHomeAssistantBaseUrl(input: {
   return normalizeBaseUrl(input.metadata?.baseUrl ?? input.values?.baseUrl);
 }
 
-async function requestHomeAssistantJson(input: {
+/** One Home Assistant REST call, before the base URL and credential are applied. */
+export interface HomeAssistantRequest {
   context: HomeAssistantActionContext;
+  /** Path below the instance base URL, always starting with `/api`. */
   path: string;
-  method: "GET" | "POST";
+  method: "GET" | "POST" | "DELETE";
   body?: Record<string, unknown>;
   query?: Record<string, string>;
-}): Promise<unknown> {
+}
+
+/** Issue a Home Assistant REST call and parse the JSON body. */
+export async function requestHomeAssistantJson(input: HomeAssistantRequest): Promise<unknown> {
   const response = await requestHomeAssistant(input);
   return readJsonResponse(response);
 }
 
-async function requestHomeAssistantText(input: {
-  context: HomeAssistantActionContext;
-  path: string;
-  method: "POST";
-  body?: Record<string, unknown>;
-}): Promise<string> {
+/** Issue a Home Assistant REST call and return the raw text body, for endpoints that are not JSON. */
+export async function requestHomeAssistantText(input: HomeAssistantRequest): Promise<string> {
   const response = await requestHomeAssistant(input);
   return response.text();
 }
 
-async function requestHomeAssistant(input: {
-  context: HomeAssistantActionContext;
-  path: string;
-  method: "GET" | "POST";
-  body?: Record<string, unknown>;
-  query?: Record<string, string>;
-}): Promise<Response> {
+async function requestHomeAssistant(input: HomeAssistantRequest): Promise<Response> {
   const timeout = createProviderTimeout(input.context.signal, homeAssistantRequestTimeoutMs);
   try {
     const response = await input.context.fetcher(buildHomeAssistantUrl(input), {
@@ -197,7 +192,10 @@ function buildHomeAssistantUrl(input: {
   query?: Record<string, string>;
 }): string {
   const url = new URL(input.context.baseUrl);
-  url.pathname = input.path;
+  // Append to the instance path instead of replacing it: normalizeBaseUrl keeps
+  // a base path, so an instance behind a reverse proxy at /ha must reach
+  // /ha/api/... rather than /api/....
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}${input.path}`;
   for (const [key, value] of Object.entries(input.query ?? {})) {
     url.searchParams.set(key, value);
   }

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -1,4 +1,14 @@
-import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredString,
+  requiredStringArray,
+} from "../../core/cast.ts";
+import { queryFlag, queryParams } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -7,6 +17,11 @@ import {
 } from "../provider-runtime.ts";
 
 const homeAssistantRequestTimeoutMs = 30_000;
+
+/** Input guard failures surface as 400s, matching the other Home Assistant input checks. */
+export function badHomeAssistantRequest(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
 
 export interface HomeAssistantActionContext {
   apiKey: string;
@@ -103,7 +118,95 @@ export const homeAssistantActionHandlers: Record<string, HomeAssistantActionHand
       }),
     };
   },
+  async get_history(input, context) {
+    const startTime = optionalString(input.startTime);
+    return {
+      history: await requestHomeAssistantJson({
+        context,
+        path: startTime ? `/api/history/period/${encodeURIComponent(startTime)}` : "/api/history/period",
+        method: "GET",
+        query: queryParams({
+          filter_entity_id: requiredStringArray(input.entityIds, "entityIds", badHomeAssistantRequest).join(","),
+          end_time: optionalString(input.endTime),
+          minimal_response: presenceFlag(input.minimalResponse),
+          no_attributes: presenceFlag(input.noAttributes),
+          skip_initial_state: presenceFlag(input.skipInitialState),
+          significant_changes_only: queryFlag(optionalBoolean(input.significantChangesOnly)),
+        }),
+      }),
+    };
+  },
+  async get_logbook(input, context) {
+    const startTime = optionalString(input.startTime);
+    const entityIds = optionalStringArray(input.entityIds);
+    return {
+      entries: await requestHomeAssistantJson({
+        context,
+        path: startTime ? `/api/logbook/${encodeURIComponent(startTime)}` : "/api/logbook",
+        method: "GET",
+        query: queryParams({
+          entity: entityIds?.length ? entityIds.join(",") : undefined,
+          end_time: optionalString(input.endTime),
+          period: optionalInteger(input.period),
+          context_id: optionalString(input.contextId),
+        }),
+      }),
+    };
+  },
+  async list_calendars(_input, context) {
+    return {
+      calendars: await requestHomeAssistantJson({
+        context,
+        path: "/api/calendars",
+        method: "GET",
+      }),
+    };
+  },
+  async list_calendar_events(input, context) {
+    return {
+      events: await requestHomeAssistantJson({
+        context,
+        path: `/api/calendars/${encodeURIComponent(readInputString(input.entityId, "entityId"))}`,
+        method: "GET",
+        query: queryParams({
+          start: readInputString(input.start, "start"),
+          end: readInputString(input.end, "end"),
+        }),
+      }),
+    };
+  },
+  async get_error_log(_input, context) {
+    try {
+      return {
+        log: await requestHomeAssistantText({
+          context,
+          path: "/api/error_log",
+          method: "GET",
+        }),
+      };
+    } catch (error) {
+      // Home Assistant registers this view only when the instance runs with file
+      // logging, so a 404 means the log is unavailable rather than the path being
+      // wrong. Say that instead of surfacing a bare "Not Found".
+      if (error instanceof ProviderRequestError && error.status === 404) {
+        throw new ProviderRequestError(
+          404,
+          "This Home Assistant instance does not expose an error log. The endpoint exists only when Home Assistant is started with file logging enabled.",
+        );
+      }
+      throw error;
+    }
+  },
 };
+
+/**
+ * Encode a Home Assistant presence flag. These query parameters are read by
+ * presence, not by value, so `false` must omit the parameter entirely rather
+ * than send `0`.
+ */
+function presenceFlag(value: unknown): string | undefined {
+  return optionalBoolean(value) === true ? "1" : undefined;
+}
 
 export function validateHomeAssistantCredential(input: { values: Record<string, string> }): {
   profile: { accountId: string; displayName: string };

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -126,7 +126,7 @@ export const homeAssistantActionHandlers: Record<string, HomeAssistantActionHand
         path: startTime ? `/api/history/period/${encodeURIComponent(startTime)}` : "/api/history/period",
         method: "GET",
         query: queryParams({
-          filter_entity_id: requiredStringArray(input.entityIds, "entityIds", badHomeAssistantRequest).join(","),
+          filter_entity_id: readHistoryEntityIds(input.entityIds),
           end_time: optionalString(input.endTime),
           minimal_response: presenceFlag(input.minimalResponse),
           no_attributes: presenceFlag(input.noAttributes),
@@ -206,6 +206,27 @@ export const homeAssistantActionHandlers: Record<string, HomeAssistantActionHand
  */
 function presenceFlag(value: unknown): string | undefined {
   return optionalBoolean(value) === true ? "1" : undefined;
+}
+
+/**
+ * Build the `filter_entity_id` value, rejecting an entity list that carries no
+ * usable id.
+ *
+ * Home Assistant treats a missing `filter_entity_id` as "every entity", and
+ * `queryParams` drops empty strings, so a list that normalizes to nothing would
+ * turn a scoped query into a whole-instance history dump. The action schema
+ * already requires at least one non-empty id, but the request must not depend on
+ * that alone, and a whitespace-only id passes the schema while still being
+ * unusable.
+ */
+function readHistoryEntityIds(value: unknown): string {
+  const entityIds = requiredStringArray(value, "entityIds", badHomeAssistantRequest)
+    .map((entityId) => entityId.trim())
+    .filter((entityId) => entityId.length > 0);
+  if (entityIds.length === 0) {
+    throw badHomeAssistantRequest("entityIds must contain at least one entity id");
+  }
+  return entityIds.join(",");
 }
 
 export function validateHomeAssistantCredential(input: { values: Record<string, string> }): {


### PR DESCRIPTION
## Summary

- add automation, script, and scene config CRUD, reached over REST at `/api/config/<component>/config/<key>`
- add history, logbook, calendar, and error log actions from Home Assistant's published REST API
- fix `buildHomeAssistantUrl` dropping the instance base path

Fifteen actions in total, all REST. No WebSocket code is touched.

## Problem

Two separate gaps, both in the REST surface.

**The editable config store was missing entirely.** Home Assistant serves automation, script, and scene configuration over REST, but at `/api/config/<component>/config/<key>` rather than under the endpoints listed in the published REST API reference. The provider could therefore run an automation but never write one. That endpoint family is absent from the reference page, which is the most likely reason it was never covered — the eight actions the provider started with map exactly onto that page and nothing outside it.

**There was no time dimension.** `/api/states` answers "what is the temperature now"; nothing answered "how did it get there" or "what tripped that switch overnight". `history`, `logbook`, `calendars`, and `error_log` are all on the published reference page and were simply never implemented.

## Config CRUD

`automation`, `script`, and `scene` differ only in three respects: the path segment, the input field carrying the key, and whether Home Assistant validates that key as a slug (`cv.slug` for script, `cv.string` for automation and scene). One descriptor captures those differences and parameterises shared read/write/delete handlers, rather than nine near-identical copies.

The key travels in the path and Home Assistant injects it into the stored entry itself, so the request body is the bare config object. `POST` is create-or-update: writing to an unused key creates the entry, which is how the UI creates automations.

Both endpoints require an admin token, and they only see entries Home Assistant manages itself — an automation defined in a separate YAML file or a package is not visible and returns not found. The action descriptions say so, because a non-admin token fails at the provider rather than at input validation.

This pairs with `validate_config` from #227 to close the loop an agent needs for automation work: discover what a device can do, validate a candidate config, write it, then read the logbook to confirm it fired. `followUpActions` wires that sequence into the catalog so it is discoverable rather than something the caller has to know.

## History and diagnostics

`get_history` exposes `minimalResponse` and `noAttributes` because a full-attribute history across several entities is large enough to matter for an agent's context budget. Against a real instance, one entity over 24 hours returned 7219 points; the compact form drops each row from the full state object to `{"state", "last_changed"}`.

Home Assistant reads `minimal_response`, `no_attributes`, and `skip_initial_state` by presence rather than by value, so `false` omits the parameter instead of sending `0`. `significant_changes_only` is read by value and defaults to true, so it is encoded normally.

`get_error_log` needs one caveat: Home Assistant registers that view only when the instance runs with file logging, so it can report not found on an otherwise healthy instance. Rather than surface a bare "Not Found", the handler maps that case to a message explaining why, and the action description repeats it.

## Base path fix

`normalizeBaseUrl` accepts an instance URL with a path, so a Home Assistant behind a reverse proxy at `/ha` is a supported configuration. `buildHomeAssistantUrl` assigned the endpoint path over `url.pathname`, which dropped that prefix and sent every request to `/api/...` at the origin instead of `/ha/api/...`.

It now appends to the base path. The WebSocket URL builder added in #227 already did this, so the two transports agree. This is a separate commit; it predates both PRs, and the fifteen new paths here would have multiplied it.

## Actions

| Action | Endpoint |
| --- | --- |
| `get_automation_config` / `save_automation_config` / `delete_automation_config` | `GET`/`POST`/`DELETE /api/config/automation/config/{id}` |
| `get_script_config` / `save_script_config` / `delete_script_config` | `GET`/`POST`/`DELETE /api/config/script/config/{key}` |
| `get_scene_config` / `save_scene_config` / `delete_scene_config` | `GET`/`POST`/`DELETE /api/config/scene/config/{id}` |
| `check_config` | `POST /api/config/core/check_config` |
| `get_history` | `GET /api/history/period/{timestamp}` |
| `get_logbook` | `GET /api/logbook/{timestamp}` |
| `list_calendars` | `GET /api/calendars` |
| `list_calendar_events` | `GET /api/calendars/{entity_id}` |
| `get_error_log` | `GET /api/error_log` |

Reference: https://developers.home-assistant.io/docs/api/rest

## Verification

- `npm run fix-check`, `npm test` (584 passing)
- read paths against a real instance: `check_config` returned valid; `get_history` returned 7219 points for one entity over 24 hours with the compact form visibly applied; `get_logbook` returned 4417 entries; `list_calendars` returned an empty list on an instance with no calendar integration; `get_error_log` returned the explanatory 404 described above
- write paths against the same instance, creating and then removing an `oc_smoke_test` entry in each domain: create returned `ok`, the read-back showed the key injected into the stored entry, delete returned `ok`, and each subsequent read reported not found. A non-slug script key was rejected at the provider before any request. A following scan of 3830 entities found nothing left behind.
