### PR TITLE
feat(wandb): add official MCP provider

### DIFF
--- a/src/providers/wandb/actions.ts
+++ b/src/providers/wandb/actions.ts
@@ -17,8 +17,8 @@ const traceQueryOutput = s.looseObject("Matching Weave traces and query metadata
 });
 
 const artifactDiffOutput = s.looseObject("A comparison of two W&B artifact versions.", {
-  artifact_a: s.looseObject("Details for the first artifact version."),
-  artifact_b: s.looseObject("Details for the second artifact version."),
+  artifact_a: s.string("The first artifact version name."),
+  artifact_b: s.string("The second artifact version name."),
   metadata_diff: s.looseObject("Artifact metadata differences."),
   tags_diff: s.looseObject("Artifact tag differences."),
   aliases_diff: s.looseObject("Artifact alias differences."),
@@ -304,7 +304,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       { required: ["registry_name"] },
     ),
     outputSchema: s.looseObject("Collections in a W&B registry.", {
-      registry: s.looseObject("The selected W&B registry."),
+      registry: s.string("The selected W&B registry name."),
       collections: jsonItems("Collections in the registry."),
       count: s.nonNegativeInteger("The number of returned collections."),
       truncated: s.boolean("Whether results were truncated."),
@@ -328,7 +328,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       { required: ["collection_name"] },
     ),
     outputSchema: s.looseObject("Versions in a W&B artifact collection.", {
-      collection: s.looseObject("The selected artifact collection."),
+      collection: s.string("The selected artifact collection name."),
       source: s.string("The artifact source type."),
       versions: jsonItems("Artifact versions in the collection."),
       count: s.nonNegativeInteger("The number of returned versions."),

--- a/src/providers/wandb/actions.ts
+++ b/src/providers/wandb/actions.ts
@@ -9,26 +9,24 @@ const service = "wandb";
 const entityName = s.nonWhitespaceString("The W&B entity or team name.");
 const projectName = s.nonWhitespaceString("The W&B project name.");
 const filterObject = s.looseObject("Optional provider-native filters.");
-const jsonObject = (description: string, properties: Record<string, JsonSchema> = {}): JsonSchema =>
-  s.looseObject(description, properties);
 const jsonItems = (description: string): JsonSchema => s.array(description, s.looseObject("One returned item."));
 
-const traceQueryOutput = jsonObject("Matching Weave traces and query metadata.", {
-  metadata: jsonObject("Trace query counts, distributions, time range, and truncation metadata."),
+const traceQueryOutput = s.looseObject("Matching Weave traces and query metadata.", {
+  metadata: s.looseObject("Trace query counts, distributions, time range, and truncation metadata."),
   traces: jsonItems("Matching Weave traces."),
 });
 
-const artifactDiffOutput = jsonObject("A comparison of two W&B artifact versions.", {
-  artifact_a: jsonObject("Details for the first artifact version."),
-  artifact_b: jsonObject("Details for the second artifact version."),
-  metadata_diff: jsonObject("Artifact metadata differences."),
-  tags_diff: jsonObject("Artifact tag differences."),
-  aliases_diff: jsonObject("Artifact alias differences."),
-  size_diff: jsonObject("Artifact size differences."),
-  file_count_diff: jsonObject("Artifact file-count differences."),
-  lineage_diff: jsonObject("Artifact lineage differences."),
+const artifactDiffOutput = s.looseObject("A comparison of two W&B artifact versions.", {
+  artifact_a: s.looseObject("Details for the first artifact version."),
+  artifact_b: s.looseObject("Details for the second artifact version."),
+  metadata_diff: s.looseObject("Artifact metadata differences."),
+  tags_diff: s.looseObject("Artifact tag differences."),
+  aliases_diff: s.looseObject("Artifact alias differences."),
+  size_diff: s.looseObject("Artifact size differences."),
+  file_count_diff: s.looseObject("Artifact file-count differences."),
+  lineage_diff: s.looseObject("Artifact lineage differences."),
   digest_match: s.boolean("Whether both artifact versions have the same digest."),
-  file_diff: jsonObject("Optional file-level differences."),
+  file_diff: s.looseObject("Optional file-level differences."),
 });
 
 export const wandbActions: ProviderActionDefinition[] = [
@@ -85,7 +83,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       project_name: projectName,
       trace_ids: s.stringArray("Child trace IDs to resolve.", { minItems: 1 }),
     }),
-    outputSchema: jsonObject("Resolved Weave trace roots.", {
+    outputSchema: s.looseObject("Resolved Weave trace roots.", {
       roots: s.record("Root span details keyed by requested trace ID.", s.looseObject("One resolved root span.")),
       resolved: s.nonNegativeInteger("The number of resolved trace IDs."),
       total_requested: s.nonNegativeInteger("The number of requested trace IDs."),
@@ -142,7 +140,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name", "analysis_name", "data"] },
     ),
-    outputSchema: jsonObject("The W&B run created for the analysis.", {
+    outputSchema: s.looseObject("The W&B run created for the analysis.", {
       run_id: s.string("The created W&B run ID."),
       run_url: s.url("The created W&B run URL."),
       logged_keys: s.stringArray("The logged metric and data keys."),
@@ -154,7 +152,7 @@ export const wandbActions: ProviderActionDefinition[] = [
     name: "list_entities",
     description: "List W&B user and team entities accessible with the configured API key.",
     inputSchema: s.actionInput({}, [], "No input is required."),
-    outputSchema: jsonObject("Accessible W&B entities.", {
+    outputSchema: s.looseObject("Accessible W&B entities.", {
       entities: s.array(
         "Accessible W&B entities.",
         s.looseObject("One W&B entity.", {
@@ -176,7 +174,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: [] },
     ),
-    outputSchema: jsonObject("W&B projects grouped by entity.", {
+    outputSchema: s.looseObject("W&B projects grouped by entity.", {
       projects: s.record("Projects keyed by W&B entity.", s.array(s.looseObject("One W&B project."))),
       truncated: s.boolean("Whether project results were truncated."),
       max_projects_per_entity: s.positiveInteger("The per-entity project limit."),
@@ -194,7 +192,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: [] },
     ),
-    outputSchema: jsonObject("Matching W&B Automations.", {
+    outputSchema: s.looseObject("Matching W&B Automations.", {
       automations: jsonItems("Matching W&B Automations."),
       count: s.nonNegativeInteger("The number of returned automations."),
       entity: s.nullableString("The filtered W&B entity."),
@@ -213,7 +211,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: [] },
     ),
-    outputSchema: jsonObject("Matching W&B integrations.", {
+    outputSchema: s.looseObject("Matching W&B integrations.", {
       integrations: jsonItems("Matching W&B integrations."),
       count: s.nonNegativeInteger("The number of returned integrations."),
       entity: s.nullableString("The filtered W&B entity."),
@@ -234,7 +232,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name"] },
     ),
-    outputSchema: jsonObject("The inferred Weave trace schema.", {
+    outputSchema: s.looseObject("The inferred Weave trace schema.", {
       fields: jsonItems("Discovered trace fields."),
       total_traces: s.nonNegativeInteger("The total matching traces."),
       root_traces: s.nonNegativeInteger("The total root traces."),
@@ -265,7 +263,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name", "run_id"] },
     ),
-    outputSchema: jsonObject("Sampled W&B run history.", {
+    outputSchema: s.looseObject("Sampled W&B run history.", {
       history: s.array("Sampled metric history rows.", s.looseObject("One sampled history row.")),
       run_id: s.string("The W&B run ID."),
       run_name: s.string("The W&B run name."),
@@ -286,7 +284,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: [] },
     ),
-    outputSchema: jsonObject("Matching W&B registries.", {
+    outputSchema: s.looseObject("Matching W&B registries.", {
       registries: jsonItems("Matching W&B registries."),
       count: s.nonNegativeInteger("The number of returned registries."),
       truncated: s.boolean("Whether results were truncated."),
@@ -305,8 +303,8 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["registry_name"] },
     ),
-    outputSchema: jsonObject("Collections in a W&B registry.", {
-      registry: jsonObject("The selected W&B registry."),
+    outputSchema: s.looseObject("Collections in a W&B registry.", {
+      registry: s.looseObject("The selected W&B registry."),
       collections: jsonItems("Collections in the registry."),
       count: s.nonNegativeInteger("The number of returned collections."),
       truncated: s.boolean("Whether results were truncated."),
@@ -329,8 +327,8 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["collection_name"] },
     ),
-    outputSchema: jsonObject("Versions in a W&B artifact collection.", {
-      collection: jsonObject("The selected artifact collection."),
+    outputSchema: s.looseObject("Versions in a W&B artifact collection.", {
+      collection: s.looseObject("The selected artifact collection."),
       source: s.string("The artifact source type."),
       versions: jsonItems("Artifact versions in the collection."),
       count: s.nonNegativeInteger("The number of returned versions."),
@@ -350,9 +348,9 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["artifact_name"] },
     ),
-    outputSchema: jsonObject("W&B artifact version details.", {
-      artifact: jsonObject("Artifact metadata."),
-      lineage: jsonObject("Artifact lineage information."),
+    outputSchema: s.looseObject("W&B artifact version details.", {
+      artifact: s.looseObject("Artifact metadata."),
+      lineage: s.looseObject("Artifact lineage information."),
       files: jsonItems("Optional artifact file entries."),
     }),
   }),
@@ -391,13 +389,13 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name", "run_id_a", "run_id_b"] },
     ),
-    outputSchema: jsonObject("A structured comparison of two W&B runs.", {
-      run_a: jsonObject("Details for the first W&B run."),
-      run_b: jsonObject("Details for the second W&B run."),
-      config_diff: jsonObject("Run configuration differences."),
-      summary_diff: jsonObject("Run summary metric differences."),
-      metadata_diff: jsonObject("Run metadata differences."),
-      history_comparison: jsonObject("Optional sampled history comparison."),
+    outputSchema: s.looseObject("A structured comparison of two W&B runs.", {
+      run_a: s.looseObject("Details for the first W&B run."),
+      run_b: s.looseObject("Details for the second W&B run."),
+      config_diff: s.looseObject("Run configuration differences."),
+      summary_diff: s.looseObject("Run summary metric differences."),
+      metadata_diff: s.looseObject("Run metadata differences."),
+      history_comparison: s.looseObject("Optional sampled history comparison."),
     }),
   }),
   defineProviderAction(service, {
@@ -414,7 +412,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name"] },
     ),
-    outputSchema: jsonObject("Aggregated Weave evaluation results.", {
+    outputSchema: s.looseObject("Aggregated Weave evaluation results.", {
       evaluations: jsonItems("Matching evaluation summaries."),
       count: s.nonNegativeInteger("The number of summarized evaluations."),
       project: s.string("The W&B project name."),
@@ -434,12 +432,12 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name", "run_id"] },
     ),
-    outputSchema: jsonObject("The W&B run health diagnosis.", {
+    outputSchema: s.looseObject("The W&B run health diagnosis.", {
       run_id: s.string("The diagnosed W&B run ID."),
       run_name: s.string("The W&B run name."),
       run_state: s.string("The W&B run state."),
       diagnosis: s.unknown("Training-health findings and recommendations."),
-      loss_stats: jsonObject("Calculated loss statistics."),
+      loss_stats: s.looseObject("Calculated loss statistics."),
     }),
   }),
   defineProviderAction(service, {
@@ -454,7 +452,7 @@ export const wandbActions: ProviderActionDefinition[] = [
       },
       { required: ["entity_name", "project_name"] },
     ),
-    outputSchema: jsonObject("The discovered W&B project structure.", {
+    outputSchema: s.looseObject("The discovered W&B project structure.", {
       entity: s.string("The W&B entity name."),
       project: s.string("The W&B project name."),
       run_count: s.nonNegativeInteger("The project run count."),

--- a/src/providers/wandb/actions.ts
+++ b/src/providers/wandb/actions.ts
@@ -1,0 +1,469 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+import type { JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "wandb";
+
+const entityName = s.nonWhitespaceString("The W&B entity or team name.");
+const projectName = s.nonWhitespaceString("The W&B project name.");
+const filterObject = s.looseObject("Optional provider-native filters.");
+const jsonObject = (description: string, properties: Record<string, JsonSchema> = {}): JsonSchema =>
+  s.looseObject(description, properties);
+const jsonItems = (description: string): JsonSchema => s.array(description, s.looseObject("One returned item."));
+
+const traceQueryOutput = jsonObject("Matching Weave traces and query metadata.", {
+  metadata: jsonObject("Trace query counts, distributions, time range, and truncation metadata."),
+  traces: jsonItems("Matching Weave traces."),
+});
+
+const artifactDiffOutput = jsonObject("A comparison of two W&B artifact versions.", {
+  artifact_a: jsonObject("Details for the first artifact version."),
+  artifact_b: jsonObject("Details for the second artifact version."),
+  metadata_diff: jsonObject("Artifact metadata differences."),
+  tags_diff: jsonObject("Artifact tag differences."),
+  aliases_diff: jsonObject("Artifact alias differences."),
+  size_diff: jsonObject("Artifact size differences."),
+  file_count_diff: jsonObject("Artifact file-count differences."),
+  lineage_diff: jsonObject("Artifact lineage differences."),
+  digest_match: s.boolean("Whether both artifact versions have the same digest."),
+  file_diff: jsonObject("Optional file-level differences."),
+});
+
+export const wandbActions: ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "query_weave_traces",
+    description:
+      "Query classic Weave traces with filters, ordering, selected columns, cost data, feedback, and detail-level controls.",
+    inputSchema: s.object(
+      "Input for querying Weave traces.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        filters: filterObject,
+        sort_by: s.nonWhitespaceString("The trace field used for sorting.", { default: "started_at" }),
+        sort_direction: s.stringEnum("The sort direction.", ["asc", "desc"]),
+        limit: s.positiveInteger("The maximum number of traces to return."),
+        include_costs: s.boolean({ description: "Whether to include calculated trace costs.", default: true }),
+        include_feedback: s.boolean({ description: "Whether to include trace feedback.", default: true }),
+        columns: s.stringArray("Trace columns to return."),
+        expand_columns: s.stringArray("Nested trace columns to expand."),
+        truncate_length: s.positiveInteger("Maximum string length before truncation.", { default: 1000 }),
+        return_full_data: s.boolean({ description: "Whether to return untruncated trace data.", default: false }),
+        metadata_only: s.boolean({
+          description: "Whether to return query metadata without trace rows.",
+          default: false,
+        }),
+        detail_level: s.stringEnum("The trace detail level.", ["schema", "summary", "full"]),
+      },
+      { required: ["entity_name", "project_name"] },
+    ),
+    outputSchema: traceQueryOutput,
+  }),
+  defineProviderAction(service, {
+    name: "count_weave_traces",
+    description: "Count matching classic Weave traces and root traces without returning trace payloads.",
+    inputSchema: s.object(
+      "Input for counting Weave traces.",
+      { entity_name: entityName, project_name: projectName, filters: filterObject },
+      { required: ["entity_name", "project_name"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        total_count: s.nonNegativeInteger("The number of matching traces."),
+        root_traces_count: s.nonNegativeInteger("The number of matching root traces."),
+      },
+      "Weave trace counts.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "resolve_trace_roots",
+    description: "Resolve the root spans for a batch of classic Weave trace IDs.",
+    inputSchema: s.requiredObject("Input for resolving Weave trace roots.", {
+      entity_name: entityName,
+      project_name: projectName,
+      trace_ids: s.stringArray("Child trace IDs to resolve.", { minItems: 1 }),
+    }),
+    outputSchema: jsonObject("Resolved Weave trace roots.", {
+      roots: s.record("Root span details keyed by requested trace ID.", s.looseObject("One resolved root span.")),
+      resolved: s.nonNegativeInteger("The number of resolved trace IDs."),
+      total_requested: s.nonNegativeInteger("The number of requested trace IDs."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "query_wandb",
+    description: "Run a read-only GraphQL query against W&B experiment data with bounded pagination.",
+    inputSchema: s.object(
+      "Input for querying W&B GraphQL data.",
+      {
+        query: s.nonWhitespaceString("A read-only W&B GraphQL query."),
+        variables: s.looseObject("GraphQL variables."),
+        max_items: s.positiveInteger("Maximum total items returned across pages.", { default: 100 }),
+        items_per_page: s.positiveInteger("Items requested per GraphQL page.", { default: 20 }),
+      },
+      { required: ["query"] },
+    ),
+    outputSchema: s.unknown("The W&B GraphQL response selected by the query."),
+  }),
+  defineProviderAction(service, {
+    name: "create_report",
+    description: "Create a W&B report with narrative text, plots, and configurable panels.",
+    inputSchema: s.object(
+      "Input for creating a W&B report.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        title: s.nonWhitespaceString("The report title."),
+        description: s.string("Optional report description."),
+        markdown_report_text: s.string({ description: "Markdown narrative for the report.", default: "" }),
+        plots_html: s.anyOf("Plotly HTML supplied as one string or a name-to-HTML map.", [
+          s.string("A Plotly HTML document."),
+          s.record("Plotly HTML documents keyed by plot name.", s.string("One Plotly HTML document.")),
+        ]),
+        panels: s.array("W&B report panel definitions.", s.looseObject("One report panel definition.")),
+      },
+      { required: ["entity_name", "project_name", "title"] },
+    ),
+    outputSchema: s.string("A confirmation containing the saved W&B report URL."),
+  }),
+  defineProviderAction(service, {
+    name: "log_analysis",
+    description: "Log analysis rows, charts, and scalar metrics to W&B as a new run.",
+    inputSchema: s.object(
+      "Input for logging an analysis run to W&B.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        analysis_name: s.nonWhitespaceString("The analysis run name."),
+        data: s.array("Tabular analysis rows to log.", s.looseObject("One analysis row."), { minItems: 1 }),
+        charts: s.array("Chart definitions to log.", s.looseObject("One chart definition.")),
+        scalars: s.record("Scalar metrics keyed by metric name.", s.number("One scalar metric value.")),
+      },
+      { required: ["entity_name", "project_name", "analysis_name", "data"] },
+    ),
+    outputSchema: jsonObject("The W&B run created for the analysis.", {
+      run_id: s.string("The created W&B run ID."),
+      run_url: s.url("The created W&B run URL."),
+      logged_keys: s.stringArray("The logged metric and data keys."),
+      table_columns: s.stringArray("The logged table columns."),
+      row_count: s.nonNegativeInteger("The number of logged analysis rows."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_entities",
+    description: "List W&B user and team entities accessible with the configured API key.",
+    inputSchema: s.actionInput({}, [], "No input is required."),
+    outputSchema: jsonObject("Accessible W&B entities.", {
+      entities: s.array(
+        "Accessible W&B entities.",
+        s.looseObject("One W&B entity.", {
+          name: s.string("The entity name."),
+          type: s.string("The entity type."),
+        }),
+      ),
+      count: s.nonNegativeInteger("The number of returned entities."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_projects",
+    description: "List W&B projects for one entity or for all entities accessible with the configured API key.",
+    inputSchema: s.object(
+      "Input for listing W&B projects.",
+      {
+        entity: s.nonWhitespaceString("Optional W&B entity name."),
+        max_projects: s.positiveInteger("Maximum projects returned per entity.", { default: 50 }),
+      },
+      { required: [] },
+    ),
+    outputSchema: jsonObject("W&B projects grouped by entity.", {
+      projects: s.record("Projects keyed by W&B entity.", s.array(s.looseObject("One W&B project."))),
+      truncated: s.boolean("Whether project results were truncated."),
+      max_projects_per_entity: s.positiveInteger("The per-entity project limit."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_automations",
+    description: "List W&B Automations that trigger on artifact, run-state, or run-metric events.",
+    inputSchema: s.object(
+      "Input for listing W&B Automations.",
+      {
+        entity: s.nonWhitespaceString("Optional W&B entity name."),
+        name: s.nonWhitespaceString("Optional automation name filter."),
+        max_items: s.positiveInteger("Maximum automations to return.", { default: 50 }),
+      },
+      { required: [] },
+    ),
+    outputSchema: jsonObject("Matching W&B Automations.", {
+      automations: jsonItems("Matching W&B Automations."),
+      count: s.nonNegativeInteger("The number of returned automations."),
+      entity: s.nullableString("The filtered W&B entity."),
+      truncated: s.boolean("Whether results were truncated."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_integrations",
+    description: "List Slack and webhook integrations available as W&B Automation targets.",
+    inputSchema: s.object(
+      "Input for listing W&B integrations.",
+      {
+        entity: s.nonWhitespaceString("Optional W&B entity name."),
+        kind: s.stringEnum("Optional integration kind.", ["slack", "webhook"]),
+        max_items: s.positiveInteger("Maximum integrations to return.", { default: 50 }),
+      },
+      { required: [] },
+    ),
+    outputSchema: jsonObject("Matching W&B integrations.", {
+      integrations: jsonItems("Matching W&B integrations."),
+      count: s.nonNegativeInteger("The number of returned integrations."),
+      entity: s.nullableString("The filtered W&B entity."),
+      kind: s.nullableString("The filtered integration kind."),
+      truncated: s.boolean("Whether results were truncated."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "infer_trace_schema",
+    description: "Sample classic Weave traces to discover field paths, types, and frequent values.",
+    inputSchema: s.object(
+      "Input for inferring a Weave trace schema.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        sample_size: s.positiveInteger("Number of traces to sample.", { default: 20 }),
+        top_n_values: s.positiveInteger("Frequent values retained per field.", { default: 5 }),
+      },
+      { required: ["entity_name", "project_name"] },
+    ),
+    outputSchema: jsonObject("The inferred Weave trace schema.", {
+      fields: jsonItems("Discovered trace fields."),
+      total_traces: s.nonNegativeInteger("The total matching traces."),
+      root_traces: s.nonNegativeInteger("The total root traces."),
+      sample_size: s.nonNegativeInteger("The number of sampled traces."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "search_docs",
+    description: "Search the official W&B documentation for relevant guidance and examples.",
+    inputSchema: s.requiredObject("Input for searching W&B documentation.", {
+      query: s.nonWhitespaceString("The W&B documentation search query."),
+    }),
+    outputSchema: s.string("Relevant excerpts from the official W&B documentation."),
+  }),
+  defineProviderAction(service, {
+    name: "get_run_history",
+    description: "Retrieve sampled time-series metric history for a W&B run.",
+    inputSchema: s.object(
+      "Input for retrieving W&B run history.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        run_id: s.nonWhitespaceString("The W&B run ID."),
+        keys: s.stringArray("Metric keys to return."),
+        samples: s.positiveInteger("Maximum sampled history points.", { default: 500 }),
+        min_step: s.nonNegativeInteger("Optional minimum training step."),
+        max_step: s.nonNegativeInteger("Optional maximum training step."),
+      },
+      { required: ["entity_name", "project_name", "run_id"] },
+    ),
+    outputSchema: jsonObject("Sampled W&B run history.", {
+      history: s.array("Sampled metric history rows.", s.looseObject("One sampled history row.")),
+      run_id: s.string("The W&B run ID."),
+      run_name: s.string("The W&B run name."),
+      total_steps: s.nonNegativeInteger("The total available run steps."),
+      sampled_points: s.nonNegativeInteger("The number of returned points."),
+      keys_returned: s.stringArray("Metric keys present in the result."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_registries",
+    description: "List W&B model registries for an organization.",
+    inputSchema: s.object(
+      "Input for listing W&B registries.",
+      {
+        organization: s.nonWhitespaceString("Optional W&B organization name."),
+        filter: filterObject,
+        max_items: s.positiveInteger("Maximum registries to return.", { default: 50 }),
+      },
+      { required: [] },
+    ),
+    outputSchema: jsonObject("Matching W&B registries.", {
+      registries: jsonItems("Matching W&B registries."),
+      count: s.nonNegativeInteger("The number of returned registries."),
+      truncated: s.boolean("Whether results were truncated."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_registry_collections",
+    description: "List artifact collections within a W&B model registry.",
+    inputSchema: s.object(
+      "Input for listing W&B registry collections.",
+      {
+        registry_name: s.nonWhitespaceString("The W&B registry name."),
+        organization: s.nonWhitespaceString("Optional W&B organization name."),
+        filter: filterObject,
+        max_items: s.positiveInteger("Maximum collections to return.", { default: 50 }),
+      },
+      { required: ["registry_name"] },
+    ),
+    outputSchema: jsonObject("Collections in a W&B registry.", {
+      registry: jsonObject("The selected W&B registry."),
+      collections: jsonItems("Collections in the registry."),
+      count: s.nonNegativeInteger("The number of returned collections."),
+      truncated: s.boolean("Whether results were truncated."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "list_artifact_versions",
+    description: "List versions of a W&B project artifact or registry collection.",
+    inputSchema: s.object(
+      "Input for listing W&B artifact versions.",
+      {
+        collection_name: s.nonWhitespaceString("The artifact collection name."),
+        entity_name: entityName,
+        project_name: projectName,
+        registry_name: s.nonWhitespaceString("Optional W&B registry name."),
+        organization: s.nonWhitespaceString("Optional W&B organization name."),
+        type_name: s.nonWhitespaceString("Optional artifact type name."),
+        source: s.stringEnum("Whether the collection belongs to a project or registry.", ["project", "registry"]),
+        max_items: s.positiveInteger("Maximum artifact versions to return.", { default: 50 }),
+      },
+      { required: ["collection_name"] },
+    ),
+    outputSchema: jsonObject("Versions in a W&B artifact collection.", {
+      collection: jsonObject("The selected artifact collection."),
+      source: s.string("The artifact source type."),
+      versions: jsonItems("Artifact versions in the collection."),
+      count: s.nonNegativeInteger("The number of returned versions."),
+      truncated: s.boolean("Whether results were truncated."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_artifact_details",
+    description: "Get metadata, lineage, and optionally files for a W&B artifact version.",
+    inputSchema: s.object(
+      "Input for reading a W&B artifact version.",
+      {
+        artifact_name: s.nonWhitespaceString("The fully qualified artifact version name."),
+        type_name: s.nonWhitespaceString("Optional artifact type name."),
+        include_files: s.boolean({ description: "Whether to include artifact file entries.", default: false }),
+        max_files: s.positiveInteger("Maximum files to return when file entries are included.", { default: 50 }),
+      },
+      { required: ["artifact_name"] },
+    ),
+    outputSchema: jsonObject("W&B artifact version details.", {
+      artifact: jsonObject("Artifact metadata."),
+      lineage: jsonObject("Artifact lineage information."),
+      files: jsonItems("Optional artifact file entries."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "compare_artifact_versions",
+    description: "Compare metadata, aliases, tags, lineage, sizes, and optionally files for two W&B artifact versions.",
+    inputSchema: s.object(
+      "Input for comparing W&B artifact versions.",
+      {
+        artifact_name_a: s.nonWhitespaceString("The first fully qualified artifact version name."),
+        artifact_name_b: s.nonWhitespaceString("The second fully qualified artifact version name."),
+        type_name: s.nonWhitespaceString("Optional artifact type name."),
+        include_file_diff: s.boolean({ description: "Whether to include file-level differences.", default: true }),
+        max_file_diff_entries: s.positiveInteger("Maximum file-difference entries to return.", { default: 50 }),
+      },
+      { required: ["artifact_name_a", "artifact_name_b"] },
+    ),
+    outputSchema: artifactDiffOutput,
+  }),
+  defineProviderAction(service, {
+    name: "compare_runs",
+    description: "Compare configuration, summary metrics, metadata, and optionally metric history for two W&B runs.",
+    inputSchema: s.object(
+      "Input for comparing W&B runs.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        run_id_a: s.nonWhitespaceString("The first W&B run ID."),
+        run_id_b: s.nonWhitespaceString("The second W&B run ID."),
+        include_history_overlap: s.boolean({
+          description: "Whether to compare overlapping sampled metric history.",
+          default: false,
+        }),
+        history_keys: s.stringArray("Metric keys used for history comparison."),
+        history_samples: s.positiveInteger("Maximum history samples per run.", { default: 50 }),
+      },
+      { required: ["entity_name", "project_name", "run_id_a", "run_id_b"] },
+    ),
+    outputSchema: jsonObject("A structured comparison of two W&B runs.", {
+      run_a: jsonObject("Details for the first W&B run."),
+      run_b: jsonObject("Details for the second W&B run."),
+      config_diff: jsonObject("Run configuration differences."),
+      summary_diff: jsonObject("Run summary metric differences."),
+      metadata_diff: jsonObject("Run metadata differences."),
+      history_comparison: jsonObject("Optional sampled history comparison."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "summarize_evaluation",
+    description: "Aggregate classic Weave evaluation results for a project or named evaluation.",
+    inputSchema: s.object(
+      "Input for summarizing Weave evaluations.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        eval_name: s.nonWhitespaceString("Optional evaluation name filter."),
+        max_evals: s.positiveInteger("Maximum evaluations to aggregate.", { default: 5 }),
+        include_per_task: s.boolean({ description: "Whether to include per-task aggregates.", default: false }),
+      },
+      { required: ["entity_name", "project_name"] },
+    ),
+    outputSchema: jsonObject("Aggregated Weave evaluation results.", {
+      evaluations: jsonItems("Matching evaluation summaries."),
+      count: s.nonNegativeInteger("The number of summarized evaluations."),
+      project: s.string("The W&B project name."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "diagnose_run",
+    description: "Inspect loss metrics and run state to diagnose the training health of a W&B run.",
+    inputSchema: s.object(
+      "Input for diagnosing a W&B run.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        run_id: s.nonWhitespaceString("The W&B run ID."),
+        loss_key: s.nonWhitespaceString("Optional training-loss metric key."),
+        val_loss_key: s.nonWhitespaceString("Optional validation-loss metric key."),
+      },
+      { required: ["entity_name", "project_name", "run_id"] },
+    ),
+    outputSchema: jsonObject("The W&B run health diagnosis.", {
+      run_id: s.string("The diagnosed W&B run ID."),
+      run_name: s.string("The W&B run name."),
+      run_state: s.string("The W&B run state."),
+      diagnosis: s.unknown("Training-health findings and recommendations."),
+      loss_stats: jsonObject("Calculated loss statistics."),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "probe_project",
+    description: "Sample W&B runs to discover a project's metrics, configuration keys, tags, groups, and structure.",
+    inputSchema: s.object(
+      "Input for probing a W&B project.",
+      {
+        entity_name: entityName,
+        project_name: projectName,
+        sample_runs: s.positiveInteger("Maximum runs to sample.", { default: 5 }),
+      },
+      { required: ["entity_name", "project_name"] },
+    ),
+    outputSchema: jsonObject("The discovered W&B project structure.", {
+      entity: s.string("The W&B entity name."),
+      project: s.string("The W&B project name."),
+      run_count: s.nonNegativeInteger("The project run count."),
+      sampled_runs: jsonItems("Sampled W&B runs."),
+      metric_keys: s.stringArray("Discovered metric keys."),
+      config_keys: s.stringArray("Discovered configuration keys."),
+      tags: s.stringArray("Discovered run tags."),
+      groups: s.stringArray("Discovered run groups."),
+      recommendations: s.stringArray("Suggested follow-up actions."),
+    }),
+  }),
+];

--- a/src/providers/wandb/definition.ts
+++ b/src/providers/wandb/definition.ts
@@ -28,7 +28,7 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "https://mcp.withwandb.com/mcp",
           description:
-            "Optional full W&B MCP endpoint. Leave blank to use the hosted service, or enter the /mcp URL exposed by a W&B Dedicated or self-hosted MCP deployment.",
+            "Optional full W&B MCP endpoint. Leave blank to use the hosted service for W&B Dedicated Cloud, or enter the /mcp URL of a separately deployed server for Self-Managed W&B. The hosted endpoint does not support W&B Multi-tenant Cloud.",
         },
       ],
     },

--- a/src/providers/wandb/definition.ts
+++ b/src/providers/wandb/definition.ts
@@ -1,0 +1,38 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { wandbActions } from "./actions.ts";
+
+const service = "wandb";
+
+/** Weights & Biases provider backed by the official W&B MCP server. */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Weights & Biases",
+  description:
+    "Query W&B experiments, Weave traces, artifacts, registries, automations, and reports through the official W&B MCP server.",
+  categories: ["AI", "Analytics", "Developer Tools"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "W&B API Key",
+      placeholder: "Paste your W&B API key",
+      description:
+        "A W&B API key sent to the MCP server as an Authorization Bearer token. Create or copy a key at https://wandb.ai/authorize.",
+      extraFields: [
+        {
+          key: "mcpEndpoint",
+          label: "MCP Endpoint URL",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "https://mcp.withwandb.com/mcp",
+          description:
+            "Optional full W&B MCP endpoint. Leave blank to use the hosted service, or enter the /mcp URL exposed by a W&B Dedicated or self-hosted MCP deployment.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://wandb.ai",
+  actions: wandbActions,
+};

--- a/src/providers/wandb/executors.ts
+++ b/src/providers/wandb/executors.ts
@@ -1,5 +1,6 @@
 import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
 
+import { optionalStringArray } from "../../core/cast.ts";
 import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderFetch, defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
 import { createWandbMcpContext, validateWandbMcpCredential, wandbMcpActionHandlers } from "./runtime.ts";
@@ -16,6 +17,7 @@ export const executors: ProviderExecutors = defineProviderExecutors({
       credential.values,
       fetcher,
       context.signal,
+      optionalStringArray(credential.metadata.availableActions),
       isPrivateNetworkAccessAllowed(),
     );
   },

--- a/src/providers/wandb/executors.ts
+++ b/src/providers/wandb/executors.ts
@@ -1,0 +1,34 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { createProviderFetch, defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
+import { createWandbMcpContext, validateWandbMcpCredential, wandbMcpActionHandlers } from "./runtime.ts";
+
+const service = "wandb";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: wandbMcpActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch) {
+    const credential = await requireApiKeyCredential(context, service);
+    return createWandbMcpContext(
+      credential.apiKey,
+      credential.values,
+      fetcher,
+      context.signal,
+      isPrivateNetworkAccessAllowed(),
+    );
+  },
+  fallbackMessage: "W&B MCP request failed",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    const guardedFetcher = createProviderFetch({
+      fetch: fetcher,
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+    return validateWandbMcpCredential(input.apiKey, input.values, guardedFetcher, signal);
+  },
+};

--- a/src/providers/wandb/runtime.test.ts
+++ b/src/providers/wandb/runtime.test.ts
@@ -68,6 +68,20 @@ describe("W&B MCP runtime", () => {
     });
   });
 
+  it.each([
+    [401, 401],
+    [403, 401],
+    [404, 400],
+    [429, 429],
+    [500, 502],
+  ])("maps MCP HTTP status %i to provider status %i", async (upstreamStatus, providerStatus) => {
+    const fetcher = vi.fn(async () => new Response("request failed", { status: upstreamStatus })) as typeof fetch;
+
+    await expect(validateWandbMcpCredential("secret-key", {}, fetcher)).rejects.toMatchObject({
+      status: providerStatus,
+    });
+  });
+
   it("maps local actions to the official W&B MCP tool names", () => {
     expect(wandbMcpTools).toMatchObject({
       query_wandb: "query_wandb_tool",

--- a/src/providers/wandb/runtime.test.ts
+++ b/src/providers/wandb/runtime.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import {
+  callWandbMcpTool,
+  createWandbMcpContext,
+  normalizeWandbMcpEndpoint,
+  validateWandbMcpCredential,
+  wandbMcpTools,
+} from "./runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("W&B MCP endpoint", () => {
+  it("uses the hosted endpoint by default", () => {
+    expect(normalizeWandbMcpEndpoint(undefined).toString()).toBe("https://mcp.withwandb.com/mcp");
+    expect(normalizeWandbMcpEndpoint("   ").toString()).toBe("https://mcp.withwandb.com/mcp");
+  });
+
+  it("preserves a custom full endpoint path and removes URL metadata", () => {
+    expect(normalizeWandbMcpEndpoint("https://wandb.example.com/custom/mcp/?tenant=one#section").toString()).toBe(
+      "https://wandb.example.com/custom/mcp/",
+    );
+  });
+
+  it("rejects embedded credentials and unsafe HTTP endpoints", () => {
+    expect(() => normalizeWandbMcpEndpoint("https://user:pass@wandb.example.com/mcp")).toThrow(
+      "must not include username or password",
+    );
+    expect(() => normalizeWandbMcpEndpoint("http://wandb.example.com/mcp")).toThrow("require private-network access");
+    expect(() => normalizeWandbMcpEndpoint("http://10.0.0.8/mcp")).toThrow("private or reserved IP addresses");
+    expect(normalizeWandbMcpEndpoint("http://10.0.0.8/mcp", true).toString()).toBe("http://10.0.0.8/mcp");
+  });
+});
+
+describe("W&B MCP runtime", () => {
+  it("validates a feature-gated tool subset with Bearer auth and Worker-safe schemas", async () => {
+    const requests: CapturedRequest[] = [];
+    const fetcher = createStreamableMcpFetch({
+      tools: [wandbMcpTools.list_entities, wandbMcpTools.query_wandb],
+      requests,
+    });
+
+    // Warm the SDK's Node-only validation path so the assertion isolates tool schema validation.
+    await validateWandbMcpCredential("secret-key", {}, fetcher);
+    vi.stubGlobal("Function", function disabledFunctionConstructor() {
+      throw new EvalError("Code generation from strings disallowed for this context");
+    });
+
+    const result = await validateWandbMcpCredential("secret-key", {}, fetcher);
+
+    expect(result.metadata).toMatchObject({
+      mcpEndpoint: "https://mcp.withwandb.com/mcp",
+      discoveredToolCount: 2,
+      availableActions: ["query_wandb", "list_entities"],
+    });
+    expect(requests.every((request) => request.url === "https://mcp.withwandb.com/mcp")).toBe(true);
+    expect(requests.every((request) => request.authorization === "Bearer secret-key")).toBe(true);
+  });
+
+  it("rejects endpoints that expose no supported W&B tools", async () => {
+    const fetcher = createStreamableMcpFetch({ tools: ["unrelated_tool"] });
+
+    await expect(validateWandbMcpCredential("secret-key", {}, fetcher)).rejects.toMatchObject({
+      status: 502,
+      message: "W&B MCP endpoint did not expose any supported tools",
+    });
+  });
+
+  it("maps local actions to the official W&B MCP tool names", () => {
+    expect(wandbMcpTools).toMatchObject({
+      query_wandb: "query_wandb_tool",
+      create_report: "create_wandb_report_tool",
+      log_analysis: "log_analysis_to_wandb",
+      list_projects: "query_wandb_entity_projects",
+      probe_project: "probe_project_tool",
+    });
+    expect(Object.keys(wandbMcpTools)).toHaveLength(22);
+  });
+
+  it("parses JSON text tool results", async () => {
+    const requests: CapturedRequest[] = [];
+    const fetcher = createStreamableMcpFetch({
+      tools: [wandbMcpTools.list_entities],
+      callResult: { content: [{ type: "text", text: '{"entities":[{"name":"team"}]}' }] },
+      requests,
+    });
+    const context = createWandbMcpContext("secret-key", { mcpEndpoint: "https://wandb.example.com/api/mcp" }, fetcher);
+
+    await expect(callWandbMcpTool(context, wandbMcpTools.list_entities, {})).resolves.toEqual({
+      entities: [{ name: "team" }],
+    });
+    expect(requests.find((request) => request.method === "tools/call")?.params).toEqual({
+      name: "list_entities_tool",
+      arguments: {},
+    });
+  });
+
+  it("returns plain text and structured tool results", async () => {
+    const plainContext = createWandbMcpContext(
+      "key",
+      {},
+      createStreamableMcpFetch({
+        tools: [wandbMcpTools.search_docs],
+        callResult: { content: [{ type: "text", text: "W&B documentation result" }] },
+      }),
+    );
+    await expect(callWandbMcpTool(plainContext, wandbMcpTools.search_docs, { query: "runs" })).resolves.toBe(
+      "W&B documentation result",
+    );
+
+    const structuredContext = createWandbMcpContext(
+      "key",
+      {},
+      createStreamableMcpFetch({
+        tools: [wandbMcpTools.query_wandb],
+        callResult: {
+          content: [{ type: "text", text: "fallback" }],
+          structuredContent: { data: { project: "demo" } },
+        },
+      }),
+    );
+    await expect(callWandbMcpTool(structuredContext, wandbMcpTools.query_wandb, { query: "query" })).resolves.toEqual({
+      data: { project: "demo" },
+    });
+  });
+
+  it("turns MCP tool errors into provider errors", async () => {
+    const context = createWandbMcpContext(
+      "key",
+      {},
+      createStreamableMcpFetch({
+        tools: [wandbMcpTools.query_wandb],
+        callResult: { isError: true, content: [{ type: "text", text: "query rejected" }] },
+      }),
+    );
+
+    await expect(callWandbMcpTool(context, wandbMcpTools.query_wandb, { query: "mutation" })).rejects.toEqual(
+      expect.objectContaining<Partial<ProviderRequestError>>({
+        status: 502,
+        message: "W&B MCP tool query_wandb_tool returned an error: query rejected",
+      }),
+    );
+  });
+});
+
+interface CapturedRequest {
+  url: string;
+  authorization: string | null;
+  method: string;
+  params?: unknown;
+}
+
+interface MockMcpOptions {
+  tools: string[];
+  callResult?: Record<string, unknown>;
+  requests?: CapturedRequest[];
+}
+
+function createStreamableMcpFetch(options: MockMcpOptions): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = readRequest(init);
+    const headers = new Headers(init?.headers);
+    options.requests?.push({
+      url: input instanceof Request ? input.url : input.toString(),
+      authorization: headers.get("authorization"),
+      method: typeof request.method === "string" ? request.method : (init?.method ?? "GET"),
+      params: request.params,
+    });
+
+    if (!Object.hasOwn(request, "id")) {
+      return new Response(null, { status: 202 });
+    }
+
+    const result =
+      request.method === "initialize"
+        ? {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            serverInfo: { name: "wandb-mcp-server", version: "0.3.7" },
+          }
+        : request.method === "tools/list"
+          ? {
+              tools: options.tools.map((name) => ({
+                name,
+                inputSchema: { type: "object" },
+                outputSchema: { type: "object" },
+              })),
+            }
+          : (options.callResult ?? { content: [] });
+
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }), {
+      headers: {
+        "content-type": "application/json",
+        "mcp-session-id": "wandb-test-session",
+      },
+    });
+  }) as typeof fetch;
+}
+
+function readRequest(init?: RequestInit): Record<string, unknown> {
+  return typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+}

--- a/src/providers/wandb/runtime.test.ts
+++ b/src/providers/wandb/runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
+import { executors } from "./executors.ts";
 import {
   callWandbMcpTool,
   createWandbMcpContext,
@@ -111,6 +112,24 @@ describe("W&B MCP runtime", () => {
     });
   });
 
+  it("unwraps FastMCP structured results for string-returning tools", async () => {
+    const context = createWandbMcpContext(
+      "key",
+      {},
+      createStreamableMcpFetch({
+        tools: [wandbMcpTools.list_entities],
+        callResult: {
+          content: [{ type: "text", text: '{"entities":[{"name":"team"}]}' }],
+          structuredContent: { result: '{"entities":[{"name":"team"}]}' },
+        },
+      }),
+    );
+
+    await expect(callWandbMcpTool(context, wandbMcpTools.list_entities, {})).resolves.toEqual({
+      entities: [{ name: "team" }],
+    });
+  });
+
   it("returns plain text and structured tool results", async () => {
     const plainContext = createWandbMcpContext(
       "key",
@@ -138,6 +157,58 @@ describe("W&B MCP runtime", () => {
     await expect(callWandbMcpTool(structuredContext, wandbMcpTools.query_wandb, { query: "query" })).resolves.toEqual({
       data: { project: "demo" },
     });
+  });
+
+  it.each([
+    ["invalid_input", 400],
+    ["quota_exceeded", 429],
+    ["timeout", 504],
+    ["api_error", 502],
+  ])("turns W&B %s result payloads into provider errors", async (error, status) => {
+    const context = createWandbMcpContext(
+      "key",
+      {},
+      createStreamableMcpFetch({
+        tools: [wandbMcpTools.query_wandb],
+        callResult: {
+          content: [{ type: "text", text: JSON.stringify({ error, message: "query rejected" }) }],
+          structuredContent: { result: JSON.stringify({ error, message: "query rejected" }) },
+        },
+      }),
+    );
+
+    await expect(callWandbMcpTool(context, wandbMcpTools.query_wandb, { query: "query" })).rejects.toEqual(
+      expect.objectContaining<Partial<ProviderRequestError>>({
+        status,
+        message: "W&B MCP tool query_wandb_tool returned an error: query rejected",
+      }),
+    );
+  });
+
+  it("rejects actions outside the tool subset stored by credential validation", async () => {
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+    const result = await executors["wandb.query_wandb"]!(
+      { query: "query" },
+      {
+        getCredential: async () => ({
+          authType: "api_key",
+          apiKey: "key",
+          values: {},
+          profile: { accountId: "account", displayName: "W&B", grantedScopes: [] },
+          metadata: { availableActions: ["list_entities"] },
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "W&B MCP action query_wandb is not available for this connection",
+      },
+    });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("turns MCP tool errors into provider errors", async () => {

--- a/src/providers/wandb/runtime.ts
+++ b/src/providers/wandb/runtime.ts
@@ -24,7 +24,7 @@ const defaultEndpoint = "https://mcp.withwandb.com/mcp";
 const requestTimeoutMs = 60_000;
 const wandbMcpJsonSchemaValidator = new CfWorkerJsonSchemaValidator();
 
-export const wandbMcpTools = {
+export const wandbMcpTools: Record<string, string> = {
   query_weave_traces: "query_weave_traces_tool",
   count_weave_traces: "count_weave_traces_tool",
   resolve_trace_roots: "resolve_trace_roots_tool",
@@ -47,19 +47,13 @@ export const wandbMcpTools = {
   summarize_evaluation: "summarize_evaluation_tool",
   diagnose_run: "diagnose_run_tool",
   probe_project: "probe_project_tool",
-} as const;
+};
 
-type WandbActionName = keyof typeof wandbMcpTools;
-
-export const wandbMcpActionHandlers: Record<
-  WandbActionName,
-  ProviderRuntimeHandler<WandbMcpContext>
-> = Object.fromEntries(
-  Object.entries(wandbMcpTools).map(([actionName, toolName]) => [
-    actionName,
-    (input: Record<string, unknown>, context: WandbMcpContext) => callWandbMcpTool(context, toolName, input),
-  ]),
-) as Record<WandbActionName, ProviderRuntimeHandler<WandbMcpContext>>;
+export const wandbMcpActionHandlers: Record<string, ProviderRuntimeHandler<WandbMcpContext>> = {};
+for (const [actionName, toolName] of Object.entries(wandbMcpTools)) {
+  wandbMcpActionHandlers[actionName] = (input: Record<string, unknown>, context: WandbMcpContext) =>
+    callWandbMcpTool(context, toolName, input);
+}
 
 export function createWandbMcpContext(
   apiKey: string,
@@ -131,7 +125,7 @@ export function normalizeWandbMcpEndpoint(
 
 export async function callWandbMcpTool(
   context: WandbMcpContext,
-  toolName: (typeof wandbMcpTools)[WandbActionName],
+  toolName: string,
   args: Record<string, unknown>,
 ): Promise<unknown> {
   return withWandbMcpClient(context, async (client) => {
@@ -231,17 +225,15 @@ function mapWandbMcpError(error: unknown): ProviderRequestError {
   }
   if (error instanceof StreamableHTTPError) {
     const status = error.code;
-    return new ProviderRequestError(
-      status === 401 || status === 403
-        ? 401
-        : status === 429
-          ? 429
-          : status && status >= 400 && status < 500
-            ? 400
-            : 502,
-      `W&B MCP request failed: ${error.message}`,
-      error,
-    );
+    let providerStatus = 502;
+    if (status === 401 || status === 403) {
+      providerStatus = 401;
+    } else if (status === 429) {
+      providerStatus = 429;
+    } else if (status && status >= 400 && status < 500) {
+      providerStatus = 400;
+    }
+    return new ProviderRequestError(providerStatus, `W&B MCP request failed: ${error.message}`, error);
   }
   if (error instanceof McpError) {
     return error.code === ErrorCode.RequestTimeout

--- a/src/providers/wandb/runtime.ts
+++ b/src/providers/wandb/runtime.ts
@@ -7,13 +7,14 @@ import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontex
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import { createHash } from "node:crypto";
-import { optionalString } from "../../core/cast.ts";
+import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export interface WandbMcpContext {
   endpoint: URL;
   apiKey: string;
+  availableActions?: ReadonlySet<string>;
   fetcher: ProviderFetch;
   signal?: AbortSignal;
 }
@@ -51,8 +52,12 @@ export const wandbMcpTools: Record<string, string> = {
 
 export const wandbMcpActionHandlers: Record<string, ProviderRuntimeHandler<WandbMcpContext>> = {};
 for (const [actionName, toolName] of Object.entries(wandbMcpTools)) {
-  wandbMcpActionHandlers[actionName] = (input: Record<string, unknown>, context: WandbMcpContext) =>
-    callWandbMcpTool(context, toolName, input);
+  wandbMcpActionHandlers[actionName] = async (input: Record<string, unknown>, context: WandbMcpContext) => {
+    if (context.availableActions && !context.availableActions.has(actionName)) {
+      throw new ProviderRequestError(400, `W&B MCP action ${actionName} is not available for this connection`);
+    }
+    return callWandbMcpTool(context, toolName, input);
+  };
 }
 
 export function createWandbMcpContext(
@@ -60,11 +65,13 @@ export function createWandbMcpContext(
   values: Record<string, string>,
   fetcher: ProviderFetch,
   signal?: AbortSignal,
+  availableActions?: readonly string[],
   allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
 ): WandbMcpContext {
   return {
     endpoint: normalizeWandbMcpEndpoint(optionalString(values.mcpEndpoint), allowPrivateNetwork),
     apiKey,
+    availableActions: availableActions ? new Set(availableActions) : undefined,
     fetcher,
     signal,
   };
@@ -186,18 +193,49 @@ function normalizeWandbMcpToolResult(toolName: string, result: WandbMcpToolResul
     );
   }
   if (result.structuredContent) {
-    return result.structuredContent;
+    const structured = optionalRecord(result.structuredContent);
+    const payload =
+      structured && Object.keys(structured).length === 1 && typeof structured.result === "string"
+        ? parseWandbMcpText(structured.result)
+        : result.structuredContent;
+    return normalizeWandbMcpPayload(toolName, payload);
   }
 
   const textItems = result.content.filter((content) => content.type === "text");
   if (textItems.length === 1) {
-    try {
-      return JSON.parse(textItems[0]!.text) as unknown;
-    } catch {
-      return textItems[0]!.text;
-    }
+    return normalizeWandbMcpPayload(toolName, parseWandbMcpText(textItems[0]!.text));
   }
   return result;
+}
+
+function parseWandbMcpText(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function normalizeWandbMcpPayload(toolName: string, payload: unknown): unknown {
+  const record = optionalRecord(payload);
+  const error = optionalString(record?.error);
+  if (!error) {
+    return payload;
+  }
+
+  const status =
+    error === "timeout"
+      ? 504
+      : error === "quota_exceeded"
+        ? 429
+        : ["invalid_input", "query_too_complex", "query_too_large", "read_only_violation"].includes(error)
+          ? 400
+          : 502;
+  throw new ProviderRequestError(
+    status,
+    `W&B MCP tool ${toolName} returned an error: ${optionalString(record?.message) ?? error}`,
+    payload,
+  );
 }
 
 function formatWandbMcpToolContent(result: Extract<WandbMcpToolResult, { content: unknown }>): string {

--- a/src/providers/wandb/runtime.ts
+++ b/src/providers/wandb/runtime.ts
@@ -1,0 +1,263 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
+import { createHash } from "node:crypto";
+import { optionalString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+export interface WandbMcpContext {
+  endpoint: URL;
+  apiKey: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+type WandbMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+const defaultEndpoint = "https://mcp.withwandb.com/mcp";
+const requestTimeoutMs = 60_000;
+const wandbMcpJsonSchemaValidator = new CfWorkerJsonSchemaValidator();
+
+export const wandbMcpTools = {
+  query_weave_traces: "query_weave_traces_tool",
+  count_weave_traces: "count_weave_traces_tool",
+  resolve_trace_roots: "resolve_trace_roots_tool",
+  query_wandb: "query_wandb_tool",
+  create_report: "create_wandb_report_tool",
+  log_analysis: "log_analysis_to_wandb",
+  list_entities: "list_entities_tool",
+  list_projects: "query_wandb_entity_projects",
+  list_automations: "list_wandb_automations_tool",
+  list_integrations: "list_wandb_integrations_tool",
+  infer_trace_schema: "infer_trace_schema_tool",
+  search_docs: "search_wandb_docs_tool",
+  get_run_history: "get_run_history_tool",
+  list_registries: "list_registries_tool",
+  list_registry_collections: "list_registry_collections_tool",
+  list_artifact_versions: "list_artifact_versions_tool",
+  get_artifact_details: "get_artifact_details_tool",
+  compare_artifact_versions: "compare_artifact_versions_tool",
+  compare_runs: "compare_runs_tool",
+  summarize_evaluation: "summarize_evaluation_tool",
+  diagnose_run: "diagnose_run_tool",
+  probe_project: "probe_project_tool",
+} as const;
+
+type WandbActionName = keyof typeof wandbMcpTools;
+
+export const wandbMcpActionHandlers: Record<
+  WandbActionName,
+  ProviderRuntimeHandler<WandbMcpContext>
+> = Object.fromEntries(
+  Object.entries(wandbMcpTools).map(([actionName, toolName]) => [
+    actionName,
+    (input: Record<string, unknown>, context: WandbMcpContext) => callWandbMcpTool(context, toolName, input),
+  ]),
+) as Record<WandbActionName, ProviderRuntimeHandler<WandbMcpContext>>;
+
+export function createWandbMcpContext(
+  apiKey: string,
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): WandbMcpContext {
+  return {
+    endpoint: normalizeWandbMcpEndpoint(optionalString(values.mcpEndpoint), allowPrivateNetwork),
+    apiKey,
+    fetcher,
+    signal,
+  };
+}
+
+export async function validateWandbMcpCredential(
+  apiKey: string,
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createWandbMcpContext(apiKey, values, fetcher, signal);
+  const discoveredTools = await listWandbMcpTools(context);
+  const discoveredToolNames = new Set(discoveredTools);
+  const availableActions = Object.entries(wandbMcpTools)
+    .filter(([, toolName]) => discoveredToolNames.has(toolName))
+    .map(([actionName]) => actionName);
+  if (availableActions.length === 0) {
+    throw new ProviderRequestError(502, "W&B MCP endpoint did not expose any supported tools");
+  }
+
+  const endpointId = formatEndpointId(context.endpoint);
+  const credentialHash = createHash("sha256").update(endpointId).update("\0").update(apiKey).digest("hex").slice(0, 16);
+  return {
+    profile: {
+      accountId: `wandb:mcp:${credentialHash}`,
+      displayName: `W&B MCP · ${context.endpoint.host}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpEndpoint: endpointId,
+      discoveredToolCount: discoveredTools.length,
+      availableActions,
+    },
+  };
+}
+
+export function normalizeWandbMcpEndpoint(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): URL {
+  const raw = optionalString(value) ?? defaultEndpoint;
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "mcpEndpoint",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password) {
+    throw new ProviderRequestError(400, "mcpEndpoint must not include username or password");
+  }
+  if (url.protocol === "http:" && !allowPrivateNetwork) {
+    throw new ProviderRequestError(400, "http mcpEndpoint URLs require private-network access to be enabled");
+  }
+  url.search = "";
+  url.hash = "";
+  return url;
+}
+
+export async function callWandbMcpTool(
+  context: WandbMcpContext,
+  toolName: (typeof wandbMcpTools)[WandbActionName],
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  return withWandbMcpClient(context, async (client) => {
+    const result = await client.callTool({ name: toolName, arguments: args }, undefined, {
+      timeout: requestTimeoutMs,
+      signal: context.signal,
+    });
+    return normalizeWandbMcpToolResult(toolName, result);
+  });
+}
+
+async function listWandbMcpTools(context: WandbMcpContext): Promise<string[]> {
+  return withWandbMcpClient(context, async (client) => {
+    const result = await client.listTools(
+      {},
+      {
+        timeout: requestTimeoutMs,
+        signal: context.signal,
+      },
+    );
+    return result.tools.map((tool) => tool.name);
+  });
+}
+
+async function withWandbMcpClient<T>(context: WandbMcpContext, run: (client: Client) => Promise<T>): Promise<T> {
+  const headers = new Headers({
+    authorization: `Bearer ${context.apiKey}`,
+    "user-agent": providerUserAgent,
+  });
+  const transport = new StreamableHTTPClientTransport(context.endpoint, {
+    fetch: context.fetcher,
+    requestInit: { headers },
+  });
+  const client = new Client(
+    { name: "oomol-connect-wandb", version: "1.0.0" },
+    { jsonSchemaValidator: wandbMcpJsonSchemaValidator },
+  );
+
+  try {
+    await client.connect(transport, { timeout: requestTimeoutMs, signal: context.signal });
+    return await run(client);
+  } catch (error) {
+    throw mapWandbMcpError(error);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function normalizeWandbMcpToolResult(toolName: string, result: WandbMcpToolResult): unknown {
+  if ("toolResult" in result) {
+    return result;
+  }
+  if (result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `W&B MCP tool ${toolName} returned an error: ${formatWandbMcpToolContent(result)}`,
+      result,
+    );
+  }
+  if (result.structuredContent) {
+    return result.structuredContent;
+  }
+
+  const textItems = result.content.filter((content) => content.type === "text");
+  if (textItems.length === 1) {
+    try {
+      return JSON.parse(textItems[0]!.text) as unknown;
+    } catch {
+      return textItems[0]!.text;
+    }
+  }
+  return result;
+}
+
+function formatWandbMcpToolContent(result: Extract<WandbMcpToolResult, { content: unknown }>): string {
+  const text = result.content
+    .map((content) => {
+      if (content.type === "text") return content.text;
+      if (content.type === "resource") return "text" in content.resource ? content.resource.text : content.resource.uri;
+      if (content.type === "resource_link") return content.uri;
+      return content.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+  return text.slice(0, 300) || "empty error content";
+}
+
+function formatEndpointId(endpoint: URL): string {
+  const pathname = endpoint.pathname === "/" ? "" : endpoint.pathname.replace(/\/+$/u, "");
+  return `${endpoint.origin}${pathname}`;
+}
+
+function mapWandbMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "W&B API key is invalid or expired", error);
+  }
+  if (error instanceof StreamableHTTPError) {
+    const status = error.code;
+    return new ProviderRequestError(
+      status === 401 || status === 403
+        ? 401
+        : status === 429
+          ? 429
+          : status && status >= 400 && status < 500
+            ? 400
+            : 502,
+      `W&B MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof McpError) {
+    return error.code === ErrorCode.RequestTimeout
+      ? new ProviderRequestError(504, "W&B MCP request timed out", error)
+      : new ProviderRequestError(502, `W&B MCP request failed: ${error.message}`, error);
+  }
+  if (isAbortError(error)) {
+    return new ProviderRequestError(504, "W&B MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `W&B MCP request failed: ${error.message}` : "W&B MCP request failed",
+    error,
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}


### PR DESCRIPTION
## Summary

- Add a searchable Weights & Biases provider backed by the official W&B MCP server.
- Map the server’s 22 default tools to typed Open Connector actions and discover the subset exposed by each deployment.
- Use the hosted `https://mcp.withwandb.com/mcp` endpoint by default, with an optional full MCP endpoint for W&B Dedicated and self-hosted deployments.
- Authenticate with the W&B API key as a Bearer token and route MCP traffic through the guarded provider fetch path.
- Validate Streamable HTTP tool schemas with the Worker-safe validator and normalize structured, JSON-text, and plain-text tool results.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (60 files, 591 tests)
- `npm run build`