### PR TITLE
fix(linear): drop the unread cursor inputs from list_linear_issues

### DIFF
--- a/src/providers/linear/actions.ts
+++ b/src/providers/linear/actions.ts
@@ -290,8 +290,6 @@ const actions: LinearActionSource[] = [
       first,
       project_id: stringId,
       assignee_id: stringId,
-      original_cursor: cursor,
-      cursor_was_corrupted: s.boolean({ description: "Whether the cursor was corrupted." }),
     }),
     object({ issues: s.array(objectSchema), page_info: pageInfo }),
   ),


### PR DESCRIPTION
`list_linear_issues` declared `original_cursor` and `cursor_was_corrupted` as inputs. The runtime reads only `after`, `first`, `project_id` and `assignee_id`, so both were accepted and then ignored.

`cursor_was_corrupted` also reads as diagnostic output rather than something a caller supplies, which invites an agent to set it and be silently ignored. Neither name appears anywhere else in the repo.

Pagination through `after` and `first` is unchanged.