### PR TITLE
feat: add zlibrary provider

### DIFF
--- a/src/providers/zlibrary/actions.ts
+++ b/src/providers/zlibrary/actions.ts
@@ -1,0 +1,131 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "zlibrary";
+
+const bookSchema = s.object(
+  "One book record returned by the Z-Library EAPI, normalized to stable field names.",
+  {
+    id: s.string("The Z-Library book identifier."),
+    title: s.string("The book title."),
+    author: s.string("The primary author name."),
+    year: s.string("The publication year as reported by Z-Library."),
+    language: s.string("The book language code."),
+    extension: s.string("The file extension, e.g. pdf, epub, mobi."),
+    size: s.string("The file size as reported by Z-Library."),
+    rating: s.string("The user rating value."),
+    quality: s.string("The quality score reported by Z-Library."),
+    hash: s.string("The book hash used to build download and metadata URLs."),
+    pages: s.string("The page count."),
+    isbn: s.string("The ISBN when available."),
+    publisher: s.string("The publisher when available."),
+    url: s.string("The Z-Library book page URL."),
+    cover: s.string("The cover image URL."),
+  },
+  {
+    optional: [
+      "year",
+      "language",
+      "extension",
+      "size",
+      "rating",
+      "quality",
+      "pages",
+      "isbn",
+      "publisher",
+      "url",
+      "cover",
+    ],
+  },
+);
+
+const bookSearchInputSchema = s.object(
+  "The input payload for searching books on Z-Library.",
+  {
+    message: s.string("The search query, e.g. a title or author name.", { minLength: 1 }),
+    limit: s.integer("The maximum number of results to return.", { minimum: 1, maximum: 100 }),
+    page: s.integer("The result page number, starting at 1.", { minimum: 1 }),
+    yearFrom: s.integer("Only books published in this year or later."),
+    yearTo: s.integer("Only books published in this year or earlier."),
+    languages: s.array("Only books in these languages.", s.string("One language code, e.g. english.")),
+    extensions: s.array("Only books in these file formats.", s.string("One file extension, e.g. pdf.")),
+    exact: s.boolean("Require exact phrase matching for the query."),
+    order: s.stringEnum("Sort order for the results.", ["popular", "date_created", "date_updated"]),
+  },
+  { optional: ["limit", "page", "yearFrom", "yearTo", "languages", "extensions", "exact", "order"] },
+);
+
+const bookSearchOutputSchema = s.requiredObject("The book search results returned by Z-Library.", {
+  books: s.array("The matching books.", bookSchema),
+  total: s.integer("The total number of matching books reported by Z-Library."),
+});
+
+const bookIdentityInputSchema = s.requiredObject("Identify one book on Z-Library.", {
+  id: s.string("The Z-Library book identifier.", { minLength: 1 }),
+  hash: s.string("The book hash used to build the metadata URL.", { minLength: 1 }),
+});
+
+const bookIdentityOutputSchema = s.requiredObject("The book record returned by Z-Library.", {
+  book: bookSchema,
+});
+
+const bookDownloadOutputSchema = s.requiredObject("The downloaded book file, uploaded to connector transit storage.", {
+  file: s.requiredObject("The downloadable book file.", {
+    name: s.string("The file name, sanitized to a safe basename."),
+    mimetype: s.string("The file MIME type."),
+    downloadUrl: s.string("The local transit URL for downloading the file."),
+  }),
+});
+
+const downloadLimitsOutputSchema = s.requiredObject(
+  "The daily download quota for the authenticated Z-Library account.",
+  {
+    limits: s.requiredObject("Daily download limits reported by the EAPI profile.", {
+      daily_amount: s.integer("Downloads already used today."),
+      daily_allowed: s.integer("Total downloads allowed per day."),
+      daily_remaining: s.integer("Downloads remaining today."),
+    }),
+  },
+);
+
+export const zlibraryActions: readonly ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "search_books",
+    description: "Search books on Z-Library by keyword with optional year, language, format, and sort filters.",
+    requiredScopes: [],
+    inputSchema: bookSearchInputSchema,
+    outputSchema: bookSearchOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_book_metadata",
+    description: "Retrieve the full metadata record for one Z-Library book by id and hash.",
+    requiredScopes: [],
+    inputSchema: bookIdentityInputSchema,
+    outputSchema: bookIdentityOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "download_book_to_file",
+    description: "Download one book file from Z-Library and upload it to connector transit storage.",
+    requiredScopes: [],
+    inputSchema: bookIdentityInputSchema,
+    outputSchema: bookDownloadOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_download_limits",
+    description: "Retrieve the daily download quota for the authenticated Z-Library account.",
+    requiredScopes: [],
+    inputSchema: s.object("The input payload for retrieving download limits.", {}),
+    outputSchema: downloadLimitsOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_recent_books",
+    description: "List the most recently added books on Z-Library.",
+    requiredScopes: [],
+    inputSchema: s.object("The input payload for listing recent books.", {}),
+    outputSchema: s.requiredObject("The recent books returned by Z-Library.", {
+      books: s.array("The recent books.", bookSchema),
+    }),
+  }),
+];

