### PR TITLE
feat(esa): add esa provider

### DIFF
--- a/src/providers/esa/actions.ts
+++ b/src/providers/esa/actions.ts
@@ -1,0 +1,632 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { esaReadScopes, esaWriteScopes } from "./scopes.ts";
+
+const service = "esa";
+
+const teamName = s.nonWhitespaceString("The esa team subdomain, optionally including the .esa.io suffix.");
+const postNumber = s.positiveInteger("The numeric esa post number.");
+const commentId = s.positiveInteger("The numeric esa comment ID.");
+const page = s.positiveInteger("Page number, starting at 1.");
+const perPage = s.integer("Items per page. esa accepts at most 100.", { minimum: 1, maximum: 100 });
+const markdown = s.string("Markdown content. Use four spaces for indentation where required.");
+const optionalPage = s.optional(page);
+const optionalPerPage = s.optional(perPage);
+
+const paginationFields = {
+  prev_page: s.optional(s.nullableInteger("The previous page, or null when this is the first page.")),
+  next_page: s.optional(s.nullableInteger("The next page, or null when this is the last page.")),
+  total_count: s.optional(s.nonNegativeInteger("Total number of matching items.")),
+  page: s.optional(s.positiveInteger("The current page number.")),
+  per_page: s.optional(s.positiveInteger("The number of items in this page.")),
+  max_per_page: s.optional(s.positiveInteger("The maximum page size accepted by esa.")),
+};
+
+const userSchema = s.looseObject(
+  {
+    id: s.integer("The esa user ID."),
+    name: s.string("The user's display name."),
+    screen_name: s.string("The user's esa screen name."),
+    icon: s.url("The user's icon URL."),
+    email: s.email("The user's email address."),
+  },
+  { description: "An esa user profile." },
+);
+
+const postStatsSchema = s.looseObject(
+  {
+    tasks_count: s.nonNegativeInteger("Number of tasks in the post."),
+    done_tasks_count: s.nonNegativeInteger("Number of completed tasks in the post."),
+    comments_count: s.nonNegativeInteger("Number of comments on the post."),
+    stargazers_count: s.nonNegativeInteger("Number of users who starred the post."),
+    watchers_count: s.nonNegativeInteger("Number of users watching the post."),
+  },
+  { description: "Post counters returned by esa." },
+);
+
+const bodyStatsSchema = s.requiredObject("The full post body size before output truncation.", {
+  characters: s.nonNegativeInteger("Number of user-perceived characters."),
+  lines: s.nonNegativeInteger("Number of newline-separated lines."),
+});
+
+const postSchema = s.object(
+  {
+    url: s.url("The post URL."),
+    revision_number: s.nonNegativeInteger("The current revision number."),
+    wip: s.stringEnum(["WIP", "Shipped"], { description: "The publication state of the post." }),
+    kind: s.string("The esa post kind."),
+    category_and_title_and_tags: s.string("The post category, title, and tags."),
+    body_md: s.optional(s.string("The post body in Markdown.")),
+    body_md_stats: s.optional(bodyStatsSchema),
+    created_at: s.optional(s.dateTime("When the post was created.")),
+    updated_at: s.optional(s.dateTime("When the post was last updated.")),
+    created_by: s.optional(userSchema),
+    updated_by: s.optional(userSchema),
+    stats: s.optional(postStatsSchema),
+    backlinks_count: s.optional(s.nonNegativeInteger("Number of posts that link to this post.")),
+  },
+  { additionalProperties: true, description: "An esa post shaped for agent use." },
+);
+
+const postSummarySchema = s.object(
+  {
+    number: s.positiveInteger("The esa post number."),
+    url: s.url("The post URL."),
+    category_and_title_and_tags: s.string("The post category, title, and tags."),
+    wip: s.stringEnum(["WIP", "Shipped"], { description: "The publication state of the post." }),
+    created_at: s.optional(s.dateTime("When the post was created.")),
+    updated_at: s.optional(s.dateTime("When the post was last updated.")),
+  },
+  { additionalProperties: true, description: "A compact esa post summary." },
+);
+
+const commentStatsSchema = s.looseObject(
+  {
+    stargazers_count: s.nonNegativeInteger("Number of users who starred the comment."),
+    star: s.boolean("Whether the authenticated user starred the comment."),
+  },
+  { description: "Comment counters returned by esa." },
+);
+
+const commentSchema = s.object(
+  {
+    id: s.positiveInteger("The comment ID."),
+    post_number: s.positiveInteger("The post number that owns the comment."),
+    url: s.url("The comment URL."),
+    body_md: s.optional(s.string("The comment body in Markdown.")),
+    created_at: s.optional(s.dateTime("When the comment was created.")),
+    updated_at: s.optional(s.dateTime("When the comment was last updated.")),
+    created_by: s.optional(userSchema),
+    stats: s.optional(commentStatsSchema),
+    stargazers: s.optional(s.array(userSchema, { description: "Users who starred the comment." })),
+  },
+  { additionalProperties: true, description: "An esa comment shaped for agent use." },
+);
+
+const categorySchema = s.object(
+  {
+    full_name: s.string("The full category path."),
+    count: s.nonNegativeInteger("Number of posts in the category."),
+    has_child: s.boolean("Whether the category has child categories."),
+  },
+  { additionalProperties: true, description: "An esa category summary." },
+);
+
+const categoryListSchema = s.looseObject(
+  {
+    current_category: s.string("The selected category path."),
+    categories: s.array(categorySchema, { description: "Categories at the selected level." }),
+    parent_categories: s.array(
+      s.looseObject(
+        {
+          current_category: s.string("The parent category path."),
+          categories: s.array(categorySchema, { description: "Categories under that parent." }),
+        },
+        { description: "One parent category level." },
+      ),
+      { description: "Parent category levels." },
+    ),
+    readme: postSchema,
+    no_category: categorySchema,
+    descendant_posts: s.array(postSchema, { description: "Posts in descendant categories." }),
+    posts: s.array(postSchema, { description: "Posts directly in the selected category." }),
+    ...paginationFields,
+  },
+  { description: "A category listing returned by esa." },
+);
+
+const postListSchema = s.object(
+  {
+    posts: s.array(postSchema, { description: "Posts returned by esa." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa post listing." },
+);
+
+const postSummaryListSchema = s.object(
+  {
+    posts: s.array(postSummarySchema, { description: "Post summaries returned by esa." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa post summary listing." },
+);
+
+const commentListSchema = s.object(
+  {
+    comments: s.array(commentSchema, { description: "Comments returned by esa." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa comment listing." },
+);
+
+const teamSchema = s.looseObject(
+  {
+    url: s.url("The team URL."),
+    name: s.string("The team subdomain."),
+    description: s.string("The team description."),
+  },
+  { description: "An esa team available to the authenticated user." },
+);
+
+const teamListSchema = s.object(
+  {
+    teams: s.array(teamSchema, { description: "Teams available to the authenticated user." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa team listing." },
+);
+
+const tagSchema = s.looseObject(
+  {
+    name: s.string("The tag name."),
+    posts_count: s.nonNegativeInteger("Number of posts carrying the tag."),
+  },
+  { description: "An esa tag and its usage count." },
+);
+
+const tagListSchema = s.object(
+  {
+    tags: s.array(tagSchema, { description: "Tags used in the team." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa tag listing." },
+);
+
+const memberSchema = s.looseObject(
+  {
+    id: s.integer("The member's esa user ID."),
+    name: s.string("The member's display name."),
+    screen_name: s.string("The member's esa screen name."),
+    role: s.string("The member's team role."),
+  },
+  { description: "An esa team member." },
+);
+
+const memberListSchema = s.object(
+  {
+    members: s.array(memberSchema, { description: "Team members returned by esa." }),
+    ...paginationFields,
+  },
+  { additionalProperties: true, description: "A paginated esa team-member listing." },
+);
+
+const originalRevisionSchema = s.requiredObject("A post revision used to detect conflicting updates.", {
+  bodyMd: markdown,
+  number: s.positiveInteger("The original revision number."),
+  user: s.nonWhitespaceString("The original revision author's screen name."),
+});
+
+const postInput = (properties: Record<string, JsonSchema>, description: string): JsonSchema =>
+  s.object({ teamName, ...properties }, { description });
+
+export const esaActions: ActionDefinition[] = [
+  readAction(
+    "get_teams",
+    "List esa teams available to the authenticated user.",
+    s.object(
+      {
+        page: optionalPage,
+        perPage: optionalPerPage,
+        role: s.optional(s.stringEnum(["member", "owner"], { description: "Optional membership-role filter." })),
+      },
+      { description: "Team-list input." },
+    ),
+    teamListSchema,
+  ),
+  readAction(
+    "get_team_stats",
+    "Get member, post, comment, star, watch, and activity statistics for an esa team.",
+    postInput({}, "Team-statistics input."),
+    s.unknownObject("Team statistics returned by esa."),
+  ),
+  readAction(
+    "get_team_tags",
+    "List tags used by posts in an esa team with their counts.",
+    postInput({ page: optionalPage, perPage: optionalPerPage }, "Team-tag-list input."),
+    tagListSchema,
+  ),
+  readAction(
+    "get_team_members",
+    "List members of an esa team with their roles and profiles.",
+    postInput(
+      {
+        page: optionalPage,
+        perPage: optionalPerPage,
+        sort: s.optional(s.stringEnum(["posts_count", "joined", "last_accessed"], { description: "Member sort key." })),
+        order: s.optional(s.stringEnum(["asc", "desc"], { description: "Sort direction." })),
+      },
+      "Team-member-list input.",
+    ),
+    memberListSchema,
+  ),
+  readAction(
+    "get_post",
+    "Get one esa post by number. The body is truncated by default to keep agent context bounded.",
+    postInput(
+      {
+        postNumber,
+        truncate: s.optional(
+          s.boolean({
+            default: true,
+            description: "Whether to truncate a long Markdown body. Defaults to true.",
+          }),
+        ),
+      },
+      "Post lookup input.",
+    ),
+    postSchema,
+  ),
+  readAction(
+    "search_posts",
+    "Search posts in an esa team with esa query syntax and pagination.",
+    postInput(
+      {
+        query: s.string("esa search query. An empty string lists posts."),
+        sort: s.optional(
+          s.stringEnum(["updated", "created", "number", "stars", "watches", "comments", "best_match"], {
+            description: "Sort key.",
+          }),
+        ),
+        order: s.optional(s.stringEnum(["asc", "desc"], { description: "Sort direction." })),
+        page: optionalPage,
+        perPage: optionalPerPage,
+      },
+      "Post-search input.",
+    ),
+    postListSchema,
+  ),
+  writeAction(
+    "create_post",
+    "Create a new esa post with optional Markdown body, tags, category, WIP state, and revision message.",
+    postInput(
+      {
+        name: s.nonWhitespaceString("The post title. A category/title value is split when category is omitted."),
+        bodyMd: s.optional(markdown),
+        tags: s.optional(s.stringArray("Tags to assign to the post.", { itemDescription: "One tag." })),
+        category: s.optional(s.string("Category path such as dev/docs.")),
+        wip: s.optional(
+          s.boolean({ default: true, description: "Whether to create the post as WIP. Defaults to true." }),
+        ),
+        message: s.optional(s.string("Optional revision message.")),
+      },
+      "Post-creation input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  writeAction(
+    "update_post",
+    "Update selected fields of an existing esa post. Use append_post or prepend_post to add Markdown without fetching the body.",
+    postInput(
+      {
+        postNumber,
+        name: s.optional(s.string("New post title. A category/title value is split when category is omitted.")),
+        bodyMd: s.optional(markdown),
+        tags: s.optional(s.stringArray("Replacement tag list.", { itemDescription: "One tag." })),
+        category: s.optional(s.string("Replacement category path.")),
+        wip: s.optional(s.boolean("Whether the post remains WIP.")),
+        message: s.optional(s.string("Optional revision message.")),
+        originalRevision: s.optional(originalRevisionSchema),
+      },
+      "Post-update input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  writeAction(
+    "append_post",
+    "Append Markdown content to an esa post without first fetching its current body.",
+    postInput(
+      {
+        postNumber,
+        content: markdown,
+        wip: s.optional(s.boolean("WIP state after the append. Defaults to the current state.")),
+        message: s.optional(s.string("Optional revision message.")),
+      },
+      "Post-append input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  writeAction(
+    "prepend_post",
+    "Prepend Markdown content to an esa post without first fetching its current body.",
+    postInput(
+      {
+        postNumber,
+        content: markdown,
+        wip: s.optional(s.boolean("WIP state after the prepend. Defaults to the current state.")),
+        message: s.optional(s.string("Optional revision message.")),
+      },
+      "Post-prepend input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  readAction(
+    "get_comment",
+    "Get one esa comment by ID, optionally including its stargazers.",
+    postInput(
+      {
+        commentId,
+        include: s.optional(s.literal("stargazers", { description: "Include users who starred the comment." })),
+      },
+      "Comment lookup input.",
+    ),
+    commentSchema,
+  ),
+  writeAction(
+    "create_comment",
+    "Create a Markdown comment on an existing esa post.",
+    postInput(
+      {
+        postNumber,
+        bodyMd: markdown,
+        user: s.optional(s.nonWhitespaceString("Comment author's screen name. Requires owner permission.")),
+      },
+      "Comment-creation input.",
+    ),
+    commentSchema,
+    ["get_post_comments"],
+  ),
+  writeAction(
+    "update_comment",
+    "Update an existing esa comment.",
+    postInput(
+      {
+        commentId,
+        bodyMd: markdown,
+        user: s.optional(s.nonWhitespaceString("Comment author's screen name. Requires owner permission.")),
+      },
+      "Comment-update input.",
+    ),
+    commentSchema,
+    ["get_comment"],
+  ),
+  writeAction(
+    "delete_comment",
+    "Permanently delete an esa comment by ID.",
+    postInput({ commentId }, "Comment-deletion input."),
+    s.requiredObject("Comment deletion result.", {
+      success: s.literal(true, { description: "Whether the comment was deleted." }),
+      message: s.string("Deletion result message."),
+    }),
+  ),
+  readAction(
+    "get_post_backlinks",
+    "List posts that link to a specific esa post.",
+    postInput({ postNumber, page: optionalPage, perPage: optionalPerPage }, "Post-backlink-list input."),
+    postSummaryListSchema,
+  ),
+  readAction(
+    "get_post_comments",
+    "List comments on an esa post with pagination.",
+    postInput({ postNumber, page: optionalPage, perPage: optionalPerPage }, "Post-comment-list input."),
+    commentListSchema,
+  ),
+  readAction(
+    "get_team_comments",
+    "List comments in an esa team with pagination.",
+    postInput({ page: optionalPage, perPage: optionalPerPage }, "Team-comment-list input."),
+    commentListSchema,
+  ),
+  readAction(
+    "get_categories",
+    "Get an esa category, its child categories, and optional posts or parents.",
+    postInput(
+      {
+        select: s.string("Category path to retrieve."),
+        include: s.optional(
+          s.stringEnum(["posts", "parent_categories"], { description: "Additional data to include." }),
+        ),
+        descendantPosts: s.optional(s.boolean("Include descendant posts when include is posts.")),
+        page: optionalPage,
+        perPage: optionalPerPage,
+      },
+      "Category lookup input.",
+    ),
+    categoryListSchema,
+  ),
+  readAction(
+    "get_top_categories",
+    "Get all top-level esa categories for a team.",
+    postInput({}, "Top-category-list input."),
+    categoryListSchema,
+  ),
+  readAction(
+    "get_all_category_paths",
+    "List esa category paths with pagination and optional path filters.",
+    postInput(
+      {
+        page: optionalPage,
+        perPage: optionalPerPage,
+        prefix: s.optional(s.string("Keep paths beginning with this value.")),
+        suffix: s.optional(s.string("Keep paths ending with this value.")),
+        match: s.optional(s.string("Keep paths containing this value.")),
+        exactMatch: s.optional(s.string("Keep only exactly matching paths.")),
+      },
+      "Category-path-list input.",
+    ),
+    s.unknownObject("A paginated esa category-path listing."),
+  ),
+  writeAction(
+    "archive_post",
+    "Archive an esa post by moving it to the Archived category.",
+    postInput(
+      { postNumber, message: s.optional(s.string("Optional archive revision message.")) },
+      "Post-archive input.",
+    ),
+    s.oneOf(
+      [
+        postSchema,
+        s.requiredObject("Result returned when the post is already archived.", {
+          message: s.string("Archive result message."),
+          category: s.string("The existing Archived category path."),
+        }),
+      ],
+      { description: "Archived post result." },
+    ),
+    ["get_post"],
+  ),
+  writeAction(
+    "ship_post",
+    "Mark an esa post as shipped without changing other fields.",
+    postInput({ postNumber }, "Post-shipping input."),
+    postSchema,
+    ["get_post"],
+  ),
+  writeAction(
+    "duplicate_post",
+    "Duplicate an esa post into a new WIP post in the same or another accessible team.",
+    postInput(
+      {
+        postNumber,
+        targetTeamName: s.optional(s.nonWhitespaceString("Destination team subdomain. Defaults to the source team.")),
+      },
+      "Post-duplication input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  writeAction(
+    "rollback_post_revision",
+    "Restore an esa post to a selected revision and create a new revision from it.",
+    postInput(
+      {
+        postNumber,
+        revisionNumber: s.positiveInteger("The revision number to restore."),
+        wip: s.optional(s.boolean("WIP state after rollback. Defaults to the target revision state.")),
+        message: s.optional(s.string("Optional rollback revision message.")),
+      },
+      "Post-revision-rollback input.",
+    ),
+    postSchema,
+    ["get_post"],
+  ),
+  readAction(
+    "get_search_options_help",
+    "Get esa's official search-syntax documentation post.",
+    s.object({}, { description: "Search-help input." }),
+    postSchema,
+  ),
+  readAction(
+    "get_markdown_syntax_help",
+    "Get esa's official Markdown-syntax documentation post.",
+    s.object({}, { description: "Markdown-help input." }),
+    postSchema,
+  ),
+  readAction(
+    "search_help",
+    "Search esa's official documentation team with esa query syntax.",
+    s.object(
+      {
+        query: s.string("esa search query for the official docs team."),
+        page: optionalPage,
+        perPage: optionalPerPage,
+      },
+      { description: "Official-documentation search input." },
+    ),
+    postListSchema,
+  ),
+  readAction(
+    "get_attachment",
+    "Get an esa attachment as a local transit file when possible, otherwise return a short-lived signed URL.",
+    postInput(
+      {
+        url: s.string("An esa attachment URL or an /uploads/... path."),
+        forceSignedUrl: s.optional(
+          s.boolean({ default: false, description: "Return a signed URL without downloading a transit file." }),
+        ),
+      },
+      "Attachment lookup input.",
+    ),
+    s.object(
+      {
+        url: s.url("The signed or public attachment URL."),
+        file: s.optional(
+          s.object(
+            {
+              fileId: s.string("The local transit-file ID."),
+              downloadUrl: s.url("The local transit-file download URL."),
+              sizeBytes: s.nonNegativeInteger("Downloaded file size in bytes."),
+              name: s.string("Downloaded file name."),
+              mimeType: s.string("Downloaded file MIME type."),
+            },
+            { description: "A downloaded attachment in local transit storage." },
+          ),
+        ),
+      },
+      { description: "Attachment result." },
+    ),
+  ),
+  readAction(
+    "list_recent_posts",
+    "List recently updated esa posts. This is the action equivalent of the esa_recent_posts MCP resource.",
+    postInput({ page: optionalPage, perPage: optionalPerPage }, "Recent-posts input."),
+    postListSchema,
+  ),
+  readAction(
+    "get_post_summary_prompt",
+    "Build the summary prompt for an esa post. The caller supplies the returned prompt to its model.",
+    postInput({ postNumber }, "Post-summary-prompt input."),
+    s.requiredObject("Post-summary prompt result.", {
+      prompt: s.string("A complete prompt containing post metadata and Markdown body."),
+    }),
+  ),
+];
+
+function readAction(
+  name: string,
+  description: string,
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+  followUpActions?: string[],
+): ActionDefinition {
+  return defineProviderAction(service, {
+    name,
+    description,
+    requiredScopes: esaReadScopes,
+    inputSchema,
+    outputSchema,
+    followUpActions,
+  });
+}
+
+function writeAction(
+  name: string,
+  description: string,
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+  followUpActions?: string[],
+): ActionDefinition {
+  return defineProviderAction(service, {
+    name,
+    description,
+    requiredScopes: esaWriteScopes,
+    inputSchema,
+    outputSchema,
+    followUpActions,
+  });
+}

--- a/src/providers/esa/actions.ts
+++ b/src/providers/esa/actions.ts
@@ -552,19 +552,23 @@ export const esaActions: ActionDefinition[] = [
   ),
   readAction(
     "get_attachment",
-    "Get an esa attachment as a local transit file when possible, otherwise return a short-lived signed URL.",
+    "Get an esa attachment as a local transit file when possible, otherwise return its downloadable URL.",
     postInput(
       {
-        url: s.string("An esa attachment URL or an /uploads/... path."),
+        url: s.string("A public HTTPS esa attachment URL or an /uploads/... path."),
         forceSignedUrl: s.optional(
-          s.boolean({ default: false, description: "Return a signed URL without downloading a transit file." }),
+          s.boolean({
+            default: false,
+            description:
+              "Skip the transit download and return the resolved URL. Secure esa attachments use a signed URL.",
+          }),
         ),
       },
       "Attachment lookup input.",
     ),
     s.object(
       {
-        url: s.url("The signed or public attachment URL."),
+        url: s.url("The resolved signed or public attachment URL."),
         file: s.optional(
           s.object(
             {

--- a/src/providers/esa/definition.test.ts
+++ b/src/providers/esa/definition.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+describe("esa provider definition", () => {
+  it("declares the documented OAuth authorization-code flow", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth).toMatchObject({
+      authorizationUrl: "https://api.esa.io/oauth/authorize",
+      tokenUrl: "https://api.esa.io/oauth/token",
+      tokenEndpointAuthMethod: "client_secret_post",
+      tokenRequestFormat: "json",
+      scopes: ["read", "write"],
+    });
+  });
+
+  it("offers a personal access token alongside OAuth", () => {
+    expect(provider.authTypes).toEqual(["oauth2", "api_key"]);
+    expect(provider.auth.find((auth) => auth.type === "api_key")).toMatchObject({
+      label: "Personal access token",
+      placeholder: "ep2_...",
+    });
+  });
+});

--- a/src/providers/esa/definition.ts
+++ b/src/providers/esa/definition.ts
@@ -1,0 +1,39 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { esaActions } from "./actions.ts";
+import { esaOAuthScopes } from "./scopes.ts";
+
+const service = "esa";
+
+/**
+ * esa provider backed by the public esa API v1.
+ *
+ * Open-source users can connect with either a personal access token or their
+ * own esa OAuth app configured with the local runtime callback URL.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "esa",
+  description: "Search, read, and manage esa team knowledge through the public esa API.",
+  categories: ["Productivity", "Developer Tools"],
+  authTypes: ["oauth2", "api_key"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://api.esa.io/oauth/authorize",
+      tokenUrl: "https://api.esa.io/oauth/token",
+      scopes: esaOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      tokenRequestFormat: "json",
+    },
+    {
+      type: "api_key",
+      label: "Personal access token",
+      placeholder: "ep2_...",
+      description:
+        "esa PAT v2 used with the Authorization Bearer header. Connection validation requires read:user; actions require their corresponding PAT v2 resource scopes. To restrict accessible teams, configure the token and API access policy in esa.",
+    },
+  ],
+  homepageUrl: "https://esa.io",
+  actions: esaActions,
+};

--- a/src/providers/esa/executors.test.ts
+++ b/src/providers/esa/executors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("esa credentials", () => {
+  it("validates a personal access token through the esa user endpoint", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "esa-pat", values: {} },
+      {
+        fetcher: async (url, init) => {
+          expect(new URL(url.toString()).pathname).toBe("/v1/user");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer esa-pat");
+          return Response.json({ id: 7, name: "Alice", screen_name: "alice" });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "alice", displayName: "Alice" },
+      metadata: { currentUser: { id: 7, screen_name: "alice" } },
+    });
+  });
+
+  it("validates an OAuth access token through the esa user endpoint", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "esa-oauth",
+        tokenType: "Bearer",
+        profile: { accountId: "alice", displayName: "Alice", grantedScopes: [] },
+        metadata: {},
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(new URL(url.toString()).pathname).toBe("/v1/user");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer esa-oauth");
+          return Response.json({ id: 7, name: "Alice", screen_name: "alice" });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "alice", displayName: "Alice" },
+      metadata: { currentUser: { id: 7, screen_name: "alice" } },
+    });
+  });
+});

--- a/src/providers/esa/executors.ts
+++ b/src/providers/esa/executors.ts
@@ -1,0 +1,35 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+
+import { optionalInteger, optionalString } from "../../core/cast.ts";
+import { defineBearerProviderExecutors } from "../provider-runtime.ts";
+import { esaActionHandlers, requestEsaJson } from "./runtime.ts";
+
+const service = "esa";
+
+export const executors: ProviderExecutors = defineBearerProviderExecutors(service, esaActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher }) {
+    return validateEsaToken(input.apiKey, fetcher);
+  },
+  async oauth2(input, { fetcher }) {
+    return validateEsaToken(input.accessToken, fetcher);
+  },
+};
+
+async function validateEsaToken(accessToken: string, fetcher: typeof fetch) {
+  const user = await requestEsaJson<Record<string, unknown>>({ accessToken, fetcher }, { path: "/v1/user" });
+  const id = optionalInteger(user.id);
+  const screenName = optionalString(user.screen_name);
+  const name = optionalString(user.name);
+
+  return {
+    profile: {
+      accountId: screenName ?? (id === undefined ? "esa:user" : String(id)),
+      displayName: name ?? screenName ?? (id === undefined ? "esa user" : String(id)),
+    },
+    metadata: {
+      currentUser: user,
+    },
+  };
+}

--- a/src/providers/esa/runtime.test.ts
+++ b/src/providers/esa/runtime.test.ts
@@ -311,6 +311,16 @@ describe("esa provider actions", () => {
       category: "Archived/dev/docs",
     });
   });
+  it("does not create a revision when the post is in the top-level Archived category", async () => {
+    const { output, requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [
+      { category: "Archived" },
+    ]);
+    expect(requests).toHaveLength(1);
+    expect(output).toEqual({
+      message: "Post is already archived",
+      category: "Archived",
+    });
+  });
 
   it("duplicates through the source-post draft endpoint and creates a WIP destination post", async () => {
     const { requests } = await execute(
@@ -385,6 +395,27 @@ describe("esa provider actions", () => {
     expect(output).toMatchObject({
       body_md: `${"a".repeat(10_000)}\n\n... (truncated)`,
       body_md_stats: { characters: 10_001, lines: 1 },
+    });
+  });
+  it("truncates long post bodies at grapheme boundaries", async () => {
+    const body = `${"a".repeat(9_999)}👨‍👩‍👧‍👦b`;
+    const { output } = await execute("get_post", { teamName: "team", postNumber: 42 }, [{ body_md: body }]);
+    expect(output).toMatchObject({
+      body_md: `${"a".repeat(9_999)}👨‍👩‍👧‍👦\n\n... (truncated)`,
+      body_md_stats: { characters: 10_001, lines: 1 },
+    });
+  });
+
+  it("rejects inherited object property names as attachment hosts", async () => {
+    await expect(
+      execute(
+        "get_attachment",
+        { teamName: "team", url: "https://constructor/uploads/a.png", forceSignedUrl: true },
+        [],
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "url must use img.esa.io, files.esa.io, dl.esa.io, or an /uploads/... path",
     });
   });
 });

--- a/src/providers/esa/runtime.test.ts
+++ b/src/providers/esa/runtime.test.ts
@@ -1,10 +1,12 @@
+import type { TransitFileStore } from "../../core/types.ts";
 import type { BearerProviderContext } from "../provider-runtime.ts";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { esaActions } from "./actions.ts";
 import { esaActionHandlers } from "./runtime.ts";
 
-type RouteCase = {
+interface RouteCase {
   name: keyof typeof esaActionHandlers;
   input: Record<string, unknown>;
   path: string;
@@ -12,9 +14,17 @@ type RouteCase = {
   query?: Record<string, string>;
   body?: unknown;
   response?: unknown;
-};
+}
 
-type CapturedRequest = { url: URL; init: RequestInit | undefined };
+interface CapturedRequest {
+  url: URL;
+  init: RequestInit | undefined;
+}
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
 
 const expectedActionNames = [
   "get_teams",
@@ -300,27 +310,15 @@ describe("esa provider actions", () => {
       post: { category: "Archived/dev/docs", message: "Archive post" },
     });
   });
-  it("does not create a revision when the post is already archived", async () => {
-    const { output, requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [
-      { category: "Archived/dev/docs" },
-    ]);
+  it.each(["Archived", "Archived/dev/docs"])(
+    "does not create a revision when the post is already archived as %s",
+    async (category) => {
+      const { output, requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [{ category }]);
 
-    expect(requests).toHaveLength(1);
-    expect(output).toEqual({
-      message: "Post is already archived",
-      category: "Archived/dev/docs",
-    });
-  });
-  it("does not create a revision when the post is in the top-level Archived category", async () => {
-    const { output, requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [
-      { category: "Archived" },
-    ]);
-    expect(requests).toHaveLength(1);
-    expect(output).toEqual({
-      message: "Post is already archived",
-      category: "Archived",
-    });
-  });
+      expect(requests).toHaveLength(1);
+      expect(output).toEqual({ message: "Post is already archived", category });
+    },
+  );
 
   it("duplicates through the source-post draft endpoint and creates a WIP destination post", async () => {
     const { requests } = await execute(
@@ -339,44 +337,39 @@ describe("esa provider actions", () => {
   });
 
   it("downloads a bounded supported image into transit storage", async () => {
-    const requests: CapturedRequest[] = [];
+    const downloadRequests = stubAttachmentDownload(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png", "content-length": "3" },
+      }),
+    );
+    const create = vi.fn(async (file: File) => {
+      expect(file.name).toBe("image.png");
+      expect(file.type).toBe("image/png");
+      return {
+        fileId: "file-1",
+        downloadUrl: "http://localhost/files/file-1",
+        sizeBytes: 3,
+        name: file.name,
+        mimeType: file.type,
+      };
+    });
+    const apiRequests: CapturedRequest[] = [];
     const output = await esaActionHandlers.get_attachment(
       { teamName: "team", url: "/uploads/image.png" },
       {
         accessToken: "esa-token",
         fetcher: async (input, init) => {
           const url = new URL(input instanceof Request ? input.url : input.toString());
-          requests.push({ url, init });
-          if (url.pathname.endsWith("/signed_urls")) {
-            return Response.json({ signed_urls: [["/uploads/image.png", "https://files.esa.io/signed/image.png"]] });
-          }
-          return new Response(new Uint8Array([1, 2, 3]), {
-            headers: { "content-type": "image/png", "content-length": "3" },
-          });
+          apiRequests.push({ url, init });
+          return Response.json({ signed_urls: [["/uploads/image.png", "https://files.esa.io/signed/image.png"]] });
         },
-        transitFiles: {
-          maxBytes: 10,
-          async create(file) {
-            expect(file.name).toBe("image.png");
-            expect(file.type).toBe("image/png");
-            return {
-              fileId: "file-1",
-              downloadUrl: "http://localhost/files/file-1",
-              sizeBytes: 3,
-              name: file.name,
-              mimeType: file.type,
-            };
-          },
-          async read() {
-            throw new Error("read is not expected in this test");
-          },
-          async delete() {
-            return false;
-          },
-        },
+        transitFiles: createTransitFileStore(10, create),
       },
     );
-    expect(requests).toHaveLength(2);
+    expect(apiRequests).toHaveLength(1);
+    expect(downloadRequests).toHaveLength(1);
+    expect(downloadRequests[0]?.url.toString()).toBe("https://files.esa.io/signed/image.png");
+    expect(create).toHaveBeenCalledOnce();
     expect(output).toEqual({
       url: "https://files.esa.io/signed/image.png",
       file: {
@@ -389,36 +382,197 @@ describe("esa provider actions", () => {
     });
   });
 
-  it("truncates long post bodies while retaining full-body statistics", async () => {
-    const body = "a".repeat(10_001);
-    const { output } = await execute("get_post", { teamName: "team", postNumber: 42 }, [{ body_md: body }]);
-    expect(output).toMatchObject({
-      body_md: `${"a".repeat(10_000)}\n\n... (truncated)`,
-      body_md_stats: { characters: 10_001, lines: 1 },
-    });
-  });
-  it("truncates long post bodies at grapheme boundaries", async () => {
-    const body = `${"a".repeat(9_999)}👨‍👩‍👧‍👦b`;
-    const { output } = await execute("get_post", { teamName: "team", postNumber: 42 }, [{ body_md: body }]);
-    expect(output).toMatchObject({
-      body_md: `${"a".repeat(9_999)}👨‍👩‍👧‍👦\n\n... (truncated)`,
-      body_md_stats: { characters: 10_001, lines: 1 },
-    });
+  it.each([
+    ["https://img.esa.io/uploads/document.pdf", "application/pdf", "3"],
+    ["https://img.esa.io/uploads/constructor", "constructor", "3"],
+    ["https://custom-bucket.example/uploads/image.png", "image/png", "11"],
+  ])("returns only the URL for an unsupported or oversized attachment at %s", async (url, mimeType, contentLength) => {
+    const downloadRequests = stubAttachmentDownload(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": mimeType, "content-length": contentLength },
+      }),
+    );
+    const create = vi.fn<TransitFileStore["create"]>();
+
+    const output = await esaActionHandlers.get_attachment(
+      { teamName: "team", url },
+      {
+        accessToken: "esa-token",
+        fetcher: async () => {
+          throw new Error("esa API fetch was not expected");
+        },
+        transitFiles: createTransitFileStore(10, create),
+      },
+    );
+
+    expect(output).toEqual({ url });
+    expect(downloadRequests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
   });
 
-  it("rejects inherited object property names as attachment hosts", async () => {
+  it("bounds an attachment response when content-length is missing", async () => {
+    stubAttachmentDownload(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const create = vi.fn<TransitFileStore["create"]>();
+
     await expect(
-      execute(
-        "get_attachment",
-        { teamName: "team", url: "https://constructor/uploads/a.png", forceSignedUrl: true },
-        [],
+      esaActionHandlers.get_attachment(
+        { teamName: "team", url: "https://img.esa.io/uploads/image.png" },
+        {
+          accessToken: "esa-token",
+          fetcher: async () => {
+            throw new Error("esa API fetch was not expected");
+          },
+          transitFiles: createTransitFileStore(2, create),
+        },
       ),
-    ).rejects.toMatchObject({
-      status: 400,
-      message: "url must use img.esa.io, files.esa.io, dl.esa.io, or an /uploads/... path",
+    ).rejects.toMatchObject({ status: 413 });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("blocks an attachment redirect to a private target", async () => {
+    const downloadRequests = stubAttachmentDownload(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/private.png" },
+      }),
+    );
+
+    await expect(
+      esaActionHandlers.get_attachment(
+        { teamName: "team", url: "https://img.esa.io/uploads/image.png" },
+        {
+          accessToken: "esa-token",
+          fetcher: async () => {
+            throw new Error("esa API fetch was not expected");
+          },
+          transitFiles: createTransitFileStore(10, vi.fn<TransitFileStore["create"]>()),
+        },
+      ),
+    ).rejects.toThrow("redirect location must not target private or reserved IP addresses");
+    expect(downloadRequests).toHaveLength(1);
+  });
+
+  it.each(["files.esa.io", "dl.esa.io"])(
+    "signs a full secure attachment URL from %s using only its pathname",
+    async (hostname) => {
+      const path = "/uploads/example/image.png";
+      const signedUrl = "https://cdn.example.com/signed/image.png";
+      const { output, requests } = await execute(
+        "get_attachment",
+        {
+          teamName: "team",
+          url: `https://${hostname}${path}?stale=token#fragment`,
+          forceSignedUrl: true,
+        },
+        [{ signed_urls: [[path, signedUrl]] }],
+      );
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url.pathname).toBe("/v1/teams/team/signed_urls");
+      expect(Object.fromEntries(requests[0]!.url.searchParams)).toEqual({
+        urls: path,
+        v: "2",
+        expires_in: "300",
+      });
+      expect(output).toEqual({ url: signedUrl });
+    },
+  );
+
+  it("skips the transit download when forceSignedUrl is true", async () => {
+    const downloadRequests = stubAttachmentDownload(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png", "content-length": "3" },
+      }),
+    );
+    const create = vi.fn<TransitFileStore["create"]>();
+    const signedUrl = "https://cdn.example.com/signed/image.png";
+
+    const output = await esaActionHandlers.get_attachment(
+      { teamName: "team", url: "/uploads/image.png", forceSignedUrl: true },
+      {
+        accessToken: "esa-token",
+        fetcher: async () => Response.json({ signed_urls: [["/uploads/image.png", signedUrl]] }),
+        transitFiles: createTransitFileStore(10, create),
+      },
+    );
+
+    expect(output).toEqual({ url: signedUrl });
+    expect(downloadRequests).toHaveLength(0);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["/not-an-upload/image.png", "url path must start with /uploads/"],
+    ["//example.com/image.png", "url path must start with /uploads/"],
+    ["http://img.esa.io/uploads/image.png", "url must use HTTPS"],
+    ["https://127.0.0.1/image.png", "url must not target private or reserved IP addresses"],
+    ["https://metadata.google.internal/image.png", "url must not target cloud metadata hosts"],
+  ])("rejects unsafe or unsupported attachment URL %s", async (url, message) => {
+    await expect(
+      esaActionHandlers.get_attachment(
+        { teamName: "team", url, forceSignedUrl: true },
+        {
+          accessToken: "esa-token",
+          fetcher: async () => {
+            throw new Error("fetch was not expected");
+          },
+        },
+      ),
+    ).rejects.toThrow(message);
+  });
+
+  it("treats a non-esa hostname inherited from Object.prototype as a public URL, not a secure esa host", async () => {
+    const url = "https://constructor/uploads/image.png";
+    const output = await esaActionHandlers.get_attachment(
+      { teamName: "team", url, forceSignedUrl: true },
+      {
+        accessToken: "esa-token",
+        fetcher: async () => {
+          throw new Error("esa signing API was not expected");
+        },
+      },
+    );
+
+    expect(output).toEqual({ url });
+  });
+
+  it("truncates at a grapheme boundary while retaining full-body statistics", async () => {
+    const familyEmoji = "👨‍👩‍👧‍👦";
+    const body = `${"a".repeat(9_999)}${familyEmoji}tail`;
+    const { output } = await execute("get_post", { teamName: "team", postNumber: 42 }, [{ body_md: body }]);
+    expect(output).toMatchObject({
+      body_md: `${"a".repeat(9_999)}\n\n... (truncated)`,
+      body_md_stats: { characters: 10_004, lines: 1 },
     });
   });
 });
+
+function stubAttachmentDownload(response: Response): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({ url: new URL(input instanceof Request ? input.url : input.toString()), init });
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number, create: TransitFileStore["create"]): TransitFileStore {
+  return {
+    maxBytes,
+    create,
+    async read() {
+      throw new Error("read is not expected in this test");
+    },
+    async delete() {
+      return false;
+    },
+  };
+}
 
 async function execute(
   name: keyof typeof esaActionHandlers,

--- a/src/providers/esa/runtime.test.ts
+++ b/src/providers/esa/runtime.test.ts
@@ -1,0 +1,412 @@
+import type { BearerProviderContext } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { esaActions } from "./actions.ts";
+import { esaActionHandlers } from "./runtime.ts";
+
+type RouteCase = {
+  name: keyof typeof esaActionHandlers;
+  input: Record<string, unknown>;
+  path: string;
+  method?: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  response?: unknown;
+};
+
+type CapturedRequest = { url: URL; init: RequestInit | undefined };
+
+const expectedActionNames = [
+  "get_teams",
+  "get_team_stats",
+  "get_team_tags",
+  "get_team_members",
+  "get_post",
+  "search_posts",
+  "create_post",
+  "update_post",
+  "append_post",
+  "prepend_post",
+  "get_comment",
+  "create_comment",
+  "update_comment",
+  "delete_comment",
+  "get_post_backlinks",
+  "get_post_comments",
+  "get_team_comments",
+  "get_categories",
+  "get_top_categories",
+  "get_all_category_paths",
+  "archive_post",
+  "ship_post",
+  "duplicate_post",
+  "rollback_post_revision",
+  "get_search_options_help",
+  "get_markdown_syntax_help",
+  "search_help",
+  "get_attachment",
+  "list_recent_posts",
+  "get_post_summary_prompt",
+];
+
+const routeCases: RouteCase[] = [
+  {
+    name: "get_teams",
+    input: { page: 2, perPage: 10, role: "owner" },
+    path: "/v1/teams",
+    query: { page: "2", per_page: "10", role: "owner" },
+    response: { teams: [] },
+  },
+  {
+    name: "get_team_stats",
+    input: { teamName: "team.esa.io" },
+    path: "/v1/teams/team/stats",
+  },
+  {
+    name: "get_team_tags",
+    input: { teamName: "team", page: 2, perPage: 10 },
+    path: "/v1/teams/team/tags",
+    query: { page: "2", per_page: "10" },
+  },
+  {
+    name: "get_team_members",
+    input: { teamName: "team", sort: "joined", order: "asc" },
+    path: "/v1/teams/team/members",
+    query: { sort: "joined", order: "asc" },
+  },
+  {
+    name: "get_post",
+    input: { teamName: "team", postNumber: 42, truncate: false },
+    path: "/v1/teams/team/posts/42",
+    response: { body_md: "full body" },
+  },
+  {
+    name: "search_posts",
+    input: { teamName: "team", query: "category:dev", sort: "updated", order: "desc", page: 2, perPage: 100 },
+    path: "/v1/teams/team/posts",
+    query: { q: "category:dev", sort: "updated", order: "desc", page: "2", per_page: "100" },
+    response: { posts: [] },
+  },
+  {
+    name: "create_post",
+    input: { teamName: "team", name: "dev/docs/Title", bodyMd: "body", tags: ["tag"], wip: false, message: "create" },
+    path: "/v1/teams/team/posts",
+    method: "POST",
+    body: {
+      post: { name: "Title", body_md: "body", tags: ["tag"], category: "dev/docs", wip: false, message: "create" },
+    },
+  },
+  {
+    name: "update_post",
+    input: {
+      teamName: "team",
+      postNumber: 42,
+      name: "New title",
+      bodyMd: "new body",
+      category: "dev/docs",
+      tags: ["tag"],
+      wip: true,
+      message: "update",
+      originalRevision: { bodyMd: "old body", number: 3, user: "alice" },
+    },
+    path: "/v1/teams/team/posts/42",
+    method: "PATCH",
+    body: {
+      post: {
+        name: "New title",
+        body_md: "new body",
+        tags: ["tag"],
+        category: "dev/docs",
+        wip: true,
+        message: "update",
+        original_revision: { body_md: "old body", number: 3, user: "alice" },
+      },
+    },
+  },
+  {
+    name: "append_post",
+    input: { teamName: "team", postNumber: 42, content: "append", wip: false, message: "append message" },
+    path: "/v1/teams/team/posts/42/append",
+    method: "POST",
+    body: { post: { content: "append", wip: false, message: "append message" } },
+  },
+  {
+    name: "prepend_post",
+    input: { teamName: "team", postNumber: 42, content: "prepend" },
+    path: "/v1/teams/team/posts/42/prepend",
+    method: "POST",
+    body: { post: { content: "prepend" } },
+  },
+  {
+    name: "get_comment",
+    input: { teamName: "team", commentId: 7, include: "stargazers" },
+    path: "/v1/teams/team/comments/7",
+    query: { include: "stargazers" },
+  },
+  {
+    name: "create_comment",
+    input: { teamName: "team", postNumber: 42, bodyMd: "comment", user: "alice" },
+    path: "/v1/teams/team/posts/42/comments",
+    method: "POST",
+    body: { comment: { body_md: "comment", user: "alice" } },
+  },
+  {
+    name: "update_comment",
+    input: { teamName: "team", commentId: 7, bodyMd: "comment", user: "alice" },
+    path: "/v1/teams/team/comments/7",
+    method: "PATCH",
+    body: { comment: { body_md: "comment", user: "alice" } },
+  },
+  {
+    name: "delete_comment",
+    input: { teamName: "team", commentId: 7 },
+    path: "/v1/teams/team/comments/7",
+    method: "DELETE",
+    response: null,
+  },
+  {
+    name: "get_post_backlinks",
+    input: { teamName: "team", postNumber: 42, page: 2, perPage: 10 },
+    path: "/v1/teams/team/posts/42/backlinks",
+    query: { page: "2", per_page: "10" },
+    response: { posts: [] },
+  },
+  {
+    name: "get_post_comments",
+    input: { teamName: "team", postNumber: 42 },
+    path: "/v1/teams/team/posts/42/comments",
+    response: { comments: [] },
+  },
+  {
+    name: "get_team_comments",
+    input: { teamName: "team", page: 3 },
+    path: "/v1/teams/team/comments",
+    query: { page: "3" },
+    response: { comments: [] },
+  },
+  {
+    name: "get_categories",
+    input: { teamName: "team", select: "dev", include: "posts", descendantPosts: true, perPage: 10 },
+    path: "/v1/teams/team/categories",
+    query: { select: "dev", include: "posts", descendant_posts: "true", per_page: "10" },
+    response: { categories: [], parent_categories: [] },
+  },
+  {
+    name: "get_top_categories",
+    input: { teamName: "team" },
+    path: "/v1/teams/team/categories/top",
+    response: { categories: [], parent_categories: [] },
+  },
+  {
+    name: "get_all_category_paths",
+    input: { teamName: "team", page: 2, prefix: "dev", suffix: "api", match: "doc", exactMatch: "dev/docs" },
+    path: "/v1/teams/team/categories/paths",
+    query: { v: "2", page: "2", prefix: "dev", suffix: "api", match: "doc", exact_match: "dev/docs" },
+  },
+  {
+    name: "ship_post",
+    input: { teamName: "team", postNumber: 42 },
+    path: "/v1/teams/team/posts/42",
+    method: "PATCH",
+    body: { post: { wip: false, message: "Ship It!" } },
+  },
+  {
+    name: "rollback_post_revision",
+    input: { teamName: "team", postNumber: 42, revisionNumber: 3, wip: false, message: "rollback" },
+    path: "/v1/teams/team/posts/42/revisions/3/rollback",
+    method: "POST",
+    body: { post: { wip: false, message: "rollback" } },
+  },
+  {
+    name: "get_search_options_help",
+    input: {},
+    path: "/v1/teams/docs/posts/104",
+    response: { body_md: "help" },
+  },
+  {
+    name: "get_markdown_syntax_help",
+    input: {},
+    path: "/v1/teams/docs/posts/49",
+    response: { body_md: "help" },
+  },
+  {
+    name: "search_help",
+    input: { query: "Markdown", page: 2, perPage: 10 },
+    path: "/v1/teams/docs/posts",
+    query: { q: "Markdown", sort: "best_match", page: "2", per_page: "10" },
+    response: { posts: [] },
+  },
+  {
+    name: "get_attachment",
+    input: { teamName: "team", url: "/uploads/image.png", forceSignedUrl: true },
+    path: "/v1/teams/team/signed_urls",
+    query: { urls: "/uploads/image.png", v: "2", expires_in: "300" },
+    response: { signed_urls: [["/uploads/image.png", "https://files.esa.io/signed/image.png"]] },
+  },
+  {
+    name: "list_recent_posts",
+    input: { teamName: "team", perPage: 20 },
+    path: "/v1/teams/team/posts",
+    query: { sort: "updated", order: "desc", per_page: "20" },
+    response: { posts: [] },
+  },
+  {
+    name: "get_post_summary_prompt",
+    input: { teamName: "team", postNumber: 42 },
+    path: "/v1/teams/team/posts/42",
+    response: {
+      name: "Title",
+      url: "https://team.esa.io/posts/42",
+      created_by: { name: "Alice" },
+      created_at: "2026-01-01",
+      updated_at: "2026-01-02",
+      body_md: "body",
+    },
+  },
+];
+
+describe("esa provider actions", () => {
+  it("keeps all esa-mcp tools and action equivalents locally executable", () => {
+    expect(esaActions.map((action) => action.name)).toEqual(expectedActionNames);
+    expect(Object.keys(esaActionHandlers)).toEqual(expectedActionNames);
+  });
+
+  for (const routeCase of routeCases) {
+    it(`maps ${routeCase.name} to the documented esa API request`, async () => {
+      const { requests } = await execute(routeCase.name, routeCase.input, [routeCase.response ?? {}]);
+      expect(requests).toHaveLength(1);
+      const [request] = requests;
+      expect(request.url.pathname).toBe(routeCase.path);
+      expect(Object.fromEntries(request.url.searchParams)).toEqual(routeCase.query ?? {});
+      expect(request.init?.method ?? "GET").toBe(routeCase.method ?? "GET");
+      expect(new Headers(request.init?.headers).get("authorization")).toBe("Bearer esa-token");
+      expect(request.init?.body === undefined ? undefined : JSON.parse(String(request.init.body))).toEqual(
+        routeCase.body,
+      );
+    });
+  }
+
+  it("archives by reading the current category before updating the post", async () => {
+    const { requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [
+      { category: "dev/docs" },
+      {},
+    ]);
+    expect(requests.map((request) => request.url.pathname)).toEqual([
+      "/v1/teams/team/posts/42",
+      "/v1/teams/team/posts/42",
+    ]);
+    expect(requests[1]?.init?.method).toBe("PATCH");
+    expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
+      post: { category: "Archived/dev/docs", message: "Archive post" },
+    });
+  });
+  it("does not create a revision when the post is already archived", async () => {
+    const { output, requests } = await execute("archive_post", { teamName: "team", postNumber: 42 }, [
+      { category: "Archived/dev/docs" },
+    ]);
+
+    expect(requests).toHaveLength(1);
+    expect(output).toEqual({
+      message: "Post is already archived",
+      category: "Archived/dev/docs",
+    });
+  });
+
+  it("duplicates through the source-post draft endpoint and creates a WIP destination post", async () => {
+    const { requests } = await execute(
+      "duplicate_post",
+      { teamName: "source", postNumber: 42, targetTeamName: "target.esa.io" },
+      [{ post: { name: "Source", body_md: "body" } }, {}],
+    );
+    expect(requests.map((request) => request.url.pathname)).toEqual([
+      "/v1/teams/source/posts/new",
+      "/v1/teams/target/posts",
+    ]);
+    expect(Object.fromEntries(requests[0]!.url.searchParams)).toEqual({ parent_post_id: "42" });
+    expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
+      post: { name: "Source", body_md: "body", wip: true },
+    });
+  });
+
+  it("downloads a bounded supported image into transit storage", async () => {
+    const requests: CapturedRequest[] = [];
+    const output = await esaActionHandlers.get_attachment(
+      { teamName: "team", url: "/uploads/image.png" },
+      {
+        accessToken: "esa-token",
+        fetcher: async (input, init) => {
+          const url = new URL(input instanceof Request ? input.url : input.toString());
+          requests.push({ url, init });
+          if (url.pathname.endsWith("/signed_urls")) {
+            return Response.json({ signed_urls: [["/uploads/image.png", "https://files.esa.io/signed/image.png"]] });
+          }
+          return new Response(new Uint8Array([1, 2, 3]), {
+            headers: { "content-type": "image/png", "content-length": "3" },
+          });
+        },
+        transitFiles: {
+          maxBytes: 10,
+          async create(file) {
+            expect(file.name).toBe("image.png");
+            expect(file.type).toBe("image/png");
+            return {
+              fileId: "file-1",
+              downloadUrl: "http://localhost/files/file-1",
+              sizeBytes: 3,
+              name: file.name,
+              mimeType: file.type,
+            };
+          },
+          async read() {
+            throw new Error("read is not expected in this test");
+          },
+          async delete() {
+            return false;
+          },
+        },
+      },
+    );
+    expect(requests).toHaveLength(2);
+    expect(output).toEqual({
+      url: "https://files.esa.io/signed/image.png",
+      file: {
+        fileId: "file-1",
+        downloadUrl: "http://localhost/files/file-1",
+        sizeBytes: 3,
+        name: "image.png",
+        mimeType: "image/png",
+      },
+    });
+  });
+
+  it("truncates long post bodies while retaining full-body statistics", async () => {
+    const body = "a".repeat(10_001);
+    const { output } = await execute("get_post", { teamName: "team", postNumber: 42 }, [{ body_md: body }]);
+    expect(output).toMatchObject({
+      body_md: `${"a".repeat(10_000)}\n\n... (truncated)`,
+      body_md_stats: { characters: 10_001, lines: 1 },
+    });
+  });
+});
+
+async function execute(
+  name: keyof typeof esaActionHandlers,
+  input: Record<string, unknown>,
+  responses: unknown[],
+): Promise<{ output: unknown; requests: CapturedRequest[] }> {
+  const requests: CapturedRequest[] = [];
+  const context: BearerProviderContext = {
+    accessToken: "esa-token",
+    fetcher: async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      requests.push({ url, init });
+      const response = responses.shift();
+      if (response === undefined) {
+        throw new Error(`Unexpected request to ${url}`);
+      }
+      return Response.json(response);
+    },
+  };
+  const output = await esaActionHandlers[name](input, context);
+  return { output, requests };
+}

--- a/src/providers/esa/runtime.ts
+++ b/src/providers/esa/runtime.ts
@@ -20,17 +20,9 @@ const fullPostBodyLimit = 10_000;
 const listPostBodyLimit = 500;
 const commentBodyLimit = 300;
 const maxAttachmentImageBytes = 30 * 1024 * 1024;
-const imageMimeTypes: Record<string, true> = {
-  "image/jpeg": true,
-  "image/png": true,
-  "image/gif": true,
-  "image/webp": true,
-};
-const signedAttachmentHosts: Record<string, true> = {
-  "files.esa.io": true,
-  "dl.esa.io": true,
-};
-const publicAttachmentHosts: Record<string, true> = { "img.esa.io": true };
+const imageMimeTypes = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+const signedAttachmentHosts = new Set(["files.esa.io", "dl.esa.io"]);
+const publicAttachmentHosts = new Set(["img.esa.io"]);
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 type EsaActionContext = BearerProviderContext;
@@ -343,7 +335,7 @@ async function archivePost(input: Record<string, unknown>, context: EsaActionCon
   const postNumber = readPositiveInteger(input, "postNumber");
   const post = await getRawPost(context, teamName, postNumber);
   const category = optionalRawString(post.category) ?? "";
-  if (category.startsWith("Archived/")) {
+  if (category === "Archived" || category.startsWith("Archived/")) {
     return { message: "Post is already archived", category };
   }
 
@@ -643,10 +635,24 @@ function transformBody(bodyMd: string | undefined, options: BodyOptions): string
   if (options.omitBody || bodyMd === undefined) {
     return undefined;
   }
-  if (options.truncateBody !== undefined && bodyMd.length > options.truncateBody) {
-    return `${bodyMd.slice(0, options.truncateBody)}\n\n... (truncated)`;
+  const truncatedBody = truncateGraphemes(bodyMd, options.truncateBody);
+  if (truncatedBody !== undefined) {
+    return `${truncatedBody}\n\n... (truncated)`;
   }
   return bodyMd;
+}
+function truncateGraphemes(value: string, limit: number | undefined): string | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  let count = 0;
+  for (const segment of graphemeSegmenter.segment(value)) {
+    if (count === limit) {
+      return value.slice(0, segment.index);
+    }
+    count++;
+  }
+  return undefined;
 }
 
 function measureBody(bodyMd: string | undefined): EsaJson | undefined {
@@ -870,10 +876,10 @@ function readAttachmentInput(
   if (url.protocol !== "https:") {
     throw invalidInput("url must use HTTPS");
   }
-  if (signedAttachmentHosts[url.hostname]) {
+  if (signedAttachmentHosts.has(url.hostname)) {
     return { needsSigning: true, path: url.pathname };
   }
-  if (publicAttachmentHosts[url.hostname]) {
+  if (publicAttachmentHosts.has(url.hostname)) {
     return { needsSigning: false, url: url.toString() };
   }
   throw invalidInput("url must use img.esa.io, files.esa.io, dl.esa.io, or an /uploads/... path");
@@ -923,7 +929,7 @@ async function downloadAttachmentImage(context: EsaActionContext, url: string) {
   const mimeType = (response.headers.get("content-type") ?? "").split(";", 1)[0]!.trim().toLowerCase();
   const contentLength = Number(response.headers.get("content-length"));
   const maxBytes = Math.min(maxAttachmentImageBytes, transitFiles.maxBytes);
-  if (!imageMimeTypes[mimeType] || (Number.isFinite(contentLength) && contentLength > maxBytes)) {
+  if (!imageMimeTypes.has(mimeType) || (Number.isFinite(contentLength) && contentLength > maxBytes)) {
     return { url };
   }
 

--- a/src/providers/esa/runtime.ts
+++ b/src/providers/esa/runtime.ts
@@ -1,0 +1,957 @@
+import type { BearerProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import {
+  compactObject,
+  optionalBoolean,
+  optionalInteger,
+  optionalRawString,
+  optionalRecord,
+  optionalString,
+} from "../../core/cast.ts";
+import { encodePathSegment, readBoundedResponseBytes } from "../../core/request.ts";
+import { ProviderRequestError, providerUserAgent, readProviderJsonBody } from "../provider-runtime.ts";
+
+export const esaApiBaseUrl = "https://api.esa.io";
+
+const docsTeamName = "docs";
+const searchOptionsHelpPostNumber = 104;
+const markdownSyntaxHelpPostNumber = 49;
+const fullPostBodyLimit = 10_000;
+const listPostBodyLimit = 500;
+const commentBodyLimit = 300;
+const maxAttachmentImageBytes = 30 * 1024 * 1024;
+const imageMimeTypes: Record<string, true> = {
+  "image/jpeg": true,
+  "image/png": true,
+  "image/gif": true,
+  "image/webp": true,
+};
+const signedAttachmentHosts: Record<string, true> = {
+  "files.esa.io": true,
+  "dl.esa.io": true,
+};
+const publicAttachmentHosts: Record<string, true> = { "img.esa.io": true };
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+type EsaActionContext = BearerProviderContext;
+type EsaJson = Record<string, unknown>;
+type EsaActionHandler = ProviderRuntimeHandler<EsaActionContext>;
+type BodyOptions = { truncateBody?: number; omitBody?: boolean };
+
+interface EsaRequestInput {
+  path: string;
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: Record<string, unknown>;
+}
+
+export const esaActionHandlers: Record<string, EsaActionHandler> = {
+  get_teams: getTeams,
+  get_team_stats: getTeamStats,
+  get_team_tags: getTeamTags,
+  get_team_members: getTeamMembers,
+  get_post: getPost,
+  search_posts: searchPosts,
+  create_post: createPost,
+  update_post: updatePost,
+  append_post: appendPost,
+  prepend_post: prependPost,
+  get_comment: getComment,
+  create_comment: createComment,
+  update_comment: updateComment,
+  delete_comment: deleteComment,
+  get_post_backlinks: getPostBacklinks,
+  get_post_comments: getPostComments,
+  get_team_comments: getTeamComments,
+  get_categories: getCategories,
+  get_top_categories: getTopCategories,
+  get_all_category_paths: getAllCategoryPaths,
+  archive_post: archivePost,
+  ship_post: shipPost,
+  duplicate_post: duplicatePost,
+  rollback_post_revision: rollbackPostRevision,
+  get_search_options_help: getSearchOptionsHelp,
+  get_markdown_syntax_help: getMarkdownSyntaxHelp,
+  search_help: searchHelp,
+  get_attachment: getAttachment,
+  list_recent_posts: listRecentPosts,
+  get_post_summary_prompt: getPostSummaryPrompt,
+};
+
+export async function requestEsaJson<T>(context: EsaActionContext, input: EsaRequestInput): Promise<T> {
+  const url = new URL(`${esaApiBaseUrl}${input.path}`);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await context.fetcher(url, {
+      method: input.method ?? "GET",
+      headers: esaHeaders(context.accessToken, input.body !== undefined),
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal: context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `esa request failed: ${error.message}` : "esa request failed",
+    );
+  }
+
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "esa returned an invalid JSON response",
+    invalidJsonStatus: response.ok ? 502 : response.status,
+    invalidJsonFallback: (text) => ({ message: text }),
+  });
+  if (!response.ok) {
+    const data = optionalRecord(payload);
+    const message = optionalString(data?.message) ?? `esa request failed with HTTP ${response.status}`;
+    throw new ProviderRequestError(response.status, message);
+  }
+
+  return payload as T;
+}
+
+export function buildEsaUrl(path: string, query?: Record<string, string | number | boolean | undefined>): string {
+  const url = new URL(`${esaApiBaseUrl}${path}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function esaHeaders(accessToken: string, hasJsonBody: boolean): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    authorization: `Bearer ${accessToken}`,
+    "user-agent": providerUserAgent,
+  };
+  if (hasJsonBody) {
+    headers["content-type"] = "application/json";
+  }
+  return headers;
+}
+
+async function getTeams(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: "/v1/teams",
+    query: { ...paginationQuery(input), role: readOptionalString(input, "role") },
+  });
+  const teams = records(data.teams, "esa teams").map((team) =>
+    compactObject({
+      url: optionalString(team.url),
+      name: optionalString(team.name),
+      description: optionalRawString(team.description),
+    }),
+  );
+  return { ...data, teams };
+}
+
+async function getTeamStats(input: Record<string, unknown>, context: EsaActionContext) {
+  return requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/stats"),
+  });
+}
+
+async function getTeamTags(input: Record<string, unknown>, context: EsaActionContext) {
+  return requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/tags"),
+    query: paginationQuery(input),
+  });
+}
+
+async function getTeamMembers(input: Record<string, unknown>, context: EsaActionContext) {
+  return requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/members"),
+    query: {
+      ...paginationQuery(input),
+      sort: readOptionalString(input, "sort"),
+      order: readOptionalString(input, "order"),
+    },
+  });
+}
+
+async function getPost(input: Record<string, unknown>, context: EsaActionContext) {
+  const raw = await getRawPost(context, readTeamName(input), readPositiveInteger(input, "postNumber"));
+  return transformPost(raw, {
+    truncateBody: readOptionalBoolean(input, "truncate") === false ? undefined : fullPostBodyLimit,
+  });
+}
+
+async function searchPosts(input: Record<string, unknown>, context: EsaActionContext) {
+  return searchPostsInTeam(context, readTeamName(input), {
+    query: readRequiredRawString(input, "query"),
+    sort: readOptionalString(input, "sort"),
+    order: readOptionalString(input, "order"),
+    ...paginationQuery(input),
+  });
+}
+
+async function createPost(input: Record<string, unknown>, context: EsaActionContext) {
+  return createPostInTeam(context, readTeamName(input), {
+    name: readRequiredString(input, "name"),
+    bodyMd: readOptionalRawString(input, "bodyMd"),
+    tags: readOptionalStringArray(input, "tags"),
+    category: readOptionalString(input, "category"),
+    wip: readOptionalBoolean(input, "wip") ?? true,
+    message: readOptionalRawString(input, "message"),
+  });
+}
+
+async function updatePost(input: Record<string, unknown>, context: EsaActionContext) {
+  return updatePostInTeam(context, readTeamName(input), readPositiveInteger(input, "postNumber"), {
+    name: readOptionalRawString(input, "name"),
+    bodyMd: readOptionalRawString(input, "bodyMd"),
+    tags: readOptionalStringArray(input, "tags"),
+    category: readOptionalRawString(input, "category"),
+    wip: readOptionalBoolean(input, "wip"),
+    message: readOptionalRawString(input, "message"),
+    originalRevision: readOriginalRevision(input),
+  });
+}
+
+async function appendPost(input: Record<string, unknown>, context: EsaActionContext) {
+  return insertPostContent(context, input, "append");
+}
+
+async function prependPost(input: Record<string, unknown>, context: EsaActionContext) {
+  return insertPostContent(context, input, "prepend");
+}
+
+async function getComment(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), `/comments/${readPositiveInteger(input, "commentId")}`),
+    query: { include: readOptionalString(input, "include") },
+  });
+  return transformComment(data, { truncateBody: fullPostBodyLimit });
+}
+
+async function createComment(input: Record<string, unknown>, context: EsaActionContext) {
+  const teamName = readTeamName(input);
+  const post = readPositiveInteger(input, "postNumber");
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, `/posts/${post}/comments`),
+    method: "POST",
+    body: {
+      comment: compactObject({
+        body_md: readRequiredRawString(input, "bodyMd"),
+        user: readOptionalString(input, "user"),
+      }),
+    },
+  });
+  return transformComment(data, { omitBody: true });
+}
+
+async function updateComment(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), `/comments/${readPositiveInteger(input, "commentId")}`),
+    method: "PATCH",
+    body: {
+      comment: compactObject({
+        body_md: readRequiredRawString(input, "bodyMd"),
+        user: readOptionalString(input, "user"),
+      }),
+    },
+  });
+  return transformComment(data, { omitBody: true });
+}
+
+async function deleteComment(input: Record<string, unknown>, context: EsaActionContext) {
+  await requestEsaJson<null>(context, {
+    path: teamPath(readTeamName(input), `/comments/${readPositiveInteger(input, "commentId")}`),
+    method: "DELETE",
+  });
+  return { success: true, message: "Comment deleted successfully" };
+}
+
+async function getPostBacklinks(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), `/posts/${readPositiveInteger(input, "postNumber")}/backlinks`),
+    query: paginationQuery(input),
+  });
+  return { ...data, posts: records(data.posts, "esa post backlinks").map(transformPostSummary) };
+}
+
+async function getPostComments(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), `/posts/${readPositiveInteger(input, "postNumber")}/comments`),
+    query: paginationQuery(input),
+  });
+  return {
+    ...data,
+    comments: records(data.comments, "esa post comments").map((comment) =>
+      transformComment(comment, { truncateBody: commentBodyLimit }),
+    ),
+  };
+}
+
+async function getTeamComments(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/comments"),
+    query: paginationQuery(input),
+  });
+  return {
+    ...data,
+    comments: records(data.comments, "esa team comments").map((comment) =>
+      transformComment(comment, { truncateBody: commentBodyLimit }),
+    ),
+  };
+}
+
+async function getCategories(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/categories"),
+    query: {
+      select: readRequiredRawString(input, "select"),
+      include: readOptionalString(input, "include"),
+      descendant_posts: readOptionalBoolean(input, "descendantPosts"),
+      ...paginationQuery(input),
+    },
+  });
+  return transformCategoryList(data);
+}
+
+async function getTopCategories(input: Record<string, unknown>, context: EsaActionContext) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/categories/top"),
+  });
+  return transformCategoryList(data);
+}
+
+async function getAllCategoryPaths(input: Record<string, unknown>, context: EsaActionContext) {
+  return requestEsaJson<EsaJson>(context, {
+    path: teamPath(readTeamName(input), "/categories/paths"),
+    query: {
+      v: 2,
+      ...paginationQuery(input),
+      prefix: readOptionalRawString(input, "prefix"),
+      suffix: readOptionalRawString(input, "suffix"),
+      match: readOptionalRawString(input, "match"),
+      exact_match: readOptionalRawString(input, "exactMatch"),
+    },
+  });
+}
+
+async function archivePost(input: Record<string, unknown>, context: EsaActionContext) {
+  const teamName = readTeamName(input);
+  const postNumber = readPositiveInteger(input, "postNumber");
+  const post = await getRawPost(context, teamName, postNumber);
+  const category = optionalRawString(post.category) ?? "";
+  if (category.startsWith("Archived/")) {
+    return { message: "Post is already archived", category };
+  }
+
+  return updatePostInTeam(context, teamName, postNumber, {
+    category: category ? `Archived/${category}` : "Archived",
+    message: readOptionalRawString(input, "message") ?? "Archive post",
+  });
+}
+
+async function shipPost(input: Record<string, unknown>, context: EsaActionContext) {
+  return updatePostInTeam(context, readTeamName(input), readPositiveInteger(input, "postNumber"), {
+    wip: false,
+    message: "Ship It!",
+  });
+}
+
+async function duplicatePost(input: Record<string, unknown>, context: EsaActionContext) {
+  const sourceTeamName = readTeamName(input);
+  const postNumber = readPositiveInteger(input, "postNumber");
+  const draft = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(sourceTeamName, "/posts/new"),
+    query: { parent_post_id: postNumber },
+  });
+  const post = requireResponseRecord(draft.post, "esa duplicate source post");
+  return createPostInTeam(context, normalizeTeamName(readOptionalString(input, "targetTeamName") ?? sourceTeamName), {
+    name: readResponseString(post.name, "esa duplicate source post name"),
+    bodyMd: optionalRawString(post.body_md),
+    wip: true,
+  });
+}
+
+async function rollbackPostRevision(input: Record<string, unknown>, context: EsaActionContext) {
+  const teamName = readTeamName(input);
+  const postNumber = readPositiveInteger(input, "postNumber");
+  const revisionNumber = readPositiveInteger(input, "revisionNumber");
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, `/posts/${postNumber}/revisions/${revisionNumber}/rollback`),
+    method: "POST",
+    body: {
+      post: compactObject({
+        wip: readOptionalBoolean(input, "wip"),
+        message: readOptionalRawString(input, "message"),
+      }),
+    },
+  });
+  return transformPost(data, { omitBody: true });
+}
+
+async function getSearchOptionsHelp(_input: Record<string, unknown>, context: EsaActionContext) {
+  const post = await getRawPost(context, docsTeamName, searchOptionsHelpPostNumber);
+  return transformPost(post, { truncateBody: fullPostBodyLimit });
+}
+
+async function getMarkdownSyntaxHelp(_input: Record<string, unknown>, context: EsaActionContext) {
+  const post = await getRawPost(context, docsTeamName, markdownSyntaxHelpPostNumber);
+  return transformPost(post, { truncateBody: fullPostBodyLimit });
+}
+
+async function searchHelp(input: Record<string, unknown>, context: EsaActionContext) {
+  return searchPostsInTeam(context, docsTeamName, {
+    query: readRequiredRawString(input, "query"),
+    sort: "best_match",
+    ...paginationQuery(input),
+  });
+}
+
+async function getAttachment(input: Record<string, unknown>, context: EsaActionContext) {
+  const attachment = readAttachmentInput(readRequiredRawString(input, "url"));
+  const url = attachment.needsSigning
+    ? await getSignedAttachmentUrl(context, readTeamName(input), attachment.path)
+    : attachment.url;
+  if (readOptionalBoolean(input, "forceSignedUrl") === true || !context.transitFiles) {
+    return { url };
+  }
+  return downloadAttachmentImage(context, url);
+}
+
+async function listRecentPosts(input: Record<string, unknown>, context: EsaActionContext) {
+  return searchPostsInTeam(context, readTeamName(input), {
+    sort: "updated",
+    order: "desc",
+    ...paginationQuery(input),
+  });
+}
+
+async function getPostSummaryPrompt(input: Record<string, unknown>, context: EsaActionContext) {
+  const post = await getRawPost(context, readTeamName(input), readPositiveInteger(input, "postNumber"));
+  return { prompt: createPostSummaryPrompt(post) };
+}
+
+async function getRawPost(context: EsaActionContext, teamName: string, postNumber: number): Promise<EsaJson> {
+  return requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, `/posts/${postNumber}`),
+  });
+}
+
+async function searchPostsInTeam(
+  context: EsaActionContext,
+  teamName: string,
+  query: Record<string, string | number | boolean | undefined>,
+) {
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, "/posts"),
+    query: compactObject({
+      q: query.query,
+      sort: query.sort,
+      order: query.order,
+      page: query.page,
+      per_page: query.per_page,
+    }),
+  });
+  return {
+    ...data,
+    posts: records(data.posts, "esa posts").map((post) => transformPost(post, { truncateBody: listPostBodyLimit })),
+  };
+}
+
+async function createPostInTeam(
+  context: EsaActionContext,
+  teamName: string,
+  input: {
+    name: string;
+    bodyMd?: string;
+    tags?: string[];
+    category?: string;
+    wip: boolean;
+    message?: string;
+  },
+) {
+  const nameAndCategory = normalizePostName(input.name, input.category);
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, "/posts"),
+    method: "POST",
+    body: {
+      post: compactObject({
+        name: nameAndCategory.name,
+        body_md: input.bodyMd,
+        tags: input.tags,
+        category: nameAndCategory.category,
+        wip: input.wip,
+        message: input.message,
+      }),
+    },
+  });
+  return transformPost(data, { omitBody: true });
+}
+
+async function updatePostInTeam(
+  context: EsaActionContext,
+  teamName: string,
+  postNumber: number,
+  input: {
+    name?: string;
+    bodyMd?: string;
+    tags?: string[];
+    category?: string;
+    wip?: boolean;
+    message?: string;
+    originalRevision?: Record<string, unknown>;
+  },
+) {
+  const nameAndCategory = normalizePostName(input.name, input.category);
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, `/posts/${postNumber}`),
+    method: "PATCH",
+    body: {
+      post: compactObject({
+        name: nameAndCategory.name,
+        body_md: input.bodyMd,
+        tags: input.tags,
+        category: nameAndCategory.category,
+        wip: input.wip,
+        message: input.message,
+        original_revision: input.originalRevision,
+      }),
+    },
+  });
+  return transformPost(data, { omitBody: true });
+}
+
+async function insertPostContent(
+  context: EsaActionContext,
+  input: Record<string, unknown>,
+  position: "append" | "prepend",
+) {
+  const teamName = readTeamName(input);
+  const postNumber = readPositiveInteger(input, "postNumber");
+  const data = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, `/posts/${postNumber}/${position}`),
+    method: "POST",
+    body: {
+      post: compactObject({
+        content: readRequiredRawString(input, "content"),
+        wip: readOptionalBoolean(input, "wip"),
+        message: readOptionalRawString(input, "message"),
+      }),
+    },
+  });
+  return transformPost(data, { omitBody: true });
+}
+
+function transformPost(post: EsaJson, options: BodyOptions = {}): EsaJson {
+  const sourceBody = optionalRawString(post.body_md);
+  const bodyMd = transformBody(sourceBody, options);
+  const bodyMdStats = options.omitBody ? undefined : measureBody(sourceBody);
+  const wip = optionalBoolean(post.wip);
+  return compactObject({
+    url: optionalString(post.url),
+    revision_number: optionalInteger(post.revision_number),
+    wip: wip === undefined ? undefined : wip ? "WIP" : "Shipped",
+    kind: optionalString(post.kind),
+    category_and_title_and_tags: optionalRawString(post.full_name),
+    body_md: bodyMd,
+    body_md_stats: bodyMdStats,
+    created_at: optionalString(post.created_at),
+    updated_at: optionalString(post.updated_at),
+    created_by: post.created_by,
+    updated_by: post.updated_by,
+    stats: compactObject({
+      tasks_count: optionalInteger(post.tasks_count),
+      done_tasks_count: optionalInteger(post.done_tasks_count),
+      comments_count: optionalInteger(post.comments_count),
+      stargazers_count: optionalInteger(post.stargazers_count),
+      watchers_count: optionalInteger(post.watchers_count),
+    }),
+    backlinks_count: optionalInteger(post.backlinks_count),
+  });
+}
+
+function transformPostSummary(post: EsaJson): EsaJson {
+  const wip = optionalBoolean(post.wip);
+  return compactObject({
+    number: optionalInteger(post.number),
+    url: optionalString(post.url),
+    category_and_title_and_tags: optionalRawString(post.full_name),
+    wip: wip === undefined ? undefined : wip ? "WIP" : "Shipped",
+    created_at: optionalString(post.created_at),
+    updated_at: optionalString(post.updated_at),
+  });
+}
+
+function transformComment(comment: EsaJson, options: BodyOptions = {}): EsaJson {
+  return compactObject({
+    id: optionalInteger(comment.id),
+    post_number: optionalInteger(comment.post_number),
+    url: optionalString(comment.url),
+    body_md: transformBody(optionalRawString(comment.body_md), options),
+    created_at: optionalString(comment.created_at),
+    updated_at: optionalString(comment.updated_at),
+    created_by: comment.created_by,
+    stats: compactObject({
+      stargazers_count: optionalInteger(comment.stargazers_count),
+      star: optionalBoolean(comment.star),
+    }),
+    stargazers: comment.stargazers,
+  });
+}
+
+function transformCategoryList(data: EsaJson): EsaJson {
+  return compactObject({
+    current_category: optionalRawString(data.current_category),
+    categories: records(data.categories, "esa categories").map(transformCategory),
+    parent_categories: records(data.parent_categories, "esa parent categories").map((parent) =>
+      compactObject({
+        current_category: optionalRawString(parent.current_category),
+        categories: records(parent.categories, "esa parent categories").map(transformCategory),
+      }),
+    ),
+    readme: optionalRecord(data.readme)
+      ? transformPost(data.readme as EsaJson, { truncateBody: listPostBodyLimit })
+      : undefined,
+    no_category: optionalRecord(data.no_category) ? transformCategory(data.no_category as EsaJson) : undefined,
+    descendant_posts: data.descendant_posts,
+    posts: data.posts
+      ? records(data.posts, "esa category posts").map((post) =>
+          transformPost(post, { truncateBody: listPostBodyLimit }),
+        )
+      : undefined,
+    total_count: optionalInteger(data.total_count),
+    per_page: optionalInteger(data.per_page),
+    page: optionalInteger(data.page),
+    prev_page: data.prev_page,
+    next_page: data.next_page,
+    max_per_page: optionalInteger(data.max_per_page),
+  });
+}
+
+function transformCategory(category: EsaJson): EsaJson {
+  return compactObject({
+    full_name: optionalRawString(category.full_name),
+    count: optionalInteger(category.count),
+    has_child: optionalBoolean(category.has_child) ?? false,
+  });
+}
+
+function transformBody(bodyMd: string | undefined, options: BodyOptions): string | undefined {
+  if (options.omitBody || bodyMd === undefined) {
+    return undefined;
+  }
+  if (options.truncateBody !== undefined && bodyMd.length > options.truncateBody) {
+    return `${bodyMd.slice(0, options.truncateBody)}\n\n... (truncated)`;
+  }
+  return bodyMd;
+}
+
+function measureBody(bodyMd: string | undefined): EsaJson | undefined {
+  if (bodyMd === undefined) {
+    return undefined;
+  }
+  let characters = 0;
+  for (const _segment of graphemeSegmenter.segment(bodyMd)) {
+    characters++;
+  }
+  let lines = bodyMd === "" ? 0 : 1;
+  for (let index = 0; index < bodyMd.length; index++) {
+    if (bodyMd.charCodeAt(index) === 10) {
+      lines++;
+    }
+  }
+  return { characters, lines };
+}
+
+function normalizePostName(
+  name: string | undefined,
+  category: string | undefined,
+): { name?: string; category?: string } {
+  if (name === undefined || category !== undefined || !name.includes("/")) {
+    return { name, category };
+  }
+  const parts = name.split("/");
+  const postName = parts.pop();
+  return { name: postName || undefined, category: parts.join("/") };
+}
+
+function normalizeTeamName(value: string): string {
+  const dotIndex = value.indexOf(".");
+  return dotIndex === -1 ? value : value.slice(0, dotIndex);
+}
+
+function teamPath(teamName: string, suffix: string): string {
+  return `/v1/teams/${encodePathSegment(teamName)}${suffix}`;
+}
+
+function paginationQuery(input: Record<string, unknown>): Record<string, number | undefined> {
+  return {
+    page: readOptionalPositiveInteger(input, "page"),
+    per_page: readOptionalPageSize(input, "perPage"),
+  };
+}
+
+function readTeamName(input: Record<string, unknown>): string {
+  return normalizeTeamName(readRequiredString(input, "teamName"));
+}
+
+function readRequiredString(input: Record<string, unknown>, fieldName: string): string {
+  const value = optionalString(input[fieldName]);
+  if (!value) {
+    throw invalidInput(`${fieldName} must be a non-empty string`);
+  }
+  return value;
+}
+
+function readRequiredRawString(input: Record<string, unknown>, fieldName: string): string {
+  const value = optionalRawString(input[fieldName]);
+  if (value === undefined) {
+    throw invalidInput(`${fieldName} must be a string`);
+  }
+  return value;
+}
+
+function readOptionalString(input: Record<string, unknown>, fieldName: string): string | undefined {
+  const value = input[fieldName];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw invalidInput(`${fieldName} must be a string`);
+  }
+  return value.trim() || undefined;
+}
+
+function readOptionalRawString(input: Record<string, unknown>, fieldName: string): string | undefined {
+  const value = input[fieldName];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw invalidInput(`${fieldName} must be a string`);
+  }
+  return value;
+}
+
+function readPositiveInteger(input: Record<string, unknown>, fieldName: string): number {
+  const value = input[fieldName];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw invalidInput(`${fieldName} must be a positive integer`);
+  }
+  return value;
+}
+
+function readOptionalPositiveInteger(input: Record<string, unknown>, fieldName: string): number | undefined {
+  if (input[fieldName] === undefined) {
+    return undefined;
+  }
+  return readPositiveInteger(input, fieldName);
+}
+
+function readOptionalPageSize(input: Record<string, unknown>, fieldName: string): number | undefined {
+  const value = readOptionalPositiveInteger(input, fieldName);
+  if (value !== undefined && value > 100) {
+    throw invalidInput(`${fieldName} must not exceed 100`);
+  }
+  return value;
+}
+
+function readOptionalBoolean(input: Record<string, unknown>, fieldName: string): boolean | undefined {
+  const value = input[fieldName];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw invalidInput(`${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
+function readOptionalStringArray(input: Record<string, unknown>, fieldName: string): string[] | undefined {
+  const value = input[fieldName];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || item.trim() === "")) {
+    throw invalidInput(`${fieldName} must be an array of non-empty strings`);
+  }
+  return value;
+}
+
+function readOriginalRevision(input: Record<string, unknown>): EsaJson | undefined {
+  const value = input.originalRevision;
+  if (value === undefined) {
+    return undefined;
+  }
+  const revision = optionalRecord(value);
+  if (!revision) {
+    throw invalidInput("originalRevision must be an object");
+  }
+  return {
+    body_md: readRequiredRawString(revision, "bodyMd"),
+    number: readPositiveInteger(revision, "number"),
+    user: readRequiredString(revision, "user"),
+  };
+}
+
+function records(value: unknown, fieldName: string): EsaJson[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, `${fieldName} response field must be an array`);
+  }
+  return value.map((item) => requireResponseRecord(item, fieldName));
+}
+
+function requireResponseRecord(value: unknown, fieldName: string): EsaJson {
+  const result = optionalRecord(value);
+  if (!result) {
+    throw new ProviderRequestError(502, `${fieldName} response must be an object`);
+  }
+  return result;
+}
+
+function readResponseString(value: unknown, fieldName: string): string {
+  const result = optionalRawString(value);
+  if (result === undefined) {
+    throw new ProviderRequestError(502, `${fieldName} response field must be a string`);
+  }
+  return result;
+}
+
+function invalidInput(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function createPostSummaryPrompt(post: EsaJson): string {
+  const author = optionalRecord(post.created_by);
+  const lines = [
+    "Please summarize the following post:",
+    "",
+    `Title: ${optionalRawString(post.name) ?? ""}`,
+    `URL: ${optionalRawString(post.url) ?? ""}`,
+    `Author: ${optionalRawString(author?.name) ?? ""}`,
+    `Created: ${optionalRawString(post.created_at) ?? ""}`,
+    `Updated: ${optionalRawString(post.updated_at) ?? ""}`,
+  ];
+  const category = optionalRawString(post.category);
+  if (category) {
+    lines.push(`Category: ${category}`);
+  }
+  const tags = post.tags;
+  if (Array.isArray(tags) && tags.length > 0 && tags.every((tag) => typeof tag === "string")) {
+    lines.push(`Tags: ${tags.join(", ")}`);
+  }
+  lines.push("", "---", "");
+  const bodyMd = optionalRawString(post.body_md);
+  if (bodyMd !== undefined) {
+    lines.push(`Content:\n${bodyMd}`);
+  }
+  return lines.join("\n");
+}
+
+function readAttachmentInput(
+  value: string,
+): { needsSigning: true; path: string } | { needsSigning: false; url: string } {
+  if (value.startsWith("/")) {
+    return { needsSigning: true, path: value };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw invalidInput("url must be an esa attachment URL or an /uploads/... path");
+  }
+  if (url.protocol !== "https:") {
+    throw invalidInput("url must use HTTPS");
+  }
+  if (signedAttachmentHosts[url.hostname]) {
+    return { needsSigning: true, path: url.pathname };
+  }
+  if (publicAttachmentHosts[url.hostname]) {
+    return { needsSigning: false, url: url.toString() };
+  }
+  throw invalidInput("url must use img.esa.io, files.esa.io, dl.esa.io, or an /uploads/... path");
+}
+
+async function getSignedAttachmentUrl(context: EsaActionContext, teamName: string, path: string): Promise<string> {
+  const response = await requestEsaJson<EsaJson>(context, {
+    path: teamPath(teamName, "/signed_urls"),
+    query: { urls: path, v: 2, expires_in: 300 },
+  });
+  const signedUrls = response.signed_urls;
+  if (!Array.isArray(signedUrls) || signedUrls.length === 0 || !Array.isArray(signedUrls[0])) {
+    throw new ProviderRequestError(502, "esa did not return a signed attachment URL");
+  }
+  const [originalUrl, signedUrl] = signedUrls[0] as unknown[];
+  if (signedUrl === null) {
+    throw new ProviderRequestError(404, `esa attachment not found: ${String(originalUrl)}`);
+  }
+  if (typeof signedUrl !== "string") {
+    throw new ProviderRequestError(502, "esa returned an invalid signed attachment URL");
+  }
+  return signedUrl;
+}
+
+async function downloadAttachmentImage(context: EsaActionContext, url: string) {
+  const transitFiles = context.transitFiles;
+  if (!transitFiles) {
+    return { url };
+  }
+
+  let response: Response;
+  try {
+    response = await context.fetcher(url, {
+      headers: { accept: "image/*", "user-agent": providerUserAgent },
+      signal: context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `esa attachment download failed: ${error.message}` : "esa attachment download failed",
+    );
+  }
+  if (!response.ok) {
+    throw new ProviderRequestError(response.status, `esa attachment download failed with HTTP ${response.status}`);
+  }
+
+  const mimeType = (response.headers.get("content-type") ?? "").split(";", 1)[0]!.trim().toLowerCase();
+  const contentLength = Number(response.headers.get("content-length"));
+  const maxBytes = Math.min(maxAttachmentImageBytes, transitFiles.maxBytes);
+  if (!imageMimeTypes[mimeType] || (Number.isFinite(contentLength) && contentLength > maxBytes)) {
+    return { url };
+  }
+
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes,
+    fieldName: "esa attachment image",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const name = attachmentFileName(url);
+  const upload = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  return {
+    url,
+    file: {
+      fileId: upload.fileId,
+      downloadUrl: upload.downloadUrl,
+      sizeBytes: upload.sizeBytes,
+      name,
+      mimeType,
+    },
+  };
+}
+
+function attachmentFileName(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const name = pathname.slice(pathname.lastIndexOf("/") + 1);
+    return decodeURIComponent(name) || "esa-attachment";
+  } catch {
+    return "esa-attachment";
+  }
+}

--- a/src/providers/esa/runtime.ts
+++ b/src/providers/esa/runtime.ts
@@ -8,8 +8,8 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
-import { encodePathSegment, readBoundedResponseBytes } from "../../core/request.ts";
-import { ProviderRequestError, providerUserAgent, readProviderJsonBody } from "../provider-runtime.ts";
+import { assertPublicHttpUrl, encodePathSegment, readBoundedResponseBytes } from "../../core/request.ts";
+import { ProviderRequestError, providerFetch, providerUserAgent, readProviderJsonBody } from "../provider-runtime.ts";
 
 export const esaApiBaseUrl = "https://api.esa.io";
 
@@ -22,7 +22,6 @@ const commentBodyLimit = 300;
 const maxAttachmentImageBytes = 30 * 1024 * 1024;
 const imageMimeTypes = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
 const signedAttachmentHosts = new Set(["files.esa.io", "dl.esa.io"]);
-const publicAttachmentHosts = new Set(["img.esa.io"]);
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 type EsaActionContext = BearerProviderContext;
@@ -635,24 +634,18 @@ function transformBody(bodyMd: string | undefined, options: BodyOptions): string
   if (options.omitBody || bodyMd === undefined) {
     return undefined;
   }
-  const truncatedBody = truncateGraphemes(bodyMd, options.truncateBody);
-  if (truncatedBody !== undefined) {
-    return `${truncatedBody}\n\n... (truncated)`;
+  if (options.truncateBody !== undefined && bodyMd.length > options.truncateBody) {
+    let truncateAt = 0;
+    for (const segment of graphemeSegmenter.segment(bodyMd)) {
+      const segmentEnd = segment.index + segment.segment.length;
+      if (segmentEnd > options.truncateBody) {
+        break;
+      }
+      truncateAt = segmentEnd;
+    }
+    return `${bodyMd.slice(0, truncateAt)}\n\n... (truncated)`;
   }
   return bodyMd;
-}
-function truncateGraphemes(value: string, limit: number | undefined): string | undefined {
-  if (limit === undefined) {
-    return undefined;
-  }
-  let count = 0;
-  for (const segment of graphemeSegmenter.segment(value)) {
-    if (count === limit) {
-      return value.slice(0, segment.index);
-    }
-    count++;
-  }
-  return undefined;
 }
 
 function measureBody(bodyMd: string | undefined): EsaJson | undefined {
@@ -864,25 +857,20 @@ function readAttachmentInput(
   value: string,
 ): { needsSigning: true; path: string } | { needsSigning: false; url: string } {
   if (value.startsWith("/")) {
+    if (!value.startsWith("/uploads/")) {
+      throw invalidInput("url path must start with /uploads/");
+    }
     return { needsSigning: true, path: value };
   }
 
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw invalidInput("url must be an esa attachment URL or an /uploads/... path");
-  }
+  const url = assertPublicHttpUrl(value, { fieldName: "url", createError: invalidInput });
   if (url.protocol !== "https:") {
     throw invalidInput("url must use HTTPS");
   }
   if (signedAttachmentHosts.has(url.hostname)) {
     return { needsSigning: true, path: url.pathname };
   }
-  if (publicAttachmentHosts.has(url.hostname)) {
-    return { needsSigning: false, url: url.toString() };
-  }
-  throw invalidInput("url must use img.esa.io, files.esa.io, dl.esa.io, or an /uploads/... path");
+  return { needsSigning: false, url: url.toString() };
 }
 
 async function getSignedAttachmentUrl(context: EsaActionContext, teamName: string, path: string): Promise<string> {
@@ -912,7 +900,7 @@ async function downloadAttachmentImage(context: EsaActionContext, url: string) {
 
   let response: Response;
   try {
-    response = await context.fetcher(url, {
+    response = await providerFetch(url, {
       headers: { accept: "image/*", "user-agent": providerUserAgent },
       signal: context.signal,
     });

--- a/src/providers/esa/scopes.ts
+++ b/src/providers/esa/scopes.ts
@@ -1,0 +1,6 @@
+export const esaReadScope = "read";
+export const esaWriteScope = "write";
+
+export const esaReadScopes: string[] = [esaReadScope];
+export const esaWriteScopes: string[] = [esaWriteScope];
+export const esaOAuthScopes: string[] = [esaReadScope, esaWriteScope];


### PR DESCRIPTION
## Summary

[esa](https://esa.io/) is a document-sharing service that helps teams collaboratively grow work-in-progress knowledge into organized documentation.

- add an open-source esa provider with 30 curated actions for teams, posts, comments, categories, attachments, and official help
- support both OAuth 2.0 and esa PAT v2 connections through shared bearer executors
- add bounded response shaping, attachment transit handling, credential validation, and provider-local tests

## Authentication and permissions

OAuth requests esa's provider-native `read` and `write` scopes. PAT v2 permissions are resource-specific; connection validation requires `read:user`, and each enabled action requires its corresponding PAT v2 scope.

OAuth may reach every esa team available to the authorized user. Users who need a team-level boundary should use PAT v2 and configure the token and API access policy in esa.

## Verification

- `npm ci`
- `npm run generate:catalog`
- `npm run lint`
- `npm run typecheck`
- `npm test -- src/providers/esa/definition.test.ts src/providers/esa/executors.test.ts src/providers/esa/runtime.test.ts` — 38 passed
- `npm test` — 824 passed across 77 files

Live verification used a PAT v2 connection restricted to one test team. Team listing returned only that team, and a direct request to another team returned 403. Read actions succeeded, and the create/update/get/delete comment lifecycle completed successfully with the test comment removed afterward.

The three official-help actions were not exercised live because they intentionally access esa's `docs` team; their request and response behavior is covered by automated tests.