### PR TITLE
feat(oauth): let clients request a scope subset

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -153,6 +153,21 @@ curl -s -X PUT http://localhost:3000/api/oauth/configs/github \
   -d '{"clientId":"...","clientSecret":"..."}'
 ```
 
+By default, authorization requests include every scope declared by the provider. A deployment that
+needs a smaller permission surface can save `requestedScopes` with the OAuth client configuration:
+
+```bash
+curl -s -X PUT http://localhost:3000/api/oauth/configs/github \
+  -H 'content-type: application/json' \
+  -d '{"clientId":"...","clientSecret":"...","requestedScopes":["read:user"]}'
+```
+
+Every requested scope must come from the provider's declared `auth[].scopes`. The runtime rejects
+unknown scopes instead of silently expanding authorization. Omit `requestedScopes` to keep the
+provider defaults, or send an empty array when the provider accepts an authorization request
+without a `scope` parameter. Config summaries expose both `requestedScopes` and the resulting
+`effectiveScopes`.
+
 Some providers declare additional OAuth client fields in `auth[].clientConfigFields`; send those as
 `extra`.
 
@@ -178,6 +193,8 @@ curl -s -X POST http://localhost:3000/api/oauth/authorizations \
   -H 'content-type: application/json' \
   -d '{"service":"github","connectionName":"work","clientId":"...","clientSecret":"..."}'
 ```
+
+Connection-scoped OAuth client requests may include the same validated `requestedScopes` subset.
 
 The callback URL is still the deployment's `/oauth/callback` (for example,
 `https://connect.example.com/oauth/callback`), and the connection keeps the supplied app values

--- a/src/oauth/oauth-client-config-service.test.ts
+++ b/src/oauth/oauth-client-config-service.test.ts
@@ -26,6 +26,30 @@ describe("OAuthClientConfigService", () => {
       { service: "alpha", configured: false, clientId: null },
     ]);
   });
+
+  it("normalizes a requested scope subset and rejects provider-undeclared scopes", () => {
+    const service = new OAuthClientConfigService({
+      catalog: createCatalogStore([oauthProvider("example")]),
+      origin: "http://localhost:3000",
+      store: new MemoryOAuthClientConfigStore(),
+    });
+
+    expect(
+      service.normalizeConfig("example", {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestedScopes: [" write ", "read", "write"],
+      }),
+    ).toMatchObject({ requestedScopes: ["write", "read"] });
+
+    expect(() =>
+      service.normalizeConfig("example", {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestedScopes: ["admin"],
+      }),
+    ).toThrowError("requestedScopes contains a scope not declared by example: admin.");
+  });
 });
 
 function oauthProvider(service: string): ProviderDefinition {
@@ -39,7 +63,7 @@ function oauthProvider(service: string): ProviderDefinition {
         type: "oauth2",
         authorizationUrl: "https://example.com/oauth/authorize",
         tokenUrl: "https://example.com/oauth/token",
-        scopes: ["read"],
+        scopes: ["read", "write"],
         tokenEndpointAuthMethod: "client_secret_post",
       },
     ],

--- a/src/oauth/oauth-client-config-service.ts
+++ b/src/oauth/oauth-client-config-service.ts
@@ -1,7 +1,7 @@
 import type { CatalogStore } from "../catalog-store.ts";
 import type { OAuth2AuthDefinition, OAuthClientConfigFieldDefinition } from "../core/types.ts";
 
-import { optionalRecord, optionalString } from "../core/cast.ts";
+import { optionalRecord, optionalString, optionalStringArray } from "../core/cast.ts";
 import { normalizeCredentialValues } from "../core/credential-fields.ts";
 import { assertPublicHttpUrl } from "../core/request.ts";
 
@@ -12,6 +12,8 @@ export type OAuthClientConfig = {
   service: string;
   clientId: string;
   clientSecret: string;
+  /** Provider-declared scope subset to request. Omit to use every provider default. */
+  requestedScopes?: string[];
   extra: Record<string, string>;
   secretExtra: Record<string, string>;
 };
