### PR TITLE
fix(oauth): render clientConfigFields in the web console

### DIFF
--- a/src/oauth/oauth-client-config-service.ts
+++ b/src/oauth/oauth-client-config-service.ts
@@ -24,6 +24,7 @@ export type OAuthClientConfigSummary = {
   clientId: string | null;
   expectedRedirectUri: string;
   auth: OAuth2AuthDefinition;
+  extra: Record<string, string>;
 };
 
 /**
@@ -164,6 +165,7 @@ export class OAuthClientConfigService {
       clientId: config?.clientId ?? null,
       expectedRedirectUri: this.expectedRedirectUri(service),
       auth,
+      extra: config?.extra ?? {},
     };
   }
 }

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -22,6 +22,8 @@ export interface CredentialField {
   secret: boolean;
   placeholder?: string;
   description?: string;
+  location?: "extra" | "secretExtra";
+  defaultValue?: string;
 }
 
 export type JsonSchema = Record<string, unknown>;
@@ -84,6 +86,7 @@ export interface OAuthConfig {
   clientId: string | null;
   expectedRedirectUri?: string;
   auth?: Extract<AuthDefinition, { type: "oauth2" }>;
+  extra?: Record<string, string>;
 }
 
 export interface RuntimeTokenSummary {

--- a/web/src/providers-page.test.ts
+++ b/web/src/providers-page.test.ts
@@ -1,4 +1,4 @@
-import type { AppData, AuthDefinition, ProviderDefinition } from "./model";
+import type { AppData, AuthDefinition, CredentialField, OAuthConfig, ProviderDefinition } from "./model";
 
 import { I18nProvider } from "@embra/i18n/react";
 import { createElement } from "react";
@@ -7,12 +7,14 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppI18n } from "./i18n";
 import {
+  clientConfigFieldsFor,
   configurableConnectionsForProvider,
   connectionDeletePath,
   connectionDisplayLabel,
   connectionSubmitLabel,
   createOAuthPopupFeatures,
   credentialConnectionRequestBody,
+  initialClientConfigFieldValues,
   isProviderLocallyAvailable,
   oauthClientActionLabel,
   oauthAuthorizationRequestBody,
@@ -24,6 +26,7 @@ import {
   shouldShowConnectionActions,
   shouldShowDisconnectAction,
   shouldShowOAuthClientForm,
+  splitClientConfigFieldValues,
   startOAuthRefreshPolling,
   validateNewConnectionName,
 } from "./providers-page";
@@ -111,6 +114,102 @@ describe("oauthClientActionLabel", () => {
     expect(oauthClientActionLabel({ service: "gmail", configured: true, clientId: "gmail-client-id" })).toBe(
       "Edit OAuth Client",
     );
+  });
+});
+
+describe("clientConfigFieldsFor", () => {
+  const tenantField: CredentialField = {
+    key: "tenant",
+    label: "Tenant",
+    inputType: "text",
+    required: true,
+    secret: false,
+    defaultValue: "common",
+  };
+
+  it("returns the oauth2 auth definition's clientConfigFields", () => {
+    const auth: AuthDefinition = { type: "oauth2", scopes: [], clientConfigFields: [tenantField] };
+
+    expect(clientConfigFieldsFor(auth)).toEqual([tenantField]);
+  });
+
+  it("returns an empty array for non-oauth2 auth", () => {
+    const auth: AuthDefinition = { type: "api_key" };
+
+    expect(clientConfigFieldsFor(auth)).toEqual([]);
+  });
+
+  it("returns an empty array when oauth2 auth declares no clientConfigFields", () => {
+    const auth: AuthDefinition = { type: "oauth2", scopes: [] };
+
+    expect(clientConfigFieldsFor(auth)).toEqual([]);
+  });
+});
+
+describe("initialClientConfigFieldValues", () => {
+  const tenantField: CredentialField = {
+    key: "tenant",
+    label: "Tenant",
+    inputType: "text",
+    required: true,
+    secret: false,
+    defaultValue: "common",
+  };
+
+  it("falls back to the field's default value when nothing is stored", () => {
+    expect(initialClientConfigFieldValues([tenantField], undefined)).toEqual({ tenant: "common" });
+  });
+
+  it("prefers a previously stored non-secret value over the default", () => {
+    const config: OAuthConfig = {
+      service: "microsoft_todo",
+      configured: true,
+      clientId: "client-id",
+      extra: { tenant: "consumers" },
+    };
+
+    expect(initialClientConfigFieldValues([tenantField], config)).toEqual({ tenant: "consumers" });
+  });
+
+  it("leaves the value empty when there is neither a stored value nor a default", () => {
+    const field: CredentialField = { ...tenantField, defaultValue: undefined };
+
+    expect(initialClientConfigFieldValues([field], undefined)).toEqual({ tenant: "" });
+  });
+});
+
+describe("splitClientConfigFieldValues", () => {
+  const tenantField: CredentialField = {
+    key: "tenant",
+    label: "Tenant",
+    inputType: "text",
+    required: true,
+    secret: false,
+  };
+  const appSecretField: CredentialField = {
+    key: "appSecret",
+    label: "App secret",
+    inputType: "password",
+    required: true,
+    secret: true,
+    location: "secretExtra",
+  };
+
+  it("routes fields without a location to extra", () => {
+    const { extra, secretExtra } = splitClientConfigFieldValues([tenantField], { tenant: "consumers" });
+
+    expect(extra).toEqual({ tenant: "consumers" });
+    expect(secretExtra).toEqual({});
+  });
+
+  it("routes fields marked secretExtra separately from extra", () => {
+    const { extra, secretExtra } = splitClientConfigFieldValues([tenantField, appSecretField], {
+      tenant: "consumers",
+      appSecret: "shh",
+    });
+
+    expect(extra).toEqual({ tenant: "consumers" });
+    expect(secretExtra).toEqual({ appSecret: "shh" });
   });
 });
 

--- a/web/src/providers-page.tsx
+++ b/web/src/providers-page.tsx
@@ -96,6 +96,7 @@ interface ConnectionManagerProps {
 
 interface OAuthConfigFormProps {
   provider: ProviderDefinition;
+  auth: AuthDefinition;
   config?: OAuthConfig;
   onRefresh(): void;
 }
@@ -1331,33 +1332,82 @@ function OAuthClientSettings(props: {
       {status ? <FormStatus message={status} /> : null}
       {shouldShowOAuthClientForm(props.auth, props.expanded) ? (
         <div className="oauth-client-editor">
-          <OAuthConfigForm provider={props.provider} config={props.config} onRefresh={props.onRefresh} />
+          <OAuthConfigForm
+            provider={props.provider}
+            auth={props.auth}
+            config={props.config}
+            onRefresh={props.onRefresh}
+          />
         </div>
       ) : null}
     </div>
   );
 }
 
+export function clientConfigFieldsFor(auth: AuthDefinition): CredentialField[] {
+  return auth.type === "oauth2" ? (auth.clientConfigFields ?? []) : [];
+}
+
+export function initialClientConfigFieldValues(
+  fields: CredentialField[],
+  config: OAuthConfig | undefined,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const field of fields) {
+    values[field.key] = config?.extra?.[field.key] ?? field.defaultValue ?? "";
+  }
+  return values;
+}
+
+export interface ClientConfigFieldValues {
+  extra: Record<string, string>;
+  secretExtra: Record<string, string>;
+}
+
+export function splitClientConfigFieldValues(
+  fields: CredentialField[],
+  values: Record<string, string>,
+): ClientConfigFieldValues {
+  const extra: Record<string, string> = {};
+  const secretExtra: Record<string, string> = {};
+  for (const field of fields) {
+    const target = field.location === "secretExtra" ? secretExtra : extra;
+    target[field.key] = values[field.key] ?? "";
+  }
+  return { extra, secretExtra };
+}
+
 function OAuthConfigForm(props: OAuthConfigFormProps): ReactNode {
   const t = useTranslate();
+  const clientConfigFields = useMemo(() => clientConfigFieldsFor(props.auth), [props.auth]);
   const [clientId, setClientId] = useState(() => props.config?.clientId ?? "");
   const [clientSecret, setClientSecret] = useState("");
+  const [extraValues, setExtraValues] = useState(() =>
+    initialClientConfigFieldValues(clientConfigFields, props.config),
+  );
   const [status, setStatus] = useState<string | null>(null);
 
   useEffect(() => {
     setClientId(props.config?.clientId ?? "");
     setClientSecret("");
+    setExtraValues(initialClientConfigFieldValues(clientConfigFields, props.config));
     setStatus(null);
-  }, [props.provider.service, props.config?.clientId]);
+    // Deliberately excludes `props.config` itself: it gets a new object identity on every
+    // background data refresh (for example when an unrelated OAuth popup completes elsewhere),
+    // and resetting on that would wipe out an in-progress edit. `clientId` changing is what
+    // actually signals a real context switch (provider changed, config saved, or config reset).
+  }, [props.provider.service, props.config?.clientId, clientConfigFields]);
 
   async function submit(event: FormEvent): Promise<void> {
     event.preventDefault();
     setStatus(t("providers.oauthClientSettings.saving"));
     try {
+      const { extra, secretExtra } = splitClientConfigFieldValues(clientConfigFields, extraValues);
       await apiPut(`/api/oauth/configs/${props.provider.service}`, {
         clientId,
         clientSecret,
-        extra: {},
+        extra,
+        secretExtra,
       });
       setStatus(t("providers.oauthClientSettings.saved"));
       props.onRefresh();
@@ -1377,6 +1427,14 @@ function OAuthConfigForm(props: OAuthConfigFormProps): ReactNode {
         <Input type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} />
         {props.config ? <small>{t("providers.oauthClientSettings.storedSecretHint")}</small> : null}
       </Label>
+      {clientConfigFields.map((field) => (
+        <CredentialInput
+          key={field.key}
+          field={field}
+          value={extraValues[field.key] ?? ""}
+          onChange={(value) => setExtraValues((previous) => ({ ...previous, [field.key]: value }))}
+        />
+      ))}
       <div className="button-row">
         <Button type="submit">
           <Settings size={16} />
@@ -1398,6 +1456,7 @@ function CredentialInput(props: { field: CredentialField; value: string; onChang
           value={props.value}
           placeholder={props.field.placeholder}
           onChange={(event) => props.onChange(event.target.value)}
+          required={props.field.required}
           spellCheck={false}
         />
       ) : (
@@ -1406,6 +1465,7 @@ function CredentialInput(props: { field: CredentialField; value: string; onChang
           placeholder={props.field.placeholder}
           value={props.value}
           onChange={(event) => props.onChange(event.target.value)}
+          required={props.field.required}
         />
       )}
       {props.field.description ? <small>{props.field.description}</small> : null}


### PR DESCRIPTION
## Summary

The OAuth client settings form in the web console always sent an empty `extra`
object when saving, so provider-declared `clientConfigFields` (for example the
Microsoft Graph tenant segment used by `outlook`, `one_drive`, and `excel`)
could never be set from the console. Worse, saving from the console with the
field left at its default silently reset any value previously configured
through the API back to that default.

## What changed

- Web console: `OAuthConfigForm` now renders each `clientConfigFields` entry
  and, on save, splits values into `extra` / `secretExtra` based on the
  field's declared `location`.
- Web console: the form now prefills each field with its previously stored
  value (falling back to the field's `defaultValue`) instead of always
  showing an empty input.
- Server: `OAuthClientConfigSummary` (returned by `GET /api/oauth/configs`)
  now includes the non-secret `extra` values so the console can show what is
  actually stored. `secretExtra` remains excluded from every response.
- Added tests for the new pure helpers: `clientConfigFieldsFor`,
  `initialClientConfigFieldValues`, `splitClientConfigFieldValues`.

Affected providers (anything declaring `auth[].clientConfigFields`):
`outlook`, `one_drive`, `excel`, `googleads`, `zendesk`, `tiktok_business`,
`twitter`, `workday`.

## Test plan

- [x] `npm run fix-check`
- [x] `npm run --workspace web build`
- [x] `npx vitest run web/src/providers-page.test.ts src/oauth` (88 passed)
