### PR TITLE
fix(cloudflare-mcp): use Cloudflare Workers icon

### DIFF
--- a/src/providers/cloudflare_mcp/definition.ts
+++ b/src/providers/cloudflare_mcp/definition.ts
@@ -36,5 +36,6 @@ export const provider: ProviderDefinition = {
     },
   ],
   homepageUrl: "https://github.com/cloudflare/mcp",
+  iconUrl: "https://workers.cloudflare.com/favicon.ico",
   actions: cloudflareMcpActions,
 };


### PR DESCRIPTION
## Summary

- give the Cloudflare MCP provider an explicit Cloudflare Workers favicon
- keep its GitHub repository as the provider homepage
- prevent the generic homepage fallback from rendering the GitHub icon

## Validation

- `npm run generate:catalog`
- `npm run fix-check`