--- a/src/providers/zlibrary/definition.test.ts
+++ b/src/providers/zlibrary/definition.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+describe("zlibrary definition", () => {
+  it("uses a custom credential with email and password fields", () => {
+    const auth = provider.auth.find((auth) => auth.type === "custom_credential");
+
+    expect(auth?.type).toBe("custom_credential");
+    const fields = auth?.fields ?? [];
+    expect(fields.map((field) => field.key)).toEqual(expect.arrayContaining(["email", "password"]));
+    expect(fields.find((field) => field.key === "password")?.secret).toBe(true);
+  });
+
+  it("offers an optional eapi domain override field", () => {
+    const auth = provider.auth.find((auth) => auth.type === "custom_credential");
+    const domainField = auth?.fields.find((field) => field.key === "eapiDomain");
+
+    expect(domainField?.required).toBe(false);
+  });
+
+  it("declares the planned actions", () => {
+    const names = provider.actions.map((action) => action.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "search_books",
+        "get_book_metadata",
+        "download_book_to_file",
+        "get_download_limits",
+        "get_recent_books",
+      ]),
+    );
+  });
+});

--- a/src/providers/zlibrary/definition.ts
+++ b/src/providers/zlibrary/definition.ts
@@ -1,0 +1,50 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { zlibraryActions } from "./actions.ts";
+
+const service = "zlibrary";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Z-Library",
+  categories: ["Books", "Reference"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "email",
+          label: "Email",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "user@example.com",
+          description:
+            "The Z-Library account email used to log in to the EAPI. Login happens lazily, on the first action that needs it.",
+        },
+        {
+          key: "password",
+          label: "Password",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "••••••••••••",
+          description: "The Z-Library account password. Stored as a secret and sent only to the selected EAPI domain.",
+        },
+        {
+          key: "eapiDomain",
+          label: "EAPI Domain (optional)",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "z-library.ec",
+          description:
+            "Pin a specific EAPI domain instead of probing the built-in fallback list. Useful when the default domains are behind the DiamWall anti-bot wall.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://z-lib.org",
+  actions: zlibraryActions,
+};

--- a/src/providers/zlibrary/executors.ts
+++ b/src/providers/zlibrary/executors.ts
@@ -1,0 +1,56 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { ZLibraryRuntimeContext } from "./runtime.ts";
+
+import { requiredString } from "../../core/cast.ts";
+import { defineProviderExecutors, ProviderRequestError, requireCustomCredential } from "../provider-runtime.ts";
+import { resolveEapiDomain, zlibraryActionHandlers, zlibraryEapiLogin } from "./runtime.ts";
+
+const service = "zlibrary";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: zlibraryActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ZLibraryRuntimeContext> {
+    const credential = await requireCustomCredential(context, service);
+    const providerContext: ZLibraryRuntimeContext = {
+      email: requiredString(credential.values.email, "email", (message) => new ProviderRequestError(400, message)),
+      password: requiredString(
+        credential.values.password,
+        "password",
+        (message) => new ProviderRequestError(400, message),
+      ),
+      eapiDomain: credential.values.eapiDomain ? String(credential.values.eapiDomain) : undefined,
+      fetcher,
+      signal: context.signal,
+    };
+    if (context.transitFiles) {
+      providerContext.transitFiles = context.transitFiles;
+    }
+    return providerContext;
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  async customCredential(input, { fetcher, signal }) {
+    const email = requiredString(input.values.email, "email", (message) => new ProviderRequestError(400, message));
+    const password = requiredString(
+      input.values.password,
+      "password",
+      (message) => new ProviderRequestError(400, message),
+    );
+    const eapiDomain = input.values.eapiDomain ? String(input.values.eapiDomain) : undefined;
+    const context: ZLibraryRuntimeContext = { email, password, eapiDomain, fetcher, signal };
+    const session = await zlibraryEapiLogin(context, resolveEapiDomain(context));
+    return {
+      profile: {
+        accountId: email,
+        displayName: email,
+      },
+      grantedScopes: [],
+      metadata: {
+        remixUserid: session.remixUserid,
+        eapiDomain: eapiDomain ?? undefined,
+      },
+    };
+  },
+};

--- a/src/providers/zlibrary/executors.ts
+++ b/src/providers/zlibrary/executors.ts
@@ -3,7 +3,7 @@ import type { ZLibraryRuntimeContext } from "./runtime.ts";
 
 import { requiredString } from "../../core/cast.ts";
 import { defineProviderExecutors, ProviderRequestError, requireCustomCredential } from "../provider-runtime.ts";
-import { resolveEapiDomain, zlibraryActionHandlers, zlibraryEapiLogin } from "./runtime.ts";
+import { zlibraryActionHandlers, zlibraryEapiLoginWithFallback } from "./runtime.ts";
 
 const service = "zlibrary";
 
@@ -40,7 +40,7 @@ export const credentialValidators: CredentialValidators = {
     );
     const eapiDomain = input.values.eapiDomain ? String(input.values.eapiDomain) : undefined;
     const context: ZLibraryRuntimeContext = { email, password, eapiDomain, fetcher, signal };
