### PR TITLE
refactor(cloudflare): rename MCP provider service

### DIFF
--- a/migrations/0011_cloudflare_service.sql
+++ b/migrations/0011_cloudflare_service.sql
@@ -1,0 +1,40 @@
+update connections
+set service = 'cloudflare'
+where service = 'cloudflare_mcp';
+
+update oauth_client_configs
+set service = 'cloudflare'
+where service = 'cloudflare_mcp';
+
+update oauth_states
+set value = json_set(value, '$.service', 'cloudflare')
+where json_extract(value, '$.service') = 'cloudflare_mcp';
+
+update runs
+set
+  service = 'cloudflare',
+  action_id = replace(action_id, 'cloudflare_mcp.', 'cloudflare.'),
+  value = replace(
+    replace(value, 'cloudflare_mcp.', 'cloudflare.'),
+    '"cloudflare_mcp"',
+    '"cloudflare"'
+  )
+where service = 'cloudflare_mcp';
+
+update runtime_tokens
+set
+  allowed_actions = replace(allowed_actions, 'cloudflare_mcp.', 'cloudflare.'),
+  blocked_actions = replace(blocked_actions, 'cloudflare_mcp.', 'cloudflare.'),
+  allowed_proxies = replace(allowed_proxies, '"cloudflare_mcp"', '"cloudflare"')
+where
+  allowed_actions like '%cloudflare_mcp.%'
+  or blocked_actions like '%cloudflare_mcp.%'
+  or allowed_proxies like '%"cloudflare_mcp"%';
+
+update runtime_policy
+set value = replace(
+  replace(value, 'cloudflare_mcp.', 'cloudflare.'),
+  '"cloudflare_mcp"',
+  '"cloudflare"'
+)
+where value like '%cloudflare_mcp%';

--- a/src/providers/cloudflare/actions.ts
+++ b/src/providers/cloudflare/actions.ts
@@ -3,13 +3,13 @@ import type { ActionDefinition } from "../../core/types.ts";
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
 
-const service = "cloudflare_mcp";
+const service = "cloudflare";
 
 const codeSchema = s.nonWhitespaceString(
   "A JavaScript async arrow function. Use `search` before `execute` to discover the exact Cloudflare API path and parameters.",
 );
 
-export const cloudflareMcpActions: ActionDefinition[] = [
+export const cloudflareActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "docs",
     description: "Search the official Cloudflare developer documentation for relevant guidance and examples.",
@@ -41,7 +41,7 @@ export const cloudflareMcpActions: ActionDefinition[] = [
       code: codeSchema,
     }),
     outputSchema: s.unknown("The value returned by the supplied search function."),
