### PR TITLE
fix(oauth): keep stored scope subsets readable after scope removals

### DIFF
--- a/src/oauth/oauth-client-config-service.test.ts
+++ b/src/oauth/oauth-client-config-service.test.ts
@@ -51,6 +51,37 @@ describe("OAuthClientConfigService", () => {
     ).toThrowError("requestedScopes contains a scope not declared by example: admin.");
   });
 
+  it("drops stored scopes the provider no longer declares instead of failing reads", async () => {
+    const store = new MemoryOAuthClientConfigStore();
+    await store.set({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      requestedScopes: ["read", "removed"],
+      extra: {},
+      secretExtra: {},
+    });
+    const service = new OAuthClientConfigService({
+      catalog: createCatalogStore([oauthProvider("example")]),
+      origin: "http://localhost:3000",
+      store,
+    });
+
+    await expect(service.listConfigs()).resolves.toMatchObject([
+      { service: "example", requestedScopes: ["read", "removed"], effectiveScopes: ["read"] },
+    ]);
+    expect(
+      service.getEffectiveScopes("example", {
+        service: "example",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        requestedScopes: ["removed"],
+        extra: {},
+        secretExtra: {},
+      }),
+    ).toEqual(["read", "write"]);
+  });
+
   it("rejects an empty requested scope subset", () => {
     const service = new OAuthClientConfigService({
       catalog: createCatalogStore([oauthProvider("example")]),

--- a/src/oauth/oauth-client-config-service.ts
+++ b/src/oauth/oauth-client-config-service.ts
@@ -171,10 +171,10 @@ export class OAuthClientConfigService {
     return auth;
   }
 
-  /** Resolve the validated scopes an authorization request should send. */
+  /** Resolve the scopes an authorization request should send. */
   getEffectiveScopes(service: string, config: OAuthClientConfig): string[] {
     const auth = this.getOAuthDefinition(service);
-    return normalizeRequestedScopes(service, config.requestedScopes, auth.scopes) ?? [...auth.scopes];
+    return filterDeclaredScopes(config.requestedScopes, auth.scopes) ?? [...auth.scopes];
   }
 
   private listOAuthProviders(): Array<{ service: string; auth: OAuth2AuthDefinition }> {
@@ -197,7 +197,7 @@ export class OAuthClientConfigService {
       expectedRedirectUri: this.expectedRedirectUri(service),
       auth,
       requestedScopes: config?.requestedScopes ?? null,
-      effectiveScopes: normalizeRequestedScopes(service, config?.requestedScopes, auth.scopes) ?? [...auth.scopes],
+      effectiveScopes: filterDeclaredScopes(config?.requestedScopes, auth.scopes) ?? [...auth.scopes],
       extra: config?.extra ?? {},
     };
   }
@@ -309,6 +309,26 @@ function normalizeRequestedScopes(
   }
 
   return normalized;
+}
+
+/**
+ * Resolve stored requested scopes against the currently declared provider
+ * scopes. A provider can stop declaring a scope after configs were saved (for
+ * example when the platform restricts who may request it); rejecting the stored
+ * value would break the config listing and every re-authorization, so read
+ * paths drop undeclared scopes and fall back to the provider defaults when none
+ * survive. Writes stay strict via normalizeRequestedScopes.
+ */
+function filterDeclaredScopes(requestedScopes: string[] | undefined, providerScopes: string[]): string[] | undefined {
+  if (requestedScopes === undefined) {
+    return undefined;
+  }
+
+  const declaredScopes = new Set(providerScopes);
+  const filtered = [...new Set(requestedScopes.map((scope) => scope.trim()))].filter((scope) =>
+    declaredScopes.has(scope),
+  );
+  return filtered.length > 0 ? filtered : undefined;
 }
 
 function readStringRecord(value: unknown): Record<string, string> {

--- a/src/providers/figma/definition.test.ts
+++ b/src/providers/figma/definition.test.ts
@@ -3,32 +3,20 @@ import { provider } from "./definition.ts";
 import { figmaPersonalAccessTokenScopes } from "./scopes.ts";
 
 describe("Figma provider definition", () => {
-  it("uses Figma's public OAuth endpoints with PKCE and refresh support", () => {
+  it("keeps OAuth on Figma's current token endpoint with PKCE and Basic client auth", () => {
     const oauth = provider.auth.find((auth) => auth.type === "oauth2");
 
-    expect(oauth).toMatchObject({
-      authorizationUrl: "https://www.figma.com/oauth",
-      tokenUrl: "https://api.figma.com/v1/oauth/token",
-      scopes: [
-        "current_user:read",
-        "file_metadata:read",
-        "file_content:read",
-        "file_versions:read",
-        "file_comments:read",
-        "file_comments:write",
-        "library_content:read",
-        "library_assets:read",
-        "file_dev_resources:read",
-        "file_dev_resources:write",
-      ],
-      tokenEndpointAuthMethod: "client_secret_basic",
-      pkce: { method: "S256" },
-      tokenRequestFields: {
-        clientId: false,
-        refresh: { grantType: "grant_type" },
-      },
-    });
+    expect(oauth?.tokenUrl).toBe("https://api.figma.com/v1/oauth/token");
+    // Refresh must reuse the token endpoint; Figma deprecated /v1/oauth/refresh.
     expect(oauth).not.toHaveProperty("refreshTokenUrl");
+    expect(oauth?.pkce).toEqual({ method: "S256" });
+    expect(oauth?.tokenEndpointAuthMethod).toBe("client_secret_basic");
+    expect(oauth?.tokenRequestFields).toEqual({ clientId: false });
+  });
+
+  it("requests only scopes public OAuth apps may use", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
     expect(oauth?.scopes).not.toContain("projects:read");
     expect(oauth?.scopes).not.toContain("project_metadata:read");
   });

--- a/src/providers/figma/definition.ts
+++ b/src/providers/figma/definition.ts
@@ -29,9 +29,6 @@ export const provider: ProviderDefinition = {
       tokenEndpointAuthMethod: "client_secret_basic",
       tokenRequestFields: {
         clientId: false,
-        refresh: {
-          grantType: "grant_type",
-        },
       },
       pkce: {
         method: "S256",

--- a/src/providers/figma/scopes.ts
+++ b/src/providers/figma/scopes.ts
@@ -1,3 +1,11 @@
+/**
+ * Scopes requested for OAuth connections. Figma does not let public OAuth apps
+ * call the projects endpoints, so the projects scopes stay out of the
+ * authorization request to keep it publishable:
+ * https://developers.figma.com/docs/rest-api/projects-endpoints/
+ * Private OAuth app users who need the projects actions must connect with a
+ * personal access token instead.
+ */
 export const figmaPublicOAuthScopes: string[] = [
   "current_user:read",
   "file_metadata:read",


### PR DESCRIPTION
PR #296 shrank figma's declared OAuth scope list, the first time a provider stopped declaring a scope, and that turned a latent strictness into a failure: a client config saved earlier with `projects:read` in its `requestedScopes` now fails the declared-scope check on every read, so `GET /api/oauth/configs` returns 500 for every provider and re-authorization of the affected service is rejected as `invalid_input`. Read paths now drop scopes the definition no longer declares and fall back to the provider defaults when none survive, writes still reject undeclared scopes, and a regression test covers both read paths.

https://github.com/oomol-lab/open-connector/blob/7827fd34177fef2c3eb8e14017d8211e5aeaa0ce/src/oauth/oauth-client-config-service.ts#L302-L309

It also removes residue from #296: the `refresh.grantType` mapping in the figma definition renamed the field to its own default, so the refresh request is byte-identical without it. The definition test now asserts invariants instead of mirroring the definition literal, and _src/providers/figma/scopes.ts_ documents why the projects scopes stay out of the OAuth authorization request.
