### PR TITLE
feat(web): add category filter to provider browser

### DIFF
--- a/web/src/i18n.test.ts
+++ b/web/src/i18n.test.ts
@@ -62,18 +62,25 @@ describe("resolveInitialLang", () => {
 describe("createAppI18n", () => {
   it("creates an i18n instance with app translations", () => {
     const french = createAppI18n("fr");
+    const japanese = createAppI18n("ja");
     const russian = createAppI18n("ru");
+    const simplifiedChinese = createAppI18n("zh-CN");
     const traditionalChinese = createAppI18n("zh-TW");
 
     expect(french.lang).toBe("fr");
     expect(french.t("nav.providers")).toBe("Fournisseurs");
     expect(french.t("language.fr")).toBe("Français");
+    expect(french.t("providers.categories.all")).toBe("Toutes les catégories");
+    expect(japanese.t("providers.categories.all")).toBe("すべてのカテゴリー");
     expect(russian.lang).toBe("ru");
     expect(russian.t("nav.providers")).toBe("Провайдеры");
     expect(russian.t("language.ru")).toBe("Русский");
+    expect(russian.t("providers.categories.all")).toBe("Все категории");
+    expect(simplifiedChinese.t("providers.categories.all")).toBe("所有分类");
     expect(traditionalChinese.lang).toBe("zh-TW");
     expect(traditionalChinese.t("nav.providers")).toBe("服務提供者");
     expect(traditionalChinese.t("language.zh-TW")).toBe("繁體中文");
+    expect(traditionalChinese.t("providers.categories.all")).toBe("所有分類");
     expect(supportedLangs).toEqual(["en", "zh-CN", "zh-TW", "ja", "ru", "fr"]);
   });
 });

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "Executable",
       "catalogOnly": "Catalog only"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "Exécutable",
       "catalogOnly": "Catalogue uniquement"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -248,9 +248,9 @@
       "executable": "Exécutable",
       "catalogOnly": "Catalogue uniquement"
     },
-    "categoryFilterLabel": "Category",
+    "categoryFilterLabel": "Catégorie",
     "categories": {
-      "all": "All categories"
+      "all": "Toutes les catégories"
     }
   },
   "actions": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -248,9 +248,9 @@
       "executable": "実行可能",
       "catalogOnly": "カタログのみ"
     },
-    "categoryFilterLabel": "Category",
+    "categoryFilterLabel": "カテゴリー",
     "categories": {
-      "all": "All categories"
+      "all": "すべてのカテゴリー"
     }
   },
   "actions": {

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "実行可能",
       "catalogOnly": "カタログのみ"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "Выполняемое",
       "catalogOnly": "Только каталог"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -248,9 +248,9 @@
       "executable": "Выполняемое",
       "catalogOnly": "Только каталог"
     },
-    "categoryFilterLabel": "Category",
+    "categoryFilterLabel": "Категория",
     "categories": {
-      "all": "All categories"
+      "all": "Все категории"
     }
   },
   "actions": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -248,9 +248,9 @@
       "executable": "可执行",
       "catalogOnly": "仅目录"
     },
-    "categoryFilterLabel": "Category",
+    "categoryFilterLabel": "分类",
     "categories": {
-      "all": "All categories"
+      "all": "所有分类"
     }
   },
   "actions": {

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "可执行",
       "catalogOnly": "仅目录"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -248,9 +248,9 @@
       "executable": "可執行",
       "catalogOnly": "僅供目錄查閱"
     },
