### PR TITLE
fix(figma): request only public OAuth app scopes and enable PKCE

### DIFF
--- a/src/providers/figma/definition.test.ts
+++ b/src/providers/figma/definition.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+describe("Figma provider definition", () => {
+  it("uses Figma's public OAuth endpoints with PKCE and refresh support", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth).toMatchObject({
+      authorizationUrl: "https://www.figma.com/oauth",
+      tokenUrl: "https://api.figma.com/v1/oauth/token",
+      refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
+      tokenEndpointAuthMethod: "client_secret_basic",
+      pkce: { method: "S256" },
+      tokenRequestFields: {
+        clientId: false,
+        refresh: { grantType: false },
+      },
+    });
+  });
+});

--- a/src/providers/figma/definition.test.ts
+++ b/src/providers/figma/definition.test.ts
@@ -9,7 +9,6 @@ describe("Figma provider definition", () => {
     expect(oauth).toMatchObject({
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
-      refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
       scopes: [
         "current_user:read",
         "file_metadata:read",
@@ -26,9 +25,10 @@ describe("Figma provider definition", () => {
       pkce: { method: "S256" },
       tokenRequestFields: {
         clientId: false,
-        refresh: { grantType: false },
+        refresh: { grantType: "grant_type" },
       },
     });
+    expect(oauth).not.toHaveProperty("refreshTokenUrl");
     expect(oauth?.scopes).not.toContain("projects:read");
     expect(oauth?.scopes).not.toContain("project_metadata:read");
   });

--- a/src/providers/figma/definition.test.ts
+++ b/src/providers/figma/definition.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { provider } from "./definition.ts";
+import { figmaPersonalAccessTokenScopes } from "./scopes.ts";
 
 describe("Figma provider definition", () => {
   it("uses Figma's public OAuth endpoints with PKCE and refresh support", () => {
@@ -9,6 +10,18 @@ describe("Figma provider definition", () => {
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
       refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
+      scopes: [
+        "current_user:read",
+        "file_metadata:read",
+        "file_content:read",
+        "file_versions:read",
+        "file_comments:read",
+        "file_comments:write",
+        "library_content:read",
+        "library_assets:read",
+        "file_dev_resources:read",
+        "file_dev_resources:write",
+      ],
       tokenEndpointAuthMethod: "client_secret_basic",
       pkce: { method: "S256" },
       tokenRequestFields: {
@@ -16,5 +29,11 @@ describe("Figma provider definition", () => {
         refresh: { grantType: false },
       },
     });
+    expect(oauth?.scopes).not.toContain("projects:read");
+    expect(oauth?.scopes).not.toContain("project_metadata:read");
+  });
+
+  it("keeps private project capabilities available to personal access tokens", () => {
+    expect(figmaPersonalAccessTokenScopes).toEqual(expect.arrayContaining(["projects:read", "project_metadata:read"]));
   });
 });

--- a/src/providers/figma/definition.ts
+++ b/src/providers/figma/definition.ts
@@ -1,7 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { figmaActions } from "./actions.ts";
-import { figmaProviderScopes } from "./scopes.ts";
+import { figmaPublicOAuthScopes } from "./scopes.ts";
 
 const service = "figma";
 
@@ -26,7 +26,7 @@ export const provider: ProviderDefinition = {
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
       refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
-      scopes: figmaProviderScopes,
+      scopes: figmaPublicOAuthScopes,
       tokenEndpointAuthMethod: "client_secret_basic",
       tokenRequestFields: {
         clientId: false,

--- a/src/providers/figma/definition.ts
+++ b/src/providers/figma/definition.ts
@@ -25,8 +25,18 @@ export const provider: ProviderDefinition = {
       type: "oauth2",
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
+      refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
       scopes: figmaProviderScopes,
       tokenEndpointAuthMethod: "client_secret_basic",
+      tokenRequestFields: {
+        clientId: false,
+        refresh: {
+          grantType: false,
+        },
+      },
+      pkce: {
+        method: "S256",
+      },
     },
   ],
   homepageUrl: "https://www.figma.com",

--- a/src/providers/figma/definition.ts
+++ b/src/providers/figma/definition.ts
@@ -25,13 +25,12 @@ export const provider: ProviderDefinition = {
       type: "oauth2",
       authorizationUrl: "https://www.figma.com/oauth",
       tokenUrl: "https://api.figma.com/v1/oauth/token",
-      refreshTokenUrl: "https://api.figma.com/v1/oauth/refresh",
       scopes: figmaPublicOAuthScopes,
       tokenEndpointAuthMethod: "client_secret_basic",
       tokenRequestFields: {
         clientId: false,
         refresh: {
-          grantType: false,
+          grantType: "grant_type",
         },
       },
       pkce: {

--- a/src/providers/figma/executors.ts
+++ b/src/providers/figma/executors.ts
@@ -27,7 +27,7 @@ import {
   readProviderProxyResponse,
   toProviderProxyError,
 } from "../provider-runtime.ts";
-import { figmaProviderScopes } from "./scopes.ts";
+import { figmaPersonalAccessTokenScopes } from "./scopes.ts";
 
 const service = "figma";
 const figmaApiBaseUrl = "https://api.figma.com";
@@ -216,7 +216,7 @@ export const credentialValidators: CredentialValidators = {
 
     return {
       profile: normalizeFigmaCurrentAccount(user),
-      grantedScopes: [...figmaProviderScopes],
+      grantedScopes: [...figmaPersonalAccessTokenScopes],
       metadata: {
         apiBaseUrl: figmaApiBaseUrl,
         validationEndpoint: "/v1/me",

--- a/src/providers/figma/scopes.ts
+++ b/src/providers/figma/scopes.ts
@@ -1,14 +1,18 @@
-export const figmaProviderScopes: string[] = [
+export const figmaPublicOAuthScopes: string[] = [
   "current_user:read",
   "file_metadata:read",
   "file_content:read",
   "file_versions:read",
   "file_comments:read",
   "file_comments:write",
-  "projects:read",
-  "project_metadata:read",
   "library_content:read",
   "library_assets:read",
   "file_dev_resources:read",
   "file_dev_resources:write",
+];
+
+export const figmaPersonalAccessTokenScopes: string[] = [
+  ...figmaPublicOAuthScopes,
+  "projects:read",
+  "project_metadata:read",
 ];


### PR DESCRIPTION
## Summary

- request only the scopes public Figma OAuth apps may use, so the authorization flow works for public apps; the projects scopes stay available to personal access token connections
- enable S256 PKCE for every Figma authorization flow
- omit the redundant `client_id` from token request bodies; HTTP Basic client authentication already carries the client credentials
- add provider contract tests

## Why

Figma does not let public OAuth apps call the projects endpoints (https://developers.figma.com/docs/rest-api/projects-endpoints/), and an authorization request that includes `projects:read` / `project_metadata:read` fails for public apps. Splitting the scope lists keeps the OAuth authorization request publishable while personal access tokens retain the project capabilities.

Refresh behavior is unchanged: the runtime already targets `/v1/oauth/token` with `grant_type=refresh_token` (`refreshTokenUrl` defaults to `tokenUrl`), which matches Figma's current documented contract.

## Validation

- `npm run fix-check`
- `npm test`
