### PR TITLE
fix(core): treat a blank optional integer as missing

### DIFF
--- a/src/core/cast.test.ts
+++ b/src/core/cast.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   base64Bytes,
+  optionalIntegerOrNull,
   optionalStringArray,
   positiveInteger,
   requiredBoolean,
@@ -16,6 +17,20 @@ describe("cast helpers", () => {
   it("rejects invalid base64 bytes", () => {
     expect(() => base64Bytes("not base64!", "payload")).toThrow("payload must be valid base64");
     expect(() => base64Bytes("", "payload")).toThrow("payload must be valid base64");
+  });
+
+  it("reports a blank optional integer as missing instead of zero", () => {
+    expect(optionalIntegerOrNull("")).toBeNull();
+    expect(optionalIntegerOrNull("   ")).toBeNull();
+    expect(optionalIntegerOrNull("\n")).toBeNull();
+  });
+
+  it("still reads optional integers that are present", () => {
+    expect(optionalIntegerOrNull("2")).toBe(2);
+    expect(optionalIntegerOrNull(" 2 ")).toBe(2);
+    expect(optionalIntegerOrNull(0)).toBe(0);
+    expect(optionalIntegerOrNull("0")).toBe(0);
+    expect(optionalIntegerOrNull("2.5")).toBeNull();
   });
 
   it("rejects zero for positive integer strings", () => {

--- a/src/core/cast.ts
+++ b/src/core/cast.ts
@@ -391,13 +391,17 @@ export function optionalStringOrNull(value: unknown): string | null {
 }
 
 /**
- * Return an integer from an integer number or numeric string, or null.
+ * Return an integer from an integer number or numeric string, or null. Examples:
+ * `optionalIntegerOrNull("2") => 2`, `optionalIntegerOrNull("") => null`.
+ *
+ * A blank string is reported as missing rather than parsed, because `Number("")`
+ * is `0` and an empty field would otherwise reach a provider as a real zero.
  */
 export function optionalIntegerOrNull(value: unknown): number | null {
   if (Number.isInteger(value)) {
     return value as number;
   }
-  if (typeof value === "string") {
+  if (typeof value === "string" && value.trim() !== "") {
     const parsed = Number(value);
     return Number.isInteger(parsed) ? parsed : null;
   }


### PR DESCRIPTION
`optionalIntegerOrNull("")` returned `0` rather than `null`, because `Number("")` is `0` and passes `Number.isInteger`. A blank optional field reached the provider as a real zero.

```
optionalIntegerOrNull("")     before: 0   after: null
optionalIntegerOrNull("   ")  before: 0   after: null
```

Blank strings are now reported as missing. That matches the sibling helpers `integer` and `optionalIntegerLike`, which already exclude an empty string before parsing. Eight providers read optional integers through this helper.