### PR TITLE
fix(cloudflare): shard catalog assets

### DIFF
--- a/scripts/copy-catalog-assets.test.ts
+++ b/scripts/copy-catalog-assets.test.ts
@@ -49,9 +49,10 @@ describe("copyCatalogAssets", () => {
     const { sourceDir, targetDir } = await fixture();
     await writeFile(join(sourceDir, "broken-provider.json"), "{invalid");
 
-    await expect(copyCatalogAssets({ sourceDir, targetDir })).rejects.toThrow(
-      "Failed to parse catalog provider file: broken-provider.json",
-    );
+    await expect(copyCatalogAssets({ sourceDir, targetDir })).rejects.toMatchObject({
+      message: "Failed to parse catalog provider file: broken-provider.json",
+      cause: expect.any(SyntaxError),
+    });
   });
 
   it("writes an empty index for an empty catalog", async () => {

--- a/scripts/copy-catalog-assets.test.ts
+++ b/scripts/copy-catalog-assets.test.ts
@@ -1,0 +1,65 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { copyCatalogAssets } from "./copy-catalog-assets.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("copyCatalogAssets", () => {
+  it("writes deterministic, size-bounded chunks in provider filename order", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    await writeFile(join(sourceDir, "zulu.json"), JSON.stringify({ service: "zulu", label: "中中" }));
+    await writeFile(join(sourceDir, "alpha.json"), JSON.stringify({ service: "alpha", label: "中中" }));
+
+    const index = await copyCatalogAssets({ sourceDir, targetDir, maxChunkBytes: 45 });
+
+    expect(index).toEqual({
+      version: 1,
+      providerCount: 2,
+      chunks: ["apps-0000.json", "apps-0001.json"],
+    });
+    expect(JSON.parse(await readFile(join(targetDir, "index.json"), "utf8"))).toEqual(index);
+    expect(JSON.parse(await readFile(join(targetDir, "apps-0000.json"), "utf8"))).toEqual([
+      { service: "alpha", label: "中中" },
+    ]);
+    expect(JSON.parse(await readFile(join(targetDir, "apps-0001.json"), "utf8"))).toEqual([
+      { service: "zulu", label: "中中" },
+    ]);
+    for (const chunk of index.chunks) {
+      expect(Buffer.byteLength(await readFile(join(targetDir, chunk), "utf8"))).toBeLessThanOrEqual(45);
+    }
+    expect((await readdir(targetDir)).sort()).toEqual(["apps-0000.json", "apps-0001.json", "index.json"]);
+  });
+
+  it("accounts for UTF-8 bytes when rejecting an oversized provider", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    await writeFile(join(sourceDir, "unicode.json"), JSON.stringify({ label: "中中" }));
+
+    await expect(copyCatalogAssets({ sourceDir, targetDir, maxChunkBytes: 19 })).rejects.toThrow(
+      "unicode.json requires 21 bytes",
+    );
+  });
+
+  it("writes an empty index for an empty catalog", async () => {
+    const { sourceDir, targetDir } = await fixture();
+
+    const index = await copyCatalogAssets({ sourceDir, targetDir });
+
+    expect(index).toEqual({ version: 1, providerCount: 0, chunks: [] });
+    expect(await readdir(targetDir)).toEqual(["index.json"]);
+  });
+});
+
+async function fixture(): Promise<{ sourceDir: string; targetDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "open-connector-catalog-"));
+  temporaryDirectories.push(root);
+  const sourceDir = join(root, "source");
+  const targetDir = join(root, "target");
+  await mkdir(sourceDir);
+  return { sourceDir, targetDir };
+}

--- a/scripts/copy-catalog-assets.test.ts
+++ b/scripts/copy-catalog-assets.test.ts
@@ -1,7 +1,10 @@
+import type { AssetsBinding } from "../src/server/cloudflare/cloudflare-bindings.ts";
+
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { loadCatalogFromAssets } from "../src/server/cloudflare/catalog-assets.ts";
 import { copyCatalogAssets } from "./copy-catalog-assets.ts";
 
 const temporaryDirectories: string[] = [];
@@ -36,6 +39,36 @@ describe("copyCatalogAssets", () => {
     expect((await readdir(targetDir)).sort()).toEqual(["apps-0000.json", "apps-0001.json", "index.json"]);
   });
 
