### PR TITLE
fix(feishu): list_messages pageSize maximum is 50, matching the API's real cap

### DIFF
--- a/src/providers/feishu/shared/im-user-actions.ts
+++ b/src/providers/feishu/shared/im-user-actions.ts
@@ -6,6 +6,13 @@ const userIdType = s.stringEnum("The user identifier type returned by Feishu.", 
 const pageSize = s.positiveInteger("The maximum number of results on this page.", {
   maximum: 100,
 });
+// GET /im/v1/messages caps page_size at 50 — a larger value fails the whole
+// request with Feishu 99992402 (field validation failed), so the schema must
+// not admit it. `list_thread_messages` (the same endpoint through the thread
+// container) already declares 50.
+const messagePageSize = s.positiveInteger("The maximum number of results on this page.", {
+  maximum: 50,
+});
 const pageToken = s.string("The page token returned by the previous request.", {
   minLength: 1,
 });
@@ -130,7 +137,7 @@ export function createFeishuImUserActions(service: string): readonly ActionDefin
           startTime: s.string("The inclusive Unix timestamp in seconds.", { minLength: 1 }),
           endTime: s.string("The exclusive Unix timestamp in seconds.", { minLength: 1 }),
           sortType: s.stringEnum("The message sort order.", ["ByCreateTimeAsc", "ByCreateTimeDesc"]),
-          pageSize,
+          pageSize: messagePageSize,
           pageToken,
         },
         {


### PR DESCRIPTION
Fixes #269.

`GET /im/v1/messages` rejects `page_size > 50` with **Feishu 99992402 (field validation failed)**, so `list_messages`' declared maximum of 100 admits inputs the provider can never serve — a consumer that trusts the schema's bound gets a hard runtime failure on every call.

`list_thread_messages` (the same endpoint through the thread container, in `im-actions.ts`) already declares 50, so this brings `list_messages` in line: a dedicated 50-capped `pageSize` for it, leaving the shared 100 for the endpoints that genuinely accept it (`list_chats`, `list_chat_members`, `search_chats`).

Verified live against a real workspace (gateway from this repo's main): `pageSize: 100` → 99992402 on every chat; `pageSize: 50` → success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)