@@ -19,6 +21,8 @@ export type OAuthClientConfig = {
 export interface OAuthClientConfigInput {
   clientId: string;
   clientSecret: string;
+  /** Provider-declared scope subset to request. Omit to use every provider default. */
+  requestedScopes?: string[];
   extra?: Record<string, unknown>;
   secretExtra?: Record<string, unknown>;
 }
@@ -33,6 +37,8 @@ export interface OAuthClientConfigSummary {
   clientId: string | null;
   expectedRedirectUri: string;
   auth: OAuth2AuthDefinition;
+  requestedScopes: string[] | null;
+  effectiveScopes: string[];
   extra: Record<string, string>;
 }
 
@@ -86,13 +92,7 @@ export class OAuthClientConfigService {
     return normalizeStoredOAuthClientConfig(await this.store.get(service));
   }
 
-  async upsertConfig(input: {
-    service: string;
-    clientId: string;
-    clientSecret: string;
-    extra?: Record<string, unknown>;
-    secretExtra?: Record<string, unknown>;
-  }): Promise<OAuthClientConfigSummary> {
+  async upsertConfig(input: OAuthClientConfigInput & { service: string }): Promise<OAuthClientConfigSummary> {
     const config = this.normalizeConfig(input.service, input);
     await this.store.set(config);
     return this.toSummary(input.service, this.getOAuthDefinition(input.service), config);
@@ -114,6 +114,7 @@ export class OAuthClientConfigService {
       service,
       clientId,
       clientSecret,
+      requestedScopes: normalizeRequestedScopes(service, input.requestedScopes, auth.scopes),
       extra: normalizeCredentialValues({
         fields: filterClientConfigFields(auth.clientConfigFields, "extra"),
         values: pickClientConfigFieldValues(auth.clientConfigFields, submittedExtra, "extra"),
@@ -170,6 +171,12 @@ export class OAuthClientConfigService {
     return auth;
   }
 
+  /** Resolve the validated scopes an authorization request should send. */
+  getEffectiveScopes(service: string, config: OAuthClientConfig): string[] {
+    const auth = this.getOAuthDefinition(service);
+    return normalizeRequestedScopes(service, config.requestedScopes, auth.scopes) ?? [...auth.scopes];
+  }
+
   private listOAuthProviders(): Array<{ service: string; auth: OAuth2AuthDefinition }> {
     return this.catalog.providers.flatMap((provider) => {
       const auth = provider.auth.find((auth) => auth.type === "oauth2");
@@ -189,6 +196,8 @@ export class OAuthClientConfigService {
       clientId: config?.clientId ?? null,
       expectedRedirectUri: this.expectedRedirectUri(service),
       auth,
+      requestedScopes: config?.requestedScopes ?? null,
+      effectiveScopes: normalizeRequestedScopes(service, config?.requestedScopes, auth.scopes) ?? [...auth.scopes],
       extra: config?.extra ?? {},
     };
   }
@@ -209,6 +218,7 @@ export function readOAuthClientConfigMetadata(
     service,
     clientId,
     clientSecret: optionalString(value?.clientSecret) ?? "",
+    requestedScopes: optionalStringArray(value?.requestedScopes),
     extra: readStringRecord(value?.extra),
     secretExtra: readStringRecord(value?.secretExtra),
   };
@@ -267,6 +277,35 @@ function normalizeStoredOAuthClientConfig(config: OAuthClientConfig | undefined)
     ...config,
     secretExtra: config.secretExtra ?? {},
   };
+}
+
+function normalizeRequestedScopes(
+  service: string,
+  requestedScopes: string[] | undefined,
+  providerScopes: string[],
+): string[] | undefined {
+  if (requestedScopes === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(requestedScopes) || requestedScopes.some((scope) => typeof scope !== "string")) {
+    throw new OAuthClientConfigError("invalid_input", "requestedScopes must be an array of strings.");
+  }
+
+  const normalized = [...new Set(requestedScopes.map((scope) => scope.trim()))];
+  if (normalized.some((scope) => !scope)) {
+    throw new OAuthClientConfigError("invalid_input", "requestedScopes must not contain empty values.");
+  }
+
+  const declaredScopes = new Set(providerScopes);
+  const undeclaredScope = normalized.find((scope) => !declaredScopes.has(scope));
+  if (undeclaredScope) {
+    throw new OAuthClientConfigError(
+      "invalid_input",
+      `requestedScopes contains a scope not declared by ${service}: ${undeclaredScope}.`,
+    );
+  }
+
+  return normalized;
 }
 
 function readStringRecord(value: unknown): Record<string, string> {

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -202,6 +202,36 @@ describe("OAuthFlowService", () => {
     });
   });
 
+  it("uses the requested scope subset from the OAuth client config", async () => {
+    const services = createServices([oauthProvider]);
+    await services.clientConfigs.upsertConfig({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      extra: { tenant: "default" },
+      requestedScopes: ["read"],
+    });
+
+    const started = await services.flow.startAuthorization({ service: "example" });
+
+    expect(new URL(started.authorizationUrl).searchParams.get("scope")).toBe("read");
+  });
+
+  it("omits the scope parameter for an explicitly empty scope subset", async () => {
+    const services = createServices([oauthProvider]);
+    await services.clientConfigs.upsertConfig({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      extra: { tenant: "default" },
+      requestedScopes: [],
+    });
+
+    const started = await services.flow.startAuthorization({ service: "example" });
+
+    expect(new URL(started.authorizationUrl).searchParams.has("scope")).toBe(false);
+  });
+
   it("requires OAuth client config before authorization", async () => {
     const services = createServices([oauthProvider]);
 
@@ -226,14 +256,17 @@ describe("OAuthFlowService", () => {
       clientConfig: {
         clientId: "custom-client-id",
         clientSecret: "custom-client-secret",
+        requestedScopes: ["read"],
         extra: { tenant: "tenant-a" },
       },
     });
     expect(new URL(started.authorizationUrl).searchParams.get("app_id")).toBe("custom-client-id");
+    expect(new URL(started.authorizationUrl).searchParams.get("scope")).toBe("read");
     expect(await services.states.take(started.state)).toMatchObject({
       clientConfig: {
         clientId: "custom-client-id",
         clientSecret: "custom-client-secret",
+        requestedScopes: ["read"],
       },
     });
 
@@ -243,6 +276,7 @@ describe("OAuthFlowService", () => {
       clientConfig: {
         clientId: "custom-client-id",
         clientSecret: "custom-client-secret",
+        requestedScopes: ["read"],
         extra: { tenant: "tenant-a" },
       },
     });
@@ -252,6 +286,7 @@ describe("OAuthFlowService", () => {
         oauthClientConfig: {
           clientId: "custom-client-id",
           clientSecret: "custom-client-secret",
+          requestedScopes: ["read"],
           extra: { tenant: "tenant-a" },
         },
       },

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -113,10 +113,11 @@ export class OAuthFlowService {
     );
     setAuthorizationParam(authorizationUrl, auth.authorizationRequestFields?.responseType, "response_type", "code");
     setAuthorizationParam(authorizationUrl, auth.authorizationRequestFields?.state, "state", state);
-    if (auth.scopes.length > 0 && auth.authorizationRequestFields?.scope !== false) {
+    const effectiveScopes = this.clientConfigs.getEffectiveScopes(service, config);
+    if (effectiveScopes.length > 0 && auth.authorizationRequestFields?.scope !== false) {
       authorizationUrl.searchParams.set(
         auth.authorizationRequestFields?.scope ?? "scope",
-        auth.scopes.join(auth.scopeSeparator ?? " "),
+        effectiveScopes.join(auth.scopeSeparator ?? " "),
       );
     }
     if (pkceCodeVerifier) {

--- a/src/server/api/http-utils.ts
+++ b/src/server/api/http-utils.ts
@@ -8,6 +8,7 @@ export type JsonRequestBody = {
   values?: Record<string, unknown>;
   clientId?: unknown;
   clientSecret?: unknown;
+  requestedScopes?: unknown;
   extra?: unknown;
   [key: string]: unknown;
 };

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -86,6 +86,9 @@ const oauthClientConfigRequestSchema = jsonSchema.object(
     clientSecret: jsonSchema.string({
       description: "OAuth app client secret. Optional only for public-client providers.",
     }),
+    requestedScopes: jsonSchema.array(jsonSchema.string(), {
+      description: "Provider-declared scope subset to request. Omit to use every provider default.",
+    }),
     extra: {
       type: "object",
       additionalProperties: { type: "string" },
@@ -344,9 +347,26 @@ export function createOpenApiDocument(
               description: "Callback URL to configure in the provider OAuth app.",
             }),
             auth: jsonSchema.unknownObject("Provider OAuth capability metadata."),
+            requestedScopes: jsonSchema.nullable(
+              jsonSchema.array(jsonSchema.string(), {
+                description: "Configured scope subset, or null when provider defaults are used.",
+              }),
+            ),
+            effectiveScopes: jsonSchema.array(jsonSchema.string(), {
+              description: "Scopes the runtime will include in new authorization requests.",
+            }),
           },
           {
-            required: ["service", "configured", "customClientAvailable", "clientId", "expectedRedirectUri", "auth"],
+            required: [
+              "service",
+              "configured",
+              "customClientAvailable",
+              "clientId",
+              "expectedRedirectUri",
+              "auth",
+              "requestedScopes",
+              "effectiveScopes",
+            ],
             description: "OAuth client config summary safe for the local console.",
           },
         ),
@@ -1028,6 +1048,9 @@ function createOAuthAuthorizationPath(): Record<string, unknown> {
                 clientSecret: jsonSchema.string({
                   description: "Optional connection-scoped OAuth app client secret.",
                 }),
+                requestedScopes: jsonSchema.array(jsonSchema.string(), {
+                  description: "Optional provider-declared scope subset to request.",
+                }),
                 extra: {
                   type: "object",
                   additionalProperties: { type: "string" },
@@ -1074,7 +1097,7 @@ function createOAuthConfigPath(): Record<string, unknown> {
       tags: ["OAuth"],
       summary: "Upsert local OAuth client configuration.",
       description:
-        "Open-source users provide their own OAuth app. Additional extra fields are declared by provider catalog auth metadata.",
+        "Open-source users provide their own OAuth app. requestedScopes may narrow the provider-declared defaults but cannot add scopes. Additional extra fields are declared by provider catalog auth metadata.",
       requestBody: {
         required: true,
         content: {

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -64,7 +64,7 @@ const oauthProvider: ProviderDefinition = {
       type: "oauth2",
       authorizationUrl: "https://example.com/oauth/authorize",
       tokenUrl: "https://example.com/oauth/token",
-      scopes: ["read"],
+      scopes: ["read", "write"],
       tokenEndpointAuthMethod: "client_secret_post",
       clientConfigFields: [
         {
@@ -182,15 +182,17 @@ describe("ConnectServer", () => {
         connectionName: "work",
         clientId: "connection-client-id",
         clientSecret: "connection-client-secret",
+        requestedScopes: ["read"],
         secretExtra: { appBearerToken: "connection-app-token" },
       }),
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      authorizationUrl: expect.stringContaining("client_id=connection-client-id"),
-      state: expect.any(String),
-    });
+    const body = (await response.json()) as { authorizationUrl: string; state: string };
+    const authorizationUrl = new URL(body.authorizationUrl);
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("connection-client-id");
+    expect(authorizationUrl.searchParams.get("scope")).toBe("read");
+    expect(body.state).toEqual(expect.any(String));
   });
 
   it("reports when connection-scoped OAuth clients are available to the console", async () => {
@@ -298,6 +300,50 @@ describe("ConnectServer", () => {
     await expect(response.json()).resolves.toMatchObject({
       authorizationUrl: expect.stringContaining("client_id=global-client-id"),
     });
+  });
+
+  it("configures a safe OAuth scope subset through the public API", async () => {
+    const app = createTestServer([oauthProvider]).createApp();
+    const config = await app.request("/api/oauth/configs/oauth_example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestedScopes: ["read"],
+      }),
+    });
+
+    expect(config.status).toBe(200);
+    await expect(config.json()).resolves.toMatchObject({
+      requestedScopes: ["read"],
+      effectiveScopes: ["read"],
+    });
+
+    const authorization = await app.request("/api/oauth/authorizations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ service: "oauth_example" }),
+    });
+    const body = (await authorization.json()) as { authorizationUrl: string };
+
+    expect(authorization.status).toBe(200);
+    expect(new URL(body.authorizationUrl).searchParams.get("scope")).toBe("read");
+  });
+
+  it("rejects malformed or provider-undeclared requested scopes through the public API", async () => {
+    const app = createTestServer([oauthProvider]).createApp();
+
+    for (const requestedScopes of ["read", ["admin"]]) {
+      const response = await app.request("/api/oauth/configs/oauth_example", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ clientId: "client-id", clientSecret: "client-secret", requestedScopes }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: { code: "invalid_input" } });
+    }
   });
 
   it("lists providers without action schemas and serves full schemas per action", async () => {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -21,7 +21,7 @@ import { compress } from "hono/compress";
 import { ConnectionError, defaultConnectionName } from "../connection-service.ts";
 import { ActionPolicyService, emptyPolicyRules } from "../core/action-policy.ts";
 import { DEFAULT_ACTION_SEARCH_LIMIT, createActionSearchIndexProvider, searchActions } from "../core/action-search.ts";
-import { optionalRecord, optionalString, requiredString } from "../core/cast.ts";
+import { optionalRecord, optionalString, requiredString, requiredStringArray } from "../core/cast.ts";
 import { createMcpServer, listMcpToolSummaries } from "../mcp.ts";
 import { OAuthClientConfigError, OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
 import { OAuthFlowError, OAuthFlowService } from "../oauth/oauth-flow-service.ts";
@@ -921,6 +921,7 @@ export class ConnectServer {
         service,
         clientId: optionalString(body.clientId) ?? "",
         clientSecret: optionalString(body.clientSecret) ?? "",
+        requestedScopes: readRequestedScopes(body),
         extra: optionalRecord(body.extra),
         secretExtra: optionalRecord(body.secretExtra),
       }),
@@ -1076,7 +1077,7 @@ export class ConnectServer {
 }
 
 function readOAuthClientConfigInput(body: Record<string, unknown>): OAuthClientConfigInput | undefined {
-  const keys = ["clientId", "clientSecret", "extra", "secretExtra"];
+  const keys = ["clientId", "clientSecret", "requestedScopes", "extra", "secretExtra"];
   if (!keys.some((key) => key in body)) {
     return undefined;
   }
@@ -1084,9 +1085,21 @@ function readOAuthClientConfigInput(body: Record<string, unknown>): OAuthClientC
   return {
     clientId: optionalString(body.clientId) ?? "",
     clientSecret: optionalString(body.clientSecret) ?? "",
+    requestedScopes: readRequestedScopes(body),
     extra: optionalRecord(body.extra),
     secretExtra: optionalRecord(body.secretExtra),
   };
+}
+
+function readRequestedScopes(body: Record<string, unknown>): string[] | undefined {
+  if (!("requestedScopes" in body)) {
+    return undefined;
+  }
+  return requiredStringArray(
+    body.requestedScopes,
+    "requestedScopes",
+    (message) => new HttpRequestError("invalid_input", `${message}.`),
+  );
 }
 
 interface ConnectionLogContext {

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -32,6 +32,7 @@ describe("D1RuntimeDatabase", () => {
       service: "gmail",
       clientId: "client-id",
       clientSecret: "client-secret",
+      requestedScopes: ["gmail.readonly"],
       extra: { tenant: "default" },
       secretExtra: {},
     });
@@ -49,6 +50,7 @@ describe("D1RuntimeDatabase", () => {
     await expect(database.oauthClientConfigStore.get("gmail")).resolves.toMatchObject({
       clientId: "client-id",
       clientSecret: "client-secret",
+      requestedScopes: ["gmail.readonly"],
       extra: { tenant: "default" },
     });
     await expect(database.connectionStore.list()).resolves.toMatchObject([

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -100,6 +100,7 @@ describe("SqliteRuntimeDatabase", () => {
       service: "gmail",
       clientId: "client-id",
       clientSecret: "client-secret",
+      requestedScopes: ["gmail.readonly"],
       extra: { tenant: "default" },
       secretExtra: {},
     });
@@ -132,6 +133,7 @@ describe("SqliteRuntimeDatabase", () => {
     await expect(second.oauthClientConfigStore.get("gmail")).resolves.toMatchObject({
       clientId: "client-id",
       clientSecret: "client-secret",
+      requestedScopes: ["gmail.readonly"],
       extra: { tenant: "default" },
     });
     await expect(second.oauthStateStore.take("state-1")).resolves.toMatchObject({

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -88,6 +88,8 @@ export interface OAuthConfig {
   clientId: string | null;
   expectedRedirectUri?: string;
   auth?: Extract<AuthDefinition, { type: "oauth2" }>;
+  requestedScopes?: string[] | null;
+  effectiveScopes?: string[];
   extra?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

- add optional `requestedScopes` to global and connection-scoped OAuth client configurations
- normalize and persist the requested subset, while rejecting scopes not declared by the provider
- use the effective subset when building authorization URLs
- expose `requestedScopes` and `effectiveScopes` in config summaries and OpenAPI
- document the API behavior

## Product behavior

- omitting `requestedScopes` preserves today's behavior and requests every provider default
- a non-empty array can only narrow the provider's declared scopes
- an empty array omits the `scope` authorization parameter
- malformed, empty-string, or provider-undeclared values fail explicitly
- this remains operator/API configuration; it does not add an end-user scope picker

This provides a safe least-privilege path for production OAuth apps without allowing callers to expand provider permissions. It is a narrow implementation of the need discussed in #267.

## Persistence and compatibility

The optional field round-trips through SQLite, D1, pending OAuth state, and connection-scoped OAuth client metadata. Existing stored configs omit the field and continue to use provider defaults.

## Validation

- `npm run fix-check`
- `npm test` (68 files, 751 tests)
- `npm run build:web`
- focused OAuth flow, public HTTP API, SQLite, and D1 tests