### PR TITLE
feat(googlechat): add Google Chat provider

### DIFF
--- a/src/providers/googlechat/actions.ts
+++ b/src/providers/googlechat/actions.ts
@@ -1,0 +1,167 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { googleChatMessagesReadonlyScope, googleChatSpacesReadonlyScope } from "./scopes.ts";
+
+const service = "googlechat";
+
+interface GoogleChatActionSource {
+  name: GoogleChatActionName;
+  description: string;
+  requiredScopes: string[];
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}
+
+const membershipCount = s.object("Counts of members that have directly joined the space.", {
+  joinedDirectHumanUserCount: s.integer("The number of human users that have directly joined the space."),
+  joinedGroupCount: s.integer("The number of groups that have directly joined the space."),
+});
+
+const space = s.object(
+  "A normalized Google Chat space.",
+  {
+    name: s.string("The resource name of the space, in the form spaces/{space}."),
+    spaceId: s.string("The bare space ID with the spaces/ prefix removed."),
+    displayName: s.string("The display name of the space. Empty for direct messages."),
+    spaceType: s.string("The space type, such as SPACE, GROUP_CHAT, or DIRECT_MESSAGE."),
+    spaceHistoryState: s.string("Whether message history is turned on or off for the space."),
+    externalUserAllowed: s.boolean("Whether the space allows users outside the Google Workspace organization."),
+    spaceUri: s.string("The URI that opens the space in the Google Chat client."),
+    createTime: s.string("The time the space was created."),
+    lastActiveTime: s.string("The time of the most recent message in the space."),
+    spaceDetails: s.looseObject("Space description and guidelines shown to members."),
+    membershipCount,
+  },
+  { required: ["name", "spaceId"] },
+);
+
+const messageSender = s.object("The user who created the message.", {
+  name: s.string("The resource name of the sender, in the form users/{user}."),
+  displayName: s.string("The display name of the sender. Only populated for app authentication."),
+  type: s.string("The sender type, either HUMAN or BOT."),
+  domainId: s.string("The Google Workspace domain ID of the sender."),
+  isAnonymous: s.boolean("Whether the sender is an anonymous user."),
+});
+
+const messageThread = s.object("The thread the message belongs to.", {
+  name: s.string("The resource name of the thread, in the form spaces/{space}/threads/{thread}."),
+  threadKey: s.string("The client-assigned ID for the thread."),
+});
+
+const message = s.object(
+  "A normalized Google Chat message.",
+  {
+    name: s.string("The resource name of the message, in the form spaces/{space}/messages/{message}."),
+    messageId: s.string("The bare message ID with the spaces/{space}/messages/ prefix removed."),
+    spaceName: s.string("The resource name of the space that owns the message."),
+    text: s.string("The plain-text body of the message."),
+    formattedText: s.string("The message body with Google Chat formatting markup preserved."),
+    argumentText: s.string("The plain-text body with all Chat app mentions stripped out."),
+    createTime: s.string("The time the message was created."),
+    lastUpdateTime: s.string("The time the message was last edited by a user."),
+    deleteTime: s.string("The time the message was deleted, when it has been deleted."),
+    threadReply: s.boolean("Whether the message is a reply inside an existing thread."),
+    sender: messageSender,
+    thread: messageThread,
+  },
+  { required: ["name", "messageId"] },
+);
+
+const actions: GoogleChatActionSource[] = [
+  action(
+    "list_spaces",
+    "List the Google Chat spaces the authenticated user is a member of, with optional filtering and pagination.",
+    [googleChatSpacesReadonlyScope],
+    input({
+      filter: s.nonEmptyString('A Google Chat filter expression, such as spaceType = "SPACE".'),
+      pageSize: s.integer("The maximum number of spaces to return.", { minimum: 1, maximum: 1000 }),
+      pageToken: s.nonEmptyString("A pagination token returned by a previous list_spaces call."),
+    }),
+    s.requiredObject("The normalized result of listing spaces.", {
+      spaces: s.array("The spaces the authenticated user belongs to.", space),
+      nextPageToken: s.nullableString("A pagination token for fetching the next page of spaces."),
+    }),
+  ),
+  action(
+    "get_space",
+    "Retrieve the details of a single Google Chat space.",
+    [googleChatSpacesReadonlyScope],
+    input(
+      {
+        space: s.nonEmptyString("The space to retrieve, either spaces/{space} or the bare {space} ID."),
+      },
+      ["space"],
+    ),
+    space,
+  ),
+  action(
+    "list_messages",
+    "List the message history of a Google Chat space, with optional filtering, ordering, and pagination.",
+    [googleChatMessagesReadonlyScope],
+    input(
+      {
+        space: s.nonEmptyString("The space whose messages to list, either spaces/{space} or the bare {space} ID."),
+        filter: s.nonEmptyString(
+          'A Google Chat filter expression over createTime or thread.name, such as createTime > "2026-01-01T00:00:00+00:00".',
+        ),
+        orderBy: s.nonEmptyString(
+          'How to order the messages, as a createTime ordering such as "createTime ASC" or "createTime DESC".',
+        ),
+        showDeleted: s.boolean("Whether to include deleted messages in the result."),
+        pageSize: s.integer("The maximum number of messages to return.", { minimum: 1, maximum: 1000 }),
+        pageToken: s.nonEmptyString("A pagination token returned by a previous list_messages call."),
+      },
+      ["space"],
+    ),
+    s.requiredObject("The normalized result of listing space messages.", {
+      messages: s.array("The messages in the requested page of space history.", message),
+      nextPageToken: s.nullableString("A pagination token for fetching the next page of messages."),
+    }),
+  ),
+  action(
+    "get_message",
+    "Retrieve a single Google Chat message by its resource name, or by space and message ID.",
+    [googleChatMessagesReadonlyScope],
+    input(
+      {
+        message: s.nonEmptyString(
+          "The message to retrieve, either the full spaces/{space}/messages/{message} name or the bare {message} ID.",
+        ),
+        space: s.nonEmptyString("The space that owns the message. Required when message is a bare ID."),
+      },
+      ["message"],
+    ),
+    message,
+  ),
+];
+
+export const googleChatActions: ActionDefinition[] = actions.map((source) =>
+  defineProviderAction(service, {
+    ...source,
+    providerPermissions: source.requiredScopes,
+  }),
+);
+
+export type GoogleChatActionName = "list_spaces" | "get_space" | "list_messages" | "get_message";
+
+function action(
+  name: GoogleChatActionName,
+  description: string,
+  requiredScopes: string[],
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+): GoogleChatActionSource {
+  return {
+    name,
+    description,
+    requiredScopes,
+    inputSchema,
+    outputSchema,
+  };
+}
+
+function input(properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema {
+  return s.actionInput(properties, required);
+}

--- a/src/providers/googlechat/actions.ts
+++ b/src/providers/googlechat/actions.ts
@@ -7,7 +7,7 @@ import { googleChatMessagesReadonlyScope, googleChatSpacesReadonlyScope } from "
 const service = "googlechat";
 
 interface GoogleChatActionSource {
-  name: GoogleChatActionName;
+  name: string;
   description: string;
   requiredScopes: string[];
   inputSchema: JsonSchema;
@@ -74,7 +74,7 @@ const actions: GoogleChatActionSource[] = [
     "list_spaces",
     "List the Google Chat spaces the authenticated user is a member of, with optional filtering and pagination.",
     [googleChatSpacesReadonlyScope],
-    input({
+    s.actionInput({
       filter: s.nonEmptyString('A Google Chat filter expression, such as spaceType = "SPACE".'),
       pageSize: s.integer("The maximum number of spaces to return.", { minimum: 1, maximum: 1000 }),
       pageToken: s.nonEmptyString("A pagination token returned by a previous list_spaces call."),
@@ -88,7 +88,7 @@ const actions: GoogleChatActionSource[] = [
     "get_space",
     "Retrieve the details of a single Google Chat space.",
     [googleChatSpacesReadonlyScope],
-    input(
+    s.actionInput(
       {
         space: s.nonEmptyString("The space to retrieve, either spaces/{space} or the bare {space} ID."),
       },
@@ -100,7 +100,7 @@ const actions: GoogleChatActionSource[] = [
     "list_messages",
     "List the message history of a Google Chat space, with optional filtering, ordering, and pagination.",
     [googleChatMessagesReadonlyScope],
-    input(
+    s.actionInput(
       {
         space: s.nonEmptyString("The space whose messages to list, either spaces/{space} or the bare {space} ID."),
         filter: s.nonEmptyString(
@@ -124,7 +124,7 @@ const actions: GoogleChatActionSource[] = [
     "get_message",
     "Retrieve a single Google Chat message by its resource name, or by space and message ID.",
     [googleChatMessagesReadonlyScope],
-    input(
+    s.actionInput(
       {
         message: s.nonEmptyString(
           "The message to retrieve, either the full spaces/{space}/messages/{message} name or the bare {message} ID.",
@@ -144,10 +144,8 @@ export const googleChatActions: ActionDefinition[] = actions.map((source) =>
   }),
 );
 
-export type GoogleChatActionName = "list_spaces" | "get_space" | "list_messages" | "get_message";
-
 function action(
-  name: GoogleChatActionName,
+  name: string,
   description: string,
   requiredScopes: string[],
   inputSchema: JsonSchema,
@@ -160,8 +158,4 @@ function action(
     inputSchema,
     outputSchema,
   };
-}
-
-function input(properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema {
-  return s.actionInput(properties, required);
 }

--- a/src/providers/googlechat/definition.ts
+++ b/src/providers/googlechat/definition.ts
@@ -1,0 +1,35 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { googleChatActions } from "./actions.ts";
+import { googleChatOAuthScopes } from "./scopes.ts";
+
+const service = "googlechat";
+
+/**
+ * Google Chat provider backed by the Chat API and a user-provided Google OAuth app.
+ *
+ * Scoped to read-only space and message history access, which the Chat API
+ * supports under user authentication.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Google Chat",
+  description: "Read Google Chat spaces and message history as the authenticated Google Workspace user.",
+  categories: ["Communication", "Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      scopes: googleChatOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      authorizationParams: {
+        access_type: "offline",
+        prompt: "consent",
+      },
+    },
+  ],
+  homepageUrl: "https://workspace.google.com/products/chat/",
+  actions: googleChatActions,
+};

--- a/src/providers/googlechat/executors.test.ts
+++ b/src/providers/googlechat/executors.test.ts
@@ -1,0 +1,55 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { googleChatActionHandlers } from "./executors.ts";
+
+const accessToken = "test-token";
+
+describe("Google Chat resource names", () => {
+  const fetcher: ProviderFetch = async () => {
+    throw new Error("invalid resource names must not be fetched");
+  };
+  const context = { accessToken, fetcher };
+
+  it.each([
+    ["a single-dot space ID", "get_space", { space: "." }],
+    ["a double-dot space ID", "list_messages", { space: "spaces/.." }],
+    ["a single-dot bare message ID", "get_message", { space: "A", message: "." }],
+    ["a double-dot space ID in a message name", "get_message", { message: "spaces/../messages/B" }],
+    ["a double-dot message ID in a message name", "get_message", { message: "spaces/A/messages/.." }],
+  ])("rejects %s", async (_description, action, input) => {
+    await expect(googleChatActionHandlers[action](input, context)).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("Google Chat message normalization", () => {
+  it("preserves message content whitespace", async () => {
+    const fetcher: ProviderFetch = async () =>
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              name: "spaces/A/messages/B.B",
+              text: "  keep me  ",
+              formattedText: "\n*keep me*\n",
+              argumentText: "  keep me  ",
+            },
+          ],
+        }),
+      );
+
+    await expect(googleChatActionHandlers.list_messages({ space: "A" }, { accessToken, fetcher })).resolves.toEqual({
+      messages: [
+        {
+          name: "spaces/A/messages/B.B",
+          messageId: "B.B",
+          spaceName: "spaces/A",
+          text: "  keep me  ",
+          formattedText: "\n*keep me*\n",
+          argumentText: "  keep me  ",
+        },
+      ],
+      nextPageToken: null,
+    });
+  });
+});

--- a/src/providers/googlechat/executors.ts
+++ b/src/providers/googlechat/executors.ts
@@ -1,0 +1,281 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext } from "../provider-runtime.ts";
+import type { GoogleChatActionName } from "./actions.ts";
+
+import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { asObject, googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
+
+export const googleChatApiBaseUrl = "https://chat.googleapis.com/v1";
+
+const service = "googlechat";
+const googleUserInfoUrl = "https://www.googleapis.com/oauth2/v3/userinfo";
+const spaceNamePattern = /^spaces\/[^/]+$/;
+const messageNamePattern = /^spaces\/[^/]+\/messages\/[^/]+$/;
+
+type GoogleChatRuntimeContext = OAuthProviderContext;
+type GoogleChatActionHandler = (input: Record<string, unknown>, context: GoogleChatRuntimeContext) => Promise<unknown>;
+
+interface ListSpacesPayload {
+  spaces?: unknown;
+  nextPageToken?: string | null;
+}
+
+interface ListMessagesPayload {
+  messages?: unknown;
+  nextPageToken?: string | null;
+}
+
+export const googleChatActionHandlers: Record<GoogleChatActionName, GoogleChatActionHandler> = {
+  list_spaces: listSpaces,
+  get_space: getSpace,
+  list_messages: listMessages,
+  get_message: getMessage,
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, googleChatActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const profile = await googleJsonRequest<{
+      email?: string;
+      name?: string;
+      sub?: string;
+    }>(googleUserInfoUrl, {
+      accessToken: input.accessToken,
+      fetcher,
+      signal,
+    });
+    return {
+      profile: {
+        accountId: profile.email ?? profile.sub ?? "googlechat:oauth2",
+        displayName: profile.name ?? profile.email ?? "Google Chat User",
+      },
+      metadata: {
+        currentAccount: profile,
+      },
+    };
+  },
+};
+
+async function listSpaces(input: Record<string, unknown>, context: GoogleChatRuntimeContext) {
+  const payload = await googleChatJsonRequest<ListSpacesPayload>(`${googleChatApiBaseUrl}/spaces`, {
+    context,
+    query: compactObject({
+      filter: optionalString(input.filter),
+      pageSize: integerQuery(input.pageSize),
+      pageToken: optionalString(input.pageToken),
+    }),
+  });
+
+  return {
+    spaces: Array.isArray(payload.spaces) ? payload.spaces.map((item) => normalizeSpace(item)) : [],
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getSpace(input: Record<string, unknown>, context: GoogleChatRuntimeContext) {
+  const spaceName = resolveSpaceName(input.space, "space is required");
+  const payload = await googleChatJsonRequest<unknown>(`${googleChatApiBaseUrl}/${encodeResourceName(spaceName)}`, {
+    context,
+  });
+
+  return normalizeSpace(payload);
+}
+
+async function listMessages(input: Record<string, unknown>, context: GoogleChatRuntimeContext) {
+  const spaceName = resolveSpaceName(input.space, "space is required");
+  const payload = await googleChatJsonRequest<ListMessagesPayload>(
+    `${googleChatApiBaseUrl}/${encodeResourceName(spaceName)}/messages`,
+    {
+      context,
+      query: compactObject({
+        filter: optionalString(input.filter),
+        orderBy: optionalString(input.orderBy),
+        showDeleted: booleanQuery(input.showDeleted),
+        pageSize: integerQuery(input.pageSize),
+        pageToken: optionalString(input.pageToken),
+      }),
+    },
+  );
+
+  return {
+    messages: Array.isArray(payload.messages) ? payload.messages.map((item) => normalizeMessage(item)) : [],
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getMessage(input: Record<string, unknown>, context: GoogleChatRuntimeContext) {
+  const messageName = resolveMessageName(input);
+  const payload = await googleChatJsonRequest<unknown>(`${googleChatApiBaseUrl}/${encodeResourceName(messageName)}`, {
+    context,
+  });
+
+  return normalizeMessage(payload);
+}
+
+function normalizeSpace(value: unknown): Record<string, unknown> {
+  const payload = asObject(value);
+  const name = requirePayloadString(payload.name, "Google Chat returned a space without a resource name");
+  const membership = optionalRecord(payload.membershipCount);
+
+  return compactObject({
+    name,
+    spaceId: stripPrefix(name, "spaces/"),
+    displayName: optionalString(payload.displayName),
+    spaceType: optionalString(payload.spaceType),
+    spaceHistoryState: optionalString(payload.spaceHistoryState),
+    externalUserAllowed: optionalBoolean(payload.externalUserAllowed),
+    spaceUri: optionalString(payload.spaceUri),
+    createTime: optionalString(payload.createTime),
+    lastActiveTime: optionalString(payload.lastActiveTime),
+    spaceDetails: optionalRecord(payload.spaceDetails),
+    membershipCount: membership
+      ? compactObject({
+          joinedDirectHumanUserCount: optionalInteger(membership.joinedDirectHumanUserCount),
+          joinedGroupCount: optionalInteger(membership.joinedGroupCount),
+        })
+      : undefined,
+  });
+}
+
+function normalizeMessage(value: unknown): Record<string, unknown> {
+  const payload = asObject(value);
+  const name = requirePayloadString(payload.name, "Google Chat returned a message without a resource name");
+  const segments = name.split("/");
+  const sender = optionalRecord(payload.sender);
+  const thread = optionalRecord(payload.thread);
+  const space = optionalRecord(payload.space);
+
+  return compactObject({
+    name,
+    messageId: segments.length >= 4 ? segments.slice(3).join("/") : name,
+    spaceName: optionalString(space?.name) ?? (segments.length >= 2 ? segments.slice(0, 2).join("/") : undefined),
+    text: optionalString(payload.text),
+    formattedText: optionalString(payload.formattedText),
+    argumentText: optionalString(payload.argumentText),
+    createTime: optionalString(payload.createTime),
+    lastUpdateTime: optionalString(payload.lastUpdateTime),
+    deleteTime: optionalString(payload.deleteTime),
+    threadReply: optionalBoolean(payload.threadReply),
+    sender: sender
+      ? compactObject({
+          name: optionalString(sender.name),
+          displayName: optionalString(sender.displayName),
+          type: optionalString(sender.type),
+          domainId: optionalString(sender.domainId),
+          isAnonymous: optionalBoolean(sender.isAnonymous),
+        })
+      : undefined,
+    thread: thread
+      ? compactObject({
+          name: optionalString(thread.name),
+          threadKey: optionalString(thread.threadKey),
+        })
+      : undefined,
+  });
+}
+
+/**
+ * Accept either the `spaces/{space}` resource name or the bare `{space}` id so
+ * agents can pass whichever form a previous action returned.
+ */
+function resolveSpaceName(value: unknown, message: string): string {
+  const raw = requireString(value, message);
+  const trimmed = trimSlashes(raw);
+  const name = trimmed.startsWith("spaces/") ? trimmed : `spaces/${trimmed}`;
+  if (!spaceNamePattern.test(name)) {
+    throw new ProviderRequestError(400, `space must be spaces/{space} or a bare space id, received "${raw}"`);
+  }
+
+  return name;
+}
+
+/**
+ * Accept either the full `spaces/{space}/messages/{message}` resource name, or a
+ * bare message id paired with a `space` input.
+ */
+function resolveMessageName(input: Record<string, unknown>): string {
+  const raw = requireString(input.message, "message is required");
+  const trimmed = trimSlashes(raw);
+  if (trimmed.startsWith("spaces/")) {
+    if (!messageNamePattern.test(trimmed)) {
+      throw new ProviderRequestError(
+        400,
+        `message must be spaces/{space}/messages/{message} when it starts with spaces/, received "${raw}"`,
+      );
+    }
+
+    return trimmed;
+  }
+
+  const spaceName = resolveSpaceName(input.space, "space is required when message is a bare message id");
+  const name = `${spaceName}/messages/${trimmed}`;
+  if (!messageNamePattern.test(name)) {
+    throw new ProviderRequestError(400, `message must be a bare message id, received "${raw}"`);
+  }
+
+  return name;
+}
+
+function googleChatJsonRequest<T>(
+  url: string,
+  input: {
+    context: Pick<GoogleChatRuntimeContext, "accessToken" | "fetcher" | "signal">;
+    method?: string;
+    query?: Record<string, string | undefined>;
+    body?: unknown;
+  },
+): Promise<T> {
+  return googleJsonRequest<T>(url, {
+    accessToken: input.context.accessToken,
+    fetcher: input.context.fetcher,
+    signal: input.context.signal,
+    method: input.method,
+    query: input.query,
+    body: input.body,
+  });
+}
+
+function encodeResourceName(name: string): string {
+  return name
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function stripPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function integerQuery(value: unknown): string | undefined {
+  const resolved = optionalInteger(value);
+  return resolved === undefined ? undefined : String(resolved);
+}
+
+function booleanQuery(value: unknown): string | undefined {
+  const resolved = optionalBoolean(value);
+  return resolved === undefined ? undefined : String(resolved);
+}
+
+function requireString(value: unknown, message: string): string {
+  const resolved = optionalString(value);
+  if (!resolved) {
+    throw new ProviderRequestError(400, message);
+  }
+
+  return resolved;
+}
+
+function requirePayloadString(value: unknown, message: string): string {
+  const resolved = optionalString(value);
+  if (!resolved) {
+    throw new ProviderRequestError(502, message);
+  }
+
+  return resolved;
+}

--- a/src/providers/googlechat/executors.ts
+++ b/src/providers/googlechat/executors.ts
@@ -1,6 +1,5 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { OAuthProviderContext } from "../provider-runtime.ts";
-import type { GoogleChatActionName } from "./actions.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { asObject, googleJsonRequest } from "../googledrive/runtime-shared.ts";
@@ -26,7 +25,7 @@ interface ListMessagesPayload {
   nextPageToken?: string | null;
 }
 
-export const googleChatActionHandlers: Record<GoogleChatActionName, GoogleChatActionHandler> = {
+export const googleChatActionHandlers: Record<string, GoogleChatActionHandler> = {
   list_spaces: listSpaces,
   get_space: getSpace,
   list_messages: listMessages,
@@ -45,6 +44,7 @@ export const credentialValidators: CredentialValidators = {
       accessToken: input.accessToken,
       fetcher,
       signal,
+      service,
     });
     return {
       profile: {
@@ -234,6 +234,7 @@ function googleChatJsonRequest<T>(
     method: input.method,
     query: input.query,
     body: input.body,
+    service,
   });
 }
 

--- a/src/providers/googlechat/executors.ts
+++ b/src/providers/googlechat/executors.ts
@@ -1,7 +1,14 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
-import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+} from "../../core/cast.ts";
 import { asObject, googleJsonRequest } from "../googledrive/runtime-shared.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
@@ -151,9 +158,9 @@ function normalizeMessage(value: unknown): Record<string, unknown> {
     name,
     messageId: segments.length >= 4 ? segments.slice(3).join("/") : name,
     spaceName: optionalString(space?.name) ?? (segments.length >= 2 ? segments.slice(0, 2).join("/") : undefined),
-    text: optionalString(payload.text),
-    formattedText: optionalString(payload.formattedText),
-    argumentText: optionalString(payload.argumentText),
+    text: optionalRawString(payload.text),
+    formattedText: optionalRawString(payload.formattedText),
+    argumentText: optionalRawString(payload.argumentText),
     createTime: optionalString(payload.createTime),
     lastUpdateTime: optionalString(payload.lastUpdateTime),
     deleteTime: optionalString(payload.deleteTime),
@@ -184,7 +191,8 @@ function resolveSpaceName(value: unknown, message: string): string {
   const raw = requireString(value, message);
   const trimmed = trimSlashes(raw);
   const name = trimmed.startsWith("spaces/") ? trimmed : `spaces/${trimmed}`;
-  if (!spaceNamePattern.test(name)) {
+  const spaceId = name.slice("spaces/".length);
+  if (!spaceNamePattern.test(name) || spaceId === "." || spaceId === "..") {
     throw new ProviderRequestError(400, `space must be spaces/{space} or a bare space id, received "${raw}"`);
   }
 
@@ -199,7 +207,14 @@ function resolveMessageName(input: Record<string, unknown>): string {
   const raw = requireString(input.message, "message is required");
   const trimmed = trimSlashes(raw);
   if (trimmed.startsWith("spaces/")) {
-    if (!messageNamePattern.test(trimmed)) {
+    const [, spaceId, , messageId] = trimmed.split("/");
+    if (
+      !messageNamePattern.test(trimmed) ||
+      spaceId === "." ||
+      spaceId === ".." ||
+      messageId === "." ||
+      messageId === ".."
+    ) {
       throw new ProviderRequestError(
         400,
         `message must be spaces/{space}/messages/{message} when it starts with spaces/, received "${raw}"`,
@@ -211,7 +226,7 @@ function resolveMessageName(input: Record<string, unknown>): string {
 
   const spaceName = resolveSpaceName(input.space, "space is required when message is a bare message id");
   const name = `${spaceName}/messages/${trimmed}`;
-  if (!messageNamePattern.test(name)) {
+  if (!messageNamePattern.test(name) || trimmed === "." || trimmed === "..") {
     throw new ProviderRequestError(400, `message must be a bare message id, received "${raw}"`);
   }
 

--- a/src/providers/googlechat/scopes.ts
+++ b/src/providers/googlechat/scopes.ts
@@ -1,0 +1,16 @@
+export const googleChatSpacesReadonlyScope = "https://www.googleapis.com/auth/chat.spaces.readonly";
+export const googleChatMessagesReadonlyScope = "https://www.googleapis.com/auth/chat.messages.readonly";
+export const googleOpenIdScope = "openid";
+export const googleEmailScope = "email";
+export const googleProfileScope = "profile";
+
+export const googleChatSpaceReadScopes: string[] = [googleChatSpacesReadonlyScope];
+export const googleChatMessageReadScopes: string[] = [googleChatMessagesReadonlyScope];
+
+export const googleChatOAuthScopes: string[] = [
+  googleChatSpacesReadonlyScope,
+  googleChatMessagesReadonlyScope,
+  googleOpenIdScope,
+  googleEmailScope,
+  googleProfileScope,
+];

--- a/src/providers/googledrive/runtime-shared.test.ts
+++ b/src/providers/googledrive/runtime-shared.test.ts
@@ -1,0 +1,76 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { googleRequest } from "./runtime-shared.ts";
+
+const accessToken = "test-token";
+const url = "https://example.googleapis.com/v1/resource";
+
+function respondWith(status: number, body: string): ProviderFetch {
+  return (async () => new Response(body, { status })) as ProviderFetch;
+}
+
+const hangingFetcher: ProviderFetch = ((_url: unknown, init?: RequestInit) =>
+  new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener("abort", () => {
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  })) as ProviderFetch;
+
+async function messageOf(run: Promise<unknown>): Promise<string> {
+  try {
+    await run;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    return (error as ProviderRequestError).message;
+  }
+  throw new Error("expected the request to reject");
+}
+
+describe("googleRequest fallback error messages", () => {
+  it("names the calling service when the error response has no body", async () => {
+    const message = await messageOf(
+      googleRequest(url, { accessToken, fetcher: respondWith(500, ""), service: "googlechat" }),
+    );
+
+    expect(message).toBe("googlechat request failed with 500");
+  });
+
+  it("names the calling service when a request times out", async () => {
+    const message = await messageOf(
+      googleRequest(url, { accessToken, fetcher: hangingFetcher, timeoutMs: 5, service: "googlechat" }),
+    );
+
+    expect(message).toBe("googlechat request timed out after 1 seconds");
+  });
+
+  it("names the calling service when a GET carries a body", async () => {
+    const message = await messageOf(
+      googleRequest(url, {
+        accessToken,
+        fetcher: respondWith(200, "{}"),
+        method: "GET",
+        body: { unexpected: true },
+        service: "googlechat",
+      }),
+    );
+
+    expect(message).toBe("googlechat GET request must not include a body");
+  });
+
+  it("falls back to Google Drive when no service is given", async () => {
+    const message = await messageOf(googleRequest(url, { accessToken, fetcher: respondWith(500, "") }));
+
+    expect(message).toBe("googledrive request failed with 500");
+  });
+
+  it("keeps Google's own error message instead of the fallback", async () => {
+    const body = JSON.stringify({ error: { message: "Insufficient permission" } });
+    const message = await messageOf(
+      googleRequest(url, { accessToken, fetcher: respondWith(403, body), service: "googlechat" }),
+    );
+
+    expect(message).toBe("Insufficient permission");
+  });
+});

--- a/src/providers/googledrive/runtime-shared.test.ts
+++ b/src/providers/googledrive/runtime-shared.test.ts
@@ -42,7 +42,7 @@ describe("googleRequest fallback error messages", () => {
       googleRequest(url, { accessToken, fetcher: hangingFetcher, timeoutMs: 5, service: "googlechat" }),
     );
 
-    expect(message).toBe("googlechat request timed out after 1 seconds");
+    expect(message).toBe("googlechat request timed out after 1 second");
   });
 
   it("names the calling service when a GET carries a body", async () => {

--- a/src/providers/googledrive/runtime-shared.ts
+++ b/src/providers/googledrive/runtime-shared.ts
@@ -201,10 +201,9 @@ async function googleFetchWithTimeout(
     });
   } catch (error) {
     if (didTimeout && isAbortLikeError(error)) {
-      throw new ProviderRequestError(
-        502,
-        `${input.service} request timed out after ${Math.max(1, Math.ceil(timeoutMs / 1000))} seconds`,
-      );
+      const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+      const unit = timeoutSeconds === 1 ? "second" : "seconds";
+      throw new ProviderRequestError(502, `${input.service} request timed out after ${timeoutSeconds} ${unit}`);
     }
     throw error;
   } finally {

--- a/src/providers/googledrive/runtime-shared.ts
+++ b/src/providers/googledrive/runtime-shared.ts
@@ -29,41 +29,33 @@ export {
 
 export type GoogleQueryValue = string | readonly string[] | undefined;
 
-const service = "googledrive";
+const defaultService = "googledrive";
 const googleDefaultRequestTimeoutMs = 30_000;
 
-export async function googleJsonRequest<T>(
-  url: string,
-  input: {
-    accessToken: string;
-    fetcher: ProviderFetch;
-    signal?: AbortSignal;
-    method?: string;
-    query?: Record<string, GoogleQueryValue>;
-    body?: unknown;
-    rawBody?: BodyInit;
-    headers?: Record<string, string>;
-    timeoutMs?: number;
-  },
-): Promise<T> {
+export interface GoogleRequestOptions {
+  accessToken: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+  method?: string;
+  query?: Record<string, GoogleQueryValue>;
+  body?: unknown;
+  rawBody?: BodyInit;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  /**
+   * Provider slug used in the fallback error messages this module generates itself.
+   * Defaults to Google Drive so existing callers keep their current wording.
+   */
+  service?: string;
+}
+
+export async function googleJsonRequest<T>(url: string, input: GoogleRequestOptions): Promise<T> {
   const response = await googleRequest(url, input);
   return (await response.json()) as T;
 }
 
-export async function googleRequest(
-  url: string,
-  input: {
-    accessToken: string;
-    fetcher: ProviderFetch;
-    signal?: AbortSignal;
-    method?: string;
-    query?: Record<string, GoogleQueryValue>;
-    body?: unknown;
-    rawBody?: BodyInit;
-    headers?: Record<string, string>;
-    timeoutMs?: number;
-  },
-): Promise<Response> {
+export async function googleRequest(url: string, input: GoogleRequestOptions): Promise<Response> {
+  const service = input.service ?? defaultService;
   const target = new URL(url);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (Array.isArray(value)) {
@@ -105,9 +97,10 @@ export async function googleRequest(
     fetcher: input.fetcher,
     timeoutMs: input.timeoutMs ?? googleDefaultRequestTimeoutMs,
     init: requestInit,
+    service,
   });
 
-  await assertGoogleResponse(response);
+  await assertGoogleResponse(response, service);
   return response;
 }
 
@@ -177,6 +170,7 @@ async function googleFetchWithTimeout(
     fetcher: ProviderFetch;
     timeoutMs?: number;
     init?: RequestInit;
+    service: string;
   },
 ): Promise<Response> {
   const timeoutMs = input.timeoutMs ?? googleDefaultRequestTimeoutMs;
@@ -209,7 +203,7 @@ async function googleFetchWithTimeout(
     if (didTimeout && isAbortLikeError(error)) {
       throw new ProviderRequestError(
         502,
-        `${service} request timed out after ${Math.max(1, Math.ceil(timeoutMs / 1000))} seconds`,
+        `${input.service} request timed out after ${Math.max(1, Math.ceil(timeoutMs / 1000))} seconds`,
       );
     }
     throw error;
@@ -225,16 +219,16 @@ function hasContentTypeHeader(headers: Record<string, string>): boolean {
   return Object.keys(headers).some((key) => key.toLowerCase() === "content-type");
 }
 
-async function assertGoogleResponse(response: Response): Promise<void> {
+async function assertGoogleResponse(response: Response, service: string): Promise<void> {
   if (response.ok) {
     return;
   }
 
-  const { message, details } = await extractGoogleError(response);
+  const { message, details } = await extractGoogleError(response, service);
   throw new ProviderRequestError(response.status, message, details);
 }
 
-async function extractGoogleError(response: Response): Promise<{ message: string; details: unknown }> {
+async function extractGoogleError(response: Response, service: string): Promise<{ message: string; details: unknown }> {
   const rawText = await response.text().catch(() => "");
   if (!rawText) {
     return {


### PR DESCRIPTION
## Summary

Adds a read-only Google Chat provider covering space discovery and message history.

| Action | Endpoint |
| --- | --- |
| `googlechat.list_spaces` | `GET /v1/spaces` |
| `googlechat.get_space` | `GET /v1/spaces/{space}` |
| `googlechat.list_messages` | `GET /v1/spaces/{space}/messages` |
| `googlechat.get_message` | `GET /v1/spaces/{space}/messages/{message}` |

## Design notes

**User authentication, not a service account.** All four methods support user auth, so the provider uses `defineOAuthProviderExecutors` and follows the same shape as the existing Google providers. Scopes are limited to `chat.spaces.readonly` and `chat.messages.readonly`.

Worth calling out for anyone setting this up, since it is easy to get wrong: per Google's documentation, *"To perform read-only API calls with user authentication, like getting spaces and listing messages, you only need to enable the API and create an OAuth client."* No Chat app configuration is required — that step only applies to create/update/delete calls.

**Flexible id inputs.** Both `space` and `message` accept either the full resource name (`spaces/{space}`) or the bare id, so an id returned by one action can be passed straight into the next without string surgery. Malformed values are rejected with a 400 `ProviderRequestError`.

**`orderBy` is a free-form string, not an enum.** The Chat API accepts `"createTime ASC"` / `"createTime DESC"`. Declaring it as a `stringEnum` would reject otherwise-valid values, so it is a documented string instead.

**Normalization** follows the other Google providers: unknown fields dropped, falsy values such as `externalUserAllowed: false` and `showDeleted: false` preserved rather than stripped by `compactObject`, and `sender.displayName` documented as only populated under app authentication.

## Testing

- `npm run fix-check` — passes (lint, format, typecheck across 1289 providers)
- `npm test` — passes (71 files, 761 tests)
- Verified against a live Google Workspace account: all four actions execute successfully, and the bare-id and full-resource-name input forms return identical results.

No unit tests added — the provider is declarative definitions plus thin HTTP calls, matching the existing convention of not testing static declarations.
