### PR TITLE
feat(mux): add asset metadata and direct upload actions

### DIFF
--- a/src/providers/mux/actions.ts
+++ b/src/providers/mux/actions.ts
@@ -238,7 +238,7 @@ export const muxActions: ActionDefinition[] = [
         newAssetSettings: directUploadAssetSettings,
         test: s.boolean("Whether to create a free, watermarked test upload."),
         timeout: s.integer("How long the signed upload URL remains valid, in seconds.", {
-          minimum: 1,
+          minimum: 60,
           maximum: 604800,
         }),
       },

--- a/src/providers/mux/actions.ts
+++ b/src/providers/mux/actions.ts
@@ -35,6 +35,56 @@ const asset = s.looseObject("A Mux video asset, including its current processing
   meta: s.looseObject("Customer-provided structured metadata for the asset."),
 });
 const assetOutput = s.actionOutput({ asset }, "A Mux asset response.");
+const assetMeta = s.object(
+  "Customer-provided metadata attached to a Mux asset. This may be exposed to video players; do not include PII.",
+  {
+    title: s.string("A human-readable asset title.", { maxLength: 512 }),
+    creatorId: s.string("Your identifier for the asset creator.", { maxLength: 128 }),
+    externalId: s.string("Your identifier linking the asset to an external record.", { maxLength: 128 }),
+  },
+  { optional: ["title", "creatorId", "externalId"] },
+);
+const directUploadAssetSettings = s.object(
+  "Asset settings applied after a direct upload completes.",
+  {
+    playbackPolicies: s.array(
+      "Playback policies to create for the resulting asset.",
+      s.stringEnum(["public", "signed"], { description: "A non-DRM Mux playback policy." }),
+      { minItems: 1, maxItems: 2 },
+    ),
+    videoQuality: s.stringEnum(["basic", "plus", "premium"], {
+      description: "The cost and encoding-quality tier for the resulting asset.",
+    }),
+    maxResolutionTier: s.stringEnum(["1080p", "1440p", "2160p"], {
+      description: "The maximum resolution tier Mux should produce.",
+    }),
+    passthrough: s.string("Opaque metadata returned in asset details and related webhooks.", { maxLength: 255 }),
+    meta: assetMeta,
+  },
+  { optional: ["playbackPolicies", "videoQuality", "maxResolutionTier", "passthrough", "meta"] },
+);
+const upload = s.looseObject("A Mux Direct Upload and its current ingest status.", {
+  id: s.nonEmptyString("The Direct Upload ID."),
+  cors_origin: s.nonEmptyString("The browser origin allowed to use the signed upload URL."),
+  status: s.stringEnum(["waiting", "asset_created", "errored", "cancelled", "timed_out"], {
+    description: "The current Direct Upload status.",
+  }),
+  timeout: s.nonNegativeInteger("The signed upload URL validity period in seconds."),
+  asset_id: s.nullableString("The resulting asset ID once the upload has been ingested."),
+  error: s.looseObject("The ingest error reported for a failed Direct Upload."),
+  new_asset_settings: s.looseObject("The asset settings used after ingest."),
+  test: s.boolean("Whether this is a Mux test upload."),
+  url: s.nullableString("The signed URL to which the source media should be uploaded."),
+});
+const uploadOutput = s.actionOutput({ upload }, "A Mux Direct Upload response.");
+const playbackLookup = s.looseObject("The Mux object associated with a playback ID.", {
+  id: s.nonEmptyString("The playback ID."),
+  object: s.looseObject("The associated Mux object.", {
+    id: s.nonEmptyString("The associated asset or live stream ID."),
+    type: s.stringEnum(["asset", "live_stream"], { description: "The associated Mux object type." }),
+  }),
+  policy: playbackPolicy,
+});
 const assetLifecycle = {
   startActionId: "mux.create_asset",
   statusActionId: "mux.get_asset",
@@ -117,6 +167,25 @@ export const muxActions: ActionDefinition[] = [
     outputSchema: assetOutput,
   }),
   defineProviderAction(service, {
+    name: "update_asset",
+    description: "Update the passthrough value or customer metadata for an existing Mux video asset.",
+    providerPermissions: [videoWritePermission],
+    followUpActions: ["mux.get_asset"],
+    inputSchema: s.actionInput(
+      {
+        assetId,
+        passthrough: s.string(
+          "Opaque metadata to include in asset details and related webhooks. Pass an empty string to clear it.",
+          { maxLength: 255 },
+        ),
+        meta: assetMeta,
+      },
+      ["assetId"],
+      "The metadata changes to apply to a Mux asset.",
+    ),
+    outputSchema: assetOutput,
+  }),
+  defineProviderAction(service, {
     name: "delete_asset",
     description: "Permanently delete a Mux video asset and all of its data.",
     providerPermissions: [videoWritePermission],
@@ -156,5 +225,83 @@ export const muxActions: ActionDefinition[] = [
       { description: "The asset and access policy for a new Mux playback ID." },
     ),
     outputSchema: s.actionOutput({ playbackId }, "The playback ID created by Mux."),
+  }),
+  defineProviderAction(service, {
+    name: "create_direct_upload",
+    description:
+      "Create a signed Mux Direct Upload URL for client-side or server-side media ingest without proxying video bytes through the connector.",
+    providerPermissions: [videoWritePermission],
+    followUpActions: ["mux.get_direct_upload", "mux.list_assets"],
+    inputSchema: s.actionInput(
+      {
+        corsOrigin: s.nonEmptyString("The browser origin that will use the signed upload URL, or * for any origin."),
+        newAssetSettings: directUploadAssetSettings,
+        test: s.boolean("Whether to create a free, watermarked test upload."),
+        timeout: s.integer("How long the signed upload URL remains valid, in seconds.", {
+          minimum: 1,
+          maximum: 604800,
+        }),
+      },
+      ["corsOrigin"],
+      "Settings for creating a Mux Direct Upload.",
+    ),
+    outputSchema: uploadOutput,
+  }),
+  defineProviderAction(service, {
+    name: "get_direct_upload",
+    description: "Retrieve the status, signed URL, and resulting asset ID for a Mux Direct Upload.",
+    providerPermissions: [videoReadPermission],
+    followUpActions: ["mux.get_asset"],
+    inputSchema: s.actionInput(
+      { uploadId: s.nonEmptyString("The Mux Direct Upload ID.") },
+      ["uploadId"],
+      "The Direct Upload to retrieve.",
+    ),
+    outputSchema: uploadOutput,
+  }),
+  defineProviderAction(service, {
+    name: "list_direct_uploads",
+    description: "List Mux Direct Uploads in the current environment, including waiting and completed uploads.",
+    providerPermissions: [videoReadPermission],
+    followUpActions: ["mux.get_direct_upload", "mux.get_asset"],
+    inputSchema: s.object(
+      "Pagination for Mux Direct Uploads.",
+      {
+        limit: s.integer("The maximum number of Direct Uploads to return.", { minimum: 1, maximum: 100 }),
+        page: s.positiveInteger("The one-based page number."),
+      },
+      { optional: ["limit", "page"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        uploads: s.array("Mux Direct Uploads in this page.", upload),
+        page: s.nullableInteger("The current page number returned by Mux."),
+        limit: s.nullableInteger("The page size returned by Mux."),
+        total: s.nullableInteger("The total number of Direct Uploads reported by Mux."),
+      },
+      "A page of Mux Direct Uploads.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "cancel_direct_upload",
+    description: "Cancel a waiting Mux Direct Upload so that a later upload cannot create an asset.",
+    providerPermissions: [videoWritePermission],
+    inputSchema: s.actionInput(
+      { uploadId: s.nonEmptyString("The Mux Direct Upload ID.") },
+      ["uploadId"],
+      "The Direct Upload to cancel.",
+    ),
+    outputSchema: uploadOutput,
+  }),
+  defineProviderAction(service, {
+    name: "get_playback_id",
+    description: "Resolve a Mux playback ID to the asset or live stream it belongs to and its access policy.",
+    providerPermissions: [videoReadPermission],
+    inputSchema: s.actionInput(
+      { playbackId: s.nonEmptyString("The Mux playback ID to resolve.") },
+      ["playbackId"],
+      "The playback ID to resolve.",
+    ),
+    outputSchema: s.actionOutput({ playbackId: playbackLookup }, "The Mux playback ID association."),
   }),
 ];

--- a/src/providers/mux/actions.ts
+++ b/src/providers/mux/actions.ts
@@ -38,9 +38,9 @@ const assetOutput = s.actionOutput({ asset }, "A Mux asset response.");
 const assetMeta = s.object(
   "Customer-provided metadata attached to a Mux asset. This may be exposed to video players; do not include PII.",
   {
-    title: s.string("A human-readable asset title.", { maxLength: 512 }),
-    creatorId: s.string("Your identifier for the asset creator.", { maxLength: 128 }),
-    externalId: s.string("Your identifier linking the asset to an external record.", { maxLength: 128 }),
+    title: s.string("A human-readable asset title.", { minLength: 1, maxLength: 512 }),
+    creatorId: s.string("Your identifier for the asset creator.", { minLength: 1, maxLength: 128 }),
+    externalId: s.string("Your identifier linking the asset to an external record.", { minLength: 1, maxLength: 128 }),
   },
   { optional: ["title", "creatorId", "externalId"] },
 );
@@ -58,7 +58,10 @@ const directUploadAssetSettings = s.object(
     maxResolutionTier: s.stringEnum(["1080p", "1440p", "2160p"], {
       description: "The maximum resolution tier Mux should produce.",
     }),
-    passthrough: s.string("Opaque metadata returned in asset details and related webhooks.", { maxLength: 255 }),
+    passthrough: s.string("Opaque metadata returned in asset details and related webhooks.", {
+      minLength: 1,
+      maxLength: 255,
+    }),
     meta: assetMeta,
   },
   { optional: ["playbackPolicies", "videoQuality", "maxResolutionTier", "passthrough", "meta"] },
@@ -118,15 +121,7 @@ export const muxActions: ActionDefinition[] = [
           description: "Opaque metadata returned in asset details and related webhooks.",
         }),
         test: s.boolean("Whether to create a free, watermarked test asset limited to 10 seconds and 24 hours."),