-    const session = await zlibraryEapiLogin(context, resolveEapiDomain(context));
+    const session = await zlibraryEapiLoginWithFallback(context);
     return {
       profile: {
         accountId: email,
@@ -49,7 +49,7 @@ export const credentialValidators: CredentialValidators = {
       grantedScopes: [],
       metadata: {
         remixUserid: session.remixUserid,
-        eapiDomain: eapiDomain ?? undefined,
+        eapiDomain: session.domain,
       },
     };
   },

--- a/src/providers/zlibrary/runtime.test.ts
+++ b/src/providers/zlibrary/runtime.test.ts
@@ -1,0 +1,147 @@
+import type { ZLibraryRuntimeContext } from "./runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { resolveEapiDomain, zlibraryActionHandlers } from "./runtime.ts";
+
+function context(overrides: Partial<ZLibraryRuntimeContext> = {}): ZLibraryRuntimeContext {
+  return {
+    email: "user@example.com",
+    password: "secret",
+    fetcher: async () => new Response("{}", { status: 200 }),
+    ...overrides,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("resolveEapiDomain", () => {
+  it("defaults to the first fallback domain", () => {
+    expect(resolveEapiDomain({ email: "a@b.c", password: "x" })).toBe("z-library.ec");
+  });
+
+  it("honors an explicit override and strips scheme and trailing slashes", () => {
+    expect(resolveEapiDomain({ email: "a@b.c", password: "x", eapiDomain: "https://1lib.sk/" })).toBe("1lib.sk");
+  });
+});
+
+describe("zlibrary search_books", () => {
+  it("posts a form-encoded search and normalizes the books", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const fetcher = async (url: RequestInfo | URL, init?: RequestInit) => {
+      const raw = String(url);
+      calls.push({ url: raw, init: init ?? {} });
+      if (raw.endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 42, remix_userkey: "key123" } });
+      }
+      return jsonResponse({
+        total: 1,
+        books: [
+          {
+            id: 7,
+            title: "Example Book",
+            author: "Jane Doe",
+            year: "2020",
+            language: "english",
+            extension: "pdf",
+            filesize: "1.2MB",
+            rating: "4.5",
+            qualityScore: "8",
+            hash: "abc123",
+            pages: "300",
+            href: "https://z-lib.org/book/7",
+          },
+        ],
+      });
+    };
+
+    const result = await zlibraryActionHandlers.search_books?.(
+      { message: "example", limit: 5, languages: ["english"] },
+      context({ fetcher }),
+    );
+
+    expect(result).toEqual({
+      books: [
+        expect.objectContaining({
+          id: "7",
+          title: "Example Book",
+          author: "Jane Doe",
+          hash: "abc123",
+        }),
+      ],
+      total: 1,
+    });
+    const searchCall = calls.find((call) => call.url.endsWith("/eapi/book/search"));
+    expect(searchCall).toBeDefined();
+    const body = searchCall?.init.body as URLSearchParams;
+    expect(body.get("message")).toBe("example");
+    expect(body.get("limit")).toBe("5");
+    expect(body.getAll("languages[]")).toEqual(["english"]);
+  });
+
+  it("throws a 401 on failed login", async () => {
+    const fetcher = async () => jsonResponse({ success: 0, error: "wrong credentials" }, 200);
+
+    await expect(zlibraryActionHandlers.search_books?.({ message: "x" }, context({ fetcher }))).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+});
+
+describe("zlibrary get_download_limits", () => {
+  it("reads the quota from the profile endpoint", async () => {
+    const fetcher = async (url: RequestInfo | URL) => {
+      const raw = String(url);
+      if (raw.endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } });
+      }
+      return jsonResponse({ user: { downloads_today: 3, downloads_limit: 10 } });
+    };
+
+    const result = await zlibraryActionHandlers.get_download_limits?.({}, context({ fetcher }));
+
+    expect(result).toEqual({
+      limits: { daily_amount: 3, daily_allowed: 10, daily_remaining: 7 },
+    });
+  });
+});
+
+describe("zlibrary download_book_to_file", () => {
+  it("uploads the file to transit storage and returns the download url", async () => {
+    let uploadedName = "";
+    const transitFiles = {
+      create: async (file: File) => {
+        uploadedName = file.name;
+        return { fileId: "f1", downloadUrl: "http://transit/f1", expiresAt: 0 };
+      },
+      maxBytes: 10_000_000,
+    } as never;
+    const fetcher = async (url: RequestInfo | URL) => {
+      const raw = String(url);
+      if (raw.endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } });
+      }
+      if (raw.endsWith("/file")) {
+        return jsonResponse({ file: { downloadLink: "https://cdn.example.com/book.pdf" } });
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/pdf", "content-disposition": 'attachment; filename="book.pdf"' },
+      });
+    };
+
+    const result = await zlibraryActionHandlers.download_book_to_file?.(
+      { id: "7", hash: "abc" },
+      context({ fetcher, transitFiles }),
+    );
+
+    expect(uploadedName).toBe("book.pdf");
+    expect(result).toEqual({
+      file: { name: "book.pdf", mimetype: "application/pdf", downloadUrl: "http://transit/f1" },
+    });
+  });
+});

