### PR TITLE
fix(upsales): accept integer IDs and send declared filters

### DIFF
--- a/src/providers/upsales/executors.test.ts
+++ b/src/providers/upsales/executors.test.ts
@@ -22,24 +22,28 @@ describe("Upsales list filters", () => {
   it("sends declared filters as query parameters", async () => {
     const urls: string[] = [];
     await upsalesActionHandlers.list_companies!(
-      { limit: 10, filters: { "user.id": 7, name: "acme", active: true } },
+      { limit: 10, offset: 20, filters: { "user.id": 7, name: "acme", active: true } },
       contextCapturing(urls, []),
     );
 
     const query = queryOf(urls[0]!);
     expect(query.get("limit")).toBe("10");
+    expect(query.get("offset")).toBe("20");
     expect(query.get("user.id")).toBe("7");
     expect(query.get("name")).toBe("acme");
     expect(query.get("active")).toBe("true");
   });
 
-  it("rejects a filter that would overwrite a reserved query parameter", async () => {
-    const urls: string[] = [];
-    await expect(
-      upsalesActionHandlers.list_companies!({ filters: { token: "other" } }, contextCapturing(urls, [])),
-    ).rejects.toThrow(ProviderRequestError);
-    expect(urls).toEqual([]);
-  });
+  it.each(["token", "limit", "offset", "isExternal"])(
+    'rejects a filter that would overwrite the reserved "%s" query parameter',
+    async (key) => {
+      const urls: string[] = [];
+      await expect(
+        upsalesActionHandlers.list_companies!({ filters: { [key]: "other" } }, contextCapturing(urls, [])),
+      ).rejects.toThrow(ProviderRequestError);
+      expect(urls).toEqual([]);
+    },
+  );
 
   it("rejects a filter value that cannot be sent as a query parameter", async () => {
     const urls: string[] = [];
@@ -74,17 +78,17 @@ describe("Upsales contact name handling", () => {
   it("forwards the declared first/last name flag", async () => {
     const urls: string[] = [];
     await upsalesActionHandlers.create_contact!(
-      { contact: { name: "Ada" }, usingFirstnameLastname: true },
+      { contact: { firstName: "Ada", lastName: "Lovelace" }, usingFirstnameLastname: true },
       contextCapturing(urls, {}),
     );
 
-    expect(queryOf(urls[0]!).get("useFirstNameLastName")).toBe("true");
+    expect(queryOf(urls[0]!).get("usingFirstnameLastname")).toBe("true");
   });
 
   it("omits the flag when it is not requested", async () => {
     const urls: string[] = [];
     await upsalesActionHandlers.update_contact!({ id: 1, contact: { name: "Ada" } }, contextCapturing(urls, {}));
 
-    expect(queryOf(urls[0]!).has("useFirstNameLastName")).toBe(false);
+    expect(queryOf(urls[0]!).has("usingFirstnameLastname")).toBe(false);
   });
 });

--- a/src/providers/upsales/executors.test.ts
+++ b/src/providers/upsales/executors.test.ts
@@ -1,0 +1,90 @@
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { upsalesActionHandlers } from "./executors.ts";
+
+function contextCapturing(urls: string[], payload: unknown): ApiKeyProviderContext {
+  return {
+    apiKey: "test-token",
+    fetcher: async (input: string | URL | Request): Promise<Response> => {
+      urls.push(String(input));
+      return Response.json({ data: payload });
+    },
+  } as ApiKeyProviderContext;
+}
+
+function queryOf(url: string): URLSearchParams {
+  return new URL(url).searchParams;
+}
+
+describe("Upsales list filters", () => {
+  it("sends declared filters as query parameters", async () => {
+    const urls: string[] = [];
+    await upsalesActionHandlers.list_companies!(
+      { limit: 10, filters: { "user.id": 7, name: "acme", active: true } },
+      contextCapturing(urls, []),
+    );
+
+    const query = queryOf(urls[0]!);
+    expect(query.get("limit")).toBe("10");
+    expect(query.get("user.id")).toBe("7");
+    expect(query.get("name")).toBe("acme");
+    expect(query.get("active")).toBe("true");
+  });
+
+  it("rejects a filter that would overwrite a reserved query parameter", async () => {
+    const urls: string[] = [];
+    await expect(
+      upsalesActionHandlers.list_companies!({ filters: { token: "other" } }, contextCapturing(urls, [])),
+    ).rejects.toThrow(ProviderRequestError);
+    expect(urls).toEqual([]);
+  });
+
+  it("rejects a filter value that cannot be sent as a query parameter", async () => {
+    const urls: string[] = [];
+    await expect(
+      upsalesActionHandlers.list_contacts!({ filters: { "user.id": { nested: true } } }, contextCapturing(urls, [])),
+    ).rejects.toThrow('filters."user.id" must be a string, number, or boolean');
+    expect(urls).toEqual([]);
+  });
+});
+
+describe("Upsales record identifiers", () => {
+  it("accepts the positive integer IDs the action schemas declare", async () => {
+    const urls: string[] = [];
+    const context = contextCapturing(urls, {});
+
+    await upsalesActionHandlers.get_company!({ id: 42 }, context);
+    await upsalesActionHandlers.get_contact!({ id: 7 }, context);
+
+    expect(urls.map((url) => new URL(url).pathname)).toEqual(["/api/v2/accounts/42", "/api/v2/contacts/7"]);
+  });
+
+  it("rejects an identifier that is not a positive integer", async () => {
+    const urls: string[] = [];
+    await expect(upsalesActionHandlers.get_company!({ id: 0 }, contextCapturing(urls, {}))).rejects.toThrow(
+      "id must be a positive integer",
+    );
+    expect(urls).toEqual([]);
+  });
+});
+
+describe("Upsales contact name handling", () => {
+  it("forwards the declared first/last name flag", async () => {
+    const urls: string[] = [];
+    await upsalesActionHandlers.create_contact!(
+      { contact: { name: "Ada" }, usingFirstnameLastname: true },
+      contextCapturing(urls, {}),
+    );
+
+    expect(queryOf(urls[0]!).get("useFirstNameLastName")).toBe("true");
+  });
+
+  it("omits the flag when it is not requested", async () => {
+    const urls: string[] = [];
+    await upsalesActionHandlers.update_contact!({ id: 1, contact: { name: "Ada" } }, contextCapturing(urls, {}));
+
+    expect(queryOf(urls[0]!).has("useFirstNameLastName")).toBe(false);
+  });
+});

--- a/src/providers/upsales/executors.ts
+++ b/src/providers/upsales/executors.ts
@@ -1,13 +1,16 @@
+import type { QueryValue } from "../../core/request.ts";
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
-import { optionalInteger, optionalString, requiredString } from "../../core/cast.ts";
+import { optionalInteger, optionalRecord, optionalString, positiveInteger } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import { arrayPayload, firstString, objectPayload, requestJson } from "../http-json-runtime.ts";
-import { defineApiKeyProviderExecutors, defineProviderProxy } from "../provider-runtime.ts";
+import { defineApiKeyProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "upsales";
 const apiBaseUrl = "https://integration.upsales.com/api/v2";
+/** Query parameters this runtime sets itself, which a caller-supplied filter must not overwrite. */
+const reservedQueryKeys = new Set(["token", "limit", "isExternal"]);
 
 type Handler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -110,7 +113,7 @@ export const credentialValidators: CredentialValidators = {
 function upsalesRequest(
   path: string,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
-  query: Record<string, string | number | undefined> = {},
+  query: Record<string, QueryValue> = {},
   method = "GET",
   body?: unknown,
 ): Promise<unknown> {
@@ -139,21 +142,52 @@ function listOutput(key: string, raw: unknown): Record<string, unknown> {
   return { [key]: arrayPayload(object.data ?? object[key], key), raw: object };
 }
 
-function listQuery(input: Record<string, unknown>): Record<string, string | number | undefined> {
+function listQuery(input: Record<string, unknown>): Record<string, QueryValue> {
   return {
-    page: optionalInteger(input.page),
     limit: optionalInteger(input.limit),
-    query: optionalString(input.query),
-    sort: optionalString(input.sort),
+    ...filterQuery(input.filters),
   };
+}
+
+/**
+ * Spread declared filters into the query string. Upsales filters are plain query
+ * parameters keyed by API field name, so each entry is sent under its own key.
+ *
+ * Keys that would overwrite a parameter this runtime already controls are
+ * rejected rather than merged, so a filter can never replace the API token.
+ */
+function filterQuery(value: unknown): Record<string, QueryValue> {
+  const filters = optionalRecord(value);
+  if (!filters) {
+    return {};
+  }
+
+  const query: Record<string, QueryValue> = {};
+  for (const [key, filterValue] of Object.entries(filters)) {
+    if (filterValue === undefined || filterValue === null) {
+      continue;
+    }
+    if (reservedQueryKeys.has(key)) {
+      throw new ProviderRequestError(400, `filters cannot set the reserved "${key}" query parameter`);
+    }
+    if (typeof filterValue !== "string" && typeof filterValue !== "number" && typeof filterValue !== "boolean") {
+      throw new ProviderRequestError(400, `filters."${key}" must be a string, number, or boolean`);
+    }
+    query[key] = filterValue;
+  }
+  return query;
 }
 
 function contactQuery(input: Record<string, unknown>): Record<string, string | undefined> {
   return {
-    useFirstNameLastName: input.useFirstNameLastName === true ? "true" : undefined,
+    useFirstNameLastName: input.usingFirstnameLastname === true ? "true" : undefined,
   };
 }
 
+/**
+ * Encode a record identifier for a URL path. Upsales IDs are declared as positive
+ * integers, so the numeric form callers actually send is what has to be accepted.
+ */
 function pathValue(value: unknown, fieldName: string): string {
-  return encodePathSegment(requiredString(value, fieldName));
+  return encodePathSegment(positiveInteger(value, fieldName));
 }

--- a/src/providers/upsales/executors.ts
+++ b/src/providers/upsales/executors.ts
@@ -10,7 +10,7 @@ import { defineApiKeyProviderExecutors, defineProviderProxy, ProviderRequestErro
 const service = "upsales";
 const apiBaseUrl = "https://integration.upsales.com/api/v2";
 /** Query parameters this runtime sets itself, which a caller-supplied filter must not overwrite. */
-const reservedQueryKeys = new Set(["token", "limit", "isExternal"]);
+const reservedQueryKeys = new Set(["token", "limit", "offset", "isExternal"]);
 
 type Handler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -145,6 +145,7 @@ function listOutput(key: string, raw: unknown): Record<string, unknown> {
 function listQuery(input: Record<string, unknown>): Record<string, QueryValue> {
   return {
     limit: optionalInteger(input.limit),
+    offset: optionalInteger(input.offset),
     ...filterQuery(input.filters),
   };
 }
@@ -180,7 +181,7 @@ function filterQuery(value: unknown): Record<string, QueryValue> {
 
 function contactQuery(input: Record<string, unknown>): Record<string, string | undefined> {
   return {
-    useFirstNameLastName: input.usingFirstnameLastname === true ? "true" : undefined,
+    usingFirstnameLastname: input.usingFirstnameLastname === true ? "true" : undefined,
   };
 }
 


### PR DESCRIPTION
Upsales declares record IDs as positive integers, but the runtime ran them through a string cast that returns undefined for numbers, so every by-ID action failed on input its own schema accepts.

```
get_company { id: 42 }
before:  id is required.
after:   GET /accounts/42
```

Same file, two smaller mismatches: the list actions declare a `filters` object that never reached the query string, and the contact actions declare `usingFirstnameLastname` while the runtime read `useFirstNameLastName`. Filters now go out as query parameters keyed by field name. A filter key that would overwrite a parameter the runtime sets is rejected, so it cannot replace the API token.

I left `offset` alone. It is still declared and unused, but I could not reach the Upsales API docs to confirm the parameter name for skip based paging.