### PR TITLE
fix(n8n): allow opted-in private network access

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,12 +81,14 @@ private targets are rejected during connection setup.
 
 Some self-hosted services are only reachable over a LAN or an overlay network
 such as Tailscale or NetBird. To allow those connections, set
-`OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true`. When enabled, provider connections
-that opt in (currently **Dokploy**) may target:
+`OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true`. When enabled, connections for the
+self-hosted providers that opt in (**Dokploy**, **n8n**, **GitLab**,
+**Home Assistant**, and others) may target:
 
 - RFC 1918 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
 - Carrier-grade NAT / shared address space `100.64.0.0/10` (Tailscale, NetBird)
 - Private hostname suffixes: `.local`, `.internal`, `.home`, `.lan`
+- Plain `http://` instance URLs, for providers that otherwise require HTTPS
 
 The following targets stay blocked even when the flag is enabled:
 

--- a/src/providers/n8n/definition.ts
+++ b/src/providers/n8n/definition.ts
@@ -28,7 +28,7 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "https://your-instance.app.n8n.cloud",
           description:
-            "Your n8n instance URL, such as https://your-instance.app.n8n.cloud for n8n Cloud or your self-hosted public HTTPS base URL. URLs ending in /api/v1 are also accepted.",
+            "Your n8n instance URL, such as https://your-instance.app.n8n.cloud for n8n Cloud or your self-hosted public HTTPS base URL. LAN and overlay-network instances (including plain http://) require the deployment to set OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true. URLs ending in /api/v1 are also accepted.",
         },
       ],
     },

--- a/src/providers/n8n/executors.test.ts
+++ b/src/providers/n8n/executors.test.ts
@@ -5,34 +5,77 @@ import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { credentialValidators, executors, proxy } from "./executors.ts";
 
-const credential: ResolvedCredential = {
-  authType: "api_key",
-  apiKey: "test-key",
-  values: { instanceUrl: "https://n8n.tailnet.ts.net" },
-  profile: { accountId: "n8n:test", displayName: "n8n test", grantedScopes: [] },
-  metadata: {},
-};
+const tailscaleInstanceUrl = "https://n8n.tailnet.ts.net";
+const lanInstanceUrl = "http://192.168.1.10:5678";
 
