### PR TITLE
fix(gitea): allow opted-in private network access

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ Some self-hosted services are only reachable over a LAN or an overlay network
 such as Tailscale or NetBird. To allow those connections, set
 `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true`. When enabled, connections for the
 self-hosted providers that opt in (**Dokploy**, **n8n**, **GitLab**,
-**Home Assistant**, **IMAP Mailbox**, and others) may target:
+**Gitea**, **Home Assistant**, **IMAP Mailbox**, and others) may target:
 
 - RFC 1918 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
 - Carrier-grade NAT / shared address space `100.64.0.0/10` (Tailscale, NetBird)

--- a/src/providers/gitea/definition.ts
+++ b/src/providers/gitea/definition.ts
@@ -28,7 +28,7 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "https://gitea.example.com",
           description:
-            "Gitea instance base URL, such as https://gitea.com or your self-hosted domain. URLs ending in /api/v1 are also accepted.",
+            "Gitea instance base URL, such as https://gitea.com or your self-hosted domain. URLs ending in /api/v1 are also accepted. Private/overlay targets and plain HTTP require the self-hosted runtime to enable OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK.",
         },
       ],
     },

--- a/src/providers/gitea/executors.test.ts
+++ b/src/providers/gitea/executors.test.ts
@@ -1,0 +1,168 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { credentialValidators, executors, proxy } from "./executors.ts";
+
+const tailscaleInstanceUrl = "https://gitea.tailnet.ts.net";
+const lanInstanceUrl = "http://192.168.1.10:3000";
+
+interface EntryPointOutcome {
+  ok: boolean;
+  message?: string;
+  result?: unknown;
+}
+
+function apiKeyCredential(baseUrl: string): Extract<ResolvedCredential, { authType: "api_key" }> {
+  return {
+    authType: "api_key",
+    apiKey: "test-token",
+    values: { baseUrl },
+    profile: { accountId: "gitea:test", displayName: "Gitea test", grantedScopes: [] },
+    metadata: {},
+  };
+}
+
+async function runEntryPoints(baseUrl: string): Promise<Record<string, EntryPointOutcome>> {
+  const credential = apiKeyCredential(baseUrl);
+  const executionContext: ExecutionContext = { getCredential: async () => credential };
+
+  const validate = await credentialValidators.apiKey!(
+    { apiKey: credential.apiKey, values: credential.values },
+    { fetcher: globalThis.fetch },
+  ).then(
+    (result) => ({ ok: true, result }),
+    (error: Error) => ({ ok: false, message: error.message }),
+  );
+  const execute = await executors["gitea.get_current_user"]!({}, executionContext);
+  const proxied = await proxy({ method: "GET", endpoint: "/user" }, executionContext);
+
+  return {
+    validate,
+    execute: { ok: execute.ok, message: execute.error?.message },
+    proxy: proxied.ok ? { ok: true } : { ok: false, message: proxied.error.message },
+  };
+}
+
+function expectAllAccepted(outcomes: Record<string, EntryPointOutcome>): void {
+  for (const [name, outcome] of Object.entries(outcomes)) {
+    expect(outcome, name).toMatchObject({ ok: true });
+  }
+}
+
+function expectAllRejected(outcomes: Record<string, EntryPointOutcome>, message: string): void {
+  for (const [name, outcome] of Object.entries(outcomes)) {
+    expect(outcome, name).toMatchObject({ ok: false });
+    expect(outcome.message, name).toContain(message);
+  }
+}
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  setPrivateNetworkAccessAllowed(false);
+  vi.unstubAllGlobals();
+});
+
+describe("Gitea private-network access", () => {
+  it("keeps public HTTPS instances working by default", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ id: 7, login: "alice" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "93.184.216.34", family: 4 }]);
+
+    expectAllAccepted(await runEntryPoints("https://gitea.example.com"));
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a Tailscale-resolving instance on every entry point by default", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
+
+    expectAllRejected(
+      await runEntryPoints(tailscaleInstanceUrl),
+      "must not resolve to private or reserved IP addresses",
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("allows credential validation, executor requests, and proxy requests when opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ id: 7, login: "alice" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "100.64.0.12", family: 4 }]);
+    setPrivateNetworkAccessAllowed(true);
+
+    const outcomes = await runEntryPoints(tailscaleInstanceUrl);
+
+    expectAllAccepted(outcomes);
+    expect(outcomes.validate!.result).toMatchObject({ metadata: { baseUrl: tailscaleInstanceUrl } });
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      `${tailscaleInstanceUrl}/api/v1/user`,
+      `${tailscaleInstanceUrl}/api/v1/user`,
+      `${tailscaleInstanceUrl}/api/v1/user`,
+    ]);
+  });
+
+  it("rejects a plain-HTTP LAN instance by default and reaches it once opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ id: 7, login: "alice" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+
+    expectAllRejected(await runEntryPoints(lanInstanceUrl), "must not target private or reserved IP addresses");
+    expect(fetch).not.toHaveBeenCalled();
+
+    setPrivateNetworkAccessAllowed(true);
+    expectAllAccepted(await runEntryPoints(lanInstanceUrl));
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      `${lanInstanceUrl}/api/v1/user`,
+      `${lanInstanceUrl}/api/v1/user`,
+      `${lanInstanceUrl}/api/v1/user`,
+    ]);
+  });
+
+  it("requires the opt-in for public plain-HTTP instances", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "93.184.216.34", family: 4 }]);
+
+    expectAllRejected(await runEntryPoints("http://gitea.example.com"), "Base URL must use https");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a private hostname by default and reaches it once opted in", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL) => Response.json({ id: 7, login: "alice" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "10.0.0.5", family: 4 }]);
+
+    expectAllRejected(await runEntryPoints("https://gitea.internal"), "must not target local hosts");
+    expect(fetch).not.toHaveBeenCalled();
+
+    setPrivateNetworkAccessAllowed(true);
+    expectAllAccepted(await runEntryPoints("https://gitea.internal"));
+  });
+
+  it("keeps loopback and metadata targets blocked even when opted in", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setPrivateNetworkAccessAllowed(true);
+
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "127.0.0.1", family: 4 }]);
+    expectAllRejected(
+      await runEntryPoints(tailscaleInstanceUrl),
+      "must not resolve to private or reserved IP addresses",
+    );
+
+    setDefaultGuardedFetchDnsLookup(null);
+    expectAllRejected(
+      await runEntryPoints("http://127.0.0.1:3000"),
+      "must not target private or reserved IP addresses",
+    );
+    expectAllRejected(
+      await runEntryPoints("http://169.254.169.254"),
+      "must not target private or reserved IP addresses",
+    );
+    expectAllRejected(await runEntryPoints("https://metadata.google.internal"), "must not target cloud metadata hosts");
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/gitea/executors.ts
+++ b/src/providers/gitea/executors.ts
@@ -6,7 +6,13 @@ import type {
 } from "../../core/types.ts";
 import type { GiteaActionContext } from "./runtime.ts";
 
