### PR TITLE
feat(provider): add Microsoft To Do

### DIFF
--- a/src/providers/microsoft_todo/actions.ts
+++ b/src/providers/microsoft_todo/actions.ts
@@ -1,0 +1,368 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { microsoftTodoReadScopes, microsoftTodoWriteScopes } from "./scopes.ts";
+
+const service = "microsoft_todo";
+
+interface MicrosoftTodoActionSource {
+  name: string;
+  description: string;
+  requiredScopes: string[];
+  providerPermissions: string[];
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}
+
+const nonEmptyString = (description: string): JsonSchema => s.string({ minLength: 1, description });
+
+const taskListId = nonEmptyString("Microsoft To Do task list ID.");
+const taskId = nonEmptyString("Microsoft To Do task ID.");
+const checklistItemId = nonEmptyString("Microsoft To Do checklist item ID.");
+const nextLink = s.url("Opaque pagination URL returned by a previous Microsoft To Do response (@odata.nextLink).");
+
+const dateTimeTimeZone = s.object(
+  "A date and time with an explicit time zone.",
+  {
+    dateTime: nonEmptyString("Date and time value, for example 2026-08-07T09:00:00."),
+    timeZone: s.string({ description: "Time zone for dateTime, for example UTC. Defaults to UTC when omitted." }),
+  },
+  { required: ["dateTime"] },
+);
+const dueDateTime = s.describe(dateTimeTimeZone, "Date and time the task is due.");
+const startDateTime = s.describe(dateTimeTimeZone, "Date and time the task is scheduled to start.");
+const reminderDateTime = s.describe(dateTimeTimeZone, "Date and time to alert the user with a reminder.");
+
+const itemBody = s.object(
+  "The body content of a task.",
+  {
+    content: s.string({ description: "Body content." }),
+    contentType: s.stringEnum(["text", "html"], { description: "Body content type." }),
+  },
+  { required: ["content"] },
+);
+
+const recurrencePatternType = s.stringEnum(
+  ["daily", "weekly", "absoluteMonthly", "relativeMonthly", "absoluteYearly", "relativeYearly"],
+  { description: "Recurrence pattern type." },
+);
+const dayOfWeek = s.stringEnum(["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"], {
+  description: "Day of the week.",
+});
+const recurrencePattern = s.object(
+  "The frequency of a task recurrence.",
+  {
+    type: recurrencePatternType,
+    interval: s.positiveInteger("Number of units between occurrences."),
+    month: s.integer({ description: "Month of the year for yearly recurrences." }),
+    dayOfMonth: s.integer({ description: "Day of the month for monthly recurrences." }),
+    daysOfWeek: s.array(dayOfWeek, { description: "Days of the week for weekly or monthly recurrences." }),
+    firstDayOfWeek: dayOfWeek,
+    index: s.stringEnum(["first", "second", "third", "fourth", "last"], {
+      description: "Which week the recurrence falls on for relative monthly/yearly recurrences.",
+    }),
+  },
+  { required: ["type", "interval"] },
+);
+const recurrenceRange = s.object(
+  "The date range over which a task recurrence repeats.",
+  {
+    type: s.stringEnum(["endDate", "noEnd", "numbered"], { description: "Recurrence range type." }),
+    startDate: s.date("Start date of the recurrence range."),
+    endDate: s.date("End date of the recurrence range."),
+    recurrenceTimeZone: s.string({ description: "Time zone for startDate and endDate." }),
+    numberOfOccurrences: s.nonNegativeInteger("Number of occurrences for a numbered recurrence range."),
+  },
+  { required: ["type", "startDate"] },
+);
+const patternedRecurrence = s.object(
+  "A recurrence pattern and range for a task.",
+  {
+    pattern: recurrencePattern,
+    range: recurrenceRange,
+  },
+  { required: ["pattern", "range"] },
+);
+
+const wellknownListName = s.stringEnum(["none", "defaultList", "flaggedEmails", "unknownFutureValue"], {
+  description: "Well-known list identifier when the list is a built-in list.",
+});
+const todoTaskList = s.looseObject(
+  {
+    id: nonEmptyString("Task list ID."),
+    displayName: nonEmptyString("Display name for the task list."),
+    isOwner: s.boolean({ description: "Whether the current user owns the task list." }),
+    isShared: s.boolean({ description: "Whether the task list is shared." }),
+    wellknownListName,
+  },
+  { description: "Microsoft To Do task list resource." },
+);
+
+const taskStatus = s.stringEnum(["notStarted", "inProgress", "completed", "waitingOnOthers", "deferred"], {
+  description: "State or progress of the task.",
+});
+const importance = s.stringEnum(["low", "normal", "high"], { description: "Importance of the task." });
+const checklistItem = s.looseObject(
+  {
+    id: nonEmptyString("Checklist item ID."),
+    displayName: nonEmptyString("Display name of the checklist item."),
+    isChecked: s.boolean({ description: "Whether the checklist item is checked." }),
+    createdDateTime: s.dateTime("When the checklist item was created."),
+    checkedDateTime: s.dateTime("When the checklist item was checked."),
+  },
+  { description: "Microsoft To Do checklist item resource." },
+);
+const todoTask = s.looseObject(
+  {
+    id: nonEmptyString("Task ID."),
+    title: nonEmptyString("Task title."),
+    body: itemBody,
+    bodyLastModifiedDateTime: s.dateTime("When the task body was last modified."),
+    status: taskStatus,
+    importance,
+    isReminderOn: s.boolean({ description: "Whether a reminder alert is set for the task." }),
+    reminderDateTime: dateTimeTimeZone,
+    recurrence: patternedRecurrence,
+    categories: s.stringArray("Categories associated with the task."),
+    createdDateTime: s.dateTime("When the task was created."),
+    lastModifiedDateTime: s.dateTime("When the task was last modified."),
+    dueDateTime: dateTimeTimeZone,
+    startDateTime: dateTimeTimeZone,
+    completedDateTime: dateTimeTimeZone,
+    hasAttachments: s.boolean({ description: "Whether the task has attachments." }),
+    checklistItems: s.array(checklistItem, { description: "Checklist items linked to the task." }),
+  },
+  { description: "Microsoft To Do task resource." },
+);
+
+const listQueryProperties = {
+  top: s.integer({ description: "Maximum number of items to return.", minimum: 1, maximum: 1000 }),
+  skip: s.nonNegativeInteger("Number of items to skip."),
+  filter: s.string({ description: "OData $filter expression." }),
+  orderby: s.string({ description: "OData $orderby expression." }),
+  nextLink,
+};
+
+const taskListsPage = s.object(
+  "A page of Microsoft To Do task lists.",
+  {
+    value: s.array(todoTaskList, { description: "Task lists in this page." }),
+    nextLink,
+  },
+  { required: ["value"], optional: ["nextLink"] },
+);
+const tasksPage = s.object(
+  "A page of Microsoft To Do tasks.",
+  {
+    value: s.array(todoTask, { description: "Tasks in this page." }),
+    nextLink,
+  },
+  { required: ["value"], optional: ["nextLink"] },
+);
+const checklistItemsPage = s.object(
+  "A page of Microsoft To Do checklist items.",
+  {
+    value: s.array(checklistItem, { description: "Checklist items in this page." }),
+    nextLink,
+  },
+  { required: ["value"], optional: ["nextLink"] },
+);
+
+const deletedConfirmation = (description: string): JsonSchema =>
+  s.object(
+    description,
+    {
+      id: nonEmptyString("ID of the deleted resource."),
+      deleted: s.literal(true, { description: "Always true when the deletion succeeded." }),
+    },
+    { required: ["id", "deleted"] },
+  );
+
+const actions: MicrosoftTodoActionSource[] = [
+  action(
+    "list_task_lists",
+    "List the current user's Microsoft To Do task lists.",
+    microsoftTodoReadScopes,
+    ["Tasks.Read"],
+    s.object(listQueryProperties, { optional: Object.keys(listQueryProperties) }),
+    taskListsPage,
+  ),
+  action(
+    "get_task_list",
+    "Get one Microsoft To Do task list by ID.",
+    microsoftTodoReadScopes,
+    ["Tasks.Read"],
+    s.object({ listId: taskListId }, { required: ["listId"] }),
+    todoTaskList,
+  ),
+  action(
+    "create_task_list",
+    "Create a new Microsoft To Do task list.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object({ displayName: nonEmptyString("Display name for the new task list.") }, { required: ["displayName"] }),
+    todoTaskList,
+  ),
+  action(
+    "update_task_list",
+    "Rename a Microsoft To Do task list.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object(
+      { listId: taskListId, displayName: nonEmptyString("Updated display name for the task list.") },
+      { required: ["listId", "displayName"] },
+    ),
+    todoTaskList,
+  ),
+  action(
+    "delete_task_list",
+    "Delete a Microsoft To Do task list and all of its tasks.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object({ listId: taskListId }, { required: ["listId"] }),
+    deletedConfirmation("Confirmation that the task list was deleted."),
+  ),
+  action(
+    "list_tasks",
+    "List tasks in a Microsoft To Do task list.",
+    microsoftTodoReadScopes,
+    ["Tasks.Read"],
+    s.object(
+      {
+        listId: taskListId,
+        expandChecklistItems: s.boolean({ description: "Include checklist items for each task." }),
+        ...listQueryProperties,
+      },
+      { required: ["listId"], optional: ["expandChecklistItems", ...Object.keys(listQueryProperties)] },
+    ),
+    tasksPage,
+  ),
+  action(
+    "get_task",
+    "Get one task from a Microsoft To Do task list.",
+    microsoftTodoReadScopes,
+    ["Tasks.Read"],
+    s.object({ listId: taskListId, taskId }, { required: ["listId", "taskId"] }),
+    todoTask,
+  ),
+  action(
+    "create_task",
+    "Create a new task in a Microsoft To Do task list.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object(
+      {
+        listId: taskListId,
+        title: nonEmptyString("Task title."),
+        body: itemBody,
+        status: taskStatus,
+        importance,
+        categories: s.stringArray("Categories to associate with the task."),
+        dueDateTime,
+        startDateTime,
+        isReminderOn: s.boolean({
+          description:
+            "Whether to alert the user with a reminder. Set reminderDateTime as well, otherwise no alert fires.",
+        }),
+        reminderDateTime,
+        recurrence: patternedRecurrence,
+      },
+      { required: ["listId", "title"] },
+    ),
+    todoTask,
+  ),
+  action(
+    "update_task",
+    "Update fields on an existing Microsoft To Do task.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object(
+      {
+        listId: taskListId,
+        taskId,
+        title: nonEmptyString("Updated task title."),
+        body: itemBody,
+        status: taskStatus,
+        importance,
+        categories: s.stringArray("Updated categories for the task."),
+        dueDateTime,
+        startDateTime,
+        completedDateTime: dateTimeTimeZone,
+        isReminderOn: s.boolean({
+          description:
+            "Whether to alert the user with a reminder. Set reminderDateTime as well, otherwise no alert fires.",
+        }),
+        reminderDateTime,
+        recurrence: patternedRecurrence,
+      },
+      { required: ["listId", "taskId"] },
+    ),
+    todoTask,
+  ),
+  action(
+    "delete_task",
+    "Delete a task from a Microsoft To Do task list.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object({ listId: taskListId, taskId }, { required: ["listId", "taskId"] }),
+    deletedConfirmation("Confirmation that the task was deleted."),
+  ),
+  action(
+    "list_checklist_items",
+    "List checklist items on a Microsoft To Do task.",
+    microsoftTodoReadScopes,
+    ["Tasks.Read"],
+    s.object({ listId: taskListId, taskId, nextLink }, { required: ["listId", "taskId"], optional: ["nextLink"] }),
+    checklistItemsPage,
+  ),
+  action(
+    "create_checklist_item",
+    "Add a checklist item to a Microsoft To Do task.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object(
+      { listId: taskListId, taskId, displayName: nonEmptyString("Display name for the checklist item.") },
+      { required: ["listId", "taskId", "displayName"] },
+    ),
+    checklistItem,
+  ),
+  action(
+    "update_checklist_item",
+    "Update a checklist item on a Microsoft To Do task.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object(
+      {
+        listId: taskListId,
+        taskId,
+        checklistItemId,
+        displayName: nonEmptyString("Updated display name for the checklist item."),
+        isChecked: s.boolean({ description: "Whether the checklist item is checked." }),
+      },
+      { required: ["listId", "taskId", "checklistItemId"] },
+    ),
+    checklistItem,
+  ),
+  action(
+    "delete_checklist_item",
+    "Delete a checklist item from a Microsoft To Do task.",
+    microsoftTodoWriteScopes,
+    ["Tasks.ReadWrite"],
+    s.object({ listId: taskListId, taskId, checklistItemId }, { required: ["listId", "taskId", "checklistItemId"] }),
+    deletedConfirmation("Confirmation that the checklist item was deleted."),
+  ),
+];
+
+export const microsoftTodoActions: ActionDefinition[] = actions.map((item) => defineProviderAction(service, item));
+
+function action(
+  name: string,
+  description: string,
+  requiredScopes: string[],
+  providerPermissions: string[],
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+): MicrosoftTodoActionSource {
+  return { name, description, requiredScopes, providerPermissions, inputSchema, outputSchema };
+}