+  // Production chunks hold ~170 providers each, so the greedy fill and its separator accounting —
+  // not the one-provider-per-chunk degenerate case above — are what the byte cap actually rests on.
+  it("packs as many providers into a chunk as the byte cap allows", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    // Each provider serializes to 9 bytes, so three of them plus two commas and `[`, `]`, `\n`
+    // fill a 32-byte chunk exactly and the fourth must start the next one.
+    for (const s of ["a", "b", "c", "d"]) {
+      await writeFile(join(sourceDir, `${s}.json`), JSON.stringify({ s }));
+    }
+
+    const index = await copyCatalogAssets({ sourceDir, targetDir, maxChunkBytes: 32 });
+
+    expect(index.chunks).toEqual(["apps-0000.json", "apps-0001.json"]);
+    expect(await readFile(join(targetDir, "apps-0000.json"), "utf8")).toBe('[{"s":"a"},{"s":"b"},{"s":"c"}]\n');
+    expect(await readFile(join(targetDir, "apps-0001.json"), "utf8")).toBe('[{"s":"d"}]\n');
+    expect(Buffer.byteLength(await readFile(join(targetDir, "apps-0000.json"), "utf8"))).toBe(32);
+  });
+
+  it("replaces chunks left behind by an earlier build", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, "apps-0007.json"), "[]\n");
+    await writeFile(join(targetDir, "apps.json"), "[]\n");
+    await writeFile(join(sourceDir, "alpha.json"), JSON.stringify({ service: "alpha" }));
+
+    await copyCatalogAssets({ sourceDir, targetDir });
+
+    expect((await readdir(targetDir)).sort()).toEqual(["apps-0000.json", "index.json"]);
+  });
+
   it("accounts for UTF-8 bytes when rejecting an oversized provider", async () => {
     const { sourceDir, targetDir } = await fixture();
     await writeFile(join(sourceDir, "unicode.json"), JSON.stringify({ label: "中中" }));
@@ -63,7 +96,51 @@ describe("copyCatalogAssets", () => {
     expect(index).toEqual({ version: 1, providerCount: 0, chunks: [] });
     expect(await readdir(targetDir)).toEqual(["index.json"]);
   });
+
+  // The index shape and the `apps-NNNN.json` naming are declared once here and once in the worker
+  // loader, so nothing but this round trip stops the two ends of the asset contract from drifting.
+  it("produces an asset layout the Cloudflare worker loader can read back", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    for (const service of ["alpha", "zulu"]) {
+      await writeFile(join(sourceDir, `${service}.json`), JSON.stringify(providerDefinition(service)));
+    }
+
+    const index = await copyCatalogAssets({ sourceDir, targetDir, maxChunkBytes: 256 });
+    const catalog = await loadCatalogFromAssets(directoryAssets(targetDir));
+
+    expect(index.chunks.length).toBeGreaterThan(1);
+    expect(catalog.providers.map((entry) => entry.service)).toEqual(["alpha", "zulu"]);
+  });
 });