-const executionContext: ExecutionContext = {
-  getCredential: async () => credential,
-};
+interface EntryPointOutcome {
+  ok: boolean;
+  message?: string;
+  result?: unknown;
+}
+
+function apiKeyCredential(instanceUrl: string): ResolvedCredential {
+  return {
+    authType: "api_key",
+    apiKey: "test-key",
+    values: { instanceUrl },
+    profile: { accountId: "n8n:test", displayName: "n8n test", grantedScopes: [] },
+    metadata: {},
+  };
+}
+
+/**
+ * Exercise the three n8n egress entry points against one instance URL:
+ * credential validation, an action executor, and the raw proxy. Each is wired to
+ * the private-network opt-in separately, so a guard that is missing on any one of
+ * them must show up as a difference here.
+ */
+async function runEntryPoints(instanceUrl: string): Promise<Record<string, EntryPointOutcome>> {
+  const credential = apiKeyCredential(instanceUrl) as Extract<ResolvedCredential, { authType: "api_key" }>;
+  const executionContext: ExecutionContext = { getCredential: async () => credential };
+
+  const validate = await credentialValidators.apiKey!(
+    { apiKey: credential.apiKey, values: credential.values },
+    { fetcher: globalThis.fetch },
+  ).then(
+    (result) => ({ ok: true, result }),
+    (error: Error) => ({ ok: false, message: error.message }),
+  );
+  const execute = await executors["n8n.list_workflows"]!({}, executionContext);
+  const proxied = await proxy({ method: "GET", endpoint: "/workflows" }, executionContext);
+
+  return {
+    validate,
+    execute: { ok: execute.ok, message: execute.error?.message },
+    proxy: proxied.ok ? { ok: true } : { ok: false, message: proxied.error.message },
+  };
+}
+
+function expectAllRejected(outcomes: Record<string, EntryPointOutcome>, message: string): void {
+  for (const [name, outcome] of Object.entries(outcomes)) {
+    expect(outcome, name).toMatchObject({ ok: false });
+    expect(outcome.message, name).toContain(message);
+  }
+}
 
 afterEach(() => {
-  setDefaultGuardedFetchDnsLookup(undefined);
+  // `null`, not `undefined`: undefined would restore the automatic node:dns
+  // default, and vitest.setup.ts disables real DNS for the whole suite.
+  setDefaultGuardedFetchDnsLookup(null);
   setPrivateNetworkAccessAllowed(false);
   vi.unstubAllGlobals();
 });
 
 describe("n8n private-network access", () => {
-  it("rejects a Tailscale-resolving instance by default", async () => {
+  it("rejects a Tailscale-resolving instance on every entry point by default", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
     setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
 
-    const result = await executors["n8n.list_workflows"]!({}, executionContext);
-
-    expect(result.ok).toBe(false);
-    expect(result.error?.message).toContain("must not resolve to private or reserved IP addresses");
+    expectAllRejected(
+      await runEntryPoints(tailscaleInstanceUrl),
+      "must not resolve to private or reserved IP addresses",
+    );
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -42,34 +85,78 @@ describe("n8n private-network access", () => {
     setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
     setPrivateNetworkAccessAllowed(true);
 
-    await expect(
-      credentialValidators.apiKey!(
-        { apiKey: credential.apiKey, values: credential.values },
-        { fetcher: globalThis.fetch, signal: undefined },
-      ),
-    ).resolves.toMatchObject({ metadata: { apiBaseUrl: "https://n8n.tailnet.ts.net/api/v1" } });
-    await expect(executors["n8n.list_workflows"]!({}, executionContext)).resolves.toMatchObject({ ok: true });
-    await expect(proxy({ method: "GET", endpoint: "/workflows" }, executionContext)).resolves.toMatchObject({
-      ok: true,
-    });
+    const outcomes = await runEntryPoints(tailscaleInstanceUrl);
 
+    expect(outcomes).toMatchObject({ validate: { ok: true }, execute: { ok: true }, proxy: { ok: true } });
+    expect(outcomes.validate!.result).toMatchObject({
+      metadata: { apiBaseUrl: `${tailscaleInstanceUrl}/api/v1` },
+    });
     expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
-      "https://n8n.tailnet.ts.net/api/v1/discover",
-      "https://n8n.tailnet.ts.net/api/v1/workflows",
-      "https://n8n.tailnet.ts.net/api/v1/workflows",
+      `${tailscaleInstanceUrl}/api/v1/discover`,
+      `${tailscaleInstanceUrl}/api/v1/workflows`,
+      `${tailscaleInstanceUrl}/api/v1/workflows`,
     ]);
   });
 
-  it("keeps loopback targets blocked even when opted in", async () => {
-    const fetch = vi.fn();
+  it("rejects a plain-HTTP LAN instance by default and reaches it once opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ data: [] }));
     vi.stubGlobal("fetch", fetch);
-    setDefaultGuardedFetchDnsLookup(async () => [{ address: "127.0.0.1", family: 4 }]);
+    // An IPv4 literal is address-validated by the URL guard itself, so no DNS lookup runs.
+    setDefaultGuardedFetchDnsLookup(null);
+
+    expectAllRejected(await runEntryPoints(lanInstanceUrl), "instanceUrl must use https");
+    expect(fetch).not.toHaveBeenCalled();
+
+    setPrivateNetworkAccessAllowed(true);
+    const outcomes = await runEntryPoints(lanInstanceUrl);
+
+    expect(outcomes).toMatchObject({ validate: { ok: true }, execute: { ok: true }, proxy: { ok: true } });
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      `${lanInstanceUrl}/api/v1/discover`,
+      `${lanInstanceUrl}/api/v1/workflows`,
+      `${lanInstanceUrl}/api/v1/workflows`,
+    ]);
+  });
+
+  it("rejects a private-hostname instance by default and reaches it once opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ data: [] }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "10.0.0.5", family: 4 }]);
+
+    expectAllRejected(await runEntryPoints("https://n8n.internal"), "instanceUrl must not target local hosts");
+    expect(fetch).not.toHaveBeenCalled();
+
     setPrivateNetworkAccessAllowed(true);
 
-    const result = await executors["n8n.list_workflows"]!({}, executionContext);
+    expect(await runEntryPoints("https://n8n.internal")).toMatchObject({
+      validate: { ok: true },
+      execute: { ok: true },
+      proxy: { ok: true },
+    });
+  });
 
-    expect(result.ok).toBe(false);
-    expect(result.error?.message).toContain("must not resolve to private or reserved IP addresses");
+  it("keeps loopback and metadata targets blocked even when opted in", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setPrivateNetworkAccessAllowed(true);
+
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "127.0.0.1", family: 4 }]);
+    expectAllRejected(
+      await runEntryPoints(tailscaleInstanceUrl),
+      "must not resolve to private or reserved IP addresses",
+    );
+
+    setDefaultGuardedFetchDnsLookup(null);
+    expectAllRejected(
+      await runEntryPoints("http://127.0.0.1:5678"),
+      "must not target private or reserved IP addresses",
+    );
+    expectAllRejected(
+      await runEntryPoints("http://169.254.169.254"),
+      "must not target private or reserved IP addresses",
+    );
+    expectAllRejected(await runEntryPoints("https://metadata.google.internal"), "must not target cloud metadata hosts");
+
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/providers/n8n/executors.test.ts
+++ b/src/providers/n8n/executors.test.ts
@@ -1,0 +1,75 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { credentialValidators, executors, proxy } from "./executors.ts";
+
+const credential: ResolvedCredential = {
+  authType: "api_key",
+  apiKey: "test-key",
+  values: { instanceUrl: "https://n8n.tailnet.ts.net" },
+  profile: { accountId: "n8n:test", displayName: "n8n test", grantedScopes: [] },
+  metadata: {},
+};
+
+const executionContext: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  setPrivateNetworkAccessAllowed(false);
+  vi.unstubAllGlobals();
+});
+
+describe("n8n private-network access", () => {
+  it("rejects a Tailscale-resolving instance by default", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
+
+    const result = await executors["n8n.list_workflows"]!({}, executionContext);
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("must not resolve to private or reserved IP addresses");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("allows credential validation, executor requests, and proxy requests when opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ data: [] }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
+    setPrivateNetworkAccessAllowed(true);
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: credential.apiKey, values: credential.values },
+        { fetcher: globalThis.fetch, signal: undefined },
+      ),
+    ).resolves.toMatchObject({ metadata: { apiBaseUrl: "https://n8n.tailnet.ts.net/api/v1" } });
+    await expect(executors["n8n.list_workflows"]!({}, executionContext)).resolves.toMatchObject({ ok: true });
+    await expect(proxy({ method: "GET", endpoint: "/workflows" }, executionContext)).resolves.toMatchObject({
+      ok: true,
+    });
+
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://n8n.tailnet.ts.net/api/v1/discover",
+      "https://n8n.tailnet.ts.net/api/v1/workflows",
+      "https://n8n.tailnet.ts.net/api/v1/workflows",
+    ]);
+  });
+
+  it("keeps loopback targets blocked even when opted in", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "127.0.0.1", family: 4 }]);
+    setPrivateNetworkAccessAllowed(true);
+
+    const result = await executors["n8n.list_workflows"]!({}, executionContext);
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain("must not resolve to private or reserved IP addresses");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/n8n/executors.ts
+++ b/src/providers/n8n/executors.ts
@@ -6,7 +6,13 @@ import type {
 } from "../../core/types.ts";
 import type { N8nActionContext } from "./runtime.ts";
 
