### PR TITLE
fix(discord): align OAuth actions with current API

### DIFF
--- a/src/core/json-schema.test.ts
+++ b/src/core/json-schema.test.ts
@@ -56,6 +56,24 @@ describe("jsonSchema.nonWhitespaceString", () => {
   });
 });
 
+describe("jsonSchema.array", () => {
+  it("preserves array uniqueness constraints", () => {
+    expect(
+      jsonSchema.stringArray("Unique identifiers.", {
+        maxItems: 100,
+        uniqueItems: true,
+        itemDescription: "An identifier.",
+      }),
+    ).toEqual({
+      type: "array",
+      items: { type: "string", minLength: 1, description: "An identifier." },
+      maxItems: 100,
+      uniqueItems: true,
+      description: "Unique identifiers.",
+    });
+  });
+});
+
 describe("jsonSchema.looseRequiredObject", () => {
   it("requires every property except explicitly optional properties", () => {
     expect(

--- a/src/core/json-schema.ts
+++ b/src/core/json-schema.ts
@@ -21,6 +21,7 @@ type ObjectOptions = JsonSchemaOptions & {
 type ArrayOptions = JsonSchemaOptions & {
   minItems?: number;
   maxItems?: number;
+  uniqueItems?: boolean;
   itemDescription?: string;
 };
 
@@ -107,6 +108,7 @@ export const jsonSchema = {
     withOptions(schema, options);
     if (options.minItems != null) schema.minItems = options.minItems;
     if (options.maxItems != null) schema.maxItems = options.maxItems;
+    if (options.uniqueItems != null) schema.uniqueItems = options.uniqueItems;
     return schema;
   },
 
@@ -337,20 +339,11 @@ export const jsonSchema = {
     };
   },
 
-  stringArray(
-    description: string,
-    options: Omit<JsonSchemaOptions, "description"> & {
-      minItems?: number;
-      maxItems?: number;
-      itemDescription?: string;
-    } = {},
-  ): JsonSchema {
-    return this.array(this.string({ minLength: 1, description: options.itemDescription }), {
+  stringArray(description: string, options: Omit<ArrayOptions, "description"> = {}): JsonSchema {
+    const { itemDescription, ...arrayOptions } = options;
+    return this.array(this.string({ minLength: 1, description: itemDescription }), {
+      ...arrayOptions,
       description,
-      minItems: options.minItems,
-      maxItems: options.maxItems,
-      default: options.default,
-      format: options.format,
     });
   },
 

--- a/src/providers/discord/actions.ts
+++ b/src/providers/discord/actions.ts
@@ -13,7 +13,7 @@ const userSchema = s.looseObject(
     id: snowflakeSchema,
     username: s.string("The username of the user."),
     global_name: s.nullableString("The global display name of the user."),
-    email: s.string("The email address of the user."),
+    email: s.nullableString("The email address of the user."),
   },
   { description: "A Discord user profile." },
 );
@@ -23,36 +23,32 @@ const binaryFileSchema = s.requiredObject("A binary file payload encoded for tra
   sizeBytes: s.integer("The file size in bytes."),
   dataBase64: s.string("The file contents encoded as base64."),
 });
-const inviteInputSchema = s.object(
-  "Input parameters for resolving a Discord invite.",
-  {
-    invite_code: s.string("The invite code or invite URL to resolve.", { minLength: 1 }),
-    code: s.string("The invite code to resolve.", { minLength: 1 }),
-    with_counts: s.boolean("Whether to include approximate member and presence counts."),
-    with_expiration: s.boolean("Whether to include expiration metadata in the invite response."),
-    guild_scheduled_event_id: snowflakeSchema,
-  },
-  { optional: ["invite_code", "code", "with_counts", "with_expiration", "guild_scheduled_event_id"] },
-);
+const inviteContextProperties = {
+  with_counts: s.boolean("Whether to include approximate member and presence counts."),
+  guild_scheduled_event_id: snowflakeSchema,
+  target_channel_id: snowflakeSchema,
+  target_message_id: snowflakeSchema,
+};
+const entitlementSkuIdsSchema = s.stringArray("The SKU IDs used to filter current-user entitlements.", {
+  maxItems: 100,
+  uniqueItems: true,
+  itemDescription: "A Discord SKU ID.",
+});
 
 export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_current_user_application_entitlements",
     description: "Get entitlements for the current OAuth user under a Discord application.",
-    requiredScopes: ["discord.entitlements.read"],
+    requiredScopes: ["applications.entitlements"],
+    // The two entitlement operations are distinct in this pinned official OpenAPI snapshot:
+    // https://github.com/discord/discord-api-spec/blob/e2bb9417565db2b26b1ea960c63b7f9075d799ab/specs/openapi.json
     inputSchema: s.object(
       {
         application_id: snowflakeSchema,
-        before: snowflakeSchema,
-        after: snowflakeSchema,
-        limit: s.integer("The maximum number of entitlements to return.", { minimum: 1, maximum: 100 }),
-        exclude_ended: s.boolean("Whether to exclude entitlements that have already ended."),
-        exclude_deleted: s.boolean("Whether to exclude entitlements marked as deleted."),
+        sku_ids: entitlementSkuIdsSchema,
+        exclude_consumed: s.boolean("Whether to exclude entitlements that have already been consumed."),
       },
-      {
-        required: ["application_id"],
-        optional: ["before", "after", "limit", "exclude_ended", "exclude_deleted"],
-      },
+      { required: ["application_id"] },
     ),
     outputSchema: s.requiredObject("Current-user application entitlements.", {
       entitlements: s.array("The entitlements visible to the current OAuth user.", rawObjectSchema),
@@ -61,14 +57,14 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_my_application_role_connection",
     description: "Read the current OAuth user's role connection data for a Discord application.",
-    requiredScopes: ["discord.role_connections.write"],
+    requiredScopes: ["role_connections.write"],
     inputSchema: applicationInputSchema("Input parameters for reading an application role connection."),
     outputSchema: s.requiredObject("The output payload for this action.", { role_connection: rawObjectSchema }),
   }),
   defineProviderAction(service, {
     name: "update_my_application_role_connection",
     description: "Set the current OAuth user's role connection platform fields or metadata for a Discord application.",
-    requiredScopes: ["discord.role_connections.write"],
+    requiredScopes: ["role_connections.write"],
     inputSchema: s.object(
       "Input parameters for updating an application role connection.",
       {
@@ -84,7 +80,7 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "delete_my_application_role_connection",
     description: "Remove the current OAuth user's role connection data for a Discord application.",
-    requiredScopes: ["discord.role_connections.write"],
+    requiredScopes: ["role_connections.write"],
     inputSchema: applicationInputSchema("Input parameters for deleting an application role connection."),
     outputSchema: s.requiredObject("The output payload for this action.", {
       success: s.boolean("Whether Discord accepted the delete request."),
@@ -128,19 +124,35 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_invite",
     description: "Get a Discord invite by code or URL.",
-    inputSchema: inviteInputSchema,
+    // Official removal of the obsolete with_expiration parameter:
+    // https://github.com/discord/discord-api-docs/commit/56aa3199c523584e4142a285817ee8be7bb86ec0
+    inputSchema: s.object(
+      "Input parameters for resolving a Discord invite.",
+      {
+        invite_code: s.string("The invite code or invite URL to resolve.", { minLength: 1 }),
+        ...inviteContextProperties,
+      },
+      { required: ["invite_code"] },
+    ),
     outputSchema: rawObjectSchema,
   }),
   defineProviderAction(service, {
     name: "resolve_invite",
     description: "Resolve a Discord invite code.",
-    inputSchema: inviteInputSchema,
+    inputSchema: s.object(
+      "Input parameters for resolving a Discord invite.",
+      {
+        code: s.string("The invite code to resolve.", { minLength: 1 }),
+        ...inviteContextProperties,
+      },
+      { required: ["code"] },
+    ),
     outputSchema: rawObjectSchema,
   }),
   defineProviderAction(service, {
     name: "get_my_guild_member",
     description: "Get the current OAuth user's member record in a guild.",
-    requiredScopes: ["discord.guild_members.read"],
+    requiredScopes: ["guilds.members.read"],
     inputSchema: guildInputSchema("Input for retrieving the current user's member record."),
     outputSchema: rawObjectSchema,
   }),
@@ -153,14 +165,14 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_my_user",
     description: "Get the current OAuth user's Discord profile.",
-    requiredScopes: ["discord.user.read"],
+    requiredScopes: ["identify"],
     inputSchema: noInputSchema,
     outputSchema: userSchema,
   }),
   defineProviderAction(service, {
     name: "get_openid_connect_userinfo",
     description: "Get the OpenID Connect userinfo payload for the current OAuth user.",
-    requiredScopes: ["discord.openid"],
+    requiredScopes: ["openid"],
     inputSchema: noInputSchema,
     outputSchema: rawObjectSchema,
   }),
@@ -175,14 +187,14 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_user",
     description: "Get the current OAuth user. Discord OAuth tokens can only read @me through this provider.",
-    requiredScopes: ["discord.user.read"],
+    requiredScopes: ["identify"],
     inputSchema: s.requiredObject("Input for retrieving a Discord user.", { user_id: s.literal("@me") }),
     outputSchema: userSchema,
   }),
   defineProviderAction(service, {
     name: "list_my_connections",
     description: "List the current OAuth user's connected external accounts.",
-    requiredScopes: ["discord.connections.read"],
+    requiredScopes: ["connections"],
     inputSchema: noInputSchema,
     outputSchema: s.requiredObject("Discord user connections.", {
       connections: s.array("The current user's connected external accounts.", rawObjectSchema),
@@ -191,7 +203,7 @@ export const discordActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_my_guilds",
     description: "List the current OAuth user's guilds.",
-    requiredScopes: ["discord.guilds.read"],
+    requiredScopes: ["guilds"],
     inputSchema: s.object(
       "Input for listing the current user's guilds.",
       {

--- a/src/providers/discord/executors.ts
+++ b/src/providers/discord/executors.ts
@@ -7,19 +7,33 @@ import {
   optionalInteger,
   optionalRecord,
   optionalString,
+  optionalStringArray,
   requiredString,
 } from "../../core/cast.ts";
 import { encodePathSegment, jsonObject } from "../../core/request.ts";
 import { defineOAuthProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "discord";
-const discordApiBaseUrl = "https://discord.com/api";
+// Pin regular REST calls to v10; use the unversioned OAuth/OIDC URLs from official discovery.
+// https://discord.com/.well-known/openid-configuration
+const discordApiBaseUrl = "https://discord.com/api/v10";
+const discordOauthApiBaseUrl = "https://discord.com/api";
 
 interface DiscordContext {
   accessToken: string;
   tokenType?: string;
   fetcher: typeof fetch;
   signal?: AbortSignal;
+}
+
+interface DiscordRequestInput {
+  readonly method?: string;
+  readonly path: string;
+  readonly baseUrl?: string;
+  readonly query?: Record<string, unknown>;
+  readonly body?: Record<string, unknown>;
+  readonly context: DiscordContext;
+  readonly authenticated?: boolean;
 }
 
 type DiscordActionHandler = (input: Record<string, unknown>, context: DiscordContext) => Promise<unknown>;
@@ -68,16 +82,21 @@ export const discordActionHandlers: Record<string, DiscordActionHandler> = {
     });
   },
   get_my_oauth2_authorization(_input, context) {
-    return discordRequestJson({ path: "/oauth2/@me", context });
+    return discordRequestJson({ path: "/oauth2/@me", baseUrl: discordOauthApiBaseUrl, context });
   },
   get_my_user(_input, context) {
     return discordRequestJson({ path: "/users/@me", context });
   },
   get_openid_connect_userinfo(_input, context) {
-    return discordRequestJson({ path: "/oauth2/userinfo", context });
+    return discordRequestJson({ path: "/oauth2/userinfo", baseUrl: discordOauthApiBaseUrl, context });
   },
   get_public_keys(_input, context) {
-    return discordRequestJson({ path: "/oauth2/keys", context, authenticated: false });
+    return discordRequestJson({
+      path: "/oauth2/keys",
+      baseUrl: discordOauthApiBaseUrl,
+      context,
+      authenticated: false,
+    });
   },
   get_user(input, context) {
     if (input.user_id !== "@me") {
@@ -114,12 +133,15 @@ export const discordActionHandlers: Record<string, DiscordActionHandler> = {
   },
 };
 
-export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, discordActionHandlers);
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, discordActionHandlers, {
+  skipDnsValidation: true,
+});
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: discordApiBaseUrl,
   auth: { type: "oauth_bearer" },
+  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {
@@ -158,13 +180,10 @@ async function getCurrentUserApplicationEntitlements(
   context: DiscordContext,
 ): Promise<unknown> {
   const entitlements = await discordRequestJson({
-    path: `/applications/${requiredPath(input.application_id, "application_id")}/entitlements`,
+    path: `/users/@me/applications/${requiredPath(input.application_id, "application_id")}/entitlements`,
     query: jsonObject({
-      before: optionalString(input.before),
-      after: optionalString(input.after),
-      limit: optionalInteger(input.limit),
-      exclude_ended: optionalBoolean(input.exclude_ended),
-      exclude_deleted: optionalBoolean(input.exclude_deleted),
+      sku_ids: optionalStringArray(input.sku_ids)?.join(","),
+      exclude_consumed: optionalBoolean(input.exclude_consumed),
     }),
     context,
   });
@@ -233,22 +252,16 @@ function fetchInvite(inviteCode: string, input: Record<string, unknown>, context
     path: `/invites/${encodePathSegment(inviteCode)}`,
     query: jsonObject({
       with_counts: optionalBoolean(input.with_counts),
-      with_expiration: optionalBoolean(input.with_expiration),
       guild_scheduled_event_id: optionalString(input.guild_scheduled_event_id),
+      target_channel_id: optionalString(input.target_channel_id),
+      target_message_id: optionalString(input.target_message_id),
     }),
     context,
     authenticated: false,
   });
 }
 
-async function discordRequestJson(input: {
-  method?: string;
-  path: string;
-  query?: Record<string, unknown>;
-  body?: Record<string, unknown>;
-  context: DiscordContext;
-  authenticated?: boolean;
-}): Promise<unknown> {
+async function discordRequestJson(input: DiscordRequestInput): Promise<unknown> {
   const response = await discordRequest(input);
   try {
     return (await response.json()) as unknown;
@@ -257,15 +270,8 @@ async function discordRequestJson(input: {
   }
 }
 
-async function discordRequest(input: {
-  method?: string;
-  path: string;
-  query?: Record<string, unknown>;
-  body?: Record<string, unknown>;
-  context: DiscordContext;
-  authenticated?: boolean;
-}): Promise<Response> {
-  const url = new URL(`${discordApiBaseUrl}${input.path}`);
+async function discordRequest(input: DiscordRequestInput): Promise<Response> {
+  const url = new URL(`${input.baseUrl ?? discordApiBaseUrl}${input.path}`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) {
       url.searchParams.set(key, String(value));
@@ -305,7 +311,7 @@ async function toDiscordError(response: Response, authenticated: boolean): Promi
     } catch {}
   }
   const resolvedMessage = message || `Discord request failed with ${response.status}`;
-  if (authenticated && (response.status === 401 || response.status === 403)) {
+  if (authenticated && response.status === 401) {
     return new ProviderRequestError(401, resolvedMessage);
   }
   if (response.status === 429) {


### PR DESCRIPTION
## Summary

- map `get_current_user_application_entitlements` to Discord’s current-user operation and expose its `sku_ids` / `exclude_consumed` inputs
- pin regular REST requests to API v10 while retaining the unversioned OAuth/OIDC endpoints published by discovery
- align invite parameters, OAuth scopes, nullable user fields, and 401/403 handling with current contracts
- add first-class `uniqueItems` support to the shared JSON Schema array helper

This corrects the endpoint mismatch that remains after #284. The general `/applications/{application_id}/entitlements` operation supports pagination, but the current-user `/users/@me/applications/{application_id}/entitlements` operation is a distinct API without pagination.

## Evidence

- live personal-OAuth probes returned 200 for the current-user endpoint, comma-delimited `sku_ids`, and `exclude_consumed=true`
- the general entitlement endpoint returned 403 with Discord code 20012 for the connected personal OAuth identity
- operation split and parameters: https://github.com/discord/discord-api-spec/blob/e2bb9417565db2b26b1ea960c63b7f9075d799ab/specs/openapi.json
- removed invite parameter: https://github.com/discord/discord-api-docs/commit/56aa3199c523584e4142a285817ee8be7bb86ec0
- OAuth/OIDC endpoint discovery: https://discord.com/.well-known/openid-configuration

## Validation

- `npm run generate:catalog`
- `npx vitest run src/core/json-schema.test.ts`
- `npm run fix-check`
- `npm run build`