+
+/** Serve a directory the way the Cloudflare assets binding does, including its SPA miss behaviour. */
+function directoryAssets(directory: string): AssetsBinding {
+  return {
+    async fetch(request) {
+      const name = new URL(request.url).pathname.replace("/catalog/", "");
+      try {
+        return new Response(await readFile(join(directory, name), "utf8"), {
+          headers: { "content-type": "application/json" },
+        });
+      } catch {
+        return new Response("<!doctype html><html></html>", {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
+    },
+  };
+}
+
+function providerDefinition(service: string): Record<string, unknown> {
+  return {
+    service,
+    displayName: service,
+    categories: ["Developer Tools"],
+    authTypes: ["no_auth"],
+    auth: [{ type: "no_auth" }],
+    actions: [],
+  };
+}
 
 async function fixture(): Promise<{ sourceDir: string; targetDir: string }> {
   const root = await mkdtemp(join(tmpdir(), "open-connector-catalog-"));

--- a/scripts/copy-catalog-assets.test.ts
+++ b/scripts/copy-catalog-assets.test.ts
@@ -45,6 +45,15 @@ describe("copyCatalogAssets", () => {
     );
   });
 
+  it("includes the provider filename when JSON parsing fails", async () => {
+    const { sourceDir, targetDir } = await fixture();
+    await writeFile(join(sourceDir, "broken-provider.json"), "{invalid");
+
+    await expect(copyCatalogAssets({ sourceDir, targetDir })).rejects.toThrow(
+      "Failed to parse catalog provider file: broken-provider.json",
+    );
+  });
+
   it("writes an empty index for an empty catalog", async () => {
     const { sourceDir, targetDir } = await fixture();
 

--- a/scripts/copy-catalog-assets.ts
+++ b/scripts/copy-catalog-assets.ts
@@ -1,21 +1,95 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const sourceDir = join(process.cwd(), "catalog/apps");
-const targetDir = join(process.cwd(), "dist/web/catalog");
-const catalogPath = join(targetDir, "apps.json");
+export const defaultCatalogChunkBytes = 4 * 1024 * 1024;
 
-const entries = (await readdir(sourceDir, { withFileTypes: true }))
-  .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-  .sort((a, b) => a.name.localeCompare(b.name));
-const providers = entries.map((entry) => entry.name.slice(0, -".json".length));
-const apps = await Promise.all(
-  entries.map(async (entry) => JSON.parse(await readFile(join(sourceDir, entry.name), "utf8")) as unknown),
-);
+export interface CopyCatalogAssetsOptions {
+  sourceDir: string;
+  targetDir: string;
+  maxChunkBytes?: number;
+}
 
-await rm(targetDir, { recursive: true, force: true });
-await mkdir(targetDir, { recursive: true });
+export interface CatalogAssetIndex {
+  version: 1;
+  providerCount: number;
+  chunks: string[];
+}
 
-await writeFile(catalogPath, `${JSON.stringify(apps)}\n`);
+/** Copy generated provider definitions into deterministic, size-bounded static asset chunks. */
+export async function copyCatalogAssets(options: CopyCatalogAssetsOptions): Promise<CatalogAssetIndex> {
+  const maxChunkBytes = options.maxChunkBytes ?? defaultCatalogChunkBytes;
+  if (!Number.isSafeInteger(maxChunkBytes) || maxChunkBytes < 4) {
+    throw new Error("Catalog chunk size must be a safe integer of at least 4 bytes");
+  }
 
-console.log(`Copied ${providers.length} catalog apps to static assets.`);
+  const entries = (await readdir(options.sourceDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const providers = await Promise.all(
+    entries.map(async (entry) => ({
+      filename: entry.name,
+      json: JSON.stringify(JSON.parse(await readFile(join(options.sourceDir, entry.name), "utf8")) as unknown),
+    })),
+  );
+  const chunks = createChunks(providers, maxChunkBytes);
+
+  await rm(options.targetDir, { recursive: true, force: true });
+  await mkdir(options.targetDir, { recursive: true });
+
+  const chunkNames = chunks.map((_, index) => `apps-${index.toString().padStart(4, "0")}.json`);
+  const index: CatalogAssetIndex = {
+    version: 1,
+    providerCount: providers.length,
+    chunks: chunkNames,
+  };
+
+  await Promise.all([
+    writeFile(join(options.targetDir, "index.json"), `${JSON.stringify(index)}\n`),
+    ...chunks.map((chunk, index) => writeFile(join(options.targetDir, chunkNames[index]!), chunk)),
+  ]);
+
+  return index;
+}
+
+interface SerializedProvider {
+  filename: string;
+  json: string;
+}
+
+function createChunks(providers: SerializedProvider[], maxChunkBytes: number): string[] {
+  const chunks: string[] = [];
+  let entries: string[] = [];
+  let chunkBytes = 3; // Opening and closing brackets plus the trailing newline.
+
+  for (const provider of providers) {
+    const providerBytes = Buffer.byteLength(provider.json);
+    const addedBytes = providerBytes + (entries.length === 0 ? 0 : 1);
+    if (providerBytes + 3 > maxChunkBytes) {
+      throw new Error(
+        `Catalog provider ${provider.filename} requires ${providerBytes + 3} bytes, exceeding the ${maxChunkBytes}-byte chunk limit`,
+      );
+    }
+
+    if (entries.length > 0 && chunkBytes + addedBytes > maxChunkBytes) {
+      chunks.push(`[${entries.join(",")}]\n`);
+      entries = [];
+      chunkBytes = 3;
+    }
+
+    chunkBytes += providerBytes + (entries.length === 0 ? 0 : 1);
+    entries.push(provider.json);
+  }
+
+  if (entries.length > 0) {
+    chunks.push(`[${entries.join(",")}]\n`);
+  }
+
+  return chunks;
+}
+
+if (import.meta.main) {
+  const sourceDir = join(process.cwd(), "catalog/apps");
+  const targetDir = join(process.cwd(), "dist/web/catalog");
+  const index = await copyCatalogAssets({ sourceDir, targetDir });
+  console.log(`Copied ${index.providerCount} catalog apps into ${index.chunks.length} static asset chunks.`);
+}

--- a/scripts/copy-catalog-assets.ts
+++ b/scripts/copy-catalog-assets.ts
@@ -26,10 +26,17 @@ export async function copyCatalogAssets(options: CopyCatalogAssetsOptions): Prom
     .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   const providers = await Promise.all(
-    entries.map(async (entry) => ({
-      filename: entry.name,
-      json: JSON.stringify(JSON.parse(await readFile(join(options.sourceDir, entry.name), "utf8")) as unknown),
-    })),
+    entries.map(async (entry) => {
+      const content = await readFile(join(options.sourceDir, entry.name), "utf8");
+      try {
+        return {
+          filename: entry.name,
+          json: JSON.stringify(JSON.parse(content) as unknown),
+        };
+      } catch (cause) {
+        throw new Error(`Failed to parse catalog provider file: ${entry.name}`, { cause });
+      }
+    }),
   );
   const chunks = createChunks(providers, maxChunkBytes);
 

--- a/src/server/cloudflare.test.ts
+++ b/src/server/cloudflare.test.ts
@@ -88,7 +88,7 @@ describe("cloudflare worker", () => {
       DB: new UnusedD1Database(),
       TRANSIT_FILES: namespace,
       TRANSIT_FILES_BACKEND: "kv",
-      ASSETS: memoryAssets({ "/catalog/apps.json": [provider] }),
+      ASSETS: memoryAssets(chunkedCatalog()),
     };
 
     const form = new FormData();
@@ -123,7 +123,7 @@ describe("cloudflare worker", () => {
       DB: new UnusedD1Database(),
       TRANSIT_FILES: bucket,
       // TRANSIT_FILES_BACKEND intentionally omitted -> must fall back to R2.
-      ASSETS: memoryAssets({ "/catalog/apps.json": [provider] }),
+      ASSETS: memoryAssets(chunkedCatalog()),
     };
 
     const form = new FormData();
@@ -155,9 +155,7 @@ function createEnv(): CloudflareEnv {
   return {
     DB: new UnusedD1Database(),
     TRANSIT_FILES: new UnusedR2Bucket(),
-    ASSETS: memoryAssets({
-      "/catalog/apps.json": [provider],
-    }),
+    ASSETS: memoryAssets(chunkedCatalog()),
   };
 }
 
@@ -165,6 +163,14 @@ function createExecutionContext(): Parameters<typeof worker.fetch>[2] {
   return {
     waitUntil() {},
     passThroughOnException() {},
+  };
+}
+
+/** The asset layout `scripts/copy-catalog-assets.ts` emits, so the worker tests boot the shipped path. */
+function chunkedCatalog(): Record<string, unknown> {
+  return {
+    "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["apps-0000.json"] },
+    "/catalog/apps-0000.json": [provider],
   };
 }
 

--- a/src/server/cloudflare/catalog-assets.test.ts
+++ b/src/server/cloudflare/catalog-assets.test.ts
@@ -38,11 +38,37 @@ describe("loadCatalogFromAssets", () => {
     expect(catalog.actionsById.get("example.ping")?.execution.locallyExecutable).toBe(true);
   });
 
+  it("loads chunked providers in index order", async () => {
+    const second = { ...provider, service: "aardvark", actions: [] };
+    const catalog = await loadCatalogFromAssets(
+      memoryAssets({
+        "/catalog/index.json": { version: 1, providerCount: 2, chunks: ["apps-0000.json", "apps-0001.json"] },
+        "/catalog/apps-0000.json": [provider],
+        "/catalog/apps-0001.json": [second],
+      }),
+    );
+
+    expect(catalog.providers.map((entry) => entry.service)).toEqual(["aardvark", "example"]);
+  });
+
   it("falls back to the legacy catalog asset when the index is missing", async () => {
     const catalog = await loadCatalogFromAssets(
       memoryAssets({
         "/catalog/apps.json": [provider],
       }),
+    );
+
+    expect(catalog.providers[0]?.service).toBe("example");
+  });
+
+  it("falls back to the legacy catalog asset when a missing index resolves to the SPA shell", async () => {
+    const catalog = await loadCatalogFromAssets(
+      memoryAssets(
+        {
+          "/catalog/apps.json": [provider],
+        },
+        "spa-shell",
+      ),
     );
 
     expect(catalog.providers[0]?.service).toBe("example");
@@ -56,6 +82,27 @@ describe("loadCatalogFromAssets", () => {
         }),
       ),
     ).rejects.toThrow("Cloudflare asset catalog request failed: /catalog/apps-0000.json returned 404");
+  });
+
+  it("fails when a missing index chunk resolves to the SPA shell", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets(
+          {
+            "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["apps-0000.json"] },
+          },
+          "spa-shell",
+        ),
+      ),
+    ).rejects.toThrow(
+      "Cloudflare asset catalog request failed: /catalog/apps-0000.json returned content type text/html; charset=utf-8 instead of JSON",
+    );
+  });
+
+  it("fails when the assets binding reports a server error", async () => {
+    await expect(
+      loadCatalogFromAssets(memoryAssets({ "/catalog/index.json": new Response("boom", { status: 500 }) })),
+    ).rejects.toThrow("Cloudflare asset catalog request failed: /catalog/index.json returned 500");
   });
 
   it("fails when the loaded provider count does not match the index", async () => {
@@ -100,23 +147,50 @@ describe("loadCatalogFromAssets", () => {
     ).rejects.toThrow("Cloudflare asset catalog must be an array: /catalog/apps-0000.json");
   });
 
+  it("rejects a catalog asset that is not valid JSON", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": new Response("{", { headers: { "content-type": "application/json" } }),
+        }),
+      ),
+    ).rejects.toThrow("Cloudflare asset catalog contains invalid JSON: /catalog/index.json");
+  });
+
   it("fails when both the index and legacy catalog are missing", async () => {
     await expect(loadCatalogFromAssets(memoryAssets({}))).rejects.toThrow(
       "Cloudflare asset catalog request failed: /catalog/apps.json returned 404",
     );
   });
+
+  it("fails when both the index and legacy catalog resolve to the SPA shell", async () => {
+    await expect(loadCatalogFromAssets(memoryAssets({}, "spa-shell"))).rejects.toThrow(
+      "Cloudflare asset catalog request failed: /catalog/apps.json returned content type text/html; charset=utf-8 instead of JSON",
+    );
+  });
 });
 
