### PR TITLE
Add MiniMax H3 video generation actions

### DIFF
--- a/src/providers/minimax/actions.ts
+++ b/src/providers/minimax/actions.ts
@@ -205,6 +205,8 @@ const createResponseOutputSchema = s.looseRequiredObject(
   },
 );
 
+const h3VideoModel = "MiniMax-H3";
+
 const textToVideoModels = ["MiniMax-Hailuo-2.3", "MiniMax-Hailuo-02", "T2V-01-Director", "T2V-01"];
 
 const imageToVideoModels = [
@@ -242,6 +244,43 @@ const videoPromptOptimizerSchema = s.boolean("Whether MiniMax may rewrite the pr
 const videoFastPretreatmentSchema = s.boolean("Whether MiniMax applies fast pre-processing to speed up generation.");
 const videoCallbackUrlSchema = s.url("URL MiniMax calls with asynchronous task status updates.");
 
+const videoGenerationV2ContentSchema = s.object(
+  "MiniMax H3 video generation content item.",
+  {
+    type: s.stringEnum("Content item type.", ["text", "image_url", "video_url", "audio_url"]),
+    text: trimmedNonEmptyString("Text prompt content."),
+    image_url: trimmedNonEmptyString("Image content URL."),
+    video_url: trimmedNonEmptyString("Video content URL."),
+    audio_url: trimmedNonEmptyString("Audio content URL."),
+    role: s.stringEnum("Content role for frame, reference image, video, or audio guidance.", [
+      "first_frame",
+      "last_frame",
+      "reference_image",
+      "reference_video",
+      "reference_audio",
+    ]),
+  },
+  { optional: ["text", "image_url", "video_url", "audio_url", "role"] },
+);
+
+const videoGenerationV2InputSchema = s.object(
+  "Request body for creating a MiniMax H3 video generation task.",
+  {
+    model: s.literal(h3VideoModel, { description: "MiniMax H3 video generation model." }),
+    content: s.array("Ordered text, image, video, or audio content for generation.", videoGenerationV2ContentSchema, {
+      minItems: 1,
+    }),
+    resolution: s.stringEnum("Generated video resolution.", ["2K"], { default: "2K" }),
+    duration: s.integer("Generated video duration in seconds.", { minimum: 4, maximum: 15 }),
+    ratio: s.stringEnum("Generated video aspect ratio.", ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"], {
+      default: "adaptive",
+    }),
+    callback_url: videoCallbackUrlSchema,
+    aigc_watermark: s.boolean("Whether to add the regional AIGC watermark when supported by the selected region."),
+  },
+  { optional: ["ratio", "callback_url", "aigc_watermark"] },
+);
+
 const textToVideoInputSchema = s.object(
   "Request body for creating a MiniMax text-to-video generation task.",
   {
@@ -275,6 +314,25 @@ const queryVideoGenerationInputSchema = s.object("Input parameters for querying 
   task_id: trimmedNonEmptyString("Identifier of the MiniMax video generation task to query."),
 });
 
+const listVideoGenerationV2InputSchema = s.object(
+  "Input parameters for listing MiniMax H3 video generation tasks.",
+  {
+    page_num: s.integer("Page number to retrieve.", { minimum: 1 }),
+    page_size: s.integer("Number of tasks to retrieve per page.", { minimum: 1 }),
+    filter: s.object(
+      "Optional MiniMax H3 video task filters.",
+      {
+        status: optionalTrimmedString("Task status filter."),
+        task_ids: s.array("Task identifiers to include.", trimmedNonEmptyString("Task identifier."), { minItems: 1 }),
+        model: s.literal(h3VideoModel, { description: "MiniMax H3 video generation model." }),
+        task_type: optionalTrimmedString("Task type filter."),
+      },
+      { optional: ["status", "task_ids", "model", "task_type"] },
+    ),
+  },
+  { optional: ["page_num", "page_size", "filter"] },
+);
+
 const downloadVideoInputSchema = s.object("Input parameters for retrieving a generated MiniMax video file.", {
   file_id: trimmedNonEmptyString("Identifier of the generated video file to retrieve."),
 });
@@ -307,6 +365,45 @@ const videoTaskStatusOutputSchema = s.looseRequiredObject(
   },
   { optional: ["task_id", "status", "file_id", "base_resp"] },
 );
+
+const videoGenerationV2TaskSchema = s.looseRequiredObject(
+  "MiniMax H3 video generation task response.",
+  {
+    id: s.string("MiniMax H3 video task identifier."),
+    model: s.string("MiniMax model that processed the task."),
+    status: s.string("Current task status."),
+    error: s.unknownObject("Task error details when generation fails."),
+    content: s.looseRequiredObject("Generated video content.", {
+      url: s.string("Generated video URL."),
+    }),
+    resolution: s.string("Generated video resolution."),
+    duration: s.integer("Generated video duration in seconds."),
+    usage: s.unknownObject("MiniMax H3 video usage details."),
+    ratio: s.string("Generated video aspect ratio."),
+    task_type: s.string("MiniMax H3 video task type."),
+    modality: s.string("Generated task modality."),
+  },
+  { optional: ["id", "model", "status", "error", "content", "resolution", "duration", "usage", "ratio", "task_type", "modality"] },
+);
+
+const videoGenerationV2CreatedOutputSchema = s.looseRequiredObject("MiniMax H3 video task creation response.", {
+  task_id: s.string("Identifier of the asynchronous MiniMax H3 video generation task."),
+});
+
+const videoGenerationV2QueryOutputSchema = s.looseRequiredObject("MiniMax H3 video task query response.", {
+  task: videoGenerationV2TaskSchema,
+});
+
+const videoGenerationV2ListOutputSchema = s.looseRequiredObject("MiniMax H3 video task list response.", {
+  items: s.array("MiniMax H3 video tasks.", videoGenerationV2TaskSchema),
+  total: s.integer("Total matching MiniMax H3 video task count."),
+});
+
+const videoGenerationV2DeleteOutputSchema = s.looseRequiredObject("MiniMax H3 video task deletion response.", {
+  task_id: s.string("Identifier of the deleted MiniMax H3 video generation task."),
+  action: s.string("Deletion action name."),
+  status: s.string("Deletion status."),
+});
 
 const videoFileOutputSchema = s.looseRequiredObject(
   "MiniMax file retrieval response for a generated video.",
@@ -360,6 +457,12 @@ export const minimaxActions: ActionDefinition[] = [
     }),
   }),
   defineProviderAction(service, {
+    name: "create_video_generation_v2",
+    description: "Create a MiniMax H3 video generation task with text, image, video, or audio content.",
+    inputSchema: videoGenerationV2InputSchema,
+    outputSchema: videoGenerationV2CreatedOutputSchema,
+  }),
+  defineProviderAction(service, {
     name: "text_to_video",
     description: "Create a MiniMax asynchronous text-to-video generation task.",
     inputSchema: textToVideoInputSchema,
@@ -376,6 +479,24 @@ export const minimaxActions: ActionDefinition[] = [
     description: "Query the status of a MiniMax video generation task and read its file id when it completes.",
     inputSchema: queryVideoGenerationInputSchema,
     outputSchema: videoTaskStatusOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "query_video_generation_v2",
+    description: "Query a MiniMax H3 video generation task.",
+    inputSchema: queryVideoGenerationInputSchema,
+    outputSchema: videoGenerationV2QueryOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "list_video_generation_v2",
+    description: "List MiniMax H3 video generation tasks.",
+    inputSchema: listVideoGenerationV2InputSchema,
+    outputSchema: videoGenerationV2ListOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_video_generation_v2",
+    description: "Delete a MiniMax H3 video generation task.",
+    inputSchema: queryVideoGenerationInputSchema,
+    outputSchema: videoGenerationV2DeleteOutputSchema,
   }),
   defineProviderAction(service, {
     name: "download_video",

--- a/src/providers/minimax/actions.ts
+++ b/src/providers/minimax/actions.ts
@@ -206,6 +206,7 @@ const createResponseOutputSchema = s.looseRequiredObject(
 );
 
 const h3VideoModel = "MiniMax-H3";
+const videoGenerationV2Statuses = ["queued", "running", "succeeded", "failed", "cancelled", "expired"];
 
 const textToVideoModels = ["MiniMax-Hailuo-2.3", "MiniMax-Hailuo-02", "T2V-01-Director", "T2V-01"];
 
@@ -244,41 +245,59 @@ const videoPromptOptimizerSchema = s.boolean("Whether MiniMax may rewrite the pr
 const videoFastPretreatmentSchema = s.boolean("Whether MiniMax applies fast pre-processing to speed up generation.");
 const videoCallbackUrlSchema = s.url("URL MiniMax calls with asynchronous task status updates.");
 
-const videoGenerationV2ContentSchema = s.object(
-  "MiniMax H3 video generation content item.",
-  {
-    type: s.stringEnum("Content item type.", ["text", "image_url", "video_url", "audio_url"]),
-    text: trimmedNonEmptyString("Text prompt content."),
-    image_url: trimmedNonEmptyString("Image content URL."),
-    video_url: trimmedNonEmptyString("Video content URL."),
-    audio_url: trimmedNonEmptyString("Audio content URL."),
-    role: s.stringEnum("Content role for frame, reference image, video, or audio guidance.", [
-      "first_frame",
-      "last_frame",
-      "reference_image",
-      "reference_video",
-      "reference_audio",
-    ]),
-  },
-  { optional: ["text", "image_url", "video_url", "audio_url", "role"] },
-);
+const videoGenerationV2TextContentSchema = s.object("MiniMax H3 text content item.", {
+  type: s.literal("text", { description: "Text content item type." }),
+  text: s.string({ description: "Text prompt content.", minLength: 1, maxLength: 7000, pattern: "\\S" }),
+});
+
+const videoGenerationV2ContentSchema = s.anyOf("MiniMax H3 video generation content item.", [
+  videoGenerationV2TextContentSchema,
+  s.object(
+    "MiniMax H3 image content item.",
+    {
+      type: s.literal("image_url", { description: "Image content item type." }),
+      image_url: s.object("Image input location.", {
+        url: trimmedNonEmptyString("Public URL, MiniMax file URI, or image data URI."),
+      }),
+      role: s.stringEnum("Image purpose in the generated video.", ["first_frame", "last_frame", "reference_image"]),
+    },
+    { optional: ["role"] },
+  ),
+  s.object("MiniMax H3 reference video content item.", {
+    type: s.literal("video_url", { description: "Video content item type." }),
+    video_url: s.object("Reference video location.", {
+      url: trimmedNonEmptyString("Public URL, MiniMax file URI, or video data URI."),
+    }),
+    role: s.literal("reference_video", { description: "Reference video content role." }),
+  }),
+  s.object("MiniMax H3 reference audio content item.", {
+    type: s.literal("audio_url", { description: "Audio content item type." }),
+    audio_url: s.object("Reference audio location.", {
+      url: trimmedNonEmptyString("Public URL, MiniMax file URI, or audio data URI."),
+    }),
+    role: s.literal("reference_audio", { description: "Reference audio content role." }),
+  }),
+]);
 
 const videoGenerationV2InputSchema = s.object(
   "Request body for creating a MiniMax H3 video generation task.",
   {
     model: s.literal(h3VideoModel, { description: "MiniMax H3 video generation model." }),
-    content: s.array("Ordered text, image, video, or audio content for generation.", videoGenerationV2ContentSchema, {
-      minItems: 1,
-    }),
-    resolution: s.stringEnum("Generated video resolution.", ["2K"], { default: "2K" }),
+    content: {
+      ...s.array("Ordered text, image, video, or audio content for generation.", videoGenerationV2ContentSchema, {
+        minItems: 1,
+      }),
+      contains: videoGenerationV2TextContentSchema,
+    },
+    resolution: s.stringEnum(["768P", "2K"], { description: "Generated video resolution.", default: "2K" }),
     duration: s.integer("Generated video duration in seconds.", { minimum: 4, maximum: 15 }),
-    ratio: s.stringEnum("Generated video aspect ratio.", ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"], {
+    ratio: s.stringEnum(["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"], {
+      description: "Generated video aspect ratio.",
       default: "adaptive",
     }),
     callback_url: videoCallbackUrlSchema,
-    aigc_watermark: s.boolean("Whether to add the regional AIGC watermark when supported by the selected region."),
   },
-  { optional: ["ratio", "callback_url", "aigc_watermark"] },
+  { optional: ["ratio", "callback_url"] },
 );
 
 const textToVideoInputSchema = s.object(
@@ -322,7 +341,7 @@ const listVideoGenerationV2InputSchema = s.object(
     filter: s.object(
       "Optional MiniMax H3 video task filters.",
       {
-        status: optionalTrimmedString("Task status filter."),
+        status: s.stringEnum("Task status filter.", videoGenerationV2Statuses),
         task_ids: s.array("Task identifiers to include.", trimmedNonEmptyString("Task identifier."), { minItems: 1 }),
         model: s.literal(h3VideoModel, { description: "MiniMax H3 video generation model." }),
         task_type: optionalTrimmedString("Task type filter."),
@@ -371,8 +390,10 @@ const videoGenerationV2TaskSchema = s.looseRequiredObject(
   {
     id: s.string("MiniMax H3 video task identifier."),
     model: s.string("MiniMax model that processed the task."),
-    status: s.string("Current task status."),
+    status: s.stringEnum("Current task status.", videoGenerationV2Statuses),
     error: s.unknownObject("Task error details when generation fails."),
+    created_at: s.integer("Unix timestamp when MiniMax created the task."),
+    updated_at: s.integer("Unix timestamp when MiniMax last updated the task."),
     content: s.looseRequiredObject("Generated video content.", {
       url: s.string("Generated video URL."),
     }),
@@ -381,9 +402,23 @@ const videoGenerationV2TaskSchema = s.looseRequiredObject(
     usage: s.unknownObject("MiniMax H3 video usage details."),
     ratio: s.string("Generated video aspect ratio."),
     task_type: s.string("MiniMax H3 video task type."),
-    modality: s.string("Generated task modality."),
   },
-  { optional: ["id", "model", "status", "error", "content", "resolution", "duration", "usage", "ratio", "task_type", "modality"] },
+  {
+    optional: [
+      "id",
+      "model",
+      "status",
+      "error",
+      "created_at",
+      "updated_at",
+      "content",
+      "resolution",
+      "duration",
+      "usage",
+      "ratio",
+      "task_type",
+    ],
+  },
 );
 
 const videoGenerationV2CreatedOutputSchema = s.looseRequiredObject("MiniMax H3 video task creation response.", {
@@ -401,7 +436,7 @@ const videoGenerationV2ListOutputSchema = s.looseRequiredObject("MiniMax H3 vide
 
 const videoGenerationV2DeleteOutputSchema = s.looseRequiredObject("MiniMax H3 video task deletion response.", {
   task_id: s.string("Identifier of the deleted MiniMax H3 video generation task."),
-  action: s.string("Deletion action name."),
+  action: s.stringEnum("Deletion action name.", ["cancel", "delete"]),
   status: s.string("Deletion status."),
 });
 

--- a/src/providers/minimax/executors.test.ts
+++ b/src/providers/minimax/executors.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { minimaxActions } from "./actions.ts";
 import { minimaxActionHandlers } from "./executors.ts";
 
 const apiBaseUrl = "https://api.minimax.io";
@@ -29,8 +31,8 @@ describe("MiniMax H3 video generation", () => {
         model: " MiniMax-H3 ",
         content: [
           { type: "text", text: "city skyline" },
-          { type: "image_url", image_url: "https://example.com/frame.png", role: "first_frame" },
-          { type: "audio_url", audio_url: "https://example.com/ref.mp3", role: "reference_audio" },
+          { type: "image_url", image_url: { url: "https://example.com/frame.png" }, role: "first_frame" },
+          { type: "audio_url", audio_url: { url: "https://example.com/ref.mp3" }, role: "reference_audio" },
         ],
         resolution: " 2K ",
         duration: 12,
@@ -52,10 +54,60 @@ describe("MiniMax H3 video generation", () => {
       callback_url: "https://example.com/callback",
       content: [
         { type: "text", text: "city skyline" },
-        { type: "image_url", image_url: "https://example.com/frame.png", role: "first_frame" },
-        { type: "audio_url", audio_url: "https://example.com/ref.mp3", role: "reference_audio" },
+        { type: "image_url", image_url: { url: "https://example.com/frame.png" }, role: "first_frame" },
+        { type: "audio_url", audio_url: { url: "https://example.com/ref.mp3" }, role: "reference_audio" },
       ],
     });
+  });
+
+  it("validates the v2 media shape and required text prompt", () => {
+    const action = minimaxActions.find((action) => action.id === "minimax.create_video_generation_v2")!;
+    const input = {
+      model: "MiniMax-H3",
+      content: [
+        { type: "text", text: "city skyline" },
+        { type: "image_url", image_url: { url: "https://example.com/frame.png" }, role: "first_frame" },
+      ],
+      resolution: "768P",
+      duration: 5,
+    };
+
+    expect(validateActionInput(action, input).valid).toBe(true);
+    expect(
+      validateActionInput(action, {
+        ...input,
+        content: [{ type: "image_url", image_url: { url: "https://example.com/frame.png" } }],
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(action, {
+        ...input,
+        content: [
+          { type: "text", text: "city skyline" },
+          { type: "video_url", video_url: "https://example.com/ref.mp4", role: "reference_video" },
+        ],
+      }).valid,
+    ).toBe(false);
+    expect(
+      validateActionInput(action, {
+        ...input,
+        content: [
+          { type: "text", text: "city skyline" },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/frame.png" },
+            role: "reference_video",
+          },
+        ],
+      }).valid,
+    ).toBe(false);
+  });
+
+  it("validates v2 list status filters", () => {
+    const action = minimaxActions.find((action) => action.id === "minimax.list_video_generation_v2")!;
+
+    expect(validateActionInput(action, { filter: { status: "succeeded" } }).valid).toBe(true);
+    expect(validateActionInput(action, { filter: { status: "Success" } }).valid).toBe(false);
   });
 
   it("routes v2 video query, list, and delete operations", async () => {
@@ -67,7 +119,7 @@ describe("MiniMax H3 video generation", () => {
       {
         page_num: 2,
         page_size: 10,
-        filter: { status: "Success", task_ids: ["task-1", "task-2"], model: "MiniMax-H3", task_type: "text" },
+        filter: { status: "succeeded", task_ids: ["task-1", "task-2"], model: "MiniMax-H3", task_type: "text" },
       },
       context,
     );
@@ -76,7 +128,7 @@ describe("MiniMax H3 video generation", () => {
     expect(vi.mocked(fetcher).mock.calls.map(([url, init]) => [String(url), init?.method])).toEqual([
       [`${apiBaseUrl}/v2/query/video_generation/task%2F1`, "GET"],
       [
-        `${apiBaseUrl}/v2/query/video_generation?page_num=2&page_size=10&filter.status=Success&filter.model=MiniMax-H3&filter.task_type=text&filter.task_ids=task-1&filter.task_ids=task-2`,
+        `${apiBaseUrl}/v2/query/video_generation?page_num=2&page_size=10&filter.status=succeeded&filter.model=MiniMax-H3&filter.task_type=text&filter.task_ids=task-1&filter.task_ids=task-2`,
         "GET",
       ],
       [`${apiBaseUrl}/v2/video_generation/task%2F1`, "DELETE"],

--- a/src/providers/minimax/executors.test.ts
+++ b/src/providers/minimax/executors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { minimaxActionHandlers } from "./executors.ts";
+
+const apiBaseUrl = "https://api.minimax.io";
+
+function createContext(fetcher: typeof fetch) {
+  return {
+    apiKey: "test-key",
+    apiBaseUrl,
+    fetcher,
+  };
+}
+
+function jsonFetcher(payload: Record<string, unknown> = {}): typeof fetch {
+  return vi.fn(async () => Response.json(payload)) as typeof fetch;
+}
+
+function requestBody(fetcher: typeof fetch): unknown {
+  const init = vi.mocked(fetcher).mock.calls[0]![1] as RequestInit;
+  return JSON.parse(String(init.body));
+}
+
+describe("MiniMax H3 video generation", () => {
+  it("creates a v2 video generation task with multimodal content", async () => {
+    const fetcher = jsonFetcher({ task_id: "task-1" });
+
+    await minimaxActionHandlers.create_video_generation_v2(
+      {
+        model: " MiniMax-H3 ",
+        content: [
+          { type: "text", text: "city skyline" },
+          { type: "image_url", image_url: "https://example.com/frame.png", role: "first_frame" },
+          { type: "audio_url", audio_url: "https://example.com/ref.mp3", role: "reference_audio" },
+        ],
+        resolution: " 2K ",
+        duration: 12,
+        ratio: " 16:9 ",
+        callback_url: " https://example.com/callback ",
+      },
+      createContext(fetcher),
+    );
+
+    expect(fetcher).toHaveBeenCalledWith(
+      `${apiBaseUrl}/v2/video_generation`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(requestBody(fetcher)).toMatchObject({
+      model: "MiniMax-H3",
+      resolution: "2K",
+      duration: 12,
+      ratio: "16:9",
+      callback_url: "https://example.com/callback",
+      content: [
+        { type: "text", text: "city skyline" },
+        { type: "image_url", image_url: "https://example.com/frame.png", role: "first_frame" },
+        { type: "audio_url", audio_url: "https://example.com/ref.mp3", role: "reference_audio" },
+      ],
+    });
+  });
+
+  it("routes v2 video query, list, and delete operations", async () => {
+    const fetcher = jsonFetcher({ task_id: "task-1" });
+    const context = createContext(fetcher);
+
+    await minimaxActionHandlers.query_video_generation_v2({ task_id: "task/1" }, context);
+    await minimaxActionHandlers.list_video_generation_v2(
+      {
+        page_num: 2,
+        page_size: 10,
+        filter: { status: "Success", task_ids: ["task-1", "task-2"], model: "MiniMax-H3", task_type: "text" },
+      },
+      context,
+    );
+    await minimaxActionHandlers.delete_video_generation_v2({ task_id: "task/1" }, context);
+
+    expect(vi.mocked(fetcher).mock.calls.map(([url, init]) => [String(url), init?.method])).toEqual([
+      [`${apiBaseUrl}/v2/query/video_generation/task%2F1`, "GET"],
+      [
+        `${apiBaseUrl}/v2/query/video_generation?page_num=2&page_size=10&filter.status=Success&filter.model=MiniMax-H3&filter.task_type=text&filter.task_ids=task-1&filter.task_ids=task-2`,
+        "GET",
+      ],
+      [`${apiBaseUrl}/v2/video_generation/task%2F1`, "DELETE"],
+    ]);
+  });
+});

--- a/src/providers/minimax/executors.ts
+++ b/src/providers/minimax/executors.ts
@@ -38,6 +38,9 @@ export const minimaxActionHandlers: Record<string, MinimaxActionHandler> = {
   estimate_input_tokens(input, context) {
     return minimaxPostJson("/v1/responses/input_tokens", normalizeMinimaxBody(input), context);
   },
+  create_video_generation_v2(input, context) {
+    return minimaxPostJson("/v2/video_generation", normalizeMinimaxVideoV2Body(input), context);
+  },
   text_to_video(input, context) {
     return minimaxPostJson("/v1/video_generation", normalizeMinimaxVideoBody(input), context);
   },
@@ -47,6 +50,17 @@ export const minimaxActionHandlers: Record<string, MinimaxActionHandler> = {
   query_video_generation(input, context) {
     const taskId = readInputString(input.task_id, "task_id");
     return minimaxGetJson(`/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`, context);
+  },
+  query_video_generation_v2(input, context) {
+    const taskId = readInputString(input.task_id, "task_id");
+    return minimaxGetJson(`/v2/query/video_generation/${encodeURIComponent(taskId)}`, context);
+  },
+  list_video_generation_v2(input, context) {
+    return minimaxGetJson(createVideoGenerationV2ListPath(input), context);
+  },
+  delete_video_generation_v2(input, context) {
+    const taskId = readInputString(input.task_id, "task_id");
+    return minimaxDeleteJson(`/v2/video_generation/${encodeURIComponent(taskId)}`, context);
   },
   download_video(input, context) {
     const fileId = readInputString(input.file_id, "file_id");
@@ -127,6 +141,19 @@ async function minimaxPostJson(
   );
 }
 
+async function minimaxDeleteJson(path: string, context: MinimaxActionContext): Promise<Record<string, unknown>> {
+  return minimaxRequestJson(
+    path,
+    {
+      method: "DELETE",
+      headers: minimaxHeaders(context.apiKey, { accept: "application/json" }),
+      signal: context.signal,
+    },
+    context.fetcher,
+    context.apiBaseUrl,
+  );
+}
+
 async function minimaxRequestJson(
   path: string,
   init: RequestInit,
@@ -193,6 +220,49 @@ function normalizeMinimaxVideoBody(input: Record<string, unknown>): Record<strin
     resolution: trimString(input.resolution),
     callback_url: trimString(input.callback_url),
   });
+}
+
+function normalizeMinimaxVideoV2Body(input: Record<string, unknown>): Record<string, unknown> {
+  return compactObject({
+    ...input,
+    model: trimString(input.model),
+    resolution: trimString(input.resolution),
+    ratio: trimString(input.ratio),
+    callback_url: trimString(input.callback_url),
+  });
+}
+
+function createVideoGenerationV2ListPath(input: Record<string, unknown>): string {
+  const search = new URLSearchParams();
+  appendQueryValue(search, "page_num", input.page_num);
+  appendQueryValue(search, "page_size", input.page_size);
+
+  const filter = optionalRecord(input.filter);
+  if (filter) {
+    appendQueryValue(search, "filter.status", filter.status);
+    appendQueryValue(search, "filter.model", filter.model);
+    appendQueryValue(search, "filter.task_type", filter.task_type);
+    const taskIds = filter.task_ids;
+    if (Array.isArray(taskIds)) {
+      for (const taskId of taskIds) {
+        appendQueryValue(search, "filter.task_ids", taskId);
+      }
+    }
+  }
+
+  const query = search.toString();
+  return query ? `/v2/query/video_generation?${query}` : "/v2/query/video_generation";
+}
+
+function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    search.append(key, String(value));
+    return;
+  }
+  const text = trimString(value);
+  if (text) {
+    search.append(key, text);
+  }
 }
 
 async function readMinimaxPayload(response: Response): Promise<Record<string, unknown>> {


### PR DESCRIPTION
Reason: MiniMax video generation now exposes H3 v2 task creation and management parameters.

Changes:
- Added MiniMax H3 v2 video generation action schemas for multimodal content, 2K output, 4-15 second durations, ratios, and regional watermark control.
- Routed v2 create, query, list, and delete actions to the documented MiniMax video generation endpoints.
- Added focused executor tests for v2 video endpoint paths, methods, query filters, and payload normalization.

Checks:
- npm test -- src/providers/minimax/executors.test.ts --reporter=verbose
- npm run typecheck
- npm run format
- npm run lint