-    "categoryFilterLabel": "Category",
+    "categoryFilterLabel": "分類",
     "categories": {
-      "all": "All categories"
+      "all": "所有分類"
     }
   },
   "actions": {

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -247,6 +247,10 @@
     "execution": {
       "executable": "可執行",
       "catalogOnly": "僅供目錄查閱"
+    },
+    "categoryFilterLabel": "Category",
+    "categories": {
+      "all": "All categories"
     }
   },
   "actions": {

--- a/web/src/model.test.ts
+++ b/web/src/model.test.ts
@@ -1,7 +1,13 @@
 import type { AppData, ProviderDefinition, RunLog } from "./model";
 
 import { describe, expect, it } from "vitest";
-import { createOverviewSummary, resolveProviderConnectionStatus, sortProviders } from "./model";
+import {
+  createOverviewSummary,
+  filterProvidersByCategory,
+  providerCategoryCounts,
+  resolveProviderConnectionStatus,
+  sortProviders,
+} from "./model";
 
 function provider(service: string, displayName: string): ProviderDefinition {
   return {
@@ -98,6 +104,56 @@ describe("sortProviders", () => {
       "google_bigquery",
       "ably",
     ]);
+  });
+});
+
+describe("filterProvidersByCategory", () => {
+  function categorized(service: string, categories: string[]): ProviderDefinition {
+    return { ...provider(service, service), categories };
+  }
+
+  it("returns everything for the all filter", () => {
+    const providers = [categorized("a", ["Data"]), categorized("b", ["Communication"])];
+
+    expect(filterProvidersByCategory(providers, "all")).toEqual(providers);
+  });
+
+  it("keeps only providers in the selected category", () => {
+    const providers = [
+      categorized("a", ["Data"]),
+      categorized("b", ["Communication"]),
+      categorized("c", ["Data", "AI"]),
+    ];
+
+    expect(filterProvidersByCategory(providers, "Data").map((item) => item.service)).toEqual(["a", "c"]);
+    expect(filterProvidersByCategory(providers, "AI").map((item) => item.service)).toEqual(["c"]);
+  });
+
+  it("returns nothing for an unmatched category", () => {
+    const providers = [categorized("a", ["Data"])];
+
+    expect(filterProvidersByCategory(providers, "Storage")).toEqual([]);
+  });
+});
+
+describe("providerCategoryCounts", () => {
+  it("counts providers per category, including multi-category providers once per category", () => {
+    const providers = [
+      { ...provider("a", "a"), categories: ["Data", "AI"] },
+      { ...provider("b", "b"), categories: ["Data"] },
+      { ...provider("c", "c"), categories: ["Communication"] },
+    ];
+
+    const counts = providerCategoryCounts(providers);
+    expect(counts.get("Data")).toBe(2);
+    expect(counts.get("AI")).toBe(1);
+    expect(counts.get("Communication")).toBe(1);
+    expect(counts.get("Storage")).toBeUndefined();
+  });
+
+  it("handles providers without categories", () => {
+    const counts = providerCategoryCounts([provider("a", "a"), provider("b", "b")]);
+    expect(counts.size).toBe(0);
   });
 });
 

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -370,6 +370,21 @@ export function filterProviders(providers: ProviderDefinition[], query: string):
   );
 }
 