--- a/src/providers/zlibrary/runtime.test.ts
+++ b/src/providers/zlibrary/runtime.test.ts
@@ -27,6 +27,12 @@ describe("resolveEapiDomain", () => {
   it("honors an explicit override and strips scheme and trailing slashes", () => {
     expect(resolveEapiDomain({ email: "a@b.c", password: "x", eapiDomain: "https://1lib.sk/" })).toBe("1lib.sk");
   });
+
+  it("rejects an override containing a path", () => {
+    expect(() => resolveEapiDomain({ email: "a@b.c", password: "x", eapiDomain: "https://1lib.sk/eapi" })).toThrow(
+      "without a path",
+    );
+  });
 });
 
 describe("zlibrary search_books", () => {
@@ -39,6 +45,7 @@ describe("zlibrary search_books", () => {
         return jsonResponse({ success: 1, user: { id: 42, remix_userkey: "key123" } });
       }
       return jsonResponse({
+        success: 1,
         total: 1,
         books: [
           {
@@ -90,6 +97,42 @@ describe("zlibrary search_books", () => {
       status: 401,
     });
   });
+
+  it("falls back when the preferred domain returns an anti-bot page", async () => {
+    const calls: string[] = [];
+    const fetcher = async (url: RequestInfo | URL) => {
+      const raw = String(url);
+      calls.push(raw);
+      if (raw.startsWith("https://blocked.example")) {
+        return new Response("<html>blocked</html>", { status: 403 });
+      }
+      if (raw.endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 42, remix_userkey: "key123" } });
+      }
+      return jsonResponse({ success: 1, total: 0, books: [] });
+    };
+
+    await expect(
+      zlibraryActionHandlers.search_books?.(
+        { message: "example" },
+        context({ fetcher, eapiDomain: "blocked.example" }),
+      ),
+    ).resolves.toEqual({ books: [], total: 0 });
+    expect(calls.some((url) => url.startsWith("https://z-library.ec"))).toBe(true);
+  });
+
+  it("surfaces an EAPI business error", async () => {
+    const fetcher = async (url: RequestInfo | URL) => {
+      if (String(url).endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 42, remix_userkey: "key123" } });
+      }
+      return jsonResponse({ success: 0, error: "search unavailable" });
+    };
+
+    await expect(zlibraryActionHandlers.search_books?.({ message: "x" }, context({ fetcher }))).rejects.toThrow(
+      "search unavailable",
+    );
+  });
 });
 
 describe("zlibrary get_download_limits", () => {
@@ -99,7 +142,7 @@ describe("zlibrary get_download_limits", () => {
       if (raw.endsWith("/eapi/user/login")) {
         return jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } });
       }
-      return jsonResponse({ user: { downloads_today: 3, downloads_limit: 10 } });
+      return jsonResponse({ success: 1, user: { downloads_today: 3, downloads_limit: 10 } });
     };
 
     const result = await zlibraryActionHandlers.get_download_limits?.({}, context({ fetcher }));