-        meta: s.object(
-          "Structured asset metadata. Do not include sensitive or personally identifiable information.",
-          {
-            title: s.string("A human-readable asset title.", { maxLength: 512 }),
-            creatorId: s.string("Your identifier for the asset creator.", { maxLength: 128 }),
-            externalId: s.string("Your identifier linking the asset to an external record.", { maxLength: 128 }),
-          },
-          { optional: ["title", "creatorId", "externalId"] },
-        ),
+        meta: assetMeta,
       },
       ["sourceUrl"],
       "Settings for creating a Mux asset from a remote media file.",
@@ -231,7 +226,7 @@ export const muxActions: ActionDefinition[] = [
     description:
       "Create a signed Mux Direct Upload URL for client-side or server-side media ingest without proxying video bytes through the connector.",
     providerPermissions: [videoWritePermission],
-    followUpActions: ["mux.get_direct_upload", "mux.list_assets"],
+    followUpActions: ["mux.get_direct_upload", "mux.cancel_direct_upload", "mux.list_assets"],
     inputSchema: s.actionInput(
       {
         corsOrigin: s.nonEmptyString("The browser origin that will use the signed upload URL, or * for any origin."),
@@ -267,18 +262,13 @@ export const muxActions: ActionDefinition[] = [
     inputSchema: s.object(
       "Pagination for Mux Direct Uploads.",
       {
-        limit: s.integer("The maximum number of Direct Uploads to return.", { minimum: 1, maximum: 100 }),
+        limit: s.integer("The maximum number of Direct Uploads to return.", { minimum: 1, default: 25 }),
         page: s.positiveInteger("The one-based page number."),
       },
       { optional: ["limit", "page"] },
     ),
     outputSchema: s.actionOutput(
-      {
-        uploads: s.array("Mux Direct Uploads in this page.", upload),
-        page: s.nullableInteger("The current page number returned by Mux."),
-        limit: s.nullableInteger("The page size returned by Mux."),
-        total: s.nullableInteger("The total number of Direct Uploads reported by Mux."),
-      },
+      { uploads: s.array("Mux Direct Uploads in this page. Mux returns no page metadata for this endpoint.", upload) },
       "A page of Mux Direct Uploads.",
     ),
   }),

--- a/src/providers/mux/runtime.test.ts
+++ b/src/providers/mux/runtime.test.ts
@@ -1,0 +1,122 @@
+import type { MuxContext } from "./runtime.ts";
+
+import { describe, expect, it, vi } from "vitest";
+import { muxActionHandlers } from "./runtime.ts";
+
+function context(fetcher: typeof fetch): MuxContext {
+  return {
+    tokenId: "token-id",
+    tokenSecret: "token-secret",
+    fetcher,
+  };
+}
+
+function upload(id = "upload-123"): Record<string, unknown> {
+  return {
+    id,
+    cors_origin: "https://example.com",
+    status: "waiting",
+    timeout: 3600,
+    url: "https://storage.googleapis.com/mux-upload",
+  };
+}
+
+describe("Mux extended video actions", () => {
+  it("updates asset metadata and preserves an empty passthrough value", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json({ data: { id: "asset-123", status: "ready" } }));
+
+    await muxActionHandlers.update_asset!(
+      {
+        assetId: "asset/123",
+        passthrough: "",
+        meta: { title: "Updated title", externalId: "record-7" },
+      },
+      context(fetcher),
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = fetcher.mock.calls[0]!;
+    expect(String(url)).toBe("https://api.mux.com/video/v1/assets/asset%2F123");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      passthrough: "",
+      meta: { title: "Updated title", external_id: "record-7" },
+    });
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("token-id:token-secret").toString("base64")}`,
+    });
+  });
+
+  it("maps Direct Upload create, list, retrieve, and cancel endpoints", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      const url = String(input);
+      const pathname = new URL(url).pathname;
+      if (pathname.endsWith("/uploads") && init?.method === "POST") {
+        return Response.json({ data: upload() });
+      }
+      if (pathname.endsWith("/uploads") && (!init?.method || init.method === "GET")) {
+        return Response.json({ data: [upload()], page: 2, limit: 10, total: 11 });
+      }
+      if (url.endsWith("/uploads/upload-123")) {
+        return Response.json({ data: { ...upload(), status: "asset_created", asset_id: "asset-123" } });
+      }
+      return Response.json({ data: { ...upload(), status: "cancelled" } });
+    });
+    const muxContext = context(fetcher);
+
+    const created = await muxActionHandlers.create_direct_upload!(
+      {
+        corsOrigin: "https://example.com",
+        newAssetSettings: {
+          playbackPolicies: ["public"],
+          videoQuality: "plus",
+          meta: { title: "Upload" },
+        },
+        test: true,
+        timeout: 120,
+      },
+      muxContext,
+    );
+    expect(created).toEqual({ upload: upload() });
+    expect(JSON.parse(String(fetcher.mock.calls[0]![1]?.body))).toEqual({
+      cors_origin: "https://example.com",
+      new_asset_settings: {
+        playback_policies: ["public"],
+        video_quality: "plus",
+        meta: { title: "Upload" },
+      },
+      test: true,
+      timeout: 120,
+    });
+
+    await muxActionHandlers.list_direct_uploads!({ limit: 10, page: 2 }, muxContext);
+    await muxActionHandlers.get_direct_upload!({ uploadId: "upload-123" }, muxContext);
+    await muxActionHandlers.cancel_direct_upload!({ uploadId: "upload-123" }, muxContext);
+
+    expect(fetcher.mock.calls.map(([url, init]) => `${init?.method ?? "GET"} ${String(url)}`)).toEqual([
+      "POST https://api.mux.com/video/v1/uploads",
+      "GET https://api.mux.com/video/v1/uploads?limit=10&page=2",
+      "GET https://api.mux.com/video/v1/uploads/upload-123",
+      "PUT https://api.mux.com/video/v1/uploads/upload-123/cancel",
+    ]);
+  });
+
+  it("resolves a playback ID to its asset or live stream", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        data: { id: "playback-123", object: { id: "live-123", type: "live_stream" }, policy: "public" },
+      }),
+    );
+
+    const result = await muxActionHandlers.get_playback_id!({ playbackId: "playback/123" }, context(fetcher));
+
+    expect(result).toEqual({
+      playbackId: {
+        id: "playback-123",
+        object: { id: "live-123", type: "live_stream" },
+        policy: "public",
+      },
+    });
+    expect(String(fetcher.mock.calls[0]![0])).toBe("https://api.mux.com/video/v1/playback-ids/playback%2F123");
+  });
+});

--- a/src/providers/mux/runtime.test.ts
+++ b/src/providers/mux/runtime.test.ts
@@ -1,6 +1,8 @@
 import type { MuxContext } from "./runtime.ts";
 
 import { describe, expect, it, vi } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { muxActions } from "./actions.ts";
 import { muxActionHandlers } from "./runtime.ts";
 
 function context(fetcher: typeof fetch): MuxContext {
@@ -22,6 +24,16 @@ function upload(id = "upload-123"): Record<string, unknown> {
 }
 
 describe("Mux extended video actions", () => {
+  it("enforces the Mux Direct Upload timeout range", () => {
+    const action = muxActions.find((candidate) => candidate.name === "create_direct_upload");
+    expect(action).toBeDefined();
+
+    expect(validateActionInput(action!, { corsOrigin: "*", timeout: 59 }).valid).toBe(false);
+    expect(validateActionInput(action!, { corsOrigin: "*", timeout: 60 }).valid).toBe(true);
+    expect(validateActionInput(action!, { corsOrigin: "*", timeout: 604800 }).valid).toBe(true);
+    expect(validateActionInput(action!, { corsOrigin: "*", timeout: 604801 }).valid).toBe(false);
+  });
+
   it("updates asset metadata and preserves an empty passthrough value", async () => {
     const fetcher = vi.fn<typeof fetch>(async () => Response.json({ data: { id: "asset-123", status: "ready" } }));
 

--- a/src/providers/mux/runtime.test.ts
+++ b/src/providers/mux/runtime.test.ts
@@ -34,6 +34,22 @@ describe("Mux extended video actions", () => {
     expect(validateActionInput(action!, { corsOrigin: "*", timeout: 604801 }).valid).toBe(false);
   });
 
+  it("rejects an update_asset request that carries no metadata change", async () => {
+    const action = muxActions.find((candidate) => candidate.name === "update_asset");
+    expect(validateActionInput(action!, { assetId: "asset-123", meta: { title: "" } }).valid).toBe(false);
+    expect(validateActionInput(action!, { assetId: "asset-123", passthrough: "" }).valid).toBe(true);
+
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json({ data: { id: "asset-123" } }));
+
+    await expect(muxActionHandlers.update_asset!({ assetId: "asset-123" }, context(fetcher))).rejects.toThrow(
+      "At least one of passthrough or meta must be provided",
+    );
+    await expect(muxActionHandlers.update_asset!({ assetId: "asset-123", meta: {} }, context(fetcher))).rejects.toThrow(
+      "At least one of passthrough or meta must be provided",
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("updates asset metadata and preserves an empty passthrough value", async () => {
     const fetcher = vi.fn<typeof fetch>(async () => Response.json({ data: { id: "asset-123", status: "ready" } }));
 
@@ -67,7 +83,7 @@ describe("Mux extended video actions", () => {
         return Response.json({ data: upload() });
       }
       if (pathname.endsWith("/uploads") && (!init?.method || init.method === "GET")) {
-        return Response.json({ data: [upload()], page: 2, limit: 10, total: 11 });
+        return Response.json({ data: [upload()] });
       }
       if (url.endsWith("/uploads/upload-123")) {
         return Response.json({ data: { ...upload(), status: "asset_created", asset_id: "asset-123" } });
@@ -101,9 +117,14 @@ describe("Mux extended video actions", () => {
       timeout: 120,
     });
 
-    await muxActionHandlers.list_direct_uploads!({ limit: 10, page: 2 }, muxContext);
-    await muxActionHandlers.get_direct_upload!({ uploadId: "upload-123" }, muxContext);
-    await muxActionHandlers.cancel_direct_upload!({ uploadId: "upload-123" }, muxContext);
+    const listed = await muxActionHandlers.list_direct_uploads!({ limit: 10, page: 2 }, muxContext);
+    expect(listed).toEqual({ uploads: [upload()] });
+
+    const retrieved = await muxActionHandlers.get_direct_upload!({ uploadId: "upload-123" }, muxContext);
+    expect(retrieved).toEqual({ upload: { ...upload(), status: "asset_created", asset_id: "asset-123" } });
+
+    const cancelled = await muxActionHandlers.cancel_direct_upload!({ uploadId: "upload-123" }, muxContext);
+    expect(cancelled).toEqual({ upload: { ...upload(), status: "cancelled" } });
 
     expect(fetcher.mock.calls.map(([url, init]) => `${init?.method ?? "GET"} ${String(url)}`)).toEqual([
       "POST https://api.mux.com/video/v1/uploads",

--- a/src/providers/mux/runtime.ts
+++ b/src/providers/mux/runtime.ts
@@ -76,7 +76,6 @@ async function createAsset(input: Record<string, unknown>, context: MuxContext):
     fieldName: "sourceUrl",
     createError: inputError,
   });
-  const meta = optionalRecord(input.meta);
   const body = compactObject({
     inputs: [{ url: sourceUrl.toString() }],
     playback_policies: readOptionalStringArray(input.playbackPolicies, "playbackPolicies"),
@@ -84,13 +83,7 @@ async function createAsset(input: Record<string, unknown>, context: MuxContext):
     max_resolution_tier: optionalString(input.maxResolutionTier),
     passthrough: optionalString(input.passthrough),
     test: optionalBoolean(input.test),
-    meta: meta
-      ? compactObject({
-          title: optionalString(meta.title),
-          creator_id: optionalString(meta.creatorId),
-          external_id: optionalString(meta.externalId),
-        })
-      : undefined,
+    meta: serializeAssetMeta(input.meta),
   });
   const payload = await requestMuxJson({
     path: "/video/v1/assets",
@@ -134,7 +127,7 @@ async function getAsset(input: Record<string, unknown>, context: MuxContext): Pr
 
 async function updateAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
   const assetId = requiredInputString(input.assetId, "assetId");
-  const passthrough = optionalUpdateString(input.passthrough, "passthrough");
+  const passthrough = optionalRawString(input.passthrough);
   const meta = serializeAssetMeta(input.meta);
   if (passthrough === undefined && meta === undefined) {
     throw inputError("At least one of passthrough or meta must be provided");
@@ -220,12 +213,7 @@ async function listDirectUploads(input: Record<string, unknown>, context: MuxCon
     phase: "execute",
   });
   const response = requiredRecord(payload, "Mux list Direct Uploads response", muxResponseError);
-  return {
-    uploads: objectArray(response.data, "Mux Direct Upload", muxResponseError),
-    page: optionalInteger(response.page) ?? null,
-    limit: optionalInteger(response.limit) ?? null,
-    total: optionalInteger(response.total) ?? null,
-  };
+  return { uploads: objectArray(response.data, "Mux Direct Upload", muxResponseError) };
 }
 
 async function cancelDirectUpload(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
@@ -337,16 +325,11 @@ function requiredInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, inputError);
 }
 
-function optionalUpdateString(value: unknown, fieldName: string): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string") {
-    throw inputError(`${fieldName} must be a string`);
-  }
-  return optionalRawString(value);
-}
-
+/**
+ * Map camelCase meta input onto the Mux asset `meta` object, or undefined when
+ * no field carries a value. Mux only documents empty-string clearing for
+ * `passthrough`, so an empty `meta` must not be sent as a content-free write.
+ */
 function serializeAssetMeta(value: unknown): Record<string, string> | undefined {
   if (value === undefined) {
     return undefined;
@@ -355,11 +338,12 @@ function serializeAssetMeta(value: unknown): Record<string, string> | undefined 
   if (!meta) {
     throw inputError("meta must be an object");
   }
-  return compactObject({
+  const serialized = compactObject({
     title: optionalString(meta.title),
     creator_id: optionalString(meta.creatorId),
     external_id: optionalString(meta.externalId),
   });
+  return Object.keys(serialized).length > 0 ? serialized : undefined;
 }
 
 function serializeDirectUploadAssetSettings(value: unknown): Record<string, unknown> | undefined {
@@ -374,7 +358,7 @@ function serializeDirectUploadAssetSettings(value: unknown): Record<string, unkn
     playback_policies: readOptionalStringArray(settings.playbackPolicies, "newAssetSettings.playbackPolicies"),
     video_quality: optionalString(settings.videoQuality),
     max_resolution_tier: optionalString(settings.maxResolutionTier),
-    passthrough: optionalUpdateString(settings.passthrough, "newAssetSettings.passthrough"),
+    passthrough: optionalString(settings.passthrough),
     meta: serializeAssetMeta(settings.meta),
   });
 }

--- a/src/providers/mux/runtime.ts
+++ b/src/providers/mux/runtime.ts
@@ -7,6 +7,7 @@ import {
   objectArray,
   optionalBoolean,
   optionalInteger,
+  optionalRawString,
   optionalRecord,
   optionalString,
   requiredRecord,
@@ -31,8 +32,14 @@ export const muxActionHandlers: Record<string, MuxActionHandler> = {
   create_asset: createAsset,
   list_assets: listAssets,
   get_asset: getAsset,
+  update_asset: updateAsset,
   delete_asset: deleteAsset,
   create_playback_id: createPlaybackId,
+  create_direct_upload: createDirectUpload,
+  get_direct_upload: getDirectUpload,
+  list_direct_uploads: listDirectUploads,
+  cancel_direct_upload: cancelDirectUpload,
+  get_playback_id: getPlaybackId,
 };
 
 export async function validateMuxCredential(context: MuxContext): Promise<CredentialValidationResult> {
@@ -125,6 +132,24 @@ async function getAsset(input: Record<string, unknown>, context: MuxContext): Pr
   return { asset: muxDataRecord(payload, "Mux asset response") };
 }
 
+async function updateAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const assetId = requiredInputString(input.assetId, "assetId");
+  const passthrough = optionalUpdateString(input.passthrough, "passthrough");
+  const meta = serializeAssetMeta(input.meta);
+  if (passthrough === undefined && meta === undefined) {
+    throw inputError("At least one of passthrough or meta must be provided");
+  }
+
+  const payload = await requestMuxJson({
+    path: `/video/v1/assets/${encodeURIComponent(assetId)}`,
+    method: "PATCH",
+    body: compactObject({ passthrough, meta }),
+    context,
+    phase: "execute",
+  });
+  return { asset: muxDataRecord(payload, "Mux update asset response") };
+}
+
 async function deleteAsset(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
   const assetId = requiredInputString(input.assetId, "assetId");
   await requestMuxJson({
@@ -155,6 +180,73 @@ async function createPlaybackId(input: Record<string, unknown>, context: MuxCont
     phase: "execute",
   });
   return { playbackId: muxDataRecord(payload, "Mux create playback ID response") };
+}
+
+async function createDirectUpload(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const newAssetSettings = serializeDirectUploadAssetSettings(input.newAssetSettings);
+  const payload = await requestMuxJson({
+    path: "/video/v1/uploads",
+    method: "POST",
+    body: compactObject({
+      cors_origin: requiredInputString(input.corsOrigin, "corsOrigin"),
+      new_asset_settings: newAssetSettings,
+      test: optionalBoolean(input.test),
+      timeout: optionalInteger(input.timeout),
+    }),
+    context,
+    phase: "execute",
+  });
+  return { upload: muxDataRecord(payload, "Mux create Direct Upload response") };
+}
+
+async function getDirectUpload(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const uploadId = requiredInputString(input.uploadId, "uploadId");
+  const payload = await requestMuxJson({
+    path: `/video/v1/uploads/${encodeURIComponent(uploadId)}`,
+    context,
+    phase: "execute",
+  });
+  return { upload: muxDataRecord(payload, "Mux Direct Upload response") };
+}
+
+async function listDirectUploads(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const payload = await requestMuxJson({
+    path: "/video/v1/uploads",
+    query: {
+      limit: stringifyInteger(input.limit),
+      page: stringifyInteger(input.page),
+    },
+    context,
+    phase: "execute",
+  });
+  const response = requiredRecord(payload, "Mux list Direct Uploads response", muxResponseError);
+  return {
+    uploads: objectArray(response.data, "Mux Direct Upload", muxResponseError),
+    page: optionalInteger(response.page) ?? null,
+    limit: optionalInteger(response.limit) ?? null,
+    total: optionalInteger(response.total) ?? null,
+  };
+}
+
+async function cancelDirectUpload(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const uploadId = requiredInputString(input.uploadId, "uploadId");
+  const payload = await requestMuxJson({
+    path: `/video/v1/uploads/${encodeURIComponent(uploadId)}/cancel`,
+    method: "PUT",
+    context,
+    phase: "execute",
+  });
+  return { upload: muxDataRecord(payload, "Mux cancel Direct Upload response") };
+}
+
+async function getPlaybackId(input: Record<string, unknown>, context: MuxContext): Promise<unknown> {
+  const playbackId = requiredInputString(input.playbackId, "playbackId");
+  const payload = await requestMuxJson({
+    path: `/video/v1/playback-ids/${encodeURIComponent(playbackId)}`,
+    context,
+    phase: "execute",
+  });
+  return { playbackId: muxDataRecord(payload, "Mux playback ID response") };
 }
 
 interface MuxRequestOptions {
@@ -243,6 +335,48 @@ function createMuxAuthorization(context: Pick<MuxContext, "tokenId" | "tokenSecr
 
 function requiredInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, inputError);
+}
+
+function optionalUpdateString(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw inputError(`${fieldName} must be a string`);
+  }
+  return optionalRawString(value);
+}
+
+function serializeAssetMeta(value: unknown): Record<string, string> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const meta = optionalRecord(value);
+  if (!meta) {
+    throw inputError("meta must be an object");
+  }
+  return compactObject({
+    title: optionalString(meta.title),
+    creator_id: optionalString(meta.creatorId),
+    external_id: optionalString(meta.externalId),
+  });
+}
+
+function serializeDirectUploadAssetSettings(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const settings = optionalRecord(value);
+  if (!settings) {
+    throw inputError("newAssetSettings must be an object");
+  }
+  return compactObject({
+    playback_policies: readOptionalStringArray(settings.playbackPolicies, "newAssetSettings.playbackPolicies"),
+    video_quality: optionalString(settings.videoQuality),
+    max_resolution_tier: optionalString(settings.maxResolutionTier),
+    passthrough: optionalUpdateString(settings.passthrough, "newAssetSettings.passthrough"),
+    meta: serializeAssetMeta(settings.meta),
+  });
 }
 
 function inputError(message: string): ProviderRequestError {


### PR DESCRIPTION
## Summary

This PR expands the Mux Video provider beyond the existing on-demand asset lifecycle. It adds asset metadata updates, Direct Upload management, and Playback ID lookup based on the official Mux Video API.

## What changed

- Added `mux.update_asset` for updating asset `passthrough` and customer metadata.
- Added `mux.create_direct_upload` for creating signed upload URLs without proxying video bytes through OpenConnector.
- Added `mux.get_direct_upload` for checking upload status and the resulting asset ID.
- Added `mux.list_direct_uploads` with page-based pagination.
- Added `mux.cancel_direct_upload` for cancelling uploads that are still waiting.
- Added `mux.get_playback_id` for resolving a Playback ID to its associated asset or live stream.
- Added runtime request mapping, input validation, response normalization, and regression tests for the new actions.
- Preserved the existing Mux Basic Auth flow, guarded provider fetcher, permission model, and upstream error handling.

## API research

The selected actions correspond to these official Mux Video API endpoints:

- `PATCH /video/v1/assets/{ASSET_ID}`
- `POST /video/v1/uploads`
- `GET /video/v1/uploads/{UPLOAD_ID}`
- `GET /video/v1/uploads`
- `PUT /video/v1/uploads/{UPLOAD_ID}/cancel`
- `GET /video/v1/playback-ids/{PLAYBACK_ID}`

References:

- https://docs.mux.com/api-reference/video
- https://github.com/muxinc/mux-node-sdk/blob/master/src/resources/video/api.md

## Validation

- `npm run generate:catalog`
- `npm run typecheck`
- `oxlint src/providers/mux/actions.ts src/providers/mux/runtime.ts src/providers/mux/runtime.test.ts`
- `npm test` — 69 test files and 737 tests passed

Direct Upload responses expose the signed upload URL to the caller; the connector does not handle or relay the media bytes.