+export function filterProvidersByCategory(providers: ProviderDefinition[], category: string): ProviderDefinition[] {
+  if (category === "all") return providers;
+  return providers.filter((provider) => provider.categories.includes(category));
+}
+
+export function providerCategoryCounts(providers: ProviderDefinition[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const provider of providers) {
+    for (const category of provider.categories) {
+      counts.set(category, (counts.get(category) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
 export function sortProviders(
   providers: ProviderDefinition[],
   connectionsByService: Map<string, ConnectionRecord>,

--- a/web/src/providers-page.test.ts
+++ b/web/src/providers-page.test.ts
@@ -443,9 +443,14 @@ describe("isProviderLocallyAvailable", () => {
 });
 
 describe("providerBrowserResetKey", () => {
-  it("changes when search or status filters change", () => {
-    expect(providerBrowserResetKey("gmail", "all")).not.toBe(providerBrowserResetKey("gmail", "connected"));
-    expect(providerBrowserResetKey("gmail", "all")).not.toBe(providerBrowserResetKey("slack", "all"));
+  it("changes when search, status, or category filters change", () => {
+    expect(providerBrowserResetKey("gmail", "all", "all")).not.toBe(
+      providerBrowserResetKey("gmail", "connected", "all"),
+    );
+    expect(providerBrowserResetKey("gmail", "all", "all")).not.toBe(providerBrowserResetKey("slack", "all", "all"));
+    expect(providerBrowserResetKey("gmail", "all", "all")).not.toBe(
+      providerBrowserResetKey("gmail", "all", "Communication"),
+    );
   });
 });
 

--- a/web/src/providers-page.tsx
+++ b/web/src/providers-page.tsx
@@ -178,6 +178,7 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
     [credentialConnectionsByService, props.data.providers],
   );
   const searchedProviders = filterProviders(sortedProviders, query);
+  const categoryFilteredProviders = filterProvidersByCategory(searchedProviders, categoryFilter);
   const statusFilteredProviders = filterProvidersByStatus(searchedProviders, statusFilter, statusByService);
   const visibleProviders = filterProvidersByCategory(statusFilteredProviders, categoryFilter);
   const {
@@ -192,17 +193,20 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
     () =>
       providerStatusOptions.map((option) => ({
         ...option,
-        count: countProvidersForStatus(searchedProviders, option.id, statusByService),
+        count: countProvidersForStatus(categoryFilteredProviders, option.id, statusByService),
       })),
-    [searchedProviders, statusByService],
+    [categoryFilteredProviders, statusByService],
   );
-  const categoryCounts = useMemo(() => providerCategoryCounts(searchedProviders), [searchedProviders]);
+  const categoryCounts = useMemo(() => providerCategoryCounts(statusFilteredProviders), [statusFilteredProviders]);
   const categoryOptions = useMemo(
     () =>
-      [...categoryCounts.entries()]
+      [
+        ...categoryCounts.entries(),
+        ...(categoryFilter !== "all" && !categoryCounts.has(categoryFilter) ? [[categoryFilter, 0] as const] : []),
+      ]
         .sort((left, right) => left[0].localeCompare(right[0]))
         .map(([category, count]) => ({ category, count })),
-    [categoryCounts],
+    [categoryCounts, categoryFilter],
   );
 
   function resetFilters(): void {
@@ -365,7 +369,7 @@ function ProviderCollectionBar(props: {
           <ToggleGroupItem
             key={option.id}
             value={option.id}
-            className="h-8 gap-2 rounded-md border px-3 text-sm data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90 data-[state=on]:[&>span:last-child]:text-primary-foreground/70 [&>span:last-child]:text-xs [&>span:last-child]:text-muted-foreground [&>span:last-child]:tabular-nums"
+            className="h-8 gap-2 rounded-md border px-3 text-sm data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90 data-[state=on]:[&>span:last-child]:text-primary-foreground/70 [&>span:last-child]:min-w-8 [&>span:last-child]:text-right [&>span:last-child]:text-xs [&>span:last-child]:text-muted-foreground [&>span:last-child]:tabular-nums"
             disabled={option.count === 0 && option.id !== "all"}
           >
             <span>{t(option.labelKey)}</span>
@@ -381,7 +385,7 @@ function ProviderCollectionBar(props: {
         >
           <SelectValue />
         </SelectTrigger>
-        <SelectContent position="popper" align="start">
+        <SelectContent className="p-1" position="popper" align="start">
           <SelectItem value="all">{t("providers.categories.all")}</SelectItem>
           {props.categoryOptions.map((option) => (
             <SelectItem key={option.category} value={option.category}>

--- a/web/src/providers-page.tsx
+++ b/web/src/providers-page.tsx
@@ -31,6 +31,8 @@ import { apiDelete, apiPost, apiPut } from "./api";
 import {
   credentialFieldsFor,
   filterProviders,
+  filterProvidersByCategory,
+  providerCategoryCounts,
   resolveProviderConnectionStatus,
   sortProviders,
   usableConnectionsForService,
@@ -40,6 +42,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
@@ -149,7 +152,8 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
   const t = useTranslate();
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<ProviderStatusFilter>("all");
-  const resetKey = providerBrowserResetKey(query, statusFilter);
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const resetKey = providerBrowserResetKey(query, statusFilter, categoryFilter);
   const statusByService = useMemo(
     () =>
       new Map(
@@ -174,7 +178,8 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
     [credentialConnectionsByService, props.data.providers],
   );
   const searchedProviders = filterProviders(sortedProviders, query);
-  const visibleProviders = filterProvidersByStatus(searchedProviders, statusFilter, statusByService);
+  const statusFilteredProviders = filterProvidersByStatus(searchedProviders, statusFilter, statusByService);
+  const visibleProviders = filterProvidersByCategory(statusFilteredProviders, categoryFilter);
   const {
     hasMore: hasMoreProviders,
     limit: visibleLimit,
@@ -182,7 +187,7 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
   } = useProgressiveProviderLimit(visibleProviders.length, resetKey);
   const loadMoreProvidersRef = useIntersectionLoader(hasMoreProviders, loadMoreProviders);
   const renderedProviders = visibleProviders.slice(0, visibleLimit);
-  const filtersActive = query.trim().length > 0 || statusFilter !== "all";
+  const filtersActive = query.trim().length > 0 || statusFilter !== "all" || categoryFilter !== "all";
   const statusCounts = useMemo(
     () =>
       providerStatusOptions.map((option) => ({
@@ -191,10 +196,19 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
       })),
     [searchedProviders, statusByService],
   );
+  const categoryCounts = useMemo(() => providerCategoryCounts(searchedProviders), [searchedProviders]);
+  const categoryOptions = useMemo(
+    () =>
+      [...categoryCounts.entries()]
+        .sort((left, right) => left[0].localeCompare(right[0]))
+        .map(([category, count]) => ({ category, count })),
+    [categoryCounts],
+  );
 
   function resetFilters(): void {
     setQuery("");
     setStatusFilter("all");
+    setCategoryFilter("all");
   }
 
   return (
@@ -217,12 +231,15 @@ function ProviderBrowser(props: ProviderBrowserProps): ReactNode {
 
       <ProviderCollectionBar
         counts={statusCounts}
+        categoryOptions={categoryOptions}
+        categoryFilter={categoryFilter}
         filtersActive={filtersActive}
         providerCount={visibleProviders.length}
         selected={statusFilter}
         totalProviderCount={props.data.providers.length}
         onReset={resetFilters}
         onSelect={setStatusFilter}
+        onSelectCategory={setCategoryFilter}
       />
 
       <p className="provider-brand-notice">{t("providers.brandNotice")}</p>
@@ -323,12 +340,15 @@ function useIntersectionLoader(enabled: boolean, onLoad: () => void): (node: HTM
 
 function ProviderCollectionBar(props: {
   counts: Array<{ id: ProviderStatusFilter; labelKey: string; count: number }>;
+  categoryOptions: Array<{ category: string; count: number }>;
+  categoryFilter: string;
   filtersActive: boolean;
   providerCount: number;
   selected: ProviderStatusFilter;
   totalProviderCount: number;
   onReset(): void;
   onSelect(value: ProviderStatusFilter): void;
+  onSelectCategory(value: string): void;
 }): ReactNode {
   const t = useTranslate();
 
@@ -353,6 +373,23 @@ function ProviderCollectionBar(props: {
           </ToggleGroupItem>
         ))}
       </ToggleGroup>
+      <Select value={props.categoryFilter} onValueChange={props.onSelectCategory}>
+        <SelectTrigger
+          className="h-8 w-48 rounded-md border px-3 text-sm"
+          size="sm"
+          aria-label={t("providers.categoryFilterLabel")}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent position="popper" align="start">
+          <SelectItem value="all">{t("providers.categories.all")}</SelectItem>
+          {props.categoryOptions.map((option) => (
+            <SelectItem key={option.category} value={option.category}>
+              {option.category} ({compactProviderCount(option.count)})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
       <div className="provider-result-meta">
         <span>
           {t("providers.resultCount", {
@@ -389,9 +426,14 @@ function ProviderCard(props: ProviderCardProps): ReactNode {
     <div className="provider-card" style={providerCardStyle}>
       <Link className="provider-card-main" to={to}>
         <ProviderIcon provider={props.provider} />
-        <span className="provider-card-title-row">
-          <span className="provider-card-title">{props.provider.displayName || props.provider.service}</span>
-          <ProviderStatusBadges status={props.status} locallyAvailable={locallyAvailable} compact />
+        <span className="provider-card-info">
+          <span className="provider-card-title-row">
+            <span className="provider-card-title">{props.provider.displayName || props.provider.service}</span>
+            <ProviderStatusBadges status={props.status} locallyAvailable={locallyAvailable} compact />
+          </span>
+          {props.provider.description ? (
+            <span className="provider-card-description">{props.provider.description}</span>
+          ) : null}
         </span>
       </Link>
       <Link
@@ -1389,8 +1431,8 @@ function countProvidersForStatus(
   return filterProvidersByStatus(providers, status, statusByService).length;
 }
 
-export function providerBrowserResetKey(query: string, status: ProviderStatusFilter): string {
-  return `${query}\u0000${status}`;
+export function providerBrowserResetKey(query: string, status: ProviderStatusFilter, category: string): string {
+  return `${query}\u0000${status}\u0000${category}`;
 }
 
 function compactProviderCount(value: number): string {

--- a/web/src/styles/providers.css
+++ b/web/src/styles/providers.css
@@ -82,9 +82,24 @@
 .provider-card-title-row {
   display: flex;
   align-items: center;
-  flex: 1;
   min-width: 0;
   gap: 8px;
+}
+
+.provider-card-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 2px;
+}
+
+.provider-card-description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--muted-foreground);
 }
 
 .provider-card-title {

--- a/web/src/styles/providers.css
+++ b/web/src/styles/providers.css
@@ -25,7 +25,6 @@
 .provider-collection-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   padding: 8px 16px;
   border-bottom: 1px solid var(--border);
@@ -33,7 +32,7 @@
 
 .provider-filter-list {
   display: flex;
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   gap: 8px;
   overflow-x: auto;
@@ -41,6 +40,7 @@
 
 .provider-result-meta {
   display: flex;
+  flex: none;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;


### PR DESCRIPTION
Adds a category dropdown to the provider browser with per-category counts, so users exploring by capability can filter instead of scrolling the flat list. Also renders each provider's short description in its card when one exists.

Closes #219.