### PR TITLE
fix(core): report every invalid action input property

### DIFF
--- a/src/core/validation.test.ts
+++ b/src/core/validation.test.ts
@@ -19,4 +19,30 @@ describe("validateActionInput", () => {
       ]),
     );
   });
+
+  it("reports every invalid property instead of stopping at the first", () => {
+    const action = {
+      id: "example.echo",
+      service: "example",
+      name: "echo",
+      description: "Example action.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          first: { type: "string" },
+          second: { type: "number" },
+          third: { type: "boolean" },
+        },
+        required: ["first", "second", "third"],
+      },
+      outputSchema: { type: "object" },
+    } as never;
+
+    const result = validateActionInput(action, { first: 1, second: "two", third: "three" });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map((error) => error.instanceLocation)).toEqual(
+      expect.arrayContaining(["#/first", "#/second", "#/third"]),
+    );
+  });
 });

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -28,7 +28,9 @@ export function validateActionInput(action: ActionDefinition, input: unknown): A
 function validatorFor(action: ActionDefinition): Validator {
   let validator = validators.get(action);
   if (validator === undefined) {
-    validator = new Validator(action.inputSchema as Schema, "2020-12");
+    // shortCircuit: false so one response lists every invalid property. Stopping
+    // at the first keeps a caller fixing input one field per round trip.
+    validator = new Validator(action.inputSchema as Schema, "2020-12", false);
     validators.set(action, validator);
   }
 


### PR DESCRIPTION
Calling an action with several invalid inputs only reports the first bad field, so a caller fixes its input one field per round trip.

```
input:   { first: 1, second: "two", third: "three" }
before:  1 error   (first)
after:   3 errors  (first, second, third)
```

Validation stopped at the first failure. It now collects them all.