--- a/src/providers/microsoft_todo/actions.ts
+++ b/src/providers/microsoft_todo/actions.ts
@@ -2,9 +2,11 @@ import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
-import { microsoftTodoReadScopes, microsoftTodoWriteScopes } from "./scopes.ts";
+import { microsoftTodoProviderScopes, microsoftTodoReadScopes, microsoftTodoWriteScopes } from "./scopes.ts";
 
 const service = "microsoft_todo";
+const readPermissions = [microsoftTodoProviderScopes.tasksRead];
+const writePermissions = [microsoftTodoProviderScopes.tasksReadWrite];
 
 interface MicrosoftTodoActionSource {
   name: string;
@@ -184,7 +186,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "list_task_lists",
     "List the current user's Microsoft To Do task lists.",
     microsoftTodoReadScopes,
-    ["Tasks.Read"],
+    readPermissions,
     s.object(listQueryProperties, { optional: Object.keys(listQueryProperties) }),
     taskListsPage,
   ),
@@ -192,7 +194,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "get_task_list",
     "Get one Microsoft To Do task list by ID.",
     microsoftTodoReadScopes,
-    ["Tasks.Read"],
+    readPermissions,
     s.object({ listId: taskListId }, { required: ["listId"] }),
     todoTaskList,
   ),