-import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
 import { giteaActionHandlers, resolveGiteaBaseUrl, validateGiteaCredential } from "./runtime.ts";
 
 const service = "gitea";
@@ -27,6 +33,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<GiteaActionC
     };
   },
   fallbackMessage: "Gitea request failed.",
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
@@ -43,10 +50,12 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     type: "api_key_authorization",
     prefix: "token ",
   },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
-    return validateGiteaCredential(input, fetcher, signal);
+    const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
+    return validateGiteaCredential(input, guardedFetcher, signal);
   },
 };

--- a/src/providers/gitea/runtime.ts
+++ b/src/providers/gitea/runtime.ts
@@ -10,7 +10,7 @@ import {
   positiveInteger,
   requiredString,
 } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const giteaApiSegment = "api/v1";
@@ -2546,7 +2546,10 @@ function buildValidationEndpoint(baseUrl: string, path: string): string {
   return new URL(pathWithoutLeadingSlash(path), buildGiteaApiBaseUrl(baseUrl)).pathname;
 }
 
-function normalizeGiteaBaseUrl(value: string | undefined): string {
+function normalizeGiteaBaseUrl(
+  value: string | undefined,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const trimmed = value?.trim();
   if (!trimmed) {
     throw new ProviderRequestError(400, "Base URL is required");
@@ -2555,9 +2558,10 @@ function normalizeGiteaBaseUrl(value: string | undefined): string {
   const parsed = assertPublicHttpUrl(trimmed, {
     fieldName: "baseUrl",
     createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
   });
 
-  if (parsed.protocol !== "https:") {
+  if (parsed.protocol === "http:" && !allowPrivateNetwork) {
     throw new ProviderRequestError(400, "Base URL must use https");
   }
 


### PR DESCRIPTION
## Summary

- wire the Gitea executor, proxy, credential validation, and base URL validation to the existing `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` opt-in
- allow trusted self-hosted Gitea instances on private LAN, CGNAT/Tailscale, and private hostnames when explicitly enabled
- allow plain HTTP instance URLs only when private-network access is enabled
- preserve guarded DNS and redirect validation, including targets that remain blocked regardless of the opt-in
- document the Gitea deployment requirement and add focused regression coverage

## Why

Gitea is commonly self-hosted on a LAN or an overlay network such as Tailscale.

Before this change, setting:

```env
OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK=true
```

did not affect the Gitea provider. Its base URL validation and request paths remained public-only, so instance URLs such as `http://192.168.1.10:3000` or hostnames resolving to private addresses were still rejected.

This change applies the existing deployment-level opt-in consistently across:

- credential validation
- action execution
- proxy requests
- Gitea base URL normalization

## Security behavior

The default behavior is unchanged: private and plain HTTP targets remain blocked unless the deployment explicitly enables private-network access.

When enabled:

- DNS-resolved address validation remains active
- redirects continue to be validated by the guarded fetch implementation
- loopback, link-local, cloud metadata, and other always-blocked targets remain rejected
- the opt-in applies only to the configured Gitea instance base URL

Private targets are only reachable from runtimes with network access to them, such as Node/Docker deployments. Enabling the flag does not make private addresses reachable from Cloudflare Workers.

## Validation

- `npm run fix-check`
- `npx vitest run src/providers/gitea/runtime.test.ts src/providers/gitea/executors.test.ts`
- full Vitest suite
- GitHub Actions: lint, formatting check, typecheck, and tests