@@ -112,6 +155,7 @@ describe("zlibrary get_download_limits", () => {
 
 describe("zlibrary download_book_to_file", () => {
   it("uploads the file to transit storage and returns the download url", async () => {
+    let loginCount = 0;
     let uploadedName = "";
     const transitFiles = {
       create: async (file: File) => {
@@ -123,10 +167,11 @@ describe("zlibrary download_book_to_file", () => {
     const fetcher = async (url: RequestInfo | URL) => {
       const raw = String(url);
       if (raw.endsWith("/eapi/user/login")) {
+        loginCount += 1;
         return jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } });
       }
       if (raw.endsWith("/file")) {
-        return jsonResponse({ file: { downloadLink: "https://cdn.example.com/book.pdf" } });
+        return jsonResponse({ success: 1, file: { downloadLink: "https://cdn.example.com/book.pdf" } });
       }
       return new Response(new Uint8Array([1, 2, 3]), {
         status: 200,
@@ -140,8 +185,56 @@ describe("zlibrary download_book_to_file", () => {
     );
 
     expect(uploadedName).toBe("book.pdf");
+    expect(loginCount).toBe(1);
     expect(result).toEqual({
       file: { name: "book.pdf", mimetype: "application/pdf", downloadUrl: "http://transit/f1" },
     });
+  });
+
+  it("rejects a missing download link", async () => {
+    const fetcher = async (url: RequestInfo | URL) =>
+      String(url).endsWith("/eapi/user/login")
+        ? jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } })
+        : jsonResponse({ success: 1, file: {} });
+
+    await expect(
+      zlibraryActionHandlers.download_book_to_file?.(
+        { id: "7", hash: "abc" },
+        context({ fetcher, transitFiles: { create: async () => undefined } as never }),
+      ),
+    ).rejects.toThrow("no download link");
+  });
+
+  it("rejects a failed download response", async () => {
+    const fetcher = async (url: RequestInfo | URL) => {
+      const raw = String(url);
+      if (raw.endsWith("/eapi/user/login")) {
+        return jsonResponse({ success: 1, user: { id: 1, remix_userkey: "k" } });
+      }
+      if (raw.endsWith("/file")) {
+        return jsonResponse({ success: 1, file: { downloadLink: "https://cdn.example.com/book.pdf" } });
+      }
+      return new Response("unavailable", { status: 503 });
+    };
+
+    await expect(
+      zlibraryActionHandlers.download_book_to_file?.(
+        { id: "7", hash: "abc" },
+        context({ fetcher, transitFiles: { create: async () => undefined } as never }),
+      ),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+
+  it("requires transit storage before making a request", async () => {
+    let requested = false;
+    const fetcher = async () => {
+      requested = true;
+      return jsonResponse({});
+    };
+
+    await expect(
+      zlibraryActionHandlers.download_book_to_file?.({ id: "7", hash: "abc" }, context({ fetcher })),
+    ).rejects.toThrow("requires local transit files");
+    expect(requested).toBe(false);
   });
 });

--- a/src/providers/zlibrary/runtime.ts
+++ b/src/providers/zlibrary/runtime.ts
@@ -1,0 +1,294 @@
+import type { TransitFileWriter } from "../../core/types.ts";
+
+import { optionalString, requiredString } from "../../core/cast.ts";
+import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+type ZLibraryCredential = {
+  email: string;
+  password: string;
+  eapiDomain?: string;
+};
+
+export type ZLibraryRuntimeContext = ZLibraryCredential & {
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+  transitFiles?: TransitFileWriter;
+};
+
+type ZLibraryActionHandler = (input: Record<string, unknown>, context: ZLibraryRuntimeContext) => Promise<unknown>;
+
+const defaultEapiDomains = ["z-library.ec", "z-library.sk", "1lib.sk"];
+
+const eapiHeaders = {
+  "user-agent": providerUserAgent,
+  accept: "application/json, text/plain, */*",
+  "content-type": "application/x-www-form-urlencoded",
+};
+
+export function resolveEapiDomain(credential: ZLibraryCredential): string {
+  const override = credential.eapiDomain?.trim();
+  if (override) {
+    return override.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+  }
+  return defaultEapiDomains[0];
+}
+
+function buildEapiUrl(domain: string, path: string): string {
+  return `https://${domain}${path}`;
+}
+
+async function readJson(response: Response, domain: string): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new ProviderRequestError(
+      response.status,
+      `zlibrary ${domain} returned non-JSON HTTP ${response.status} (possible anti-bot block page)`,
+    );
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new ProviderRequestError(response.status, `zlibrary ${domain} returned an unexpected JSON payload`);
+  }
+  return payload as Record<string, unknown>;
+}
+
+export async function zlibraryEapiLogin(
+  context: ZLibraryRuntimeContext,
+  domain: string,
+): Promise<{ remixUserid: string; remixUserkey: string }> {
+  const body = new URLSearchParams({
+    email: context.email,
+    password: context.password,
+  });
+  const response = await context.fetcher(buildEapiUrl(domain, "/eapi/user/login"), {
+    method: "POST",
+    headers: eapiHeaders,
+    body,
+    signal: context.signal,
+  });
+  const payload = await readJson(response, domain);
+  const user = (payload.user ?? {}) as Record<string, unknown>;
+  const remixUserkey = optionalString(user.remix_userkey);
+  if (payload.success !== 1 || !remixUserkey) {
+    throw new ProviderRequestError(
+      response.status === 200 ? 401 : response.status,
+      optionalString(payload.error) ??
+        optionalString(payload.message) ??
+        "zlibrary login failed: check the email and password",
+    );
+  }
+  return {
+    remixUserid: String(user.id ?? ""),
+    remixUserkey,
+  };
+}
+
+async function eapiPost(
+  context: ZLibraryRuntimeContext,
+  domain: string,
+  path: string,
+  data: Record<string, string | string[]>,
+): Promise<Record<string, unknown>> {
+  const session = await zlibraryEapiLogin(context, domain);
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        body.append(key, item);
+      }
+    } else {
+      body.append(key, value);
+    }
+  }
+  const response = await context.fetcher(buildEapiUrl(domain, path), {
+    method: "POST",
+    headers: {
+      ...eapiHeaders,
+      cookie: `remix_userid=${session.remixUserid}; remix_userkey=${session.remixUserkey}`,
+    },
+    body,
+    signal: context.signal,
+  });
+  return readJson(response, domain);
+}
+
+async function eapiGet(
+  context: ZLibraryRuntimeContext,
+  domain: string,
+  path: string,
+): Promise<Record<string, unknown>> {
+  const session = await zlibraryEapiLogin(context, domain);
+  const response = await context.fetcher(buildEapiUrl(domain, path), {
+    method: "GET",
+    headers: {
+      ...eapiHeaders,
+      cookie: `remix_userid=${session.remixUserid}; remix_userkey=${session.remixUserkey}`,
+    },
+    signal: context.signal,
+  });
+  return readJson(response, domain);
+}
+
+function normalizeBook(raw: Record<string, unknown>): Record<string, unknown> {
+  const author = optionalString(raw.author) ?? "";
+  return {
+    id: String(raw.id ?? ""),
+    title: optionalString(raw.title) ?? "",
+    author,
+    year: optionalString(raw.year) ?? "",
+    language: optionalString(raw.language) ?? "",
+    extension: optionalString(raw.extension) ?? "",
+    size: optionalString(raw.filesize) ?? "",
+    rating: optionalString(raw.rating) ?? "",
+    quality: optionalString(raw.qualityScore) ?? "",
+    hash: optionalString(raw.hash) ?? "",
+    pages: optionalString(raw.pages) ?? "",
+    isbn: optionalString(raw.isbn) ?? "",
+    publisher: optionalString(raw.publisher) ?? "",
+    url: optionalString(raw.href) ?? "",
+    cover: optionalString(raw.cover) ?? "",
+  };
+}
+
+function sanitizeDownloadFilename(filename: string): string {
+  const candidate = filename.split("/").pop()?.split("\\").pop()?.trim() ?? "";
+  if (!candidate || candidate === "." || candidate === "..") {
+    return "";
+  }
+  return candidate;
+}
+
+async function downloadBookFile(
+  context: ZLibraryRuntimeContext,
+  domain: string,
+  bookId: string,
+  bookHash: string,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(500, "zlibrary file output requires local transit files");
+  }
+
+  const linkPayload = await eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}/file`);
+  const filePayload = (linkPayload.file ?? linkPayload) as Record<string, unknown>;
+  const downloadLink = optionalString(filePayload.downloadLink) ?? optionalString(filePayload.url) ?? "";
+
+  if (!downloadLink) {
+    throw new ProviderRequestError(502, `zlibrary returned no download link for book ${bookId}`);
+  }
+  const absoluteUrl = downloadLink.startsWith("/") ? buildEapiUrl(domain, downloadLink) : downloadLink;
+
+  const session = await zlibraryEapiLogin(context, domain);
+  const response = await context.fetcher(absoluteUrl, {
+    method: "GET",
+    headers: {
+      "user-agent": providerUserAgent,
+      cookie: `remix_userid=${session.remixUserid}; remix_userkey=${session.remixUserkey}`,
+    },
+    signal: context.signal,
+  });
+  if (!response.ok) {
+    throw new ProviderRequestError(response.status, `zlibrary download failed with HTTP ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength === 0) {
+    throw new ProviderRequestError(502, `zlibrary download produced an empty file for book ${bookId}`);
+  }
+
+  let name = "";
+  const disposition = response.headers.get("content-disposition") ?? "";
+  const extended = /filename\*\s*=\s*UTF-8''([^;\s]+)/iu.exec(disposition);
+  const quoted = /filename\s*=\s*"([^"]*)"/iu.exec(disposition);
+  const bare = /filename\s*=\s*([^;"\s]+)/iu.exec(disposition);
+  if (extended) {
+    name = decodeURIComponent(extended[1]);
+  } else if (quoted) {
+    name = quoted[1];
+  } else if (bare) {
+    name = bare[1];
+  }
+  name = sanitizeDownloadFilename(name) || `${bookId}.bin`;
+
+  const upload = await context.transitFiles.create(new File([bytes], name, { type: contentType }));
+  return {
+    name,
+    mimetype: contentType,
+    downloadUrl: upload.downloadUrl,
+  };
+}
+
+export const zlibraryActionHandlers: Record<string, ZLibraryActionHandler> = {
+  async search_books(input, context) {
+    const domain = resolveEapiDomain(context);
+    const data: Record<string, string | string[]> = {
+      message: requiredString(input.message, "message", (message) => new ProviderRequestError(400, message)),
+      limit: String(input.limit ?? 10),
+      page: String(input.page ?? 1),
+    };
+    const yearFrom = input.yearFrom;
+    if (typeof yearFrom === "number") data.yearFrom = String(yearFrom);
+    const yearTo = input.yearTo;
+    if (typeof yearTo === "number") data.yearTo = String(yearTo);
+    if (Array.isArray(input.languages) && input.languages.length > 0) {
+      data["languages[]"] = input.languages.map(String);
+    }
+    if (Array.isArray(input.extensions) && input.extensions.length > 0) {
+      data["extensions[]"] = input.extensions.map(String);
+    }
+    if (input.exact === true) data.e = "1";
+    const order = input.order;
+    if (typeof order === "string") data.order = order;
+
+    const payload = await eapiPost(context, domain, "/eapi/book/search", data);
+    const books = Array.isArray(payload.books)
+      ? payload.books.map((book) => normalizeBook(book as Record<string, unknown>))
+      : [];
+    const total =
+      typeof payload.total === "number" ? payload.total : Array.isArray(payload.books) ? payload.books.length : 0;
+    return { books, total };
+  },
+
+  async get_book_metadata(input, context) {
+    const domain = resolveEapiDomain(context);
+    const bookId = requiredString(input.id, "id", (message) => new ProviderRequestError(400, message));
+    const bookHash = requiredString(input.hash, "hash", (message) => new ProviderRequestError(400, message));
+    const payload = await eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}`);
+    const raw = (payload.book ?? payload) as Record<string, unknown>;
+    return { book: normalizeBook(raw) };
+  },
+
+  async download_book_to_file(input, context) {
+    const domain = resolveEapiDomain(context);
+    const bookId = requiredString(input.id, "id", (message) => new ProviderRequestError(400, message));
+    const bookHash = requiredString(input.hash, "hash", (message) => new ProviderRequestError(400, message));
+    const file = await downloadBookFile(context, domain, bookId, bookHash);
+    return { file };
+  },
+
+  async get_download_limits(_input, context) {
+    const domain = resolveEapiDomain(context);
+    const payload = await eapiGet(context, domain, "/eapi/user/profile");
+    const user = (payload.user ?? {}) as Record<string, unknown>;
+    const today = Number(user.downloads_today ?? user.dailyDownloadsCount ?? 0);
+    const allowed = Number(user.downloads_limit ?? user.dailyDownloadLimit ?? 0);
+    return {
+      limits: {
+        daily_amount: today,
+        daily_allowed: allowed,
+        daily_remaining: Math.max(0, allowed - today),
+      },
+    };
+  },
+
+  async get_recent_books(_input, context) {
+    const domain = resolveEapiDomain(context);
+    const payload = await eapiGet(context, domain, "/eapi/book/recently");
+    const books = Array.isArray(payload.books)
+      ? payload.books.map((book) => normalizeBook(book as Record<string, unknown>))
+      : [];
+    return { books };
+  },
+};

--- a/src/providers/zlibrary/runtime.ts
+++ b/src/providers/zlibrary/runtime.ts
@@ -3,11 +3,11 @@ import type { TransitFileWriter } from "../../core/types.ts";
 import { optionalString, requiredString } from "../../core/cast.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
-type ZLibraryCredential = {
+interface ZLibraryCredential {
   email: string;
   password: string;
   eapiDomain?: string;
-};
+}
 
 export type ZLibraryRuntimeContext = ZLibraryCredential & {
   fetcher: typeof fetch;
@@ -25,12 +25,45 @@ const eapiHeaders = {
   "content-type": "application/x-www-form-urlencoded",
 };
 
-export function resolveEapiDomain(credential: ZLibraryCredential): string {
-  const override = credential.eapiDomain?.trim();
-  if (override) {
-    return override.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+interface ZLibrarySession {
+  remixUserid: string;
+  remixUserkey: string;
+}
+
+class ZLibraryAntiBotError extends ProviderRequestError {}
+
+function normalizeEapiDomain(value: string, fieldName: string): string {
+  let url: URL;
+  try {
+    url = new URL(value.includes("://") ? value : `https://${value}`);
+  } catch {
+    throw new ProviderRequestError(400, `${fieldName} must be a valid HTTPS domain`);
   }
-  return defaultEapiDomains[0];
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.port ||
+    (url.pathname !== "/" && url.pathname !== "") ||
+    url.search ||
+    url.hash
+  ) {
+    throw new ProviderRequestError(400, `${fieldName} must be an HTTPS domain without a path, port, or credentials`);
+  }
+  return url.hostname;
+}
+
+function resolveEapiDomains(credential: ZLibraryCredential): string[] {
+  const configuredDomains = [
+    credential.eapiDomain?.trim(),
+    process.env.ZLIBRARY_EAPI_DOMAIN?.trim(),
+    ...defaultEapiDomains,
+  ].filter((value): value is string => Boolean(value));
+  return [...new Set(configuredDomains.map((value) => normalizeEapiDomain(value, "Z-Library EAPI domain")))];
+}
+
+export function resolveEapiDomain(credential: ZLibraryCredential): string {
+  return resolveEapiDomains(credential)[0];
 }
 
 function buildEapiUrl(domain: string, path: string): string {
@@ -43,8 +76,8 @@ async function readJson(response: Response, domain: string): Promise<Record<stri
   try {
     payload = JSON.parse(text);
   } catch {
-    throw new ProviderRequestError(
-      response.status,
+    throw new ZLibraryAntiBotError(
+      response.status === 200 ? 502 : response.status,
       `zlibrary ${domain} returned non-JSON HTTP ${response.status} (possible anti-bot block page)`,
     );
   }
@@ -54,10 +87,41 @@ async function readJson(response: Response, domain: string): Promise<Record<stri
   return payload as Record<string, unknown>;
 }
 
-export async function zlibraryEapiLogin(
+function assertSuccessfulPayload(
+  payload: Record<string, unknown>,
+  response: Response,
+  path: string,
+): Record<string, unknown> {
+  if (payload.success !== 1) {
+    throw new ProviderRequestError(
+      response.status === 200 ? 502 : response.status,
+      optionalString(payload.error) ?? optionalString(payload.message) ?? `zlibrary request to ${path} failed`,
+      payload,
+    );
+  }
+  return payload;
+}
+
+async function withEapiDomainFallback<T>(
   context: ZLibraryRuntimeContext,
-  domain: string,
-): Promise<{ remixUserid: string; remixUserkey: string }> {
+  operation: (domain: string) => Promise<T>,
+): Promise<T> {
+  const domains = resolveEapiDomains(context);
+  let antiBotError: ZLibraryAntiBotError | undefined;
+  for (const domain of domains) {
+    try {
+      return await operation(domain);
+    } catch (error) {
+      if (!(error instanceof ZLibraryAntiBotError)) {
+        throw error;
+      }
+      antiBotError = error;
+    }
+  }
+  throw antiBotError ?? new ProviderRequestError(502, "zlibrary has no configured EAPI domain");
+}
+
+export async function zlibraryEapiLogin(context: ZLibraryRuntimeContext, domain: string): Promise<ZLibrarySession> {
   const body = new URLSearchParams({
     email: context.email,
     password: context.password,
@@ -111,24 +175,25 @@ async function eapiPost(
     body,
     signal: context.signal,
   });
-  return readJson(response, domain);
+  return assertSuccessfulPayload(await readJson(response, domain), response, path);
 }
 
 async function eapiGet(
   context: ZLibraryRuntimeContext,
   domain: string,
   path: string,
+  session?: ZLibrarySession,
 ): Promise<Record<string, unknown>> {
-  const session = await zlibraryEapiLogin(context, domain);
+  const activeSession = session ?? (await zlibraryEapiLogin(context, domain));
   const response = await context.fetcher(buildEapiUrl(domain, path), {
     method: "GET",
     headers: {
       ...eapiHeaders,
-      cookie: `remix_userid=${session.remixUserid}; remix_userkey=${session.remixUserkey}`,
+      cookie: `remix_userid=${activeSession.remixUserid}; remix_userkey=${activeSession.remixUserkey}`,
     },
     signal: context.signal,
   });
-  return readJson(response, domain);
+  return assertSuccessfulPayload(await readJson(response, domain), response, path);
 }
 
 function normalizeBook(raw: Record<string, unknown>): Record<string, unknown> {
@@ -170,7 +235,8 @@ async function downloadBookFile(
     throw new ProviderRequestError(500, "zlibrary file output requires local transit files");
   }
 
-  const linkPayload = await eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}/file`);
+  const session = await zlibraryEapiLogin(context, domain);
+  const linkPayload = await eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}/file`, session);
   const filePayload = (linkPayload.file ?? linkPayload) as Record<string, unknown>;
   const downloadLink = optionalString(filePayload.downloadLink) ?? optionalString(filePayload.url) ?? "";
 
@@ -179,7 +245,6 @@ async function downloadBookFile(
   }
   const absoluteUrl = downloadLink.startsWith("/") ? buildEapiUrl(domain, downloadLink) : downloadLink;
 
-  const session = await zlibraryEapiLogin(context, domain);
   const response = await context.fetcher(absoluteUrl, {
     method: "GET",
     headers: {
@@ -222,7 +287,6 @@ async function downloadBookFile(
 
 export const zlibraryActionHandlers: Record<string, ZLibraryActionHandler> = {
   async search_books(input, context) {
-    const domain = resolveEapiDomain(context);
     const data: Record<string, string | string[]> = {
       message: requiredString(input.message, "message", (message) => new ProviderRequestError(400, message)),
       limit: String(input.limit ?? 10),
@@ -242,7 +306,9 @@ export const zlibraryActionHandlers: Record<string, ZLibraryActionHandler> = {
     const order = input.order;
     if (typeof order === "string") data.order = order;
 
-    const payload = await eapiPost(context, domain, "/eapi/book/search", data);
+    const payload = await withEapiDomainFallback(context, (domain) =>
+      eapiPost(context, domain, "/eapi/book/search", data),
+    );
     const books = Array.isArray(payload.books)
       ? payload.books.map((book) => normalizeBook(book as Record<string, unknown>))
       : [];
@@ -252,25 +318,24 @@ export const zlibraryActionHandlers: Record<string, ZLibraryActionHandler> = {
   },
 
   async get_book_metadata(input, context) {
-    const domain = resolveEapiDomain(context);
     const bookId = requiredString(input.id, "id", (message) => new ProviderRequestError(400, message));
     const bookHash = requiredString(input.hash, "hash", (message) => new ProviderRequestError(400, message));
-    const payload = await eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}`);
+    const payload = await withEapiDomainFallback(context, (domain) =>
+      eapiGet(context, domain, `/eapi/book/${bookId}/${bookHash}`),
+    );
     const raw = (payload.book ?? payload) as Record<string, unknown>;
     return { book: normalizeBook(raw) };
   },
 
   async download_book_to_file(input, context) {
-    const domain = resolveEapiDomain(context);
     const bookId = requiredString(input.id, "id", (message) => new ProviderRequestError(400, message));
     const bookHash = requiredString(input.hash, "hash", (message) => new ProviderRequestError(400, message));
-    const file = await downloadBookFile(context, domain, bookId, bookHash);
+    const file = await withEapiDomainFallback(context, (domain) => downloadBookFile(context, domain, bookId, bookHash));
     return { file };
   },
 
   async get_download_limits(_input, context) {
-    const domain = resolveEapiDomain(context);
-    const payload = await eapiGet(context, domain, "/eapi/user/profile");
+    const payload = await withEapiDomainFallback(context, (domain) => eapiGet(context, domain, "/eapi/user/profile"));
     const user = (payload.user ?? {}) as Record<string, unknown>;
     const today = Number(user.downloads_today ?? user.dailyDownloadsCount ?? 0);
     const allowed = Number(user.downloads_limit ?? user.dailyDownloadLimit ?? 0);
@@ -284,11 +349,19 @@ export const zlibraryActionHandlers: Record<string, ZLibraryActionHandler> = {
   },
 
   async get_recent_books(_input, context) {
-    const domain = resolveEapiDomain(context);
-    const payload = await eapiGet(context, domain, "/eapi/book/recently");
+    const payload = await withEapiDomainFallback(context, (domain) => eapiGet(context, domain, "/eapi/book/recently"));
     const books = Array.isArray(payload.books)
       ? payload.books.map((book) => normalizeBook(book as Record<string, unknown>))
       : [];
     return { books };
   },
 };
+
+export async function zlibraryEapiLoginWithFallback(
+  context: ZLibraryRuntimeContext,
+): Promise<ZLibrarySession & { domain: string }> {
+  return withEapiDomainFallback(context, async (domain) => ({
+    ...(await zlibraryEapiLogin(context, domain)),
+    domain,
+  }));
+}


### PR DESCRIPTION
Adds a `zlibrary` provider with search, metadata, download-to-file, download limits, and recent books actions.

Auth is a `custom_credential` (email + password) with lazy login to the EAPI, plus an optional `eapiDomain` field to pin a working domain when the defaults are behind the anti-bot wall. File downloads go through transit storage.

Closes #244.