### PR TITLE
fix(oauth): require a non-empty requested scope subset

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -164,9 +164,8 @@ curl -s -X PUT http://localhost:3000/api/oauth/configs/github \
 
 Every requested scope must come from the provider's declared `auth[].scopes`. The runtime rejects
 unknown scopes instead of silently expanding authorization. Omit `requestedScopes` to keep the
-provider defaults, or send an empty array when the provider accepts an authorization request
-without a `scope` parameter. Config summaries expose both `requestedScopes` and the resulting
-`effectiveScopes`.
+provider defaults; when present, the array must contain at least one scope. Config summaries expose
+both `requestedScopes` and the resulting `effectiveScopes`.
 
 Some providers declare additional OAuth client fields in `auth[].clientConfigFields`; send those as
 `extra`.

--- a/src/oauth/oauth-client-config-service.test.ts
+++ b/src/oauth/oauth-client-config-service.test.ts
@@ -50,6 +50,22 @@ describe("OAuthClientConfigService", () => {
       }),
     ).toThrowError("requestedScopes contains a scope not declared by example: admin.");
   });
+
+  it("rejects an empty requested scope subset", () => {
+    const service = new OAuthClientConfigService({
+      catalog: createCatalogStore([oauthProvider("example")]),
+      origin: "http://localhost:3000",
+      store: new MemoryOAuthClientConfigStore(),
+    });
+
+    expect(() =>
+      service.normalizeConfig("example", {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestedScopes: [],
+      }),
+    ).toThrowError("requestedScopes must contain at least one scope.");
+  });
 });
 
 function oauthProvider(service: string): ProviderDefinition {

--- a/src/oauth/oauth-client-config-service.ts
+++ b/src/oauth/oauth-client-config-service.ts
@@ -12,7 +12,7 @@ export type OAuthClientConfig = {
   service: string;
   clientId: string;
   clientSecret: string;
-  /** Provider-declared scope subset to request. Omit to use every provider default. */
+  /** Non-empty provider-declared scope subset to request. Omit to use every provider default. */
   requestedScopes?: string[];
   extra: Record<string, string>;
   secretExtra: Record<string, string>;
@@ -21,7 +21,7 @@ export type OAuthClientConfig = {
 export interface OAuthClientConfigInput {
   clientId: string;
   clientSecret: string;
-  /** Provider-declared scope subset to request. Omit to use every provider default. */
+  /** Non-empty provider-declared scope subset to request. Omit to use every provider default. */
   requestedScopes?: string[];
   extra?: Record<string, unknown>;
   secretExtra?: Record<string, unknown>;
@@ -292,6 +292,9 @@ function normalizeRequestedScopes(
   }
 
   const normalized = [...new Set(requestedScopes.map((scope) => scope.trim()))];
+  if (normalized.length === 0) {
+    throw new OAuthClientConfigError("invalid_input", "requestedScopes must contain at least one scope.");
+  }
   if (normalized.some((scope) => !scope)) {
     throw new OAuthClientConfigError("invalid_input", "requestedScopes must not contain empty values.");
   }

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -217,21 +217,6 @@ describe("OAuthFlowService", () => {
     expect(new URL(started.authorizationUrl).searchParams.get("scope")).toBe("read");
   });
 
-  it("omits the scope parameter for an explicitly empty scope subset", async () => {
-    const services = createServices([oauthProvider]);
-    await services.clientConfigs.upsertConfig({
-      service: "example",
-      clientId: "client-id",
-      clientSecret: "client-secret",
-      extra: { tenant: "default" },
-      requestedScopes: [],
-    });
-
-    const started = await services.flow.startAuthorization({ service: "example" });
-
-    expect(new URL(started.authorizationUrl).searchParams.has("scope")).toBe(false);
-  });
-
   it("requires OAuth client config before authorization", async () => {
     const services = createServices([oauthProvider]);
 

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -87,7 +87,8 @@ const oauthClientConfigRequestSchema = jsonSchema.object(
       description: "OAuth app client secret. Optional only for public-client providers.",
     }),
     requestedScopes: jsonSchema.array(jsonSchema.string(), {
-      description: "Provider-declared scope subset to request. Omit to use every provider default.",
+      minItems: 1,
+      description: "Non-empty provider-declared scope subset to request. Omit to use every provider default.",
     }),
     extra: {
       type: "object",
@@ -1049,7 +1050,8 @@ function createOAuthAuthorizationPath(): Record<string, unknown> {
                   description: "Optional connection-scoped OAuth app client secret.",
                 }),
                 requestedScopes: jsonSchema.array(jsonSchema.string(), {
-                  description: "Optional provider-declared scope subset to request.",
+                  minItems: 1,
+                  description: "Optional non-empty provider-declared scope subset to request.",
                 }),
                 extra: {
                   type: "object",

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -331,19 +331,20 @@ describe("ConnectServer", () => {
     expect(new URL(body.authorizationUrl).searchParams.get("scope")).toBe("read");
   });
 
-  it("rejects malformed or provider-undeclared requested scopes through the public API", async () => {
+  it.each([
+    ["malformed", "read"],
+    ["empty", []],
+    ["provider-undeclared", ["admin"]],
+  ])("rejects %s requested scopes through the public API", async (_case, requestedScopes) => {
     const app = createTestServer([oauthProvider]).createApp();
+    const response = await app.request("/api/oauth/configs/oauth_example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ clientId: "client-id", clientSecret: "client-secret", requestedScopes }),
+    });
 
-    for (const requestedScopes of ["read", ["admin"]]) {
-      const response = await app.request("/api/oauth/configs/oauth_example", {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ clientId: "client-id", clientSecret: "client-secret", requestedScopes }),
-      });
-
-      expect(response.status).toBe(400);
-      await expect(response.json()).resolves.toMatchObject({ error: { code: "invalid_input" } });
-    }
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "invalid_input" } });
   });
 
   it("lists providers without action schemas and serves full schemas per action", async () => {


### PR DESCRIPTION
## Summary

- reject explicitly empty `requestedScopes` arrays
- keep omission as the signal to use provider defaults
- require at least one scope in the OpenAPI contract and update the operator documentation
- cover empty, malformed, and provider-undeclared inputs separately

## Why

An empty array was documented as omitting the OAuth `scope` parameter, but that behavior is provider-dependent. Static authorization parameters can still supply a scope—for example, Tencent Docs declares `scope=all`—so accepting `[]` can unexpectedly request broad permissions. Rejecting empty subsets keeps the least-privilege contract predictable: omit the field for provider defaults, or provide a non-empty validated subset.

Follow-up to #294.

## Validation

- `npm run fix-check`
- `npm test` (69 files, 755 tests)