### PR TITLE
fix(mail): keep the thread when replying

### DIFF
--- a/src/mail/imap-smtp/protocol.ts
+++ b/src/mail/imap-smtp/protocol.ts
@@ -147,6 +147,8 @@ export interface MailFolderStatus {
 
 export interface MailFetchedMessage {
   summary: MailSummary;
+  /** Message-IDs from the message's own `References` header, oldest first. */
+  references: string[];
   cc: MailAddress[];
   replyTo: MailAddress[];
   text: string | null;
@@ -346,6 +348,9 @@ export function createMailProtocol(config: MailProtocolConfig, deps: MailProtoco
             flags: true,
             size: true,
             bodyStructure: true,
+            // The IMAP envelope carries no `References`, so a reply can only
+            // continue the thread if the header is fetched alongside it.
+            headers: ["references"],
           },
           { uid: true },
         );
@@ -372,6 +377,7 @@ export function createMailProtocol(config: MailProtocolConfig, deps: MailProtoco
 
         return {
           summary: normalizeSummary(message),
+          references: readReferences(toRecord(message)?.headers),
           cc: normalizeEnvelopeAddresses(message, "cc"),
           replyTo: normalizeEnvelopeAddresses(message, "replyTo"),
           text: parsedBody.text,
@@ -750,6 +756,26 @@ function normalizeMailbox(value: unknown): MailFolder {
     flags: normalizeStringArray(record?.flags),
     specialUse: readString(record?.specialUse),
   };
+}
+
+/**
+ * Read the Message-IDs out of a fetched `References` header block.
+ *
+ * Header fields fold across lines, so continuations are joined before the field
+ * is read. Anything that is not a `<...>` reference is ignored.
+ */
+function readReferences(value: unknown): string[] {
+  const raw =
+    value instanceof Uint8Array ? new TextDecoder().decode(value) : typeof value === "string" ? value : undefined;
+  if (!raw) {
+    return [];
+  }
+
+  const line = raw
+    .replaceAll(/\r?\n[ \t]+/g, " ")
+    .split(/\r?\n/)
+    .find((candidate) => /^references:/i.test(candidate));
+  return line?.slice(line.indexOf(":") + 1).match(/<[^>]+>/g) ?? [];
 }
 
 function normalizeSummary(value: unknown): MailSummary {

--- a/src/mail/imap-smtp/protocol.ts
+++ b/src/mail/imap-smtp/protocol.ts
@@ -147,7 +147,7 @@ export interface MailFolderStatus {
 
 export interface MailFetchedMessage {
   summary: MailSummary;
-  /** Message-IDs from the message's own `References` header, oldest first. */
+  /** Message-IDs to seed a reply's `References` header, oldest first. */
   references: string[];
   cc: MailAddress[];
   replyTo: MailAddress[];
@@ -348,9 +348,9 @@ export function createMailProtocol(config: MailProtocolConfig, deps: MailProtoco
             flags: true,
             size: true,
             bodyStructure: true,
-            // The IMAP envelope carries no `References`, so a reply can only
-            // continue the thread if the header is fetched alongside it.
-            headers: ["references"],
+            // The IMAP envelope carries no thread headers, so a reply can only
+            // continue the thread if they are fetched alongside it.
+            headers: ["references", "in-reply-to"],
           },
           { uid: true },
         );
@@ -759,10 +759,10 @@ function normalizeMailbox(value: unknown): MailFolder {
 }
 
 /**
- * Read the Message-IDs out of a fetched `References` header block.
+ * Read the Message-IDs that seed a reply's `References` header.
  *
- * Header fields fold across lines, so continuations are joined before the field
- * is read. Anything that is not a `<...>` reference is ignored.
+ * Header fields fold across lines, so continuations are joined before reading
+ * them. RFC 5322 uses a single `In-Reply-To` value when `References` is absent.
  */
 function readReferences(value: unknown): string[] {
   const raw =
@@ -771,11 +771,15 @@ function readReferences(value: unknown): string[] {
     return [];
   }
 
-  const line = raw
-    .replaceAll(/\r?\n[ \t]+/g, " ")
-    .split(/\r?\n/)
-    .find((candidate) => /^references:/i.test(candidate));
-  return line?.slice(line.indexOf(":") + 1).match(/<[^>]+>/g) ?? [];
+  const lines = raw.replaceAll(/\r?\n[ \t]+/g, " ").split(/\r?\n/);
+  const referencesLine = lines.find((line) => /^references:/i.test(line));
+  if (referencesLine) {
+    return referencesLine.slice(referencesLine.indexOf(":") + 1).match(/<[^>]+>/g) ?? [];
+  }
+
+  const inReplyToLine = lines.find((line) => /^in-reply-to:/i.test(line));
+  const inReplyTo = inReplyToLine?.slice(inReplyToLine.indexOf(":") + 1).match(/<[^>]+>/g) ?? [];
+  return inReplyTo.length === 1 ? inReplyTo : [];
 }
 
 function normalizeSummary(value: unknown): MailSummary {

--- a/src/mail/imap-smtp/runtime.test.ts
+++ b/src/mail/imap-smtp/runtime.test.ts
@@ -197,7 +197,30 @@ describe("IMAP/SMTP mail runtime", () => {
     );
   });
 
-  it("reads the References chain from the fetched message headers", async () => {
+  it.each([
+    {
+      name: "reads a folded References chain",
+      headers: "References: <a@example.com>\r\n <b@example.com>\r\n\r\n",
+      expected: ["<a@example.com>", "<b@example.com>"],
+    },
+    {
+      name: "falls back to a single In-Reply-To value",
+      headers: "In-Reply-To: <a@example.com>\r\n\r\n",
+      expected: ["<a@example.com>"],
+    },
+    {
+      name: "does not use multiple In-Reply-To values as a fallback",
+      headers: "In-Reply-To: <a@example.com> <b@example.com>\r\n\r\n",
+      expected: [],
+    },
+  ])("$name from the fetched message headers", async ({ headers, expected }) => {
+    const fetchOne = vi.fn(async () => ({
+      uid: 1,
+      envelope: { from: [{ address: "author@example.com" }], to: [{ address: "user@qq.com" }] },
+      flags: new Set<string>(),
+      size: 100,
+      headers: Buffer.from(headers),
+    }));
     const protocol = createMailProtocol(
       { displayName: "Mail Test", attachmentFallbackPrefix: "mail-test" },
       {
@@ -206,14 +229,7 @@ describe("IMAP/SMTP mail runtime", () => {
           logout: vi.fn(async () => undefined),
           list: vi.fn(async () => []),
           mailboxOpen: vi.fn(async () => undefined),
-          fetchOne: vi.fn(async () => ({
-            uid: 1,
-            envelope: { from: [{ address: "author@example.com" }], to: [{ address: "user@qq.com" }] },
-            flags: new Set<string>(),
-            size: 100,
-            // Header fields fold across lines, which is how a long chain arrives.
-            headers: Buffer.from("References: <a@example.com>\r\n <b@example.com>\r\n\r\n"),
-          })),
+          fetchOne,
         }),
       },
     );
@@ -229,7 +245,11 @@ describe("IMAP/SMTP mail runtime", () => {
           skipAttachmentBodies: true,
         },
       ),
-    ).resolves.toMatchObject({ references: ["<a@example.com>", "<b@example.com>"] });
+    ).resolves.toMatchObject({ references: expected });
+
+    expect(fetchOne).toHaveBeenCalledWith(1, expect.objectContaining({ headers: ["references", "in-reply-to"] }), {
+      uid: true,
+    });
   });
 
   it("bounds temporary filenames while preserving a short extension", () => {

--- a/src/mail/imap-smtp/runtime.test.ts
+++ b/src/mail/imap-smtp/runtime.test.ts
@@ -129,6 +129,7 @@ describe("IMAP/SMTP mail runtime", () => {
           hasAttachments: false,
           size: 100,
         },
+        references: [],
         cc: [],
         replyTo: [{ name: null, email: "reply@example.com" }],
         text: "Original message",
@@ -151,6 +152,84 @@ describe("IMAP/SMTP mail runtime", () => {
     );
 
     expect(sendMail).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ to: ["reply@example.com"] }));
+  });
+
+  it.each([
+    [["<a@example.com>", "<b@example.com>"], "<a@example.com> <b@example.com> <message-id>"],
+    [[], "<message-id>"],
+    [["<a@example.com>", "<message-id>"], "<a@example.com> <message-id>"],
+  ])("continues the thread by appending the parent to its References chain", async (references, expected) => {
+    const sendMail = vi.fn(async () => ({ messageId: null, accepted: [], rejected: [], response: "ok" }));
+    const protocol = {
+      fetchMessage: vi.fn(async () => ({
+        summary: {
+          uid: 1,
+          messageId: "<message-id>",
+          subject: "Subject",
+          from: { name: null, email: "author@example.com" },
+          to: [{ name: null, email: "user@qq.com" }],
+          date: null,
+          flags: [],
+          seen: false,
+          hasAttachments: false,
+          size: 100,
+        },
+        references,
+        cc: [],
+        replyTo: [],
+        text: "Original message",
+        html: null,
+        attachments: [],
+        truncated: false,
+      })),
+      sendMail,
+    } as unknown as MailProtocol;
+
+    await executeMailAction(
+      "reply_email",
+      { uid: 1, text: "Reply" },
+      { values: { email: "user@qq.com", authorizationCode }, fetcher: fetch, protocol, config: qqMailRuntimeConfig },
+    );
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ inReplyTo: "<message-id>", references: expected }),
+    );
+  });
+
+  it("reads the References chain from the fetched message headers", async () => {
+    const protocol = createMailProtocol(
+      { displayName: "Mail Test", attachmentFallbackPrefix: "mail-test" },
+      {
+        createImapClient: () => ({
+          connect: vi.fn(async () => undefined),
+          logout: vi.fn(async () => undefined),
+          list: vi.fn(async () => []),
+          mailboxOpen: vi.fn(async () => undefined),
+          fetchOne: vi.fn(async () => ({
+            uid: 1,
+            envelope: { from: [{ address: "author@example.com" }], to: [{ address: "user@qq.com" }] },
+            flags: new Set<string>(),
+            size: 100,
+            // Header fields fold across lines, which is how a long chain arrives.
+            headers: Buffer.from("References: <a@example.com>\r\n <b@example.com>\r\n\r\n"),
+          })),
+        }),
+      },
+    );
+
+    await expect(
+      protocol.fetchMessage(
+        qqMailRuntimeConfig.readCredential({ email: "user@qq.com", authorizationCode }),
+        "INBOX",
+        1,
+        {
+          peek: true,
+          maxBytes: 1024,
+          skipAttachmentBodies: true,
+        },
+      ),
+    ).resolves.toMatchObject({ references: ["<a@example.com>", "<b@example.com>"] });
   });
 
   it("bounds temporary filenames while preserving a short extension", () => {

--- a/src/mail/imap-smtp/runtime.ts
+++ b/src/mail/imap-smtp/runtime.ts
@@ -589,6 +589,7 @@ async function buildReplySendInput(
   }
 
   const cc = input.cc ?? (input.replyAll ? filterRecipientEmails(original.cc, credential.email) : undefined);
+  const referenceChain = buildReferenceChain(original);
   const resolvedAttachments = input.attachments ? await resolveOutgoingAttachments(input.attachments, context) : null;
   return {
     sendInput: {
@@ -598,16 +599,28 @@ async function buildReplySendInput(
       subject: input.subject ?? prefixSubject("Re:", original.summary.subject),
       ...(input.text !== undefined ? { text: buildReplyText(input.text, original) } : {}),
       ...(input.html !== undefined ? { html: buildReplyHtml(input.html, original) } : {}),
-      ...(original.summary.messageId
-        ? {
-            inReplyTo: original.summary.messageId,
-            references: original.summary.messageId,
-          }
-        : {}),
+      ...(original.summary.messageId ? { inReplyTo: original.summary.messageId } : {}),
+      ...(referenceChain ? { references: referenceChain } : {}),
       ...(resolvedAttachments ? { attachments: resolvedAttachments.attachments } : {}),
     },
     cleanup: resolvedAttachments?.cleanup ?? noop,
   };
+}
+
+/**
+ * Build the reply's `References` header: the parent's own chain with the parent's
+ * Message-ID appended (RFC 5322 section 3.6.4).
+ *
+ * Sending only the parent's Message-ID discards everything above it, which makes
+ * conformant clients start a fresh thread instead of continuing the existing one.
+ */
+function buildReferenceChain(original: MailFetchedMessage): string {
+  const messageId = original.summary.messageId;
+  const chain = original.references.filter((reference) => reference !== messageId);
+  if (messageId) {
+    chain.push(messageId);
+  }
+  return chain.join(" ");
 }
 
 async function buildForwardSendInput(


### PR DESCRIPTION
A reply set `References` to the parent's Message-ID and nothing else. RFC 5322 wants the parent's own chain with the parent appended, so replying to anything deeper than the first message split the thread in clients that follow the header.

```
parent References: <a> <b>,  parent Message-ID: <c>
before:  references: "<c>"
after:   references: "<a> <b> <c>"
```

The chain was not available to fix before now. `References` is not part of the IMAP envelope, so it is fetched with the message and parsed onto the fetched result. Folded header lines are joined first, since a long chain always arrives wrapped.

`forward_email` is unchanged, as a forward starts its own thread.