@@ -200,7 +202,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "create_task_list",
     "Create a new Microsoft To Do task list.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object({ displayName: nonEmptyString("Display name for the new task list.") }, { required: ["displayName"] }),
     todoTaskList,
   ),
@@ -208,7 +210,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "update_task_list",
     "Rename a Microsoft To Do task list.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object(
       { listId: taskListId, displayName: nonEmptyString("Updated display name for the task list.") },
       { required: ["listId", "displayName"] },
@@ -219,7 +221,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "delete_task_list",
     "Delete a Microsoft To Do task list and all of its tasks.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object({ listId: taskListId }, { required: ["listId"] }),
     deletedConfirmation("Confirmation that the task list was deleted."),
   ),
@@ -227,7 +229,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "list_tasks",
     "List tasks in a Microsoft To Do task list.",
     microsoftTodoReadScopes,
-    ["Tasks.Read"],
+    readPermissions,
     s.object(
       {
         listId: taskListId,
@@ -242,7 +244,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "get_task",
     "Get one task from a Microsoft To Do task list.",
     microsoftTodoReadScopes,
-    ["Tasks.Read"],
+    readPermissions,
     s.object({ listId: taskListId, taskId }, { required: ["listId", "taskId"] }),
     todoTask,
   ),
@@ -250,7 +252,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "create_task",
     "Create a new task in a Microsoft To Do task list.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object(
       {
         listId: taskListId,
@@ -276,7 +278,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "update_task",
     "Update fields on an existing Microsoft To Do task.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object(
       {
         listId: taskListId,
@@ -304,7 +306,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "delete_task",
     "Delete a task from a Microsoft To Do task list.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object({ listId: taskListId, taskId }, { required: ["listId", "taskId"] }),
     deletedConfirmation("Confirmation that the task was deleted."),
   ),
@@ -312,7 +314,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "list_checklist_items",
     "List checklist items on a Microsoft To Do task.",
     microsoftTodoReadScopes,
-    ["Tasks.Read"],
+    readPermissions,
     s.object({ listId: taskListId, taskId, nextLink }, { required: ["listId", "taskId"], optional: ["nextLink"] }),
     checklistItemsPage,
   ),
@@ -320,7 +322,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "create_checklist_item",
     "Add a checklist item to a Microsoft To Do task.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object(
       { listId: taskListId, taskId, displayName: nonEmptyString("Display name for the checklist item.") },
       { required: ["listId", "taskId", "displayName"] },
@@ -331,7 +333,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "update_checklist_item",
     "Update a checklist item on a Microsoft To Do task.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object(
       {
         listId: taskListId,
@@ -348,7 +350,7 @@ const actions: MicrosoftTodoActionSource[] = [
     "delete_checklist_item",
     "Delete a checklist item from a Microsoft To Do task.",
     microsoftTodoWriteScopes,
-    ["Tasks.ReadWrite"],
+    writePermissions,
     s.object({ listId: taskListId, taskId, checklistItemId }, { required: ["listId", "taskId", "checklistItemId"] }),
     deletedConfirmation("Confirmation that the checklist item was deleted."),
   ),

--- a/src/providers/microsoft_todo/definition.ts
+++ b/src/providers/microsoft_todo/definition.ts
@@ -1,0 +1,46 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { microsoftTodoActions } from "./actions.ts";
+import { microsoftTodoOAuthScopes } from "./scopes.ts";
+
+const service = "microsoft_todo";
+
+/**
+ * Microsoft To Do provider backed by the Microsoft Graph To Do APIs.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Microsoft To Do",
+  categories: ["Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize",
+      tokenUrl: "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token",
+      scopes: microsoftTodoOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkce: {
+        method: "S256",
+      },
+      authorizationParams: {
+        response_mode: "query",
+      },
+      clientConfigFields: [
+        {
+          key: "tenant",
+          label: "Tenant",
+          inputType: "text",
+          required: true,
+          secret: false,
+          defaultValue: "common",
+          placeholder: "common",
+          description:
+            "The Microsoft identity platform tenant segment to use, such as common, organizations, consumers, or a specific tenant ID.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://to-do.office.com",
+  actions: microsoftTodoActions,
+};

--- a/src/providers/microsoft_todo/executors.ts
+++ b/src/providers/microsoft_todo/executors.ts
@@ -1,0 +1,39 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+
+import { optionalString, requiredString } from "../../core/cast.ts";
+import { defineOAuthProviderExecutors } from "../provider-runtime.ts";
+import { microsoftTodoActionHandlers, microsoftTodoJsonRequest } from "./runtime.ts";
+
+const service = "microsoft_todo";
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, microsoftTodoActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher }) {
+    const profile = await microsoftTodoJsonRequest<{
+      id?: unknown;
+      displayName?: unknown;
+      mail?: unknown;
+      userPrincipalName?: unknown;
+    }>("me", {
+      accessToken: input.accessToken,
+      fetcher,
+      query: {
+        $select: ["id", "displayName", "mail", "userPrincipalName"].join(","),
+      },
+    });
+    const accountId = requiredString(profile.id, "microsoft_todo current account id");
+    const displayName = optionalString(profile.displayName);
+    const mail = optionalString(profile.mail);
+    const userPrincipalName = optionalString(profile.userPrincipalName);
+    return {
+      profile: {
+        accountId,
+        displayName: mail ?? userPrincipalName ?? displayName ?? accountId,
+      },
+      metadata: {
+        currentAccount: profile,
+      },
+    };
+  },
+};

--- a/src/providers/microsoft_todo/runtime.test.ts
+++ b/src/providers/microsoft_todo/runtime.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { microsoftTodoActionHandlers } from "./runtime.ts";
+
+it("follows an allowed nextLink for task pagination", async () => {
+  const nextLink = "https://graph.microsoft.com/v1.0/me/todo/lists/list-1/tasks?$skiptoken=abc";
+  const fetcher = async (input: string | URL | Request): Promise<Response> => {
+    expect(new URL(input instanceof Request ? input.url : input.toString()).toString()).toBe(nextLink);
+    return Response.json({ value: [] });
+  };
+
+  const output = await microsoftTodoActionHandlers.list_tasks(
+    { listId: "list-1", nextLink },
+    { accessToken: "token", fetcher },
+  );
+
+  expect(output).toEqual({ value: [] });
+});
+
+it("follows an allowed nextLink for checklist item pagination", async () => {
+  const nextLink = "https://graph.microsoft.com/v1.0/me/todo/lists/list-1/tasks/task-1/checklistItems?$skiptoken=abc";
+  const fetcher = async (input: string | URL | Request): Promise<Response> => {
+    expect(new URL(input instanceof Request ? input.url : input.toString()).toString()).toBe(nextLink);
+    return Response.json({ value: [] });
+  };
+
+  const output = await microsoftTodoActionHandlers.list_checklist_items(
+    { listId: "list-1", taskId: "task-1", nextLink },
+    { accessToken: "token", fetcher },
+  );
+
+  expect(output).toEqual({ value: [] });
+});
+
+it("rejects a nextLink that does not target graph.microsoft.com", async () => {
+  const fetcher = async (): Promise<Response> => Response.json({ value: [] });
+
+  await expect(
+    microsoftTodoActionHandlers.list_tasks(
+      { listId: "list-1", nextLink: "https://evil.example.com/v1.0/me/todo/lists/list-1/tasks" },
+      { accessToken: "token", fetcher },
+    ),
+  ).rejects.toThrow(ProviderRequestError);
+});
+
+it("rejects a nextLink outside the Microsoft To Do pagination endpoints", async () => {
+  const fetcher = async (): Promise<Response> => Response.json({ value: [] });
+
+  await expect(
+    microsoftTodoActionHandlers.list_tasks(
+      { listId: "list-1", nextLink: "https://graph.microsoft.com/v1.0/me/messages" },
+      { accessToken: "token", fetcher },
+    ),
+  ).rejects.toThrow(ProviderRequestError);
+});
+
+it("defaults timeZone to UTC when a dateTimeTimeZone input omits it", async () => {
+  const fetcher = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      dueDateTime: { dateTime: "2026-08-10T09:00:00", timeZone: "UTC" },
+    });
+    return Response.json({ id: "task-1", title: "Task" });
+  };
+
+  await microsoftTodoActionHandlers.create_task(
+    { listId: "list-1", title: "Task", dueDateTime: { dateTime: "2026-08-10T09:00:00" } },
+    { accessToken: "token", fetcher },
+  );
+});
+
+it("returns a confirmation object for a 204 No Content delete response", async () => {
+  const fetcher = async (): Promise<Response> => new Response(null, { status: 204 });
+
+  const output = await microsoftTodoActionHandlers.delete_task(
+    { listId: "list-1", taskId: "task-1" },
+    { accessToken: "token", fetcher },
+  );
+
+  expect(output).toEqual({ id: "task-1", deleted: true });
+});

--- a/src/providers/microsoft_todo/runtime.test.ts
+++ b/src/providers/microsoft_todo/runtime.test.ts
@@ -32,6 +32,28 @@ it("follows an allowed nextLink for checklist item pagination", async () => {
   expect(output).toEqual({ value: [] });
 });
 
+it("maps @odata.nextLink to nextLink in list responses", async () => {
+  const odataNextLink = "https://graph.microsoft.com/v1.0/me/todo/lists/list-1/tasks?$skiptoken=abc";
+  const fetcher = async (): Promise<Response> =>
+    Response.json({
+      "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#...",
+      value: [{ id: "task-1" }],
+      "@odata.nextLink": odataNextLink,
+    });
+
+  const output = await microsoftTodoActionHandlers.list_tasks({ listId: "list-1" }, { accessToken: "token", fetcher });
+
+  expect(output).toEqual({ value: [{ id: "task-1" }], nextLink: odataNextLink });
+});
+
+it("omits nextLink from list responses when Graph does not return @odata.nextLink", async () => {
+  const fetcher = async (): Promise<Response> => Response.json({ value: [{ id: "task-1" }] });
+
+  const output = await microsoftTodoActionHandlers.list_tasks({ listId: "list-1" }, { accessToken: "token", fetcher });
+
+  expect(output).toEqual({ value: [{ id: "task-1" }] });
+});
+
 it("rejects a nextLink that does not target graph.microsoft.com", async () => {
   const fetcher = async (): Promise<Response> => Response.json({ value: [] });
 

--- a/src/providers/microsoft_todo/runtime.ts
+++ b/src/providers/microsoft_todo/runtime.ts
@@ -22,59 +22,48 @@ interface MicrosoftTodoRequestInput {
   signal?: AbortSignal;
 }
 
+interface MicrosoftTodoGraphPage {
+  value?: unknown;
+  "@odata.nextLink"?: unknown;
+}
+
+interface MicrosoftTodoPage {
+  value: unknown[];
+  nextLink?: string;
+}
+
+function toPage(response: MicrosoftTodoGraphPage): MicrosoftTodoPage {
+  const value = Array.isArray(response.value) ? response.value : [];
+  const nextLink = optionalString(response["@odata.nextLink"]);
+  return nextLink ? { value, nextLink } : { value };
+}
+
 export const microsoftTodoActionHandlers: Record<string, MicrosoftTodoActionHandler> = {
-  list_task_lists(input, context) {
-    return listTaskLists(input, context);
-  },
-  get_task_list(input, context) {
-    return getTaskList(input, context);
-  },
-  create_task_list(input, context) {
-    return createTaskList(input, context);
-  },
-  update_task_list(input, context) {
-    return updateTaskList(input, context);
-  },
-  delete_task_list(input, context) {
-    return deleteTaskList(input, context);
-  },
-  list_tasks(input, context) {
-    return listTasks(input, context);
-  },
-  get_task(input, context) {
-    return getTask(input, context);
-  },
-  create_task(input, context) {
-    return createTask(input, context);
-  },
-  update_task(input, context) {
-    return updateTask(input, context);
-  },
-  delete_task(input, context) {
-    return deleteTask(input, context);
-  },
-  list_checklist_items(input, context) {
-    return listChecklistItems(input, context);
-  },
-  create_checklist_item(input, context) {
-    return createChecklistItem(input, context);
-  },
-  update_checklist_item(input, context) {
-    return updateChecklistItem(input, context);
-  },
-  delete_checklist_item(input, context) {
-    return deleteChecklistItem(input, context);
-  },
+  list_task_lists: listTaskLists,
+  get_task_list: getTaskList,
+  create_task_list: createTaskList,
+  update_task_list: updateTaskList,
+  delete_task_list: deleteTaskList,
+  list_tasks: listTasks,
+  get_task: getTask,
+  create_task: createTask,
+  update_task: updateTask,
+  delete_task: deleteTask,
+  list_checklist_items: listChecklistItems,
+  create_checklist_item: createChecklistItem,
+  update_checklist_item: updateChecklistItem,
+  delete_checklist_item: deleteChecklistItem,
 };
 
 async function listTaskLists(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
   const nextLink = optionalString(input.nextLink);
-  return microsoftTodoJsonRequest(nextLink ?? "me/todo/lists", {
+  const response = await microsoftTodoJsonRequest<MicrosoftTodoGraphPage>(nextLink ?? "me/todo/lists", {
     accessToken,
     fetcher,
     signal,
     query: nextLink ? undefined : listQuery(input),
   });
+  return toPage(response);
 }
 
 async function getTaskList(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
@@ -120,12 +109,11 @@ async function listTasks(input: Record<string, unknown>, { accessToken, fetcher,
   const listId = requiredString(input.listId, "listId");
   const nextLink = optionalString(input.nextLink);
   const query = nextLink ? undefined : listQuery(input, { $expand: expandChecklistItemsQuery(input) });
-  return microsoftTodoJsonRequest(nextLink ?? `me/todo/lists/${encodePathSegment(listId)}/tasks`, {
-    accessToken,
-    fetcher,
-    signal,
-    query,
-  });
+  const response = await microsoftTodoJsonRequest<MicrosoftTodoGraphPage>(
+    nextLink ?? `me/todo/lists/${encodePathSegment(listId)}/tasks`,
+    { accessToken, fetcher, signal, query },
+  );
+  return toPage(response);
 }
 
 async function getTask(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
@@ -183,10 +171,11 @@ async function listChecklistItems(
   const listId = requiredString(input.listId, "listId");
   const taskId = requiredString(input.taskId, "taskId");
   const nextLink = optionalString(input.nextLink);
-  return microsoftTodoJsonRequest(
+  const response = await microsoftTodoJsonRequest<MicrosoftTodoGraphPage>(
     nextLink ?? `me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}/checklistItems`,
     { accessToken, fetcher, signal },
   );
+  return toPage(response);
 }
 
 async function createChecklistItem(
@@ -365,11 +354,11 @@ function isAllowedMicrosoftTodoNextLinkPath(pathname: string): boolean {
     return true;
   }
   // v1.0/me/todo/lists/{listId}/tasks
-  if (segments.length === 6 && segments[4] !== "" && segments[5] === "tasks") {
+  if (segments.length === 6 && segments[5] === "tasks") {
     return true;
   }
   // v1.0/me/todo/lists/{listId}/tasks/{taskId}/checklistItems
-  return segments.length === 8 && segments[4] !== "" && segments[5] === "tasks" && segments[7] === "checklistItems";
+  return segments.length === 8 && segments[5] === "tasks" && segments[7] === "checklistItems";
 }
 
 function trimTrailingSlash(value: string): string {

--- a/src/providers/microsoft_todo/runtime.ts
+++ b/src/providers/microsoft_todo/runtime.ts
@@ -1,0 +1,412 @@
+import type { OAuthProviderContext } from "../provider-runtime.ts";
+
+import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+const microsoftTodoGraphBaseUrl = "https://graph.microsoft.com/v1.0";
+const graphHost = "graph.microsoft.com";
+
+export type MicrosoftTodoActionHandler = (
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+) => Promise<unknown>;
+
+interface MicrosoftTodoRequestInput {
+  accessToken: string;
+  fetcher: typeof fetch;
+  method?: string;
+  query?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+export const microsoftTodoActionHandlers: Record<string, MicrosoftTodoActionHandler> = {
+  list_task_lists(input, context) {
+    return listTaskLists(input, context);
+  },
+  get_task_list(input, context) {
+    return getTaskList(input, context);
+  },
+  create_task_list(input, context) {
+    return createTaskList(input, context);
+  },
+  update_task_list(input, context) {
+    return updateTaskList(input, context);
+  },
+  delete_task_list(input, context) {
+    return deleteTaskList(input, context);
+  },
+  list_tasks(input, context) {
+    return listTasks(input, context);
+  },
+  get_task(input, context) {
+    return getTask(input, context);
+  },
+  create_task(input, context) {
+    return createTask(input, context);
+  },
+  update_task(input, context) {
+    return updateTask(input, context);
+  },
+  delete_task(input, context) {
+    return deleteTask(input, context);
+  },
+  list_checklist_items(input, context) {
+    return listChecklistItems(input, context);
+  },
+  create_checklist_item(input, context) {
+    return createChecklistItem(input, context);
+  },
+  update_checklist_item(input, context) {
+    return updateChecklistItem(input, context);
+  },
+  delete_checklist_item(input, context) {
+    return deleteChecklistItem(input, context);
+  },
+};
+
+async function listTaskLists(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const nextLink = optionalString(input.nextLink);
+  return microsoftTodoJsonRequest(nextLink ?? "me/todo/lists", {
+    accessToken,
+    fetcher,
+    signal,
+    query: nextLink ? undefined : listQuery(input),
+  });
+}
+
+async function getTaskList(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  return microsoftTodoJsonRequest(`me/todo/lists/${encodePathSegment(listId)}`, { accessToken, fetcher, signal });
+}
+
+async function createTaskList(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const displayName = requiredString(input.displayName, "displayName");
+  return microsoftTodoJsonRequest("me/todo/lists", {
+    accessToken,
+    fetcher,
+    signal,
+    method: "POST",
+    body: { displayName },
+  });
+}
+
+async function updateTaskList(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  const displayName = requiredString(input.displayName, "displayName");
+  return microsoftTodoJsonRequest(`me/todo/lists/${encodePathSegment(listId)}`, {
+    accessToken,
+    fetcher,
+    signal,
+    method: "PATCH",
+    body: { displayName },
+  });
+}
+
+async function deleteTaskList(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  await microsoftTodoRequest(`me/todo/lists/${encodePathSegment(listId)}`, {
+    accessToken,
+    fetcher,
+    signal,
+    method: "DELETE",
+  });
+  return { id: listId, deleted: true };
+}
+
+async function listTasks(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  const nextLink = optionalString(input.nextLink);
+  const query = nextLink ? undefined : listQuery(input, { $expand: expandChecklistItemsQuery(input) });
+  return microsoftTodoJsonRequest(nextLink ?? `me/todo/lists/${encodePathSegment(listId)}/tasks`, {
+    accessToken,
+    fetcher,
+    signal,
+    query,
+  });
+}
+
+async function getTask(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  return microsoftTodoJsonRequest(`me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}`, {
+    accessToken,
+    fetcher,
+    signal,
+  });
+}
+
+async function createTask(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  return microsoftTodoJsonRequest(`me/todo/lists/${encodePathSegment(listId)}/tasks`, {
+    accessToken,
+    fetcher,
+    signal,
+    method: "POST",
+    body: taskBody(input, { title: requiredString(input.title, "title") }),
+  });
+}
+
+async function updateTask(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  return microsoftTodoJsonRequest(`me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}`, {
+    accessToken,
+    fetcher,
+    signal,
+    method: "PATCH",
+    body: taskBody(input, {
+      title: optionalString(input.title),
+      completedDateTime: dateTimeTimeZone(input.completedDateTime),
+    }),
+  });
+}
+
+async function deleteTask(input: Record<string, unknown>, { accessToken, fetcher, signal }: OAuthProviderContext) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  await microsoftTodoRequest(`me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}`, {
+    accessToken,
+    fetcher,
+    signal,
+    method: "DELETE",
+  });
+  return { id: taskId, deleted: true };
+}
+
+async function listChecklistItems(
+  input: Record<string, unknown>,
+  { accessToken, fetcher, signal }: OAuthProviderContext,
+) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  const nextLink = optionalString(input.nextLink);
+  return microsoftTodoJsonRequest(
+    nextLink ?? `me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}/checklistItems`,
+    { accessToken, fetcher, signal },
+  );
+}
+
+async function createChecklistItem(
+  input: Record<string, unknown>,
+  { accessToken, fetcher, signal }: OAuthProviderContext,
+) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  const displayName = requiredString(input.displayName, "displayName");
+  return microsoftTodoJsonRequest(
+    `me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}/checklistItems`,
+    { accessToken, fetcher, signal, method: "POST", body: { displayName } },
+  );
+}
+
+async function updateChecklistItem(
+  input: Record<string, unknown>,
+  { accessToken, fetcher, signal }: OAuthProviderContext,
+) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  const checklistItemId = requiredString(input.checklistItemId, "checklistItemId");
+  return microsoftTodoJsonRequest(
+    `me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}/checklistItems/${encodePathSegment(checklistItemId)}`,
+    {
+      accessToken,
+      fetcher,
+      signal,
+      method: "PATCH",
+      body: compactObject({
+        displayName: optionalString(input.displayName),
+        isChecked: typeof input.isChecked === "boolean" ? input.isChecked : undefined,
+      }),
+    },
+  );
+}
+
+async function deleteChecklistItem(
+  input: Record<string, unknown>,
+  { accessToken, fetcher, signal }: OAuthProviderContext,
+) {
+  const listId = requiredString(input.listId, "listId");
+  const taskId = requiredString(input.taskId, "taskId");
+  const checklistItemId = requiredString(input.checklistItemId, "checklistItemId");
+  await microsoftTodoRequest(
+    `me/todo/lists/${encodePathSegment(listId)}/tasks/${encodePathSegment(taskId)}/checklistItems/${encodePathSegment(checklistItemId)}`,
+    { accessToken, fetcher, signal, method: "DELETE" },
+  );
+  return { id: checklistItemId, deleted: true };
+}
+
+function listQuery(
+  input: Record<string, unknown>,
+  extra: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return {
+    $top: typeof input.top === "number" ? String(input.top) : undefined,
+    $skip: typeof input.skip === "number" ? String(input.skip) : undefined,
+    $filter: optionalString(input.filter),
+    $orderby: optionalString(input.orderby),
+    ...extra,
+  };
+}
+
+function expandChecklistItemsQuery(input: Record<string, unknown>): string | undefined {
+  return input.expandChecklistItems === true ? "checklistItems" : undefined;
+}
+
+function taskBody(input: Record<string, unknown>, extra: Record<string, unknown>): Record<string, unknown> {
+  return compactObject({
+    ...extra,
+    body: optionalRecord(input.body),
+    status: optionalString(input.status),
+    importance: optionalString(input.importance),
+    categories: Array.isArray(input.categories) ? input.categories : undefined,
+    dueDateTime: dateTimeTimeZone(input.dueDateTime),
+    startDateTime: dateTimeTimeZone(input.startDateTime),
+    isReminderOn: typeof input.isReminderOn === "boolean" ? input.isReminderOn : undefined,
+    reminderDateTime: dateTimeTimeZone(input.reminderDateTime),
+    recurrence: optionalRecord(input.recurrence),
+  });
+}
+
+/**
+ * Normalize a Microsoft Graph dateTimeTimeZone input, defaulting timeZone to UTC when omitted.
+ */
+function dateTimeTimeZone(value: unknown): Record<string, unknown> | undefined {
+  const record = optionalRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const dateTime = requiredString(record.dateTime, "dateTime");
+  const timeZone = optionalString(record.timeZone) ?? "UTC";
+  return { dateTime, timeZone };
+}
+
+export async function microsoftTodoJsonRequest<T = unknown>(
+  pathOrUrl: string,
+  input: MicrosoftTodoRequestInput,
+): Promise<T> {
+  const response = await microsoftTodoRequest(pathOrUrl, input);
+  return (await response.json()) as T;
+}
+
+async function microsoftTodoRequest(pathOrUrl: string, input: MicrosoftTodoRequestInput): Promise<Response> {
+  const target = buildMicrosoftTodoUrl(pathOrUrl, input.query);
+  const hasJsonBody = input.body !== undefined;
+  const method = (input.method ?? (hasJsonBody ? "POST" : "GET")).toUpperCase();
+  const headers = {
+    authorization: `Bearer ${input.accessToken}`,
+    ...(input.headers ?? {}),
+  };
+
+  if ((method === "GET" || method === "HEAD") && hasJsonBody) {
+    throw new ProviderRequestError(400, `microsoft_todo ${method} request must not include a body`);
+  }
+
+  const response = await input.fetcher(target.toString(), {
+    method,
+    signal: input.signal,
+    headers:
+      hasJsonBody && !hasContentTypeHeader(headers)
+        ? {
+            ...headers,
+            "content-type": "application/json",
+          }
+        : headers,
+    ...(hasJsonBody ? { body: JSON.stringify(input.body) } : {}),
+  });
+
+  await assertMicrosoftTodoResponse(response);
+  return response;
+}
+
+function buildMicrosoftTodoUrl(pathOrUrl: string, query?: Record<string, string | undefined>): URL {
+  const isAbsolutePath = pathOrUrl.startsWith("https://") || pathOrUrl.startsWith("http://");
+  const target = isAbsolutePath ? new URL(pathOrUrl) : new URL(pathOrUrl, `${microsoftTodoGraphBaseUrl}/`);
+
+  if (target.hostname !== graphHost) {
+    throw new ProviderRequestError(400, "nextLink must target graph.microsoft.com");
+  }
+  if (isAbsolutePath) {
+    assertAllowedMicrosoftTodoNextLink(target);
+  }
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
+    }
+
+    target.searchParams.set(key, value);
+  }
+
+  return target;
+}
+
+function assertAllowedMicrosoftTodoNextLink(target: URL): void {
+  if (target.protocol !== "https:") {
+    throw new ProviderRequestError(400, "nextLink must use https");
+  }
+  if (!isAllowedMicrosoftTodoNextLinkPath(target.pathname)) {
+    throw new ProviderRequestError(400, "nextLink must target Microsoft To Do pagination endpoints");
+  }
+}
+
+function isAllowedMicrosoftTodoNextLinkPath(pathname: string): boolean {
+  const segments = trimTrailingSlash(pathname).split("/").filter(Boolean);
+
+  if (segments[0] !== "v1.0" || segments[1] !== "me" || segments[2] !== "todo" || segments[3] !== "lists") {
+    return false;
+  }
+
+  // v1.0/me/todo/lists
+  if (segments.length === 4) {
+    return true;
+  }
+  // v1.0/me/todo/lists/{listId}/tasks
+  if (segments.length === 6 && segments[4] !== "" && segments[5] === "tasks") {
+    return true;
+  }
+  // v1.0/me/todo/lists/{listId}/tasks/{taskId}/checklistItems
+  return segments.length === 8 && segments[4] !== "" && segments[5] === "tasks" && segments[7] === "checklistItems";
+}
+
+function trimTrailingSlash(value: string): string {
+  let normalizedValue = value;
+  while (normalizedValue.endsWith("/") && normalizedValue.length > 1) {
+    normalizedValue = normalizedValue.slice(0, -1);
+  }
+  return normalizedValue;
+}
+
+function hasContentTypeHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((key) => key.toLowerCase() === "content-type");
+}
+
+async function assertMicrosoftTodoResponse(response: Response): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const message = await extractMicrosoftTodoErrorMessage(response);
+  throw new ProviderRequestError(response.status, message);
+}
+
+async function extractMicrosoftTodoErrorMessage(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (!text) {
+    return `microsoft_todo request failed with status ${response.status}`;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as { error?: { message?: unknown }; message?: unknown };
+    return (
+      (typeof parsed.error?.message === "string" && parsed.error.message) ||
+      (typeof parsed.message === "string" && parsed.message) ||
+      text
+    );
+  } catch {
+    return text;
+  }
+}