-function memoryAssets(files: Record<string, unknown>): AssetsBinding {
+/**
+ * How the assets binding answers a path it does not have.
+ *
+ * `not_found_handling: "single-page-application"` serves `index.html` with status 200 for binding
+ * fetches too, so `"spa-shell"` is what the deployed worker actually sees.
+ */
+type MissingAssetBehavior = "404" | "spa-shell";
+
+function memoryAssets(files: Record<string, unknown>, missing: MissingAssetBehavior = "404"): AssetsBinding {
   return {
     async fetch(request) {
       expect(request.headers.get("accept")).toBe("application/json");
       const pathname = new URL(request.url).pathname;
       if (!(pathname in files)) {
-        return new Response("not found", { status: 404 });
+        return missing === "spa-shell"
+          ? new Response("<!doctype html><html></html>", { headers: { "content-type": "text/html; charset=utf-8" } })
+          : new Response("not found", { status: 404 });
       }
 
-      return Response.json(files[pathname]);
+      const file = files[pathname];
+      return file instanceof Response ? file : Response.json(file);
     },
   };
 }

--- a/src/server/cloudflare/catalog-assets.test.ts
+++ b/src/server/cloudflare/catalog-assets.test.ts
@@ -38,17 +38,21 @@ describe("loadCatalogFromAssets", () => {
     expect(catalog.actionsById.get("example.ping")?.execution.locallyExecutable).toBe(true);
   });
 
-  it("loads chunked providers in index order", async () => {
-    const second = { ...provider, service: "aardvark", actions: [] };
+  // The store sorts providers, so chunk order is not observable; what must be pinned is that every
+  // chunk the index lists is fetched and merged, not just the first one.
+  it("merges providers from every chunk the index lists", async () => {
     const catalog = await loadCatalogFromAssets(
       memoryAssets({
-        "/catalog/index.json": { version: 1, providerCount: 2, chunks: ["apps-0000.json", "apps-0001.json"] },
+        "/catalog/index.json": { version: 1, providerCount: 3, chunks: ["apps-0000.json", "apps-0001.json"] },
         "/catalog/apps-0000.json": [provider],
-        "/catalog/apps-0001.json": [second],
+        "/catalog/apps-0001.json": [
+          { ...provider, service: "zulu", actions: [] },
+          { ...provider, service: "aardvark", actions: [] },
+        ],
       }),
     );
 
-    expect(catalog.providers.map((entry) => entry.service)).toEqual(["aardvark", "example"]);
+    expect(catalog.providers.map((entry) => entry.service)).toEqual(["aardvark", "example", "zulu"]);
   });
 
   it("falls back to the legacy catalog asset when the index is missing", async () => {
@@ -157,15 +161,15 @@ describe("loadCatalogFromAssets", () => {
     ).rejects.toThrow("Cloudflare asset catalog contains invalid JSON: /catalog/index.json");
   });
 
-  it("fails when both the index and legacy catalog are missing", async () => {
+  it("names both the index and the legacy catalog when neither is present", async () => {
     await expect(loadCatalogFromAssets(memoryAssets({}))).rejects.toThrow(
-      "Cloudflare asset catalog request failed: /catalog/apps.json returned 404",
+      "Cloudflare asset catalog request failed: /catalog/index.json returned 404, and /catalog/apps.json returned 404",
     );
   });
 
-  it("fails when both the index and legacy catalog resolve to the SPA shell", async () => {
+  it("names both the index and the legacy catalog when both resolve to the SPA shell", async () => {
     await expect(loadCatalogFromAssets(memoryAssets({}, "spa-shell"))).rejects.toThrow(
-      "Cloudflare asset catalog request failed: /catalog/apps.json returned content type text/html; charset=utf-8 instead of JSON",
+      "Cloudflare asset catalog request failed: /catalog/index.json returned content type text/html; charset=utf-8 instead of JSON, and /catalog/apps.json returned content type text/html; charset=utf-8 instead of JSON",
     );
   });
 });

--- a/src/server/cloudflare/catalog-assets.test.ts
+++ b/src/server/cloudflare/catalog-assets.test.ts
@@ -24,12 +24,13 @@ const provider = {
 };
 
 describe("loadCatalogFromAssets", () => {
-  it("loads providers from the catalog asset", async () => {
+  it("loads providers from catalog index chunks", async () => {
     const catalog = await loadCatalogFromAssets(
       memoryAssets({
-        "/catalog/apps.json": [provider],
+        "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["apps-0000.json"] },
+        "/catalog/apps-0000.json": [provider],
       }),
-      { executableActionIds: ["example.ping"] },
+      { executableServices: ["example"] },
     );
 
     expect(catalog.providers).toHaveLength(1);
@@ -37,7 +38,69 @@ describe("loadCatalogFromAssets", () => {
     expect(catalog.actionsById.get("example.ping")?.execution.locallyExecutable).toBe(true);
   });
 
-  it("fails when the catalog asset is missing", async () => {
+  it("falls back to the legacy catalog asset when the index is missing", async () => {
+    const catalog = await loadCatalogFromAssets(
+      memoryAssets({
+        "/catalog/apps.json": [provider],
+      }),
+    );
+
+    expect(catalog.providers[0]?.service).toBe("example");
+  });
+
+  it("fails when an index chunk is missing", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["apps-0000.json"] },
+        }),
+      ),
+    ).rejects.toThrow("Cloudflare asset catalog request failed: /catalog/apps-0000.json returned 404");
+  });
+
+  it("fails when the loaded provider count does not match the index", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": { version: 1, providerCount: 2, chunks: ["apps-0000.json"] },
+          "/catalog/apps-0000.json": [provider],
+        }),
+      ),
+    ).rejects.toThrow("index declares 2, loaded 1");
+  });
+
+  it("rejects invalid index chunk paths", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["../apps.json"] },
+        }),
+      ),
+    ).rejects.toThrow("index contains an invalid chunk name");
+  });
+
+  it("rejects unsupported catalog index versions", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": { version: 2, providerCount: 0, chunks: [] },
+        }),
+      ),
+    ).rejects.toThrow("Unsupported Cloudflare asset catalog index version: 2");
+  });
+
+  it("rejects catalog chunks that are not arrays", async () => {
+    await expect(
+      loadCatalogFromAssets(
+        memoryAssets({
+          "/catalog/index.json": { version: 1, providerCount: 1, chunks: ["apps-0000.json"] },
+          "/catalog/apps-0000.json": provider,
+        }),
+      ),
+    ).rejects.toThrow("Cloudflare asset catalog must be an array: /catalog/apps-0000.json");
+  });
+
+  it("fails when both the index and legacy catalog are missing", async () => {
     await expect(loadCatalogFromAssets(memoryAssets({}))).rejects.toThrow(
       "Cloudflare asset catalog request failed: /catalog/apps.json returned 404",
     );
@@ -47,6 +110,7 @@ describe("loadCatalogFromAssets", () => {
 function memoryAssets(files: Record<string, unknown>): AssetsBinding {
   return {
     async fetch(request) {
+      expect(request.headers.get("accept")).toBe("application/json");
       const pathname = new URL(request.url).pathname;
       if (!(pathname in files)) {
         return new Response("not found", { status: 404 });

--- a/src/server/cloudflare/catalog-assets.ts
+++ b/src/server/cloudflare/catalog-assets.ts
@@ -7,6 +7,7 @@ import { createCatalogStore, resolveExecutableActionIds } from "../../catalog-st
 const catalogIndexPath = "/catalog/index.json";
 const legacyCatalogPath = "/catalog/apps.json";
 const chunkNamePattern = /^apps-\d{4}\.json$/;
+const jsonContentTypePattern = /^application\/(?:[\w.+-]+\+)?json$/i;
 
 interface CatalogAssetIndex {
   version: 1;
@@ -14,28 +15,20 @@ interface CatalogAssetIndex {
   chunks: string[];
 }
 
+/** A catalog asset read attempt: either the parsed JSON, or why the asset is treated as absent. */
+type CatalogAsset = { found: true; value: unknown } | { found: false; reason: string };
+
 export async function loadCatalogFromAssets(
   assets: AssetsBinding,
   options: LoadCatalogOptions = {},
 ): Promise<CatalogStore> {
-  const indexResponse = await fetchAsset(assets, catalogIndexPath);
-  if (indexResponse.status === 404) {
-    const providers = requireProviderArray(await readJsonAsset(assets, legacyCatalogPath), legacyCatalogPath);
-    return createCatalogStore(providers, {
-      executableActionIds: resolveExecutableActionIds(providers, options),
-    });
-  }
-  if (!indexResponse.ok) {
-    throw assetRequestError(catalogIndexPath, indexResponse.status);
+  const indexAsset = await readJsonAsset(assets, catalogIndexPath);
+  if (!indexAsset.found) {
+    return createCatalog(await requireProviderArrayAsset(assets, legacyCatalogPath), options);
   }
 
-  const index = parseCatalogIndex(await readResponseJson(indexResponse, catalogIndexPath));
-  const chunks = await Promise.all(
-    index.chunks.map(async (chunk) => {
-      const path = `/catalog/${chunk}`;
-      return requireProviderArray(await readJsonAsset(assets, path), path);
-    }),
-  );
+  const index = parseCatalogIndex(indexAsset.value, catalogIndexPath);
+  const chunks = await Promise.all(index.chunks.map((chunk) => requireProviderArrayAsset(assets, `/catalog/${chunk}`)));
   const providers = chunks.flat();
   if (providers.length !== index.providerCount) {
     throw new Error(
@@ -43,14 +36,18 @@ export async function loadCatalogFromAssets(
     );
   }
 
+  return createCatalog(providers, options);
+}
+
+function createCatalog(providers: ProviderDefinition[], options: LoadCatalogOptions): CatalogStore {
   return createCatalogStore(providers, {
     executableActionIds: resolveExecutableActionIds(providers, options),
   });
 }
 
-function parseCatalogIndex(value: unknown): CatalogAssetIndex {
+function parseCatalogIndex(value: unknown, path: string): CatalogAssetIndex {
   if (!isRecord(value)) {
-    throw new Error("Cloudflare asset catalog index must be an object");
+    throw new Error(`Cloudflare asset catalog index must be an object: ${path}`);
   }
   const keys = Object.keys(value).sort();
   if (keys.join(",") !== "chunks,providerCount,version") {
@@ -83,28 +80,54 @@ function parseCatalogIndex(value: unknown): CatalogAssetIndex {
   };
 }
 
-function requireProviderArray(value: unknown, path: string): ProviderDefinition[] {
-  if (!Array.isArray(value)) {
+async function requireProviderArrayAsset(assets: AssetsBinding, path: string): Promise<ProviderDefinition[]> {
+  const asset = await readJsonAsset(assets, path);
+  if (!asset.found) {
+    throw assetRequestError(path, asset.reason);
+  }
+  if (!Array.isArray(asset.value)) {
     throw new Error(`Cloudflare asset catalog must be an array: ${path}`);
   }
-  return value as ProviderDefinition[];
+
+  return asset.value as ProviderDefinition[];
 }
 
-async function readJsonAsset(assets: AssetsBinding, path: string): Promise<unknown> {
+/**
+ * Read one catalog asset as JSON, reporting absence instead of throwing.
+ *
+ * `not_found_handling: "single-page-application"` (see `wrangler.example.jsonc`) makes the assets
+ * binding answer an unknown path with `index.html` and status 200 rather than 404, and it does so
+ * for binding fetches regardless of the request's `Accept` header. Absence is therefore decided by
+ * the response content type as well as by the status, so a deployment whose assets predate catalog
+ * chunking still resolves to the legacy catalog instead of failing on the SPA shell.
+ */
+async function readJsonAsset(assets: AssetsBinding, path: string): Promise<CatalogAsset> {
   const response = await fetchAsset(assets, path);
-  if (!response.ok) {
-    throw assetRequestError(path, response.status);
+  if (response.status === 404) {
+    return { found: false, reason: "returned 404" };
   }
-  return readResponseJson(response, path);
+  if (!response.ok) {
+    throw assetRequestError(path, `returned ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!isJsonContentType(contentType)) {
+    return { found: false, reason: `returned content type ${contentType ?? "(none)"} instead of JSON` };
+  }
+
+  return { found: true, value: await readResponseJson(response, path) };
 }
 
 function fetchAsset(assets: AssetsBinding, path: string): Promise<Response> {
-  // Avoid treating a missing JSON asset as an SPA navigation that returns index.html.
   return assets.fetch(
     new Request(new URL(path, "https://assets.local"), {
       headers: { accept: "application/json" },
     }),
   );
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+  return contentType !== null && jsonContentTypePattern.test(contentType.split(";", 1)[0]!.trim());
 }
 
 async function readResponseJson(response: Response, path: string): Promise<unknown> {
@@ -115,8 +138,8 @@ async function readResponseJson(response: Response, path: string): Promise<unkno
   }
 }
 
-function assetRequestError(path: string, status: number): Error {
-  return new Error(`Cloudflare asset catalog request failed: ${path} returned ${status}`);
+function assetRequestError(path: string, reason: string): Error {
+  return new Error(`Cloudflare asset catalog request failed: ${path} ${reason}`);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/server/cloudflare/catalog-assets.ts
+++ b/src/server/cloudflare/catalog-assets.ts
@@ -4,23 +4,121 @@ import type { AssetsBinding } from "./cloudflare-bindings.ts";
 
 import { createCatalogStore, resolveExecutableActionIds } from "../../catalog-store.ts";
 
-const catalogAssetPath = "/catalog/apps.json";
+const catalogIndexPath = "/catalog/index.json";
+const legacyCatalogPath = "/catalog/apps.json";
+const chunkNamePattern = /^apps-\d{4}\.json$/;
+
+interface CatalogAssetIndex {
+  version: 1;
+  providerCount: number;
+  chunks: string[];
+}
 
 export async function loadCatalogFromAssets(
   assets: AssetsBinding,
   options: LoadCatalogOptions = {},
 ): Promise<CatalogStore> {
-  const providers = (await readJsonAsset(assets, catalogAssetPath)) as ProviderDefinition[];
+  const indexResponse = await fetchAsset(assets, catalogIndexPath);
+  if (indexResponse.status === 404) {
+    const providers = requireProviderArray(await readJsonAsset(assets, legacyCatalogPath), legacyCatalogPath);
+    return createCatalogStore(providers, {
+      executableActionIds: resolveExecutableActionIds(providers, options),
+    });
+  }
+  if (!indexResponse.ok) {
+    throw assetRequestError(catalogIndexPath, indexResponse.status);
+  }
+
+  const index = parseCatalogIndex(await readResponseJson(indexResponse, catalogIndexPath));
+  const chunks = await Promise.all(
+    index.chunks.map(async (chunk) => {
+      const path = `/catalog/${chunk}`;
+      return requireProviderArray(await readJsonAsset(assets, path), path);
+    }),
+  );
+  const providers = chunks.flat();
+  if (providers.length !== index.providerCount) {
+    throw new Error(
+      `Cloudflare asset catalog provider count mismatch: index declares ${index.providerCount}, loaded ${providers.length}`,
+    );
+  }
+
   return createCatalogStore(providers, {
     executableActionIds: resolveExecutableActionIds(providers, options),
   });
 }
 
-async function readJsonAsset(assets: AssetsBinding, path: string): Promise<unknown> {
-  const response = await assets.fetch(new Request(new URL(path, "https://assets.local")));
-  if (!response.ok) {
-    throw new Error(`Cloudflare asset catalog request failed: ${path} returned ${response.status}`);
+function parseCatalogIndex(value: unknown): CatalogAssetIndex {
+  if (!isRecord(value)) {
+    throw new Error("Cloudflare asset catalog index must be an object");
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.join(",") !== "chunks,providerCount,version") {
+    throw new Error("Cloudflare asset catalog index must contain only version, providerCount, and chunks");
+  }
+  if (value.version !== 1) {
+    throw new Error(`Unsupported Cloudflare asset catalog index version: ${String(value.version)}`);
+  }
+  if (
+    typeof value.providerCount !== "number" ||
+    !Number.isSafeInteger(value.providerCount) ||
+    value.providerCount < 0
+  ) {
+    throw new Error("Cloudflare asset catalog index providerCount must be a non-negative safe integer");
+  }
+  if (!Array.isArray(value.chunks) || !value.chunks.every((chunk): chunk is string => typeof chunk === "string")) {
+    throw new Error("Cloudflare asset catalog index chunks must be an array of strings");
+  }
+  if (!value.chunks.every((chunk) => chunkNamePattern.test(chunk))) {
+    throw new Error("Cloudflare asset catalog index contains an invalid chunk name");
+  }
+  if (new Set(value.chunks).size !== value.chunks.length) {
+    throw new Error("Cloudflare asset catalog index contains duplicate chunks");
   }
 
-  return response.json() as Promise<unknown>;
+  return {
+    version: 1,
+    providerCount: value.providerCount,
+    chunks: value.chunks,
+  };
+}
+
+function requireProviderArray(value: unknown, path: string): ProviderDefinition[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Cloudflare asset catalog must be an array: ${path}`);
+  }
+  return value as ProviderDefinition[];
+}
+
+async function readJsonAsset(assets: AssetsBinding, path: string): Promise<unknown> {
+  const response = await fetchAsset(assets, path);
+  if (!response.ok) {
+    throw assetRequestError(path, response.status);
+  }
+  return readResponseJson(response, path);
+}
+
+function fetchAsset(assets: AssetsBinding, path: string): Promise<Response> {
+  // Avoid treating a missing JSON asset as an SPA navigation that returns index.html.
+  return assets.fetch(
+    new Request(new URL(path, "https://assets.local"), {
+      headers: { accept: "application/json" },
+    }),
+  );
+}
+
+async function readResponseJson(response: Response, path: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`Cloudflare asset catalog contains invalid JSON: ${path}`);
+  }
+}
+
+function assetRequestError(path: string, status: number): Error {
+  return new Error(`Cloudflare asset catalog request failed: ${path} returned ${status}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/server/cloudflare/catalog-assets.ts
+++ b/src/server/cloudflare/catalog-assets.ts
@@ -24,7 +24,13 @@ export async function loadCatalogFromAssets(
 ): Promise<CatalogStore> {
   const indexAsset = await readJsonAsset(assets, catalogIndexPath);
   if (!indexAsset.found) {
-    return createCatalog(await requireProviderArrayAsset(assets, legacyCatalogPath), options);
+    const legacyAsset = await readJsonAsset(assets, legacyCatalogPath);
+    if (!legacyAsset.found) {
+      // Naming both paths matters: current builds emit only the index, so an operator seeing just
+      // the legacy failure would chase an asset the build stopped producing.
+      throw assetRequestError(catalogIndexPath, `${indexAsset.reason}, and ${legacyCatalogPath} ${legacyAsset.reason}`);
+    }
+    return createCatalog(requireProviderArray(legacyAsset.value, legacyCatalogPath), options);
   }
 
   const index = parseCatalogIndex(indexAsset.value, catalogIndexPath);
@@ -85,11 +91,16 @@ async function requireProviderArrayAsset(assets: AssetsBinding, path: string): P
   if (!asset.found) {
     throw assetRequestError(path, asset.reason);
   }
-  if (!Array.isArray(asset.value)) {
+
+  return requireProviderArray(asset.value, path);
+}
+
+function requireProviderArray(value: unknown, path: string): ProviderDefinition[] {
+  if (!Array.isArray(value)) {
     throw new Error(`Cloudflare asset catalog must be an array: ${path}`);
   }
 
-  return asset.value as ProviderDefinition[];
+  return value as ProviderDefinition[];
 }
 
 /**

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -3,4 +3,4 @@
 
 /catalog/*
   Cache-Control: public, max-age=0, must-revalidate
-  Cloudflare-CDN-Cache-Control: public, max-age=31536000, stale-while-revalidate=86400
+  Cloudflare-CDN-Cache-Control: public, max-age=0, must-revalidate

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,6 +1,6 @@
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
-/catalog/apps.json
+/catalog/*
   Cache-Control: public, max-age=0, must-revalidate
   Cloudflare-CDN-Cache-Control: public, max-age=31536000, stale-while-revalidate=86400


### PR DESCRIPTION
## Summary

- replace the monolithic Cloudflare `/catalog/apps.json` build output with a versioned `/catalog/index.json`
- write deterministic, sequential catalog chunks capped at 4 MiB by their final UTF-8 byte size
- load all indexed chunks through the existing `ASSETS` binding while preserving `CatalogStore` and public API response shapes
- retain a loader fallback to `/catalog/apps.json` for deployments using the previous asset format
- request catalog assets as JSON so a missing index is not treated as an SPA navigation

This is the catalog follow-up requested in #235 after the executable registry reduction merged in #237.

## Why

On the current `main` catalog (1,210 providers and 12,894 actions), the generated `apps.json` is 26,030,332 bytes (24.8245 MiB), leaving only 184,068 bytes before Cloudflare's 25 MiB per-asset limit. The provider catalog already consists of individual source files, so combining everything into one deployment asset creates an avoidable single-file limit.

## Cloudflare build comparison

Measured on the same current `main` catalog with Wrangler 4.115.0, `--dry-run`, and `--minify`:

| Measurement | Before | This PR |
| --- | ---: | ---: |
| Largest catalog asset | 26,030,332 bytes (24.8245 MiB) | 4,192,730 bytes (3.9985 MiB) |
| Catalog asset files | 1 | 8 (1 index + 7 chunks) |
| Total static assets | 11 | 18 |
| Worker minified upload | 11,672.94 KiB | 11,674.91 KiB |
| Worker gzip | 2,805.33 KiB | 2,806.08 KiB |

New builds do not emit the complete `apps.json`. The small Worker increase is the index validation, compatibility fallback, and chunk loading logic.

## Compatibility and validation

- provider files are sorted by filename before chunking for deterministic output
- chunk limits include JSON brackets, commas, trailing newline, and UTF-8 multibyte characters
- a provider too large for one chunk fails the build with its filename and byte count
- index version, fields, chunk names, duplicate names, chunk shapes, and provider count are validated before creating the catalog
- indexed chunks are loaded in parallel and flattened in index order
- a missing `index.json` falls back to the legacy `apps.json`; new builds emit only the indexed format
- existing executable-service resolution from #237 remains unchanged

Checks:

- `node scripts/generate-catalog.ts` — 1,210 apps / 12,894 actions
- `oxlint . --fix`
- `oxfmt .`
- `node scripts/typecheck.ts src scripts-all examples`
- `vitest run` — 61 test files and 613 tests passed
- Wrangler dry-run builds for both the current baseline and this branch

Closes #235