-    followUpActions: ["cloudflare_mcp.execute"],
+    followUpActions: ["cloudflare.execute"],
   }),
   defineProviderAction(service, {
     name: "execute",

--- a/src/providers/cloudflare/definition.ts
+++ b/src/providers/cloudflare/definition.ts
@@ -1,8 +1,8 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
-import { cloudflareMcpActions } from "./actions.ts";
+import { cloudflareActions } from "./actions.ts";
 
-const service = "cloudflare_mcp";
+const service = "cloudflare";
 
 /**
  * Cloudflare provider backed by Cloudflare's official unified MCP service.
@@ -12,7 +12,7 @@ const service = "cloudflare_mcp";
  */
 export const provider: ProviderDefinition = {
   service,
-  displayName: "Cloudflare MCP",
+  displayName: "Cloudflare",
   description:
     "Search Cloudflare documentation and API schemas, then manage Cloudflare resources through the official unified MCP service. API tokens connect directly; OAuth uses a public client registered through https://mcp.cloudflare.com/register with this Open Connector deployment's callback URL.",
   categories: ["Developer Tools", "Infrastructure"],
@@ -37,5 +37,5 @@ export const provider: ProviderDefinition = {
   ],
   homepageUrl: "https://github.com/cloudflare/mcp",
   iconUrl: "https://workers.cloudflare.com/favicon.ico",
-  actions: cloudflareMcpActions,
+  actions: cloudflareActions,
 };

--- a/src/providers/cloudflare/executors.ts
+++ b/src/providers/cloudflare/executors.ts
@@ -9,7 +9,7 @@ import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validatio
 import { createHash } from "node:crypto";
 import { defineBearerProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
-const service = "cloudflare_mcp";
+const service = "cloudflare";
 const cloudflareMcpEndpoint = "https://mcp.cloudflare.com/mcp";
 const cloudflareMcpRequestTimeoutMs = 60_000;
 const expectedTools = ["docs", "execute", "search"];

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -472,6 +472,9 @@ class SqliteD1Database implements D1DatabaseBinding {
     this.database.exec(
       readFileSync(new URL("../../../migrations/0010_connection_revision.sql", import.meta.url), "utf8"),
     );
+    this.database.exec(
+      readFileSync(new URL("../../../migrations/0011_cloudflare_service.sql", import.meta.url), "utf8"),
+    );
   }
 
   prepare(query: string): D1PreparedStatementBinding {

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -163,7 +163,13 @@ export class D1OAuthClientConfigStore implements IOAuthClientConfigStore {
   }
 
   async get(service: string): Promise<OAuthClientConfig | undefined> {
-    return await getSecretJson<OAuthClientConfig>(this.database, this.secretCodec, "oauth_client_configs", service);
+    const config = await getSecretJson<OAuthClientConfig>(
+      this.database,
+      this.secretCodec,
+      "oauth_client_configs",
+      service,
+    );
+    return config ? { ...config, service } : undefined;
   }
 
   async set(config: OAuthClientConfig): Promise<void> {
@@ -185,10 +191,13 @@ export class D1OAuthClientConfigStore implements IOAuthClientConfigStore {
 
   async list(): Promise<OAuthClientConfig[]> {
     const { results } = await this.database
-      .prepare("select value from oauth_client_configs order by service")
+      .prepare("select service, value from oauth_client_configs order by service")
       .all<RuntimeRow>();
     return await Promise.all(
-      results.map(async (row) => parseJson<OAuthClientConfig>(await this.secretCodec.decode(readString(row, "value")))),
+      results.map(async (row) => ({
+        ...parseJson<OAuthClientConfig>(await this.secretCodec.decode(readString(row, "value"))),
+        service: readString(row, "service"),
+      })),
     );
   }
 }

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -49,6 +49,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0008_runtime_token_policy.sql",
       "0009_runtime_token_proxy.sql",
       "0010_connection_revision.sql",
+      "0011_cloudflare_service.sql",
     ];
     expect(entries.filter((entry) => entry.message === "sqlite migration started")).toEqual(
       migrations.map((migration) => ({ fields: { migration }, message: "sqlite migration started" })),
@@ -448,6 +449,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0008_runtime_token_policy.sql",
       "0009_runtime_token_proxy.sql",
       "0010_connection_revision.sql",
+      "0011_cloudflare_service.sql",
     ]) {
       raw.exec(readFileSync(new URL(`../../../migrations/${migration}`, import.meta.url), "utf8"));
     }
@@ -555,6 +557,9 @@ describe("SqliteRuntimeDatabase", () => {
     expect(
       inspected.prepare("select name from runtime_migrations where name = ?").get("0010_connection_revision.sql"),
     ).toBeDefined();
+    expect(
+      inspected.prepare("select name from runtime_migrations where name = ?").get("0011_cloudflare_service.sql"),
+    ).toBeDefined();
     expect(inspected.prepare("pragma table_info(connections)").all()).toContainEqual(
       expect.objectContaining({ name: "id", notnull: 1 }),
     );
@@ -567,6 +572,152 @@ describe("SqliteRuntimeDatabase", () => {
         .get("runs_started_at_id_idx"),
     ).toBeDefined();
     inspected.close();
+  });
+
+  it("migrates persisted Cloudflare MCP service identifiers", async () => {
+    const databasePath = await createDatabasePath();
+    const legacy = new DatabaseSync(databasePath);
+    const appliedMigrations = [
+      "0001_runtime.sql",
+      "0002_run_service.sql",
+      "0003_action_idempotency.sql",
+      "0004_action_run_audit.sql",
+      "0005_run_retention.sql",
+      "0006_connection_identity.sql",
+      "0007_runtime_policy.sql",
+      "0008_runtime_token_policy.sql",
+      "0009_runtime_token_proxy.sql",
+      "0010_connection_revision.sql",
+    ];
+    for (const migration of appliedMigrations) {
+      legacy.exec(readFileSync(new URL(`../../../migrations/${migration}`, import.meta.url), "utf8"));
+    }
+    legacy.exec(`
+      create table runtime_migrations (
+        name text primary key,
+        applied_at text not null
+      );
+    `);
+    const recordMigration = legacy.prepare("insert into runtime_migrations (name, applied_at) values (?, ?)");
+    for (const migration of appliedMigrations) {
+      recordMigration.run(migration, "2026-08-05T00:00:00.000Z");
+    }
+    legacy
+      .prepare(
+        `insert into connections
+          (id, revision, service, connection_name, value, updated_at)
+        values (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "connection-id",
+        "connection-revision",
+        "cloudflare_mcp",
+        "default",
+        JSON.stringify({ authType: "api_key", apiKey: "token", values: { apiKey: "token" } }),
+        "2026-08-05T00:00:00.000Z",
+      );
+    legacy.prepare("insert into oauth_client_configs (service, value, updated_at) values (?, ?, ?)").run(
+      "cloudflare_mcp",
+      JSON.stringify({
+        service: "cloudflare_mcp",
+        clientId: "client-id",
+        clientSecret: "",
+        extra: {},
+        secretExtra: {},
+      }),
+      "2026-08-05T00:00:00.000Z",
+    );
+    legacy.prepare("insert into oauth_states (state, value, created_at) values (?, ?, ?)").run(
+      "oauth-state",
+      JSON.stringify({
+        service: "cloudflare_mcp",
+        connectionName: "default",
+        state: "oauth-state",
+        createdAt: "2026-08-05T00:00:00.000Z",
+      }),
+      "2026-08-05T00:00:00.000Z",
+    );
+    legacy
+      .prepare(
+        `insert into runs
+          (id, service, action_id, caller, started_at, completed_at, ok, value)
+        values (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "run-id",
+        "cloudflare_mcp",
+        "cloudflare_mcp.execute",
+        "http",
+        "2026-08-05T00:00:00.000Z",
+        "2026-08-05T00:00:01.000Z",
+        1,
+        JSON.stringify({
+          id: "run-id",
+          service: "cloudflare_mcp",
+          actionId: "cloudflare_mcp.execute",
+          caller: "http",
+          startedAt: "2026-08-05T00:00:00.000Z",
+          completedAt: "2026-08-05T00:00:01.000Z",
+          durationMs: 1000,
+          ok: true,
+        }),
+      );
+    legacy
+      .prepare(
+        `insert into runtime_tokens
+          (id, name, token_hash, allowed_actions, blocked_actions, allowed_proxies, created_at)
+        values (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "token-id",
+        "Cloudflare token",
+        "token-hash",
+        JSON.stringify(["cloudflare_mcp.*"]),
+        JSON.stringify(["cloudflare_mcp.execute"]),
+        JSON.stringify(["cloudflare_mcp"]),
+        "2026-08-05T00:00:00.000Z",
+      );
+    legacy.prepare("insert into runtime_policy (id, value, updated_at) values (1, ?, ?)").run(
+      JSON.stringify({
+        allowedActions: ["cloudflare_mcp.*"],
+        blockedActions: ["cloudflare_mcp.execute"],
+        allowedProxies: ["cloudflare_mcp"],
+        blockedProxies: ["cloudflare_mcp"],
+      }),
+      "2026-08-05T00:00:00.000Z",
+    );
+    legacy.close();
+
+    const migrated = new SqliteRuntimeDatabase(databasePath);
+    await expect(migrated.connectionStore.get("cloudflare", "default")).resolves.toMatchObject({
+      service: "cloudflare",
+    });
+    await expect(migrated.oauthClientConfigStore.get("cloudflare")).resolves.toMatchObject({
+      service: "cloudflare",
+      clientId: "client-id",
+    });
+    await expect(migrated.oauthClientConfigStore.list()).resolves.toMatchObject([{ service: "cloudflare" }]);
+    await expect(migrated.oauthStateStore.take("oauth-state")).resolves.toMatchObject({ service: "cloudflare" });
+    await expect(migrated.runLogStore.get("run-id")).resolves.toMatchObject({
+      service: "cloudflare",
+      actionId: "cloudflare.execute",
+    });
+    await expect(migrated.runtimeTokenStore.list()).resolves.toMatchObject([
+      {
+        allowedActions: ["cloudflare.*"],
+        blockedActions: ["cloudflare.execute"],
+        allowedProxies: ["cloudflare"],
+      },
+    ]);
+    await expect(migrated.runtimePolicyStore.get()).resolves.toMatchObject({
+      rules: {
+        allowedActions: ["cloudflare.*"],
+        blockedActions: ["cloudflare.execute"],
+        allowedProxies: ["cloudflare"],
+        blockedProxies: ["cloudflare"],
+      },
+    });
+    migrated.close();
   });
 
   it("encrypts stored credentials when a secret codec is configured", async () => {

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -234,12 +234,13 @@ export class SqliteOAuthClientConfigStore implements IOAuthClientConfigStore {
   }
 
   async get(service: string): Promise<OAuthClientConfig | undefined> {
-    return await getSecretJson<OAuthClientConfig>({
+    const config = await getSecretJson<OAuthClientConfig>({
       database: this.database,
       secretCodec: this.secretCodec,
       table: "oauth_client_configs",
       service,
     });
+    return config ? { ...config, service } : undefined;
   }
 
   async set(config: OAuthClientConfig): Promise<void> {
@@ -257,9 +258,12 @@ export class SqliteOAuthClientConfigStore implements IOAuthClientConfigStore {
   }
 
   async list(): Promise<OAuthClientConfig[]> {
-    const rows = this.database.prepare("select value from oauth_client_configs order by service").all();
+    const rows = this.database.prepare("select service, value from oauth_client_configs order by service").all();
     return await Promise.all(
-      rows.map(async (row) => parseJson<OAuthClientConfig>(await this.secretCodec.decode(readString(row, "value")))),
+      rows.map(async (row) => ({
+        ...parseJson<OAuthClientConfig>(await this.secretCodec.decode(readString(row, "value"))),
+        service: readString(row, "service"),
+      })),
     );
   }
 }


### PR DESCRIPTION
## Summary

- rename the official MCP-backed provider service from `cloudflare_mcp` to `cloudflare`
- expose the shorter model-facing Action IDs `cloudflare.docs`, `cloudflare.search`, and `cloudflare.execute`
- rename the Provider display name and source directory while retaining the official MCP implementation details
- migrate persisted connections, OAuth client config keys and pending states, run history, runtime-token rules, and stored runtime policy rules
- treat the OAuth config row key as the authoritative service ID so encrypted legacy payloads remain usable without decrypting them in SQL

## Motivation

The `cloudflare_mcp` service name makes models interpret the Actions as the separately connected Cloudflare MCP server and prefer that tool surface instead of the Cloudflare Provider exposed through Open Connector. The shorter `cloudflare` namespace makes the Open Connector Actions unambiguous in model-facing catalogs.

## Compatibility

Stored runtime data is migrated from `cloudflare_mcp` to `cloudflare`. Deployment-level policy environment variables are outside runtime storage and operators using explicit `cloudflare_mcp.*` or `cloudflare_mcp` rules will need to rename those entries.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` — 69 files, 724 tests passed
- focused SQLite/D1 storage tests — 34 tests passed