--- a/src/providers/microsoft_todo/scopes.ts
+++ b/src/providers/microsoft_todo/scopes.ts
@@ -1,0 +1,14 @@
+export const microsoftTodoProviderScopes = {
+  userRead: "User.Read",
+  tasksRead: "Tasks.Read",
+  tasksReadWrite: "Tasks.ReadWrite",
+  offlineAccess: "offline_access",
+} as const;
+
+export const microsoftTodoReadScopes: string[] = [microsoftTodoProviderScopes.tasksRead];
+export const microsoftTodoWriteScopes: string[] = [microsoftTodoProviderScopes.tasksReadWrite];
+export const microsoftTodoOAuthScopes: string[] = [
+  microsoftTodoProviderScopes.userRead,
+  microsoftTodoProviderScopes.tasksReadWrite,
+  microsoftTodoProviderScopes.offlineAccess,
+];


### PR DESCRIPTION
## Summary

Adds an OAuth2 provider for Microsoft Graph's To Do API, using the same
`{tenant}`-templated OAuth configuration already used by `outlook`,
`one_drive`, and `excel`.

## What changed

- `list_task_lists` / `get_task_list` / `create_task_list` /
  `update_task_list` / `delete_task_list`
- `list_tasks` / `get_task` / `create_task` / `update_task` / `delete_task`,
  including reminders (`isReminderOn` / `reminderDateTime`) and recurrence
  (`patternedRecurrence`)
- `list_checklist_items` / `create_checklist_item` / `update_checklist_item` /
  `delete_checklist_item`
- Shared `nextLink` pagination with an allowlisted-path SSRF guard, matching
  the pattern already used by `outlook`.
- `credentialValidators.oauth2` verifies the connection against Graph's `/me`.
- Targeted tests for the nextLink allowlist, `dateTimeTimeZone` defaulting to
  UTC, and 204 No Content delete handling.

## API research

- https://learn.microsoft.com/en-us/graph/api/resources/todotask
- https://learn.microsoft.com/en-us/graph/api/resources/todotasklist
- https://learn.microsoft.com/en-us/graph/api/resources/checklistitem

## Test plan

- [x] `npm run generate:catalog`
- [x] `npm run fix-check`
- [x] `npx vitest run src/providers/microsoft_todo` (6 passed)
- [x] Manual OAuth flow verified against a real personal Microsoft account
      (task list/task CRUD confirmed working end to end)