### PR TITLE
fix(pandadoc): resolve list_templates id through the API

### DIFF
--- a/src/providers/pandadoc/actions.ts
+++ b/src/providers/pandadoc/actions.ts
@@ -87,7 +87,7 @@ export const pandadocActions: ProviderActionDefinition[] = [
       {
         ...pageInput,
         q: s.string("Search query."),
-        id: s.string("Filter locally by template ID."),
+        id: s.string("Only return the template with this ID."),
         shared: s.boolean("Whether to include shared templates."),
         deleted: s.boolean("Whether to include deleted templates."),
         folder_uuid: s.string("Folder UUID filter."),

--- a/src/providers/pandadoc/runtime.ts
+++ b/src/providers/pandadoc/runtime.ts
@@ -76,6 +76,7 @@ export const pandadocActionHandlers: Record<string, PandadocActionHandler> = {
         path: "/public/v1/templates",
         query: {
           q: optionalString(input.q),
+          id: optionalString(input.id),
           page: optionalInteger(input.page),
           count: optionalInteger(input.count),
           shared: optionalBoolean(input.shared),
@@ -88,10 +89,8 @@ export const pandadocActionHandlers: Record<string, PandadocActionHandler> = {
       "PandaDoc template list response",
       providerResponseError,
     );
-    const id = optionalString(input.id);
-    const results = listResults(payload).filter((item) => !id || optionalString(item.id) === id);
     return compactObject({
-      results,
+      results: listResults(payload),
       count: optionalInteger(payload.count),
       next: optionalString(payload.next) ?? null,
       previous: optionalString(payload.previous) ?? null,


### PR DESCRIPTION
Looking up a template by ID returns an empty result when the template is not on the first page, because one page is fetched and then filtered locally.

```
before:  list_templates({ id: "tpl_055" })  ->  results: []
after:   list_templates({ id: "tpl_055" })  ->  results: [tpl_055]
```

PandaDoc accepts `id` as a query parameter, so the filter was never needed.

https://developers.pandadoc.com/reference/list-templates