-import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
 import { createN8nActionContext, n8nActionHandlers, resolveN8nApiBaseUrl, validateN8nCredential } from "./runtime.ts";
 
 const service = "n8n";
@@ -17,16 +23,19 @@ export const executors: ProviderExecutors = defineProviderExecutors<N8nActionCon
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<N8nActionContext> {
     return createN8nActionContext(await requireApiKeyCredential(context, service), fetcher, context.signal);
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: async (context) => resolveN8nApiBaseUrl(await requireApiKeyCredential(context, service)),
   auth: { type: "api_key_header", name: "x-n8n-api-key" },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
-    return validateN8nCredential(input, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateN8nCredential(input, guardedFetcher, signal);
   },
 };

--- a/src/providers/n8n/runtime.ts
+++ b/src/providers/n8n/runtime.ts
@@ -488,7 +488,21 @@ export async function validateN8nCredential(
   };
 }
 
-export function normalizeN8nInstanceUrl(input?: string): string {
+/**
+ * Normalize a user-supplied n8n instance URL to its canonical origin (+ base path)
+ * form and reject unsafe targets.
+ *
+ * `allowPrivateNetwork` defaults to the deployment opt-in and may be passed
+ * explicitly to pin the policy. With it off, the historical public-only contract
+ * applies: https only, plus n8n's public-hostname shape check. With it on, a
+ * self-hosted instance may be a plain-HTTP LAN/overlay target, so the shape check
+ * is skipped and the shared guard alone decides — loopback, link-local,
+ * cloud-metadata, reserved, and IPv6 targets stay blocked either way.
+ */
+export function normalizeN8nInstanceUrl(
+  input?: string,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const raw = input?.trim();
   if (!raw) {
     throw providerInputError("instanceUrl is required");
@@ -502,16 +516,16 @@ export function normalizeN8nInstanceUrl(input?: string): string {
     throw providerInputError("instanceUrl must be a valid URL");
   }
 
-  if (parsed.protocol !== "https:") {
-    throw providerInputError("instanceUrl must use https");
-  }
+  // Checked ahead of the shared guard so a non-HTTP scheme keeps reporting the
+  // n8n-specific message instead of the guard's generic "must use http or https".
+  assertN8nInstanceProtocol(parsed, allowPrivateNetwork);
   if (parsed.username || parsed.password) {
     throw providerInputError("instanceUrl must not include URL credentials");
   }
   if (!parsed.hostname) {
     throw providerInputError("instanceUrl must include a host");
   }
-  validateN8nPublicHostnameShape(parsed.hostname);
+  parsed = assertN8nInstanceTarget(parsed.href, allowPrivateNetwork);
 
   parsed.hash = "";
   parsed.search = "";
@@ -795,15 +809,43 @@ function trimTrailingSlash(value: string): string {
 }
 
 function validatePublicN8nInstanceUrl(instanceUrl: string): void {
-  const parsed = assertPublicHttpUrl(instanceUrl, {
+  assertN8nInstanceTarget(instanceUrl, isPrivateNetworkAccessAllowed());
+}
+
+/**
+ * Apply the shared SSRF egress policy to one n8n URL and return the guard's
+ * normalized URL.
+ *
+ * The public-hostname shape check below is a bespoke guard that predates the
+ * deployment opt-in and rejects every private target on its own (IP literals,
+ * `.local`/`.internal`, single-label hosts). It must therefore be skipped when
+ * private-network access is enabled, or the opt-in would be inert; the shared
+ * `assertPublicHttpUrl` policy still blocks loopback, link-local, cloud metadata,
+ * reserved ranges, and IPv6 in both modes.
+ */
+function assertN8nInstanceTarget(value: string, allowPrivateNetwork: boolean): URL {
+  const parsed = assertPublicHttpUrl(value, {
     fieldName: "instanceUrl",
     createError: providerInputError,
-    allowPrivateNetwork: isPrivateNetworkAccessAllowed(),
+    allowPrivateNetwork,
   });
-  if (parsed.protocol !== "https:") {
-    throw providerInputError("instanceUrl must use https");
+  assertN8nInstanceProtocol(parsed, allowPrivateNetwork);
+  if (!allowPrivateNetwork) {
+    validateN8nPublicHostnameShape(parsed.hostname);
   }
-  validateN8nPublicHostnameShape(parsed.hostname);
+  return parsed;
+}
+
+/**
+ * n8n Cloud and any internet-exposed instance must be HTTPS. A self-hosted LAN or
+ * overlay-network instance usually terminates plain HTTP, so `http:` is accepted
+ * only under the deployment private-network opt-in.
+ */
+function assertN8nInstanceProtocol(url: URL, allowPrivateNetwork: boolean): void {
+  if (url.protocol === "https:" || (url.protocol === "http:" && allowPrivateNetwork)) {
+    return;
+  }
+  throw providerInputError("instanceUrl must use https");
 }
 
 function validateN8nPublicHostnameShape(hostname: string): void {

--- a/src/providers/n8n/runtime.ts
+++ b/src/providers/n8n/runtime.ts
@@ -10,7 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const n8nValidationPath = "/discover";
@@ -798,6 +798,7 @@ function validatePublicN8nInstanceUrl(instanceUrl: string): void {
   const parsed = assertPublicHttpUrl(instanceUrl, {
     fieldName: "instanceUrl",
     createError: providerInputError,
+    allowPrivateNetwork: isPrivateNetworkAccessAllowed(),
   });
   if (parsed.protocol !== "https:") {
     throw providerInputError("instanceUrl must use https");


### PR DESCRIPTION
## Summary
- wire the n8n executor, proxy, credential verification, and runtime URL validation to the existing `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` opt-in
- preserve public-hostname/DNS validation and always-blocked targets
- add focused regression coverage for default rejection, explicit opt-in, and blocked ranges

## Validation
- `npm run fix-check`
- `npx vitest run src/providers/n8n/executors.test.ts`
- `git diff --check`

The change was trial-verified against a self-hosted n8n instance reachable over a trusted private network. No generated graph artifacts are included.