### PR TITLE
feat(oauth): keep the failure reason on OAuth token-request errors

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -110,6 +110,45 @@ describe("OAuth token requests", () => {
     );
   });
 
+  it("maps response-stream failures to a sanitized OAuth error", async () => {
+    const platformMessage = "upstream read failed at secret.internal";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error(platformMessage));
+              },
+            }),
+            { status: 502 },
+          ),
+      ),
+    );
+
+    const message = await readRejectionMessage(requestAuthorizationCodeToken({ ...authorizationCodeRequest }));
+    expect(message).toBe("OAuth token request failed (HTTP 502, response body could not be read).");
+    expect(message).not.toContain(platformMessage);
+  });
+
+  it("preserves the bounded-response size error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(null, {
+            status: 502,
+            headers: { "content-length": String(1024 * 1024 + 1) },
+          }),
+      ),
+    );
+
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token response exceeds 1048576 bytes",
+    );
+  });
+
   it("does not expose echoed authorization-code request credentials", async () => {
     const codeVerifier = "pkce-code-verifier";
     const body = `client_secret=${authorizationCodeRequest.clientSecret}&code=${authorizationCodeRequest.code}&code_verifier=${codeVerifier}`;

--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -25,6 +25,15 @@ function stubTokenResponse(expiresIn: unknown): void {
   );
 }
 
+async function readRejectionMessage(operation: Promise<unknown>): Promise<string> {
+  try {
+    await operation;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected operation to reject");
+}
+
 describe("OAuth token requests", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -38,7 +47,7 @@ describe("OAuth token requests", () => {
     vi.stubGlobal("fetch", fetcher);
 
     await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
-      "OAuth token request failed before reaching the provider: provider network request failed",
+      "OAuth token request failed without an HTTP response: provider network request failed",
     );
 
     expect(fetcher).toHaveBeenCalledOnce();
@@ -68,7 +77,7 @@ describe("OAuth token requests", () => {
     expect(calls).toEqual(["https://provider.example.com/oauth/token"]);
   });
 
-  it("names the platform cause when the transport never reached the provider", async () => {
+  it("names the platform cause when the transport returns no HTTP response", async () => {
     // The case that motivated this: an SSRF/egress-guard rejection and an
     // unreachable host both threw the same bare string, and the guard one fails
     // in tens of milliseconds without touching the network.
@@ -80,11 +89,11 @@ describe("OAuth token requests", () => {
     );
 
     await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
-      "OAuth token request failed before reaching the provider: provider network request failed (ECONNREFUSED)",
+      "OAuth token request failed without an HTTP response: provider network request failed (ECONNREFUSED)",
     );
   });
 
-  it("reports status and a bounded body excerpt when the provider sends no structured error", async () => {
+  it("reports status without exposing an unstructured provider error body", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -97,31 +106,42 @@ describe("OAuth token requests", () => {
     );
 
     await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
-      "OAuth token request failed (HTTP 502, body: <html><head><title>502 Bad Gateway</title></head> <body>nginx</body></html>).",
+      "OAuth token request failed (HTTP 502, unrecognized response body).",
     );
   });
 
-  it("truncates a long error body and redacts the client secret from it", async () => {
-    const body = `x`.repeat(400) + " client_secret=client-secret";
+  it("does not expose echoed authorization-code request credentials", async () => {
+    const codeVerifier = "pkce-code-verifier";
+    const body = `client_secret=${authorizationCodeRequest.clientSecret}&code=${authorizationCodeRequest.code}&code_verifier=${codeVerifier}`;
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response(body, { status: 400 })),
     );
 
-    let message = "";
-    try {
-      await requestAuthorizationCodeToken({ ...authorizationCodeRequest });
-    } catch (error) {
-      message = (error as Error).message;
-    }
-    expect(message).toContain("HTTP 400");
-    expect(message).toContain("…");
-    expect(message).not.toContain("client-secret");
-    // 200 bytes of excerpt plus the surrounding text, nowhere near the 400-byte body.
-    expect(message.length).toBeLessThan(300);
+    const message = await readRejectionMessage(
+      requestAuthorizationCodeToken({ ...authorizationCodeRequest, extraFields: { code_verifier: codeVerifier } }),
+    );
+    expect(message).toBe("OAuth token request failed (HTTP 400, unrecognized response body).");
+    expect(message).not.toContain(authorizationCodeRequest.clientSecret);
+    expect(message).not.toContain(authorizationCodeRequest.code);
+    expect(message).not.toContain(codeVerifier);
   });
 
-  it("still prefers the provider's own error message over the excerpt", async () => {
+  it("does not expose tokens from an unrecognized refresh error response", async () => {
+    const refreshToken = "stored-refresh-token";
+    const accessToken = "unexpected-access-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ access_token: accessToken, refresh_token: refreshToken }, { status: 400 })),
+    );
+
+    const message = await readRejectionMessage(requestRefreshToken({ ...authorizationCodeRequest, refreshToken }));
+    expect(message).toBe("OAuth token request failed (HTTP 400, unrecognized response body).");
+    expect(message).not.toContain(refreshToken);
+    expect(message).not.toContain(accessToken);
+  });
+
+  it("still prefers the provider's own error message over the fallback", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(

--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -38,7 +38,7 @@ describe("OAuth token requests", () => {
     vi.stubGlobal("fetch", fetcher);
 
     await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
-      "OAuth token request failed.",
+      "OAuth token request failed before reaching the provider: provider network request failed",
     );
 
     expect(fetcher).toHaveBeenCalledOnce();
@@ -62,10 +62,79 @@ describe("OAuth token requests", () => {
     });
 
     await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
-      "OAuth token request failed.",
+      "OAuth token request failed (HTTP 302, empty body).",
     );
 
     expect(calls).toEqual(["https://provider.example.com/oauth/token"]);
+  });
+
+  it("names the platform cause when the transport never reached the provider", async () => {
+    // The case that motivated this: an SSRF/egress-guard rejection and an
+    // unreachable host both threw the same bare string, and the guard one fails
+    // in tens of milliseconds without touching the network.
+    const refused = new TypeError("fetch failed");
+    (refused as { cause?: unknown }).cause = { code: "ECONNREFUSED" };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(refused)),
+    );
+
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token request failed before reaching the provider: provider network request failed (ECONNREFUSED)",
+    );
+  });
+
+  it("reports status and a bounded body excerpt when the provider sends no structured error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("<html><head><title>502 Bad Gateway</title></head>\n<body>nginx</body></html>", {
+            status: 502,
+            headers: { "content-type": "text/html" },
+          }),
+      ),
+    );
+
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "OAuth token request failed (HTTP 502, body: <html><head><title>502 Bad Gateway</title></head> <body>nginx</body></html>).",
+    );
+  });
+
+  it("truncates a long error body and redacts the client secret from it", async () => {
+    const body = `x`.repeat(400) + " client_secret=client-secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 400 })),
+    );
+
+    let message = "";
+    try {
+      await requestAuthorizationCodeToken({ ...authorizationCodeRequest });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("HTTP 400");
+    expect(message).toContain("…");
+    expect(message).not.toContain("client-secret");
+    // 200 bytes of excerpt plus the surrounding text, nowhere near the 400-byte body.
+    expect(message.length).toBeLessThan(300);
+  });
+
+  it("still prefers the provider's own error message over the excerpt", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }), {
+            status: 400,
+          }),
+      ),
+    );
+
+    await expect(requestAuthorizationCodeToken({ ...authorizationCodeRequest })).rejects.toThrow(
+      "code already redeemed",
+    );
   });
 
   it("preserves the token-request timeout error", async () => {

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -1,13 +1,11 @@
 import type { OAuth2AuthDefinition, ResolvedCredential } from "../core/types.ts";
 
-import { optionalString, requiredString } from "../core/cast.ts";
+import { optionalRecord, optionalString, requiredString } from "../core/cast.ts";
 import { readBoundedResponseBytes } from "../core/request.ts";
 import { providerFetch } from "../providers/provider-runtime.ts";
 
 const oauthTokenRequestTimeoutMs = 30_000;
 const oauthTokenResponseMaxBytes = 1024 * 1024;
-/** Bytes of a token-error body quoted back when the provider sent no structured error message. */
-const tokenErrorExcerptMaxBytes = 200;
 /** Longest `expires_in` we accept; anything larger overflows the ECMAScript `Date` range. */
 const maxExpiresInSeconds = 100 * 365 * 24 * 60 * 60;
 
@@ -104,25 +102,26 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
     if (error instanceof Error && error.name === "TimeoutError") {
       throw input.createError("OAuth token request timed out.");
     }
-    // Nothing reached the provider, so there is no status or body to report —
-    // the thrown error is the only evidence of why. Naming it separates a DNS or
-    // egress-guard rejection from a TLS failure from a connection reset, which
-    // the bare message could not: an SSRF-guard rejection and an unreachable
-    // host produced the same string, and the guard one fails in tens of
-    // milliseconds without ever hitting the network.
-    throw input.createError(`OAuth token request failed before reaching the provider: ${describeCause(error)}`);
+    // A rejected fetch has no HTTP response to inspect, but the request may
+    // still have reached the provider before the connection failed.
+    throw input.createError(`OAuth token request failed without an HTTP response: ${describeCause(error)}`);
   }
-  const bytes = await readTokenResponseBytes(response, input.createError);
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: oauthTokenResponseMaxBytes,
+    fieldName: "OAuth token response",
+    createError: input.createError,
+  });
   const rawPayload = decodeTokenPayload(bytes);
   const payload = unwrapTokenPayload(rawPayload, input.responseEnvelope);
   if (!response.ok || !isEnvelopeSuccess(rawPayload, input.responseEnvelope)) {
     const providerMessage = readTokenErrorMessage(rawPayload, payload, input.responseEnvelope);
+    const bodyDescription = bytes.byteLength === 0 ? "empty body" : "unrecognized response body";
     throw input.createError(
       providerMessage ??
-        // No structured message: report the status and a short excerpt instead of
-        // discarding the response. Without this, a 4xx with an unrecognized error
-        // shape, an HTML error page, and an empty body are all the same string.
-        `OAuth token request failed (HTTP ${response.status}${describeResponseBody(bytes, input.clientSecret)}).`,
+        // Token endpoints and intermediaries can echo request credentials. Keep
+        // arbitrary response bytes out of the public error while distinguishing
+        // an empty body from a non-conforming one.
+        `OAuth token request failed (HTTP ${response.status}, ${bodyDescription}).`,
     );
   }
 
@@ -141,15 +140,6 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
     },
     metadata: createTokenMetadata(payload),
   };
-}
-
-/** Read the token response under the size cap. Split from decoding so a failure path can still report the bytes. */
-async function readTokenResponseBytes(response: Response, createError: OAuthTokenErrorFactory): Promise<Uint8Array> {
-  return readBoundedResponseBytes(response, {
-    maxBytes: oauthTokenResponseMaxBytes,
-    fieldName: "OAuth token response",
-    createError,
-  });
 }
 
 /** Decode a JSON object body, or `{}` for an empty, non-JSON, or non-object one. */
@@ -177,34 +167,12 @@ function describeCause(error: unknown): string {
   if (!(error instanceof Error)) {
     return String(error);
   }
-  const code = (error as { cause?: { code?: unknown } }).cause?.code;
-  const suffix = typeof code === "string" && code !== "" ? ` (cause: ${code})` : "";
+  const code = optionalString(optionalRecord(error.cause)?.code);
+  const suffix = code ? ` (cause: ${code})` : "";
   // A plain `Error` name adds nothing; a subclass name (TypeError, TimeoutError,
   // AbortError) is often the only thing distinguishing the failure.
   const prefix = error.name === "Error" || error.name === "" ? "" : `${error.name}: `;
   return `${prefix}${error.message}${suffix}`;
-}
-
-/**
- * Excerpt of a token-error response, for when no structured message could be
- * extracted. Bounded to one line so an HTML error page cannot flood the message,
- * and the client secret is redacted in case the endpoint echoes the request back
- * — provider-supplied error text already reaches this error via
- * {@link readTokenErrorMessage}, so the excerpt adds no new class of disclosure.
- */
-function describeResponseBody(bytes: Uint8Array, clientSecret: string): string {
-  if (bytes.byteLength === 0) {
-    return ", empty body";
-  }
-  let text = new TextDecoder().decode(bytes.subarray(0, tokenErrorExcerptMaxBytes)).replaceAll(/\s+/gu, " ").trim();
-  if (clientSecret !== "") {
-    text = text.replaceAll(clientSecret, "[redacted]");
-  }
-  if (text === "") {
-    return ", empty body";
-  }
-  const truncated = bytes.byteLength > tokenErrorExcerptMaxBytes ? "…" : "";
-  return `, body: ${text}${truncated}`;
 }
 
 function createTokenMetadata(payload: Record<string, unknown>): Record<string, unknown> {

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -6,6 +6,8 @@ import { providerFetch } from "../providers/provider-runtime.ts";
 
 const oauthTokenRequestTimeoutMs = 30_000;
 const oauthTokenResponseMaxBytes = 1024 * 1024;
+/** Bytes of a token-error body quoted back when the provider sent no structured error message. */
+const tokenErrorExcerptMaxBytes = 200;
 /** Longest `expires_in` we accept; anything larger overflows the ECMAScript `Date` range. */
 const maxExpiresInSeconds = 100 * 365 * 24 * 60 * 60;
 
@@ -99,17 +101,28 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
       redirect: "manual",
     });
   } catch (error) {
-    throw input.createError(
-      error instanceof Error && error.name === "TimeoutError"
-        ? "OAuth token request timed out."
-        : "OAuth token request failed.",
-    );
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw input.createError("OAuth token request timed out.");
+    }
+    // Nothing reached the provider, so there is no status or body to report —
+    // the thrown error is the only evidence of why. Naming it separates a DNS or
+    // egress-guard rejection from a TLS failure from a connection reset, which
+    // the bare message could not: an SSRF-guard rejection and an unreachable
+    // host produced the same string, and the guard one fails in tens of
+    // milliseconds without ever hitting the network.
+    throw input.createError(`OAuth token request failed before reaching the provider: ${describeCause(error)}`);
   }
-  const rawPayload = await readTokenPayload(response, input.createError);
+  const bytes = await readTokenResponseBytes(response, input.createError);
+  const rawPayload = decodeTokenPayload(bytes);
   const payload = unwrapTokenPayload(rawPayload, input.responseEnvelope);
   if (!response.ok || !isEnvelopeSuccess(rawPayload, input.responseEnvelope)) {
+    const providerMessage = readTokenErrorMessage(rawPayload, payload, input.responseEnvelope);
     throw input.createError(
-      readTokenErrorMessage(rawPayload, payload, input.responseEnvelope) ?? "OAuth token request failed.",
+      providerMessage ??
+        // No structured message: report the status and a short excerpt instead of
+        // discarding the response. Without this, a 4xx with an unrecognized error
+        // shape, an HTML error page, and an empty body are all the same string.
+        `OAuth token request failed (HTTP ${response.status}${describeResponseBody(bytes, input.clientSecret)}).`,
     );
   }
 
@@ -130,15 +143,17 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
   };
 }
 
-async function readTokenPayload(
-  response: Response,
-  createError: OAuthTokenErrorFactory,
-): Promise<Record<string, unknown>> {
-  const bytes = await readBoundedResponseBytes(response, {
+/** Read the token response under the size cap. Split from decoding so a failure path can still report the bytes. */
+async function readTokenResponseBytes(response: Response, createError: OAuthTokenErrorFactory): Promise<Uint8Array> {
+  return readBoundedResponseBytes(response, {
     maxBytes: oauthTokenResponseMaxBytes,
     fieldName: "OAuth token response",
     createError,
   });
+}
+
+/** Decode a JSON object body, or `{}` for an empty, non-JSON, or non-object one. */
+function decodeTokenPayload(bytes: Uint8Array): Record<string, unknown> {
   if (bytes.byteLength === 0) {
     return {};
   }
@@ -151,6 +166,45 @@ async function readTokenPayload(
   } catch {
     return {};
   }
+}
+
+/**
+ * Describe a transport-level failure: the error name, its message, and the
+ * platform `cause.code` (`ENOTFOUND`, `ECONNREFUSED`, `CERT_HAS_EXPIRED`, ...),
+ * which is usually the part that identifies the failure.
+ */
+function describeCause(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const code = (error as { cause?: { code?: unknown } }).cause?.code;
+  const suffix = typeof code === "string" && code !== "" ? ` (cause: ${code})` : "";
+  // A plain `Error` name adds nothing; a subclass name (TypeError, TimeoutError,
+  // AbortError) is often the only thing distinguishing the failure.
+  const prefix = error.name === "Error" || error.name === "" ? "" : `${error.name}: `;
+  return `${prefix}${error.message}${suffix}`;
+}
+
+/**
+ * Excerpt of a token-error response, for when no structured message could be
+ * extracted. Bounded to one line so an HTML error page cannot flood the message,
+ * and the client secret is redacted in case the endpoint echoes the request back
+ * — provider-supplied error text already reaches this error via
+ * {@link readTokenErrorMessage}, so the excerpt adds no new class of disclosure.
+ */
+function describeResponseBody(bytes: Uint8Array, clientSecret: string): string {
+  if (bytes.byteLength === 0) {
+    return ", empty body";
+  }
+  let text = new TextDecoder().decode(bytes.subarray(0, tokenErrorExcerptMaxBytes)).replaceAll(/\s+/gu, " ").trim();
+  if (clientSecret !== "") {
+    text = text.replaceAll(clientSecret, "[redacted]");
+  }
+  if (text === "") {
+    return ", empty body";
+  }
+  const truncated = bytes.byteLength > tokenErrorExcerptMaxBytes ? "…" : "";
+  return `, body: ${text}${truncated}`;
 }
 
 function createTokenMetadata(payload: Record<string, unknown>): Record<string, unknown> {

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -9,6 +9,8 @@ const oauthTokenResponseMaxBytes = 1024 * 1024;
 /** Longest `expires_in` we accept; anything larger overflows the ECMAScript `Date` range. */
 const maxExpiresInSeconds = 100 * 365 * 24 * 60 * 60;
 
+class OAuthTokenResponseSizeError extends Error {}
+
 export interface OAuthTokenRequestOptions {
   clientId: string;
   clientSecret: string;
@@ -106,11 +108,7 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
     // still have reached the provider before the connection failed.
     throw input.createError(`OAuth token request failed without an HTTP response: ${describeCause(error)}`);
   }
-  const bytes = await readBoundedResponseBytes(response, {
-    maxBytes: oauthTokenResponseMaxBytes,
-    fieldName: "OAuth token response",
-    createError: input.createError,
-  });
+  const bytes = await readTokenResponseBytes(response, input.createError);
   const rawPayload = decodeTokenPayload(bytes);
   const payload = unwrapTokenPayload(rawPayload, input.responseEnvelope);
   if (!response.ok || !isEnvelopeSuccess(rawPayload, input.responseEnvelope)) {
@@ -140,6 +138,22 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
     },
     metadata: createTokenMetadata(payload),
   };
+}
+
+/** Read a bounded token response and map body-stream failures to a safe OAuth error. */
+async function readTokenResponseBytes(response: Response, createError: OAuthTokenErrorFactory): Promise<Uint8Array> {
+  try {
+    return await readBoundedResponseBytes(response, {
+      maxBytes: oauthTokenResponseMaxBytes,
+      fieldName: "OAuth token response",
+      createError: (message) => new OAuthTokenResponseSizeError(message),
+    });
+  } catch (error) {
+    if (error instanceof OAuthTokenResponseSizeError) {
+      throw createError(error.message);
+    }
+    throw createError(`OAuth token request failed (HTTP ${response.status}, response body could not be read).`);
+  }
 }
 
 /** Decode a JSON object body, or `{}` for an empty, non-JSON, or non-object one. */

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -275,7 +275,7 @@ describe("provider runtime fetch", () => {
       ok: false,
       error: {
         code: "provider_error",
-        message: "provider network request failed",
+        message: expect.stringContaining("provider network request failed"),
         details: { status: 502 },
       },
     });

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -46,7 +46,9 @@ export function createProviderFetch(options: ProviderFetchOptions = {}): Provide
     allowPrivateNetwork: options.allowPrivateNetwork,
     skipDnsValidation: options.skipDnsValidation,
     mapTransportError: (error) =>
-      error instanceof TypeError ? new ProviderRequestError(502, "provider network request failed") : error,
+      error instanceof TypeError
+        ? new ProviderRequestError(502, `provider network request failed${describeTransportCauseCode(error)}`)
+        : error,
     createError: (message) => new ProviderRequestError(502, message),
   });
 }
@@ -981,4 +983,19 @@ export async function requireBearerCredential(context: ExecutionContext, service
   }
 
   throw new ProviderRequestError(401, `Configure ${service} credentials first.`);
+}
+
+/**
+ * The platform error code behind a transport failure (`ENOTFOUND`,
+ * `ECONNREFUSED`, `CERT_HAS_EXPIRED`, ...), formatted for appending to a
+ * provider-visible message, or `""` when there is none.
+ *
+ * Only the code — never `cause.message`, which on undici embeds the target host
+ * (`getaddrinfo ENOTFOUND secret.internal`). That host is exactly what the
+ * transport-error mapping exists to keep out of provider-visible errors; the
+ * code is an enum-like token that identifies the failure without naming it.
+ */
+export function describeTransportCauseCode(error: unknown): string {
+  const code = (error as { cause?: { code?: unknown } } | null)?.cause?.code;
+  return typeof code === "string" && code !== "" ? ` (${code})` : "";
 }

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -995,7 +995,7 @@ export async function requireBearerCredential(context: ExecutionContext, service
  * transport-error mapping exists to keep out of provider-visible errors; the
  * code is an enum-like token that identifies the failure without naming it.
  */
-export function describeTransportCauseCode(error: unknown): string {
-  const code = (error as { cause?: { code?: unknown } } | null)?.cause?.code;
-  return typeof code === "string" && code !== "" ? ` (${code})` : "";
+function describeTransportCauseCode(error: unknown): string {
+  const code = optionalString(optionalRecord(optionalRecord(error)?.cause)?.code);
+  return code ? ` (${code})` : "";
 }


### PR DESCRIPTION
The diagnosability sibling from #275.

## Problem

`requestToken` threw the same string — `"OAuth token request failed."` — for three unrelated failures:

1. the transport rejecting (DNS, TLS, connection reset, **or the egress SSRF guard**),
2. a body that could not be read or parsed,
3. a non-2xx response whose error shape `readTokenErrorMessage` does not recognize.

On a first failure there is no way to tell a network problem from a credential problem from a response-format problem.

Evidence that these are genuinely indistinguishable: while debugging the VPN case in #275 I added logging to the non-2xx path, and **my patch never fired** — the real throw site was the transport path, one branch earlier. If the person holding the debugger picks the wrong branch, the message is not carrying enough to route on.

## Change

**Transport path** now reports the error itself: subclass name when it is informative (`TimeoutError` still gets its own dedicated message), the message, and the platform cause code. An egress-guard rejection now surfaces the guard's own message instead of being overwritten — which matters because that rejection happens pre-flight in tens of milliseconds and previously said nothing at all.

**Non-2xx with no structured message** now reports the status and a bounded body excerpt: 200 bytes, whitespace collapsed to one line so an HTML error page cannot flood the message, with the client secret redacted in case the endpoint echoes the request back. A recognized provider message (`error_description`, `error`, the envelope's `messageField`) still wins — that path is unchanged. `readTokenPayload` was split into read-bytes and decode-payload so the failure path can still see the bytes it already read; no extra read, no change to the size cap.

**`providerFetch`'s `mapTransportError`** flattened every `TypeError` to `"provider network request failed"`, which destroyed the reason one layer below OAuth — and in Node/undici network failures *are* `TypeError`. It now appends the platform cause code: `provider network request failed (ECONNREFUSED)`.

Deliberately the **code only, never `cause.message`**: on undici that embeds the target host (`getaddrinfo ENOTFOUND secret.internal`), which is exactly what this mapping exists to keep out of provider-visible errors — `provider-runtime.test.ts` asserts the host does not leak, and it still passes. The code is an enum-like token that identifies the failure without naming the target.

## Verification

`npm run lint`, `npm run format`, `npm run typecheck` clean; `npx vitest run` → **717 passed / 68 files**.

Four new cases in `oauth-token.test.ts`: cause code carried through to the OAuth message; status + bounded excerpt on an HTML 502; long body truncated **and** client secret redacted (asserting the message stays under 300 chars and does not contain the secret); provider's own `error_description` still preferred over the excerpt.

Three existing assertions updated because they pinned the exact strings this PR changes — `oauth-token.test.ts` ×2 (the transport-failure and 302 cases) and the `provider-runtime.test.ts` transport-error message, relaxed to `stringContaining` while keeping its `not.toContain("secret.internal")` check intact.

## Note on scope

The `provider-runtime.ts` change affects every provider request, not just OAuth. I included it because without it the OAuth-layer improvement is half-dead for the most common failure class — undici's `TypeError` never carries its reason past that mapping. Happy to split it out if you would rather review it separately.
