### PR TITLE
feat(grafana): register proxy executor for the Grafana HTTP API

### DIFF
--- a/src/providers/proxy.registry.test.ts
+++ b/src/providers/proxy.registry.test.ts
@@ -61,6 +61,15 @@ describe("grafana proxy", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected failure");
     expect(result.error.message).toContain("endpoint is not supported");
+
+    const prefixCollision = await registeredProxyExecutors.grafana!(
+      { method: "GET", endpoint: "/apifoo" },
+      executionContext,
+    );
+
+    expect(prefixCollision.ok).toBe(false);
+    if (prefixCollision.ok) throw new Error("expected failure");
+    expect(prefixCollision.error.message).toContain("endpoint is not supported");
     expect(calls).toHaveLength(0);
   });
 });

--- a/src/providers/proxy.registry.test.ts
+++ b/src/providers/proxy.registry.test.ts
@@ -1,0 +1,66 @@
+import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registeredProxyExecutors } from "./proxy.registry.ts";
+
+const grafanaCredential: ResolvedCredential = {
+  authType: "api_key",
+  apiKey: "glsa_test_service_account_token",
+  values: { baseUrl: "https://example-stack.grafana.net" },
+  profile: { accountId: "1", displayName: "Main Org.", grantedScopes: [] },
+  metadata: {},
+};
+
+const executionContext: ExecutionContext = {
+  getCredential: async () => grafanaCredential,
+};
+
+function stubFetchSequence(responses: Response[]): Array<{ url: string; init: RequestInit | undefined }> {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: input instanceof Request ? input.url : String(input), init });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("unexpected extra request");
+    }
+    return response;
+  });
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("grafana proxy", () => {
+  it("forwards /api requests to the credential baseUrl with a bearer token", async () => {
+    const calls = stubFetchSequence([
+      new Response(JSON.stringify({ results: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+
+    const result = await registeredProxyExecutors.grafana!(
+      { method: "POST", endpoint: "/api/ds/query", body: { queries: [] } },
+      executionContext,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    expect(result.response.status).toBe(200);
+    expect(calls.map((call) => call.url)).toEqual(["https://example-stack.grafana.net/api/ds/query"]);
+    expect(new Headers(calls[0]!.init?.headers).get("authorization")).toBe("Bearer glsa_test_service_account_token");
+  });
+
+  it("rejects endpoints outside /api", async () => {
+    const calls = stubFetchSequence([]);
+
+    const result = await registeredProxyExecutors.grafana!({ method: "GET", endpoint: "/login" }, executionContext);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error.message).toContain("endpoint is not supported");
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/providers/proxy.registry.ts
+++ b/src/providers/proxy.registry.ts
@@ -132,6 +132,12 @@ export const registeredProxyExecutors: Record<string, ProviderProxyExecutor> = {
     baseUrl: "https://slides.googleapis.com/v1",
     auth: { type: "oauth_bearer" },
   }),
+  grafana: defineProviderProxy({
+    service: "grafana",
+    baseUrl: credentialProviderProxyBaseUrl("baseUrl"),
+    auth: { type: "bearer" },
+    allowedEndpoint: allowedPathPrefixes("/api"),
+  }),
   hackernews: defineProviderProxy({
     service: "hackernews",
     baseUrl: "https://hacker-news.firebaseio.com/v0",


### PR DESCRIPTION
## Why

Grafana connections currently return `proxy_not_supported` (501) for `POST /v1/proxy/grafana`. The grafana provider's actions cover resource management (folders / dashboards / data sources / alert listing), but there is no way to reach other Grafana HTTP API endpoints — most notably `POST /api/ds/query`, which is how you actually query data (Loki logs, Prometheus metrics) through a connected Grafana. For agent workflows like "check this service's recent error logs", the connection can manage dashboards but cannot read any data.

## What

Registers `grafana` in the shared proxy registry (`src/providers/proxy.registry.ts`), following the existing `defineProviderProxy` pattern:

- `baseUrl` resolved from the connection's `baseUrl` field — the same extra field the actions runtime already uses, so it works for both Grafana Cloud stacks (`https://<stack>.grafana.net`) and self-hosted instances
- the service account token is forwarded as a bearer token (Grafana's documented auth scheme)
- endpoints are restricted to the `/api` prefix via `allowedPathPrefixes`, keeping the proxy scoped to Grafana's HTTP API surface

## Testing

- `npm run fix-check` and `npm test` pass
- Added `src/providers/proxy.registry.test.ts` with two tests for the entry: (1) a `/api/ds/query` request is forwarded to `<baseUrl>/api/ds/query` with `Authorization: Bearer <token>`; (2) endpoints outside `/api` are rejected without any egress request
- The allowlist path was additionally verified against a locally running server (`/v1/proxy/grafana` with `endpoint: "/login"` → 400 `endpoint is not supported for this provider`)

## Example

```bash
oo connector proxy grafana --method POST --endpoint /api/ds/query \
  --body '{"queries":[{"refId":"A","datasource":{"uid":"<loki-uid>"},"expr":"{job=\"app\"} |~ \"error\"","queryType":"range"}],"from":"now-1h","to":"now"}'
```