### PR TITLE
fix(gmail): remove the admin-only scope from user OAuth

### DIFF
--- a/src/providers/gmail/actions.ts
+++ b/src/providers/gmail/actions.ts
@@ -9,7 +9,6 @@ import {
   gmailReadScopes,
   gmailSendScopes,
   gmailSettingsBasicScopes,
-  gmailSettingsSharingScopes,
 } from "./scopes.ts";
 
 const service = "gmail";
@@ -595,14 +594,14 @@ export const gmailActions: ActionDefinition[] = [
   action({
     name: "get_auto_forwarding",
     description: "Get the current Gmail auto-forwarding configuration.",
-    requiredScopes: gmailSettingsSharingScopes,
+    requiredScopes: gmailSettingsBasicScopes,
     properties: withUser(),
     outputSchema: gmailObject,
   }),
   action({
     name: "list_forwarding_addresses",
     description: "List registered forwarding addresses.",
-    requiredScopes: gmailSettingsSharingScopes,
+    requiredScopes: gmailSettingsBasicScopes,
     properties: withUser(),
     outputSchema: gmailObject,
   }),

--- a/src/providers/gmail/definition.test.ts
+++ b/src/providers/gmail/definition.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+const gmailSettingsSharingScope = "https://www.googleapis.com/auth/gmail.settings.sharing";
+const gmailSettingsBasicScope = "https://www.googleapis.com/auth/gmail.settings.basic";
+
+describe("Gmail provider definition", () => {
+  it("does not request the Workspace administrator-only sharing scope for user OAuth", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth?.scopes).not.toContain(gmailSettingsSharingScope);
+  });
+
+  it("uses a user-authorizable scope for forwarding read actions", () => {
+    const forwardingReadActions = provider.actions.filter((action) =>
+      ["get_auto_forwarding", "list_forwarding_addresses"].includes(action.name),
+    );
+
+    expect(forwardingReadActions).toHaveLength(2);
+    for (const action of forwardingReadActions) {
+      expect(action.requiredScopes).toEqual([gmailSettingsBasicScope]);
+    }
+  });
+});

--- a/src/providers/gmail/scopes.ts
+++ b/src/providers/gmail/scopes.ts
@@ -4,7 +4,6 @@ export const gmailComposeScope = "https://www.googleapis.com/auth/gmail.compose"
 export const gmailSendScope = "https://www.googleapis.com/auth/gmail.send";
 export const gmailLabelsScope = "https://www.googleapis.com/auth/gmail.labels";
 export const gmailSettingsBasicScope = "https://www.googleapis.com/auth/gmail.settings.basic";
-export const gmailSettingsSharingScope = "https://www.googleapis.com/auth/gmail.settings.sharing";
 
 export const gmailReadScopes: string[] = [gmailReadonlyScope];
 export const gmailModifyScopes: string[] = [gmailModifyScope];
@@ -12,7 +11,6 @@ export const gmailComposeScopes: string[] = [gmailComposeScope];
 export const gmailSendScopes: string[] = [gmailSendScope];
 export const gmailLabelScopes: string[] = [gmailLabelsScope];
 export const gmailSettingsBasicScopes: string[] = [gmailSettingsBasicScope];
-export const gmailSettingsSharingScopes: string[] = [gmailSettingsSharingScope];
 
 export const gmailOAuthScopes: string[] = [
   gmailReadonlyScope,
@@ -21,5 +19,4 @@ export const gmailOAuthScopes: string[] = [
   gmailSendScope,
   gmailLabelsScope,
   gmailSettingsBasicScope,
-  gmailSettingsSharingScope,
 ];


### PR DESCRIPTION
## Summary

- remove `gmail.settings.sharing` from the Gmail provider's default user OAuth request
- keep the forwarding read actions, but declare `gmail.settings.basic` instead of the administrator-only sharing scope
- add a provider-definition regression test for both contracts

## Why

Open Connector's Gmail provider uses an ordinary web-server OAuth flow. Google documents `gmail.settings.sharing` as restricted to administrative use by Google Workspace service accounts with domain-wide delegation:

https://developers.google.com/workspace/gmail/api/auth/scopes

The two existing read actions do not need that scope. Google's current method references allow `gmail.settings.basic` for both:

- https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings/getAutoForwarding
- https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.forwardingAddresses/list

Keeping the sharing scope in the default request makes personal Gmail authorization ask for a permission that this flow cannot use and complicates production OAuth verification.

## Validation

- `npm run fix-check`
- `npm run generate:catalog`
- `npm test` (69 files, 748 tests)