### PR TITLE
feat(totp): add local authenticator provider

### DIFF
--- a/src/providers/totp/actions.ts
+++ b/src/providers/totp/actions.ts
@@ -1,0 +1,25 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "totp";
+
+export const totpActions: readonly ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "generate_code",
+    description: "Generate the current six-digit TOTP code for the configured website account.",
+    requiredScopes: [],
+    inputSchema: s.object("The input payload for generating the current TOTP code.", {}),
+    outputSchema: s.requiredObject("The current TOTP code and its validity window.", {
+      code: s.stringPattern("^\\d{6}$", { description: "The current six-digit TOTP code." }),
+      expiresAt: s.dateTime("The ISO 8601 timestamp when this code expires."),
+      remainingSeconds: s.integer("The number of whole or partial seconds until this code expires.", {
+        minimum: 1,
+        maximum: 30,
+      }),
+      website: s.url("The website associated with the configured account."),
+      username: s.string("The username associated with the configured account."),
+    }),
+  }),
+];

--- a/src/providers/totp/definition.ts
+++ b/src/providers/totp/definition.ts
@@ -1,0 +1,55 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { totpActions } from "./actions.ts";
+
+const service = "totp";
+
+/**
+ * Local TOTP authenticator backed by custom-credential storage.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "TOTP Authenticator",
+  description: "Store a website account and generate its current time-based one-time password locally.",
+  categories: ["Security"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "website",
+          label: "Website URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "https://example.com",
+          description: "The HTTP or HTTPS website associated with this authenticator account.",
+        },
+        {
+          key: "username",
+          label: "Username",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "user@example.com",
+          description: "The username associated with this authenticator account.",
+        },
+        {
+          key: "secret",
+          label: "TOTP Secret",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "JBSWY3DPEHPK3PXP",
+          description: "The Base32-encoded TOTP secret. It is stored as a secret and never returned by actions.",
+        },
+      ],
+      testAction: {
+        actionName: "generate_code",
+        input: {},
+      },
+    },
+  ],
+  actions: totpActions,
+};

--- a/src/providers/totp/executors.test.ts
+++ b/src/providers/totp/executors.test.ts
@@ -1,0 +1,68 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { credentialValidators, executors } from "./executors.ts";
+
+const values = {
+  website: "https://example.com/login",
+  username: "alice@example.com",
+  secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+};
+
+const credential: ResolvedCredential = {
+  authType: "custom_credential",
+  values,
+  profile: {
+    accountId: "https://example.com#alice@example.com",
+    displayName: "alice@example.com at example.com",
+    grantedScopes: [],
+  },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("TOTP executors", () => {
+  it("generates a code for the configured website account", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(59_000);
+
+    const result = await executors["totp.generate_code"]!({}, context);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        code: "287082",
+        expiresAt: "1970-01-01T00:01:00.000Z",
+        remainingSeconds: 1,
+        website: values.website,
+        username: values.username,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(values.secret);
+  });
+
+  it("validates credentials and returns a non-secret account profile", async () => {
+    const result = await credentialValidators.customCredential!({ values }, { fetcher: fetch });
+
+    expect(result).toEqual({
+      profile: {
+        accountId: "https://example.com#alice@example.com",
+        displayName: "alice@example.com at example.com",
+      },
+      grantedScopes: [],
+      metadata: {
+        websiteOrigin: "https://example.com",
+        algorithm: "SHA-1",
+        digits: 6,
+        periodSeconds: 30,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(values.secret);
+  });
+});

--- a/src/providers/totp/executors.ts
+++ b/src/providers/totp/executors.ts
@@ -1,0 +1,62 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { generateTotpCode, readTotpCredential, totpDigits, totpPeriodSeconds } from "./runtime.ts";
+
+const service = "totp";
+
+interface TotpActionContext {
+  secret: string;
+  username: string;
+  website: string;
+}
+
+const totpActionHandlers: Record<
+  string,
+  (input: Record<string, unknown>, context: TotpActionContext) => Promise<unknown>
+> = {
+  async generate_code(_input, context): Promise<unknown> {
+    return {
+      ...(await generateTotpCode(context.secret)),
+      website: context.website,
+      username: context.username,
+    };
+  },
+};
+
+export const executors: ProviderExecutors = defineProviderExecutors<TotpActionContext>({
+  service,
+  handlers: totpActionHandlers,
+  async createContext(context: ExecutionContext): Promise<TotpActionContext> {
+    const credential = readTotpCredential((await requireCustomCredential(context, service)).values);
+    return {
+      secret: credential.secret,
+      username: credential.username,
+      website: credential.website,
+    };
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  async customCredential(input): Promise<CredentialValidationResult> {
+    const credential = readTotpCredential(input.values);
+    return {
+      profile: {
+        accountId: `${credential.websiteUrl.origin}#${credential.username}`,
+        displayName: `${credential.username} at ${credential.websiteUrl.host}`,
+      },
+      grantedScopes: [],
+      metadata: {
+        websiteOrigin: credential.websiteUrl.origin,
+        algorithm: "SHA-1",
+        digits: totpDigits,
+        periodSeconds: totpPeriodSeconds,
+      },
+    };
+  },
+};

--- a/src/providers/totp/runtime.test.ts
+++ b/src/providers/totp/runtime.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { generateTotpCode, readTotpCredential } from "./runtime.ts";
+
+describe("TOTP runtime", () => {
+  it.each([
+    [59_000, "287082"],
+    [1_111_111_109_000, "081804"],
+    [1_111_111_111_000, "050471"],
+    [1_234_567_890_000, "005924"],
+    [2_000_000_000_000, "279037"],
+    [20_000_000_000_000, "353130"],
+  ])("generates the RFC 6238 SHA-1 code at %i milliseconds", async (timestampMs, expectedCode) => {
+    const result = await generateTotpCode("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", timestampMs);
+
+    expect(result.code).toBe(expectedCode);
+  });
+
+  it("returns the code expiry and remaining lifetime", async () => {
+    await expect(generateTotpCode("JBSW Y3DP-EHPK3PXP", 31_250)).resolves.toEqual({
+      code: "996554",
+      expiresAt: "1970-01-01T00:01:00.000Z",
+      remainingSeconds: 29,
+    });
+  });
+
+  it("validates the website, username, and secret without exposing the secret in errors", () => {
+    expect(() =>
+      readTotpCredential({ website: "https://example.com/login", username: "alice", secret: "not-a-secret!" }),
+    ).toThrow("secret must be a valid Base32-encoded TOTP secret");
+    expect(() =>
+      readTotpCredential({ website: "javascript:alert(1)", username: "alice", secret: "JBSWY3DPEHPK3PXP" }),
+    ).toThrow("website must be a valid HTTP or HTTPS URL");
+  });
+});

--- a/src/providers/totp/runtime.test.ts
+++ b/src/providers/totp/runtime.test.ts
@@ -31,4 +31,19 @@ describe("TOTP runtime", () => {
       readTotpCredential({ website: "javascript:alert(1)", username: "alice", secret: "JBSWY3DPEHPK3PXP" }),
     ).toThrow("website must be a valid HTTP or HTTPS URL");
   });
+
+  it("rejects website URLs containing userinfo credentials", () => {
+    expect(() =>
+      readTotpCredential({
+        website: "https://user:password@example.com/login",
+        username: "alice",
+        secret: "JBSWY3DPEHPK3PXP",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        status: 400,
+        message: "website must be a valid HTTP or HTTPS URL",
+      }),
+    );
+  });
 });

--- a/src/providers/totp/runtime.ts
+++ b/src/providers/totp/runtime.ts
@@ -93,7 +93,7 @@ function decodeBase32Secret(input: string): ArrayBuffer {
 function parseWebsiteUrl(website: string): URL {
   try {
     const url = new URL(website);
-    if ((url.protocol === "http:" || url.protocol === "https:") && url.hostname) {
+    if ((url.protocol === "http:" || url.protocol === "https:") && url.hostname && !url.username && !url.password) {
       return url;
     }
   } catch {

--- a/src/providers/totp/runtime.ts
+++ b/src/providers/totp/runtime.ts
@@ -1,0 +1,107 @@
+import { requiredString } from "../../core/cast.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+const base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+export const totpDigits = 6;
+export const totpPeriodSeconds = 30;
+
+export interface TotpCredential {
+  secret: string;
+  username: string;
+  website: string;
+  websiteUrl: URL;
+}
+
+export interface TotpCode {
+  code: string;
+  expiresAt: string;
+  remainingSeconds: number;
+}
+
+/**
+ * Validate and normalize the three fields stored for a TOTP connection.
+ */
+export function readTotpCredential(values: Record<string, string>): TotpCredential {
+  const createError = (message: string): ProviderRequestError => new ProviderRequestError(400, message);
+  const website = requiredString(values.website, "website", createError);
+  const username = requiredString(values.username, "username", createError);
+  const secret = requiredString(values.secret, "secret", createError);
+  const websiteUrl = parseWebsiteUrl(website);
+  decodeBase32Secret(secret);
+  return { website, username, secret, websiteUrl };
+}
+
+/**
+ * Generate an RFC 6238 SHA-1 TOTP value for a Unix timestamp in milliseconds.
+ */
+export async function generateTotpCode(secret: string, timestampMs: number = Date.now()): Promise<TotpCode> {
+  if (!Number.isFinite(timestampMs) || timestampMs < 0) {
+    throw new ProviderRequestError(400, "timestamp must be a non-negative finite number");
+  }
+
+  const counter = Math.floor(timestampMs / 1000 / totpPeriodSeconds);
+  const counterBytes = new ArrayBuffer(8);
+  new DataView(counterBytes).setBigUint64(0, BigInt(counter));
+  const key = await crypto.subtle.importKey("raw", decodeBase32Secret(secret), { name: "HMAC", hash: "SHA-1" }, false, [
+    "sign",
+  ]);
+  const digest = new Uint8Array(await crypto.subtle.sign("HMAC", key, counterBytes));
+  const offset = digest[digest.length - 1]! & 0x0f;
+  const binaryCode =
+    ((digest[offset]! & 0x7f) << 24) |
+    ((digest[offset + 1]! & 0xff) << 16) |
+    ((digest[offset + 2]! & 0xff) << 8) |
+    (digest[offset + 3]! & 0xff);
+  const code = String(binaryCode % 10 ** totpDigits).padStart(totpDigits, "0");
+  const expiresAtMs = (counter + 1) * totpPeriodSeconds * 1000;
+
+  return {
+    code,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    remainingSeconds: Math.max(1, Math.ceil((expiresAtMs - timestampMs) / 1000)),
+  };
+}
+
+function decodeBase32Secret(input: string): ArrayBuffer {
+  const normalized = input.toUpperCase().replace(/[\s-]+/gu, "");
+  if (!/^[A-Z2-7]+=*$/u.test(normalized)) {
+    throw invalidSecretError();
+  }
+
+  const unpadded = normalized.replace(/=+$/u, "");
+  const bytes: number[] = [];
+  let bitBuffer = 0;
+  let bitCount = 0;
+  for (const character of unpadded) {
+    bitBuffer = (bitBuffer << 5) | base32Alphabet.indexOf(character);
+    bitCount += 5;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((bitBuffer >>> bitCount) & 0xff);
+      bitBuffer &= (1 << bitCount) - 1;
+    }
+  }
+
+  if (bytes.length === 0 || (bitCount > 0 && (bitBuffer & ((1 << bitCount) - 1)) !== 0)) {
+    throw invalidSecretError();
+  }
+  const decoded = new Uint8Array(bytes.length);
+  decoded.set(bytes);
+  return decoded.buffer;
+}
+
+function parseWebsiteUrl(website: string): URL {
+  try {
+    const url = new URL(website);
+    if ((url.protocol === "http:" || url.protocol === "https:") && url.hostname) {
+      return url;
+    }
+  } catch {
+    // Use the stable validation error below.
+  }
+  throw new ProviderRequestError(400, "website must be a valid HTTP or HTTPS URL");
+}
+
+function invalidSecretError(): ProviderRequestError {
+  return new ProviderRequestError(400, "secret must be a valid Base32-encoded TOTP secret");
+}


### PR DESCRIPTION
## Summary

Add a local TOTP Authenticator provider that stores a website, username, and Base32 TOTP secret in a named connection and exposes `totp.generate_code` for retrieving the current code. The implementation reuses the existing custom-credential, connection-alias, and action-policy infrastructure and performs all code generation locally without network access.

## Changes

- Add a `totp` custom-credential provider for a website URL, username, and sensitive TOTP secret.
- Add `totp.generate_code`, returning the current six-digit code, expiry timestamp, remaining lifetime, website, and username without ever returning the underlying secret.
- Implement RFC 6238 TOTP generation with Web Crypto using SHA-1, six digits, and a 30-second period, with validation for HTTP/HTTPS website URLs and Base32 secrets.
- Add RFC 6238 reference vectors and targeted coverage for expiry calculation, credential validation, and the complete executor path.

## Design notes

- Each named connection represents one website account; callers select the record through the existing connection alias mechanism.
- The first version deliberately supports the most common RFC 6238 profile only: SHA-1, six digits, and a 30-second period. It does not add configurable algorithms, digit counts, or periods.
- The provider never contacts the recorded website. The URL is used only for identification, display, and input validation.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` — 75 test files and 782 tests passed
- `git diff --check origin/main...HEAD`
- GitHub Actions `Lint, Typecheck & Test` — passed on the repository's Node 24 environment

## Manual steps

- Configure `OOMOL_CONNECT_ENCRYPTION_KEY` before storing TOTP secrets outside local development; without it, credentials follow the existing runtime behavior and are stored in plaintext.
- Restrict `totp.generate_code` to callers that require access through runtime-token or action-policy rules.

Deployment impact: No database, infrastructure, or rollout-order changes. This PR only adds an optional provider; secure storage still uses the existing `OOMOL_CONNECT_ENCRYPTION_KEY` configuration.

## Risks and rollback

- A TOTP code is a second authentication factor. Any client allowed to invoke this action can retrieve the current code, so deployments must protect runtime access tokens and action permissions.
- Without a configured data-encryption key, the TOTP secret is stored in plaintext like other credentials.
- Roll back by reverting this PR. Delete any `totp` connections from runtime storage when they are no longer needed.
