### PR TITLE
feat(xero): add Xero accounting provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ src/providers/registry*.generated.ts
 *.log
 *.tsbuildinfo
 data/
+
+# Local Xero OAuth app credentials (never commit)
+xero-credentials.json
+xero-encryption-key.txt

--- a/src/providers/xero/actions.ts
+++ b/src/providers/xero/actions.ts
@@ -28,6 +28,19 @@ const pageOutput = s.integer({
   description: "The page number that was returned.",
 });
 const xeroId = s.uuid("A Xero resource ID.");
+const transactionId = s.uuid("The Xero identifier for a bank transaction, overpayment, or prepayment.");
+const accountStatuses = ["ACTIVE", "ARCHIVED", "DELETED"];
+const bankTransactionStatuses = ["AUTHORISED", "DELETED", "PAID", "VOIDED"];
+const bankTransactionTypes = [
+  "RECEIVE",
+  "RECEIVE-OVERPAYMENT",
+  "RECEIVE-PREPAYMENT",
+  "SPEND",
+  "SPEND-OVERPAYMENT",
+  "SPEND-PREPAYMENT",
+  "RECEIVE-TRANSFER",
+  "SPEND-TRANSFER",
+];
 const invoiceStatuses = ["DRAFT", "SUBMITTED", "AUTHORISED", "PAID", "VOIDED", "DELETED"];
 
 const lineItemInput = s.object(
@@ -144,9 +157,9 @@ const invoiceDetail = s.object(
 
 const bankTransactionSummary = s.object(
   {
-    bank_transaction_id: xeroId,
-    type: s.stringEnum(["RECEIVE", "SPEND"]),
-    status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
+    transaction_id: transactionId,
+    type: s.stringEnum(bankTransactionTypes),
+    status: s.stringEnum(bankTransactionStatuses),
     date: s.nullableString("The transaction date (YYYY-MM-DD)."),
     total: money,
     currency_code: s.string(),
@@ -154,7 +167,7 @@ const bankTransactionSummary = s.object(
     line_item_count: s.integer(),
   },
   {
-    required: ["bank_transaction_id", "type", "status", "date", "total", "currency_code", "line_item_count"],
+    required: ["transaction_id", "type", "status", "date", "total", "currency_code", "line_item_count"],
     additionalProperties: true,
     description: "A bank transaction summary.",
   },
@@ -162,9 +175,9 @@ const bankTransactionSummary = s.object(
 
 const bankTransactionDetail = s.object(
   {
-    bank_transaction_id: xeroId,
-    type: s.stringEnum(["RECEIVE", "SPEND"]),
-    status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
+    transaction_id: transactionId,
+    type: s.stringEnum(bankTransactionTypes),
+    status: s.stringEnum(bankTransactionStatuses),
     date: s.nullableString("The transaction date (YYYY-MM-DD)."),
     reference: s.nullableString("The transaction reference."),
     total: money,
@@ -173,7 +186,7 @@ const bankTransactionDetail = s.object(
     line_items: s.array(lineItemOutput, { description: "The transaction line items." }),
   },
   {
-    required: ["bank_transaction_id", "type", "status", "date", "total", "currency_code", "line_items"],
+    required: ["transaction_id", "type", "status", "date", "total", "currency_code", "line_items"],
     additionalProperties: true,
     description: "A bank transaction with line items.",
   },
@@ -185,7 +198,7 @@ const accountSummary = s.object(
     code: s.string(),
     name: s.string(),
     type: s.string(),
-    status: s.stringEnum(["ACTIVE", "ARCHIVED", "GONE"]),
+    status: s.stringEnum(accountStatuses),
     tax_type: s.nullableString("The default tax type."),
     currency_code: s.string(),
   },
@@ -332,8 +345,6 @@ export const xeroActions: ActionDefinition[] = [
         email_address: s.string({ description: "The contact email address." }),
         first_name: s.string({ description: "The contact first name." }),
         last_name: s.string({ description: "The contact last name." }),
-        is_customer: s.boolean({ default: false, description: "Whether this contact buys from you." }),
-        is_supplier: s.boolean({ default: true, description: "Whether this contact sells to you." }),
       },
       {
         required: ["name"],
@@ -382,7 +393,7 @@ export const xeroActions: ActionDefinition[] = [
         }),
         date: s.date("The invoice date. When omitted, Xero uses today in the organisation timezone."),
         due_date: s.date(
-          "The due date. Defaults to 30 days after the invoice date, or 30 days from today when the date is omitted.",
+          "The due date. When omitted, a 30-day term is applied only when date is provided; otherwise Xero determines the date.",
         ),
         reference: s.string({ description: "The invoice reference." }),
         line_items: s.array(lineItemInput, { description: "The invoice line items." }),
@@ -421,7 +432,7 @@ export const xeroActions: ActionDefinition[] = [
     inputSchema: s.object(
       {
         ...tenantField,
-        status: s.stringEnum(["ACTIVE", "ARCHIVED", "GONE"], { description: "Filter by account status." }),
+        status: s.stringEnum(accountStatuses, { description: "Filter by account status." }),
       },
       { description: "Account list input." },
     ),
@@ -448,11 +459,11 @@ export const xeroActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "search_bank_transactions",
     requiredScopes: [xeroBankTransactionsReadScope],
-    description: "Search bank transactions by status with pagination.",
+    description: "Search bank transactions, overpayments, prepayments, and transfers by status with pagination.",
     inputSchema: s.object(
       {
         ...tenantField,
-        status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"], { description: "Filter by transaction status." }),
+        status: s.stringEnum(bankTransactionStatuses, { description: "Filter by transaction status." }),
         page: pageInput,
       },
       {

--- a/src/providers/xero/actions.ts
+++ b/src/providers/xero/actions.ts
@@ -23,6 +23,10 @@ const pageInput = s.integer({
   default: 1,
   description: "The page number to return. Xero returns up to 100 items per page.",
 });
+const pageOutput = s.integer({
+  minimum: 1,
+  description: "The page number that was returned.",
+});
 const xeroId = s.uuid("A Xero resource ID.");
 const invoiceStatuses = ["DRAFT", "SUBMITTED", "AUTHORISED", "PAID", "VOIDED", "DELETED"];
 
@@ -81,7 +85,7 @@ const invoiceSummary = s.object(
     invoice_number: s.string(),
     type: s.stringEnum(["ACCREC", "ACCPAY"]),
     status: s.stringEnum(invoiceStatuses),
-    date: s.string({ description: "The invoice date (YYYY-MM-DD)." }),
+    date: s.nullableString("The invoice date (YYYY-MM-DD)."),
     due_date: s.nullableString("The due date (YYYY-MM-DD)."),
     total: money,
     amount_due: money,
@@ -112,7 +116,7 @@ const invoiceDetail = s.object(
     invoice_number: s.string(),
     type: s.stringEnum(["ACCREC", "ACCPAY"]),
     status: s.stringEnum(invoiceStatuses),
-    date: s.string({ description: "The invoice date (YYYY-MM-DD)." }),
+    date: s.nullableString("The invoice date (YYYY-MM-DD)."),
     due_date: s.nullableString("The due date (YYYY-MM-DD)."),
     reference: s.nullableString("The invoice reference."),
     total: money,
@@ -143,7 +147,7 @@ const bankTransactionSummary = s.object(
     bank_transaction_id: xeroId,
     type: s.stringEnum(["RECEIVE", "SPEND"]),
     status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
-    date: s.string({ description: "The transaction date (YYYY-MM-DD)." }),
+    date: s.nullableString("The transaction date (YYYY-MM-DD)."),
     total: money,
     currency_code: s.string(),
     contact_name: s.nullableString("The linked contact name."),
@@ -161,7 +165,7 @@ const bankTransactionDetail = s.object(
     bank_transaction_id: xeroId,
     type: s.stringEnum(["RECEIVE", "SPEND"]),
     status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
-    date: s.string({ description: "The transaction date (YYYY-MM-DD)." }),
+    date: s.nullableString("The transaction date (YYYY-MM-DD)."),
     reference: s.nullableString("The transaction reference."),
     total: money,
     currency_code: s.string(),
@@ -245,7 +249,7 @@ const searchResults = <T extends JsonSchema>(itemSchema: T, description: string)
   s.object(
     {
       items: s.array(itemSchema, { description }),
-      page: pageInput,
+      page: pageOutput,
       returned: s.integer(),
     },
     {
@@ -376,8 +380,10 @@ export const xeroActions: ActionDefinition[] = [
           default: "ACCREC",
           description: "ACCREC bills the customer; ACCPAY records a bill from a supplier.",
         }),
-        date: s.date("The invoice date. Defaults to today."),
-        due_date: s.date("The due date. Defaults to the invoice date plus 30 days."),
+        date: s.date("The invoice date. When omitted, Xero uses today in the organisation timezone."),
+        due_date: s.date(
+          "The due date. Defaults to 30 days after the invoice date, or 30 days from today when the date is omitted.",
+        ),
         reference: s.string({ description: "The invoice reference." }),
         line_items: s.array(lineItemInput, { description: "The invoice line items." }),
       },

--- a/src/providers/xero/actions.ts
+++ b/src/providers/xero/actions.ts
@@ -1,0 +1,495 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import {
+  xeroBalanceSheetReadScope,
+  xeroBankTransactionsReadScope,
+  xeroContactsReadScope,
+  xeroContactsWriteScope,
+  xeroInvoicesReadScope,
+  xeroInvoicesWriteScope,
+  xeroProfitAndLossReadScope,
+  xeroSettingsReadScope,
+} from "./scopes.ts";
+
+const service = "xero";
+
+const money = s.number("A monetary amount.");
+const tenantId = s.uuid("The Xero tenant (organisation) ID for this connection.");
+const tenantField = { tenant_id: tenantId };
+const pageInput = s.integer({
+  minimum: 1,
+  default: 1,
+  description: "The page number to return. Xero returns up to 100 items per page.",
+});
+const xeroId = s.uuid("A Xero resource ID.");
+const invoiceStatuses = ["DRAFT", "SUBMITTED", "AUTHORISED", "PAID", "VOIDED", "DELETED"];
+
+const lineItemInput = s.object(
+  {
+    description: s.string({ description: "The line item description." }),
+    quantity: s.number({ description: "The quantity." }),
+    unit_amount: s.number({ description: "The unit price excluding tax." }),
+    account_code: s.string({ description: "The account code this line is posted to." }),
+  },
+  {
+    required: ["description", "quantity", "unit_amount", "account_code"],
+    description: "An invoice or bank transaction line item.",
+  },
+);
+
+const lineItemOutput = s.object(
+  {
+    line_item_id: xeroId,
+    description: s.nullableString("The line item description."),
+    quantity: money,
+    unit_amount: money,
+    line_amount: money,
+    account_code: s.nullableString("The account code this line is posted to."),
+  },
+  {
+    required: ["line_item_id", "quantity", "unit_amount", "line_amount"],
+    additionalProperties: true,
+    description: "A line item with computed amounts.",
+  },
+);
+
+const contactSummary = s.object(
+  {
+    contact_id: xeroId,
+    name: s.string(),
+    first_name: s.nullableString("The contact's first name."),
+    last_name: s.nullableString("The contact's last name."),
+    email_address: s.nullableString("The contact's email address."),
+    phone: s.nullableString("The contact's phone number."),
+    is_customer: s.boolean(),
+    is_supplier: s.boolean(),
+    account_number: s.nullableString("The account number in the accounting system."),
+    status: s.string(),
+  },
+  {
+    required: ["contact_id", "name", "is_customer", "is_supplier", "status"],
+    additionalProperties: true,
+    description: "A contact summary.",
+  },
+);
+
+const invoiceSummary = s.object(
+  {
+    invoice_id: xeroId,
+    invoice_number: s.string(),
+    type: s.stringEnum(["ACCREC", "ACCPAY"]),
+    status: s.stringEnum(invoiceStatuses),
+    date: s.string({ description: "The invoice date (YYYY-MM-DD)." }),
+    due_date: s.nullableString("The due date (YYYY-MM-DD)."),
+    total: money,
+    amount_due: money,
+    currency_code: s.string(),
+    contact_name: s.nullableString("The linked contact name."),
+    line_item_count: s.integer(),
+  },
+  {
+    required: [
+      "invoice_id",
+      "invoice_number",
+      "type",
+      "status",
+      "date",
+      "total",
+      "amount_due",
+      "currency_code",
+      "line_item_count",
+    ],
+    additionalProperties: true,
+    description: "An invoice summary.",
+  },
+);
+
+const invoiceDetail = s.object(
+  {
+    invoice_id: xeroId,
+    invoice_number: s.string(),
+    type: s.stringEnum(["ACCREC", "ACCPAY"]),
+    status: s.stringEnum(invoiceStatuses),
+    date: s.string({ description: "The invoice date (YYYY-MM-DD)." }),
+    due_date: s.nullableString("The due date (YYYY-MM-DD)."),
+    reference: s.nullableString("The invoice reference."),
+    total: money,
+    amount_due: money,
+    currency_code: s.string(),
+    contact_name: s.nullableString("The linked contact name."),
+    line_items: s.array(lineItemOutput, { description: "The invoice line items." }),
+  },
+  {
+    required: [
+      "invoice_id",
+      "invoice_number",
+      "type",
+      "status",
+      "date",
+      "total",
+      "amount_due",
+      "currency_code",
+      "line_items",
+    ],
+    additionalProperties: true,
+    description: "An invoice with line items.",
+  },
+);
+
+const bankTransactionSummary = s.object(
+  {
+    bank_transaction_id: xeroId,
+    type: s.stringEnum(["RECEIVE", "SPEND"]),
+    status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
+    date: s.string({ description: "The transaction date (YYYY-MM-DD)." }),
+    total: money,
+    currency_code: s.string(),
+    contact_name: s.nullableString("The linked contact name."),
+    line_item_count: s.integer(),
+  },
+  {
+    required: ["bank_transaction_id", "type", "status", "date", "total", "currency_code", "line_item_count"],
+    additionalProperties: true,
+    description: "A bank transaction summary.",
+  },
+);
+
+const bankTransactionDetail = s.object(
+  {
+    bank_transaction_id: xeroId,
+    type: s.stringEnum(["RECEIVE", "SPEND"]),
+    status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"]),
+    date: s.string({ description: "The transaction date (YYYY-MM-DD)." }),
+    reference: s.nullableString("The transaction reference."),
+    total: money,
+    currency_code: s.string(),
+    contact_name: s.nullableString("The linked contact name."),
+    line_items: s.array(lineItemOutput, { description: "The transaction line items." }),
+  },
+  {
+    required: ["bank_transaction_id", "type", "status", "date", "total", "currency_code", "line_items"],
+    additionalProperties: true,
+    description: "A bank transaction with line items.",
+  },
+);
+
+const accountSummary = s.object(
+  {
+    account_id: xeroId,
+    code: s.string(),
+    name: s.string(),
+    type: s.string(),
+    status: s.stringEnum(["ACTIVE", "ARCHIVED", "GONE"]),
+    tax_type: s.nullableString("The default tax type."),
+    currency_code: s.string(),
+  },
+  {
+    required: ["account_id", "code", "name", "type", "status", "currency_code"],
+    additionalProperties: true,
+    description: "An account summary.",
+  },
+);
+
+const tenantSummary = s.object(
+  {
+    tenant_id: tenantId,
+    tenant_name: s.string(),
+    tenant_type: s.string(),
+  },
+  {
+    required: ["tenant_id", "tenant_name", "tenant_type"],
+    description: "An organisation connected to this Xero account.",
+  },
+);
+
+const reportRow = s.object(
+  {
+    label: s.string(),
+    value: s.nullableString("The formatted cell value."),
+    is_total: s.boolean(),
+  },
+  {
+    required: ["label", "is_total"],
+    description: "A row inside a report section.",
+  },
+);
+
+const reportSection = s.object(
+  {
+    title: s.nullableString("The section title, for example Operating Income."),
+    rows: s.array(reportRow, { description: "The rows in this section." }),
+  },
+  {
+    required: ["rows"],
+    description: "A report section with labelled rows.",
+  },
+);
+
+const reportOutput = s.object(
+  {
+    report_id: s.string(),
+    report_name: s.string(),
+    titles: s.stringArray("The report titles."),
+    generated_at: s.nullableString("When the report was generated (ISO 8601)."),
+    sections: s.array(reportSection, { description: "The report body as labelled sections." }),
+  },
+  {
+    required: ["report_id", "report_name", "titles", "sections"],
+    description: "A financial report with labelled sections an agent can summarise.",
+  },
+);
+
+const searchResults = <T extends JsonSchema>(itemSchema: T, description: string) =>
+  s.object(
+    {
+      items: s.array(itemSchema, { description }),
+      page: pageInput,
+      returned: s.integer(),
+    },
+    {
+      required: ["items", "page", "returned"],
+      description: "A page of results.",
+    },
+  );
+
+export const xeroActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_organisations",
+    description: "List the Xero organisations (tenants) connected to this account.",
+    inputSchema: s.object({}, { description: "No input is required." }),
+    outputSchema: s.object(
+      {
+        organisations: s.array(tenantSummary, { description: "The connected organisations." }),
+      },
+      {
+        required: ["organisations"],
+        description: "Connected Xero organisations.",
+      },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_organisation",
+    requiredScopes: [xeroSettingsReadScope],
+    description: "Get the organisation profile for a tenant.",
+    inputSchema: s.object(tenantField, { description: "Organisation lookup input." }),
+    outputSchema: s.object(
+      {
+        organisation_id: xeroId,
+        name: s.string(),
+        legal_name: s.string(),
+        currency_code: s.string(),
+        country_code: s.string(),
+        timezone: s.string(),
+        tax_system_type: s.string(),
+      },
+      {
+        required: ["organisation_id", "name", "legal_name", "currency_code", "country_code"],
+        additionalProperties: true,
+        description: "An organisation profile.",
+      },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "search_contacts",
+    requiredScopes: [xeroContactsReadScope],
+    description: "Search contacts by name fragment with pagination.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        search: s.string({ description: "A name fragment to match. When omitted, all contacts are returned." }),
+        page: pageInput,
+      },
+      {
+        description: "Contact search input.",
+      },
+    ),
+    outputSchema: searchResults(contactSummary, "Matching contacts."),
+  }),
+  defineProviderAction(service, {
+    name: "get_contact",
+    requiredScopes: [xeroContactsReadScope],
+    description: "Get a contact by ID.",
+    inputSchema: s.object(
+      { ...tenantField, contact_id: xeroId },
+      { required: ["contact_id"], description: "Contact lookup input." },
+    ),
+    outputSchema: s.nullable(contactSummary),
+  }),
+  defineProviderAction(service, {
+    name: "create_contact",
+    requiredScopes: [xeroContactsWriteScope],
+    description: "Create a contact. Requires a connection with the accounting.contacts scope.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        name: s.string({ description: "The contact name." }),
+        email_address: s.string({ description: "The contact email address." }),
+        first_name: s.string({ description: "The contact first name." }),
+        last_name: s.string({ description: "The contact last name." }),
+        is_customer: s.boolean({ default: false, description: "Whether this contact buys from you." }),
+        is_supplier: s.boolean({ default: true, description: "Whether this contact sells to you." }),
+      },
+      {
+        required: ["name"],
+        description: "Contact creation input.",
+      },
+    ),
+    outputSchema: s.object({ contact: contactSummary }, { required: ["contact"], description: "The created contact." }),
+  }),
+  defineProviderAction(service, {
+    name: "search_invoices",
+    requiredScopes: [xeroInvoicesReadScope],
+    description: "Search invoices by status with pagination.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        status: s.stringEnum(invoiceStatuses, { description: "Filter by invoice status." }),
+        page: pageInput,
+      },
+      {
+        description: "Invoice search input.",
+      },
+    ),
+    outputSchema: searchResults(invoiceSummary, "Matching invoices."),
+  }),
+  defineProviderAction(service, {
+    name: "get_invoice",
+    requiredScopes: [xeroInvoicesReadScope],
+    description: "Get an invoice with its line items by ID.",
+    inputSchema: s.object(
+      { ...tenantField, invoice_id: xeroId },
+      { required: ["invoice_id"], description: "Invoice lookup input." },
+    ),
+    outputSchema: s.nullable(invoiceDetail),
+  }),
+  defineProviderAction(service, {
+    name: "create_invoice",
+    requiredScopes: [xeroInvoicesWriteScope],
+    description: "Create an invoice for a contact. Requires a connection with the accounting.invoices scope.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        contact_id: xeroId,
+        type: s.stringEnum(["ACCREC", "ACCPAY"], {
+          default: "ACCREC",
+          description: "ACCREC bills the customer; ACCPAY records a bill from a supplier.",
+        }),
+        date: s.date("The invoice date. Defaults to today."),
+        due_date: s.date("The due date. Defaults to the invoice date plus 30 days."),
+        reference: s.string({ description: "The invoice reference." }),
+        line_items: s.array(lineItemInput, { description: "The invoice line items." }),
+      },
+      {
+        required: ["contact_id", "line_items"],
+        description: "Invoice creation input.",
+      },
+    ),
+    outputSchema: s.object({ invoice: invoiceDetail }, { required: ["invoice"], description: "The created invoice." }),
+  }),
+  defineProviderAction(service, {
+    name: "update_invoice_status",
+    requiredScopes: [xeroInvoicesWriteScope],
+    description:
+      "Move an invoice through its lifecycle: submit, approve, or void. Requires the accounting.invoices scope.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        invoice_id: xeroId,
+        status: s.stringEnum(["SUBMITTED", "AUTHORISED", "VOIDED"], {
+          description: "The status to move the invoice to.",
+        }),
+      },
+      {
+        required: ["invoice_id", "status"],
+        description: "Invoice status update input.",
+      },
+    ),
+    outputSchema: s.object({ invoice: invoiceSummary }, { required: ["invoice"], description: "The updated invoice." }),
+  }),
+  defineProviderAction(service, {
+    name: "list_accounts",
+    requiredScopes: [xeroSettingsReadScope],
+    description: "List the chart of accounts for a tenant.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        status: s.stringEnum(["ACTIVE", "ARCHIVED", "GONE"], { description: "Filter by account status." }),
+      },
+      { description: "Account list input." },
+    ),
+    outputSchema: s.object(
+      {
+        accounts: s.array(accountSummary, { description: "The chart of accounts." }),
+      },
+      {
+        required: ["accounts"],
+        description: "The chart of accounts.",
+      },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_account",
+    requiredScopes: [xeroSettingsReadScope],
+    description: "Get an account by ID.",
+    inputSchema: s.object(
+      { ...tenantField, account_id: xeroId },
+      { required: ["account_id"], description: "Account lookup input." },
+    ),
+    outputSchema: s.nullable(accountSummary),
+  }),
+  defineProviderAction(service, {
+    name: "search_bank_transactions",
+    requiredScopes: [xeroBankTransactionsReadScope],
+    description: "Search bank transactions by status with pagination.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        status: s.stringEnum(["AUTHORISED", "DRAFT", "VOIDED"], { description: "Filter by transaction status." }),
+        page: pageInput,
+      },
+      {
+        description: "Bank transaction search input.",
+      },
+    ),
+    outputSchema: searchResults(bankTransactionSummary, "Matching bank transactions."),
+  }),
+  defineProviderAction(service, {
+    name: "get_bank_transaction",
+    requiredScopes: [xeroBankTransactionsReadScope],
+    description: "Get a bank transaction with its line items by ID.",
+    inputSchema: s.object(
+      { ...tenantField, bank_transaction_id: xeroId },
+      { required: ["bank_transaction_id"], description: "Bank transaction lookup input." },
+    ),
+    outputSchema: s.nullable(bankTransactionDetail),
+  }),
+  defineProviderAction(service, {
+    name: "get_profit_and_loss",
+    requiredScopes: [xeroProfitAndLossReadScope],
+    description: "Get the profit and loss report for a tenant, as labelled sections an agent can summarise.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        from_date: s.date("The report start date."),
+        to_date: s.date("The report end date. Defaults to today."),
+      },
+      { description: "Profit and loss report input." },
+    ),
+    outputSchema: reportOutput,
+  }),
+  defineProviderAction(service, {
+    name: "get_balance_sheet",
+    requiredScopes: [xeroBalanceSheetReadScope],
+    description: "Get the balance sheet report for a tenant, as labelled sections an agent can summarise.",
+    inputSchema: s.object(
+      {
+        ...tenantField,
+        date: s.date("The as-at date for the balance sheet. Defaults to today in the organisation timezone."),
+      },
+      { description: "Balance sheet report input." },
+    ),
+    outputSchema: reportOutput,
+  }),
+];

--- a/src/providers/xero/definition.ts
+++ b/src/providers/xero/definition.ts
@@ -1,0 +1,34 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { xeroActions } from "./actions.ts";
+import { xeroOAuthScopes } from "./scopes.ts";
+
+const service = "xero";
+
+/**
+ * Xero provider backed by the Xero Accounting and Identity APIs.
+ *
+ * Open-source users bring their own Xero OAuth app. Xero access tokens expire
+ * after 30 minutes, so the runtime refreshes them with the refresh token
+ * granted through `offline_access`; see `src/oauth/oauth-credential-refresh-service.ts`.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Xero",
+  categories: ["Finance", "Data"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://login.xero.com/identity/connect/authorize",
+      tokenUrl: "https://identity.xero.com/connect/token",
+      scopes: xeroOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      // Xero web apps reject authorization requests that include a PKCE
+      // code challenge ("Requested wrong apps scopes" / access_denied), so
+      // PKCE stays off even though the runtime supports it.
+    },
+  ],
+  homepageUrl: "https://www.xero.com",
+  actions: xeroActions,
+};

--- a/src/providers/xero/executors.test.ts
+++ b/src/providers/xero/executors.test.ts
@@ -1,0 +1,379 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { credentialValidators, xeroActionHandlers } from "./executors.ts";
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+function createFetcher(routes: Record<string, unknown | ((request: RecordedRequest) => unknown)>): {
+  fetcher: ProviderFetch;
+  requests: RecordedRequest[];
+} {
+  const requests: RecordedRequest[] = [];
+  const fetcher: ProviderFetch = async (input, init) => {
+    const url = String(input);
+    const request: RecordedRequest = {
+      url,
+      method: init?.method ?? "GET",
+      headers: Object.fromEntries(
+        Object.entries(init?.headers ?? {}).map(([key, value]) => [key.toLowerCase(), String(value)]),
+      ),
+    };
+    if (init?.body) {
+      request.body = JSON.parse(String(init.body));
+    }
+    requests.push(request);
+    const pathname = url.split("?")[0];
+    const route = routes[pathname];
+    if (route === undefined) {
+      return new Response(JSON.stringify({ error: `no route for ${pathname}` }), { status: 404 });
+    }
+    const payload = typeof route === "function" ? route(request) : route;
+    return new Response(JSON.stringify(payload), { status: 200 });
+  };
+  return { fetcher, requests };
+}
+
+const accessToken = "test-access-token";
+const connectionsFixture = [{ tenantId: "tenant-123", tenantName: "Demo Company", tenantType: "ORG" }];
+const contactsFixture = [
+  {
+    ContactID: "contact-1",
+    Name: "Jane Doe",
+    FirstName: "Jane",
+    LastName: "Doe",
+    EmailAddress: "jane@example.com",
+    Phones: [{ PhoneNumber: "021 555 1234" }],
+    IsCustomer: true,
+    IsSupplier: false,
+    AccountNumber: "AC-1001",
+    Status: "ACTIVE",
+  },
+];
+const invoiceFixture = {
+  InvoiceID: "invoice-1",
+  InvoiceNumber: "INV-0001",
+  Type: "ACCREC",
+  Status: "DRAFT",
+  Date: "2026-08-01",
+  DueDate: "2026-08-31",
+  Reference: "Consulting work",
+  Total: 1150,
+  AmountDue: 1150,
+  CurrencyCode: "NZD",
+  Contact: { Name: "Jane Doe" },
+  LineItems: [
+    {
+      LineItemID: "line-1",
+      Description: "Consulting",
+      Quantity: 2,
+      UnitAmount: 500,
+      LineAmount: 1000,
+      AccountCode: "200",
+    },
+  ],
+};
+
+describe("credentialValidators", () => {
+  it("maps the first connection to the credential profile", async () => {
+    const { fetcher } = createFetcher({ "https://api.xero.com/connections": connectionsFixture });
+    await expect(
+      credentialValidators.oauth2?.(
+        { authType: "oauth2", accessToken, profile: null as never, metadata: {} } as never,
+        {
+          fetcher,
+        } as never,
+      ),
+    ).resolves.toEqual({
+      profile: { accountId: "tenant-123", displayName: "Demo Company" },
+    });
+  });
+
+  it("falls back to a neutral profile when no organisation is connected", async () => {
+    const { fetcher } = createFetcher({ "https://api.xero.com/connections": [] });
+    await expect(
+      credentialValidators.oauth2?.(
+        { authType: "oauth2", accessToken, profile: null as never, metadata: {} } as never,
+        {
+          fetcher,
+        } as never,
+      ),
+    ).resolves.toEqual({
+      profile: { accountId: "xero", displayName: "Xero" },
+    });
+  });
+});
+
+describe("list_organisations", () => {
+  it("maps the identity connections to tenant summaries", async () => {
+    const { fetcher, requests } = createFetcher({ "https://api.xero.com/connections": connectionsFixture });
+    await expect(xeroActionHandlers.list_organisations({}, { accessToken, fetcher })).resolves.toEqual({
+      organisations: [{ tenant_id: "tenant-123", tenant_name: "Demo Company", tenant_type: "ORG" }],
+    });
+    expect(requests[0].headers.authorization).toBe(`Bearer ${accessToken}`);
+  });
+});
+
+describe("tenant resolution", () => {
+  const baseRoutes = {
+    "https://api.xero.com/connections": connectionsFixture,
+    "https://api.xero.com/api.xro/2.0/Contacts": { Contacts: contactsFixture },
+  };
+
+  it("falls back to the first connection and sends the Xero-Tenant-Id header", async () => {
+    const { fetcher, requests } = createFetcher(baseRoutes);
+    await xeroActionHandlers.search_contacts({ search: "Jane" }, { accessToken, fetcher });
+    const contactsRequest = requests.find((request) => request.url.includes("/Contacts"));
+    expect(contactsRequest?.headers["xero-tenant-id"]).toBe("tenant-123");
+    expect(decodeURIComponent(contactsRequest?.url ?? "")).toContain('Name.Contains("Jane")');
+  });
+
+  it("escapes quotes in the contact name filter", async () => {
+    const { fetcher, requests } = createFetcher(baseRoutes);
+    await xeroActionHandlers.search_contacts(
+      { tenant_id: "tenant-123", search: 'Acme "Holdings"' },
+      { accessToken, fetcher },
+    );
+    const contactsRequest = requests.find((request) => request.url.includes("/Contacts"));
+    expect(new URL(contactsRequest?.url ?? "https://invalid.example").searchParams.get("where")).toBe(
+      'Name.Contains("Acme ""Holdings""")',
+    );
+  });
+
+  it("uses an explicit tenant_id without calling the connections endpoint", async () => {
+    const { fetcher, requests } = createFetcher(baseRoutes);
+    await xeroActionHandlers.search_contacts({ tenant_id: "tenant-999", page: 2 }, { accessToken, fetcher });
+    expect(requests.some((request) => request.url.includes("/connections"))).toBe(false);
+    const contactsRequest = requests.find((request) => request.url.includes("/Contacts"));
+    expect(contactsRequest?.headers["xero-tenant-id"]).toBe("tenant-999");
+    expect(contactsRequest?.url).toContain("page=2");
+  });
+
+  it("rejects with a stable error when no organisation is connected", async () => {
+    const { fetcher } = createFetcher({ "https://api.xero.com/connections": [] });
+    await expect(xeroActionHandlers.get_organisation({}, { accessToken, fetcher })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe("get_contact", () => {
+  it("maps the PascalCase Xero payload to the snake_case output", async () => {
+    const { fetcher } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Contacts/contact-1": { Contacts: contactsFixture },
+    });
+    await expect(
+      xeroActionHandlers.get_contact({ tenant_id: "tenant-123", contact_id: "contact-1" }, { accessToken, fetcher }),
+    ).resolves.toEqual({
+      contact_id: "contact-1",
+      name: "Jane Doe",
+      first_name: "Jane",
+      last_name: "Doe",
+      email_address: "jane@example.com",
+      phone: "021 555 1234",
+      is_customer: true,
+      is_supplier: false,
+      account_number: "AC-1001",
+      status: "ACTIVE",
+    });
+  });
+});
+
+describe("create_invoice", () => {
+  it("posts the Xero payload shape and returns the created invoice", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Invoices": { Invoices: [invoiceFixture] },
+    });
+    const result = await xeroActionHandlers.create_invoice(
+      {
+        tenant_id: "tenant-123",
+        contact_id: "contact-1",
+        line_items: [{ description: "Consulting", quantity: 2, unit_amount: 500, account_code: "200" }],
+      },
+      { accessToken, fetcher },
+    );
+    const postRequest = requests.find((request) => request.method === "POST");
+    expect(postRequest?.body).toEqual({
+      Type: "ACCREC",
+      Contact: { ContactID: "contact-1" },
+      Status: "DRAFT",
+      LineItems: [{ Description: "Consulting", Quantity: 2, UnitAmount: 500, AccountCode: "200" }],
+    });
+    expect(postRequest?.headers["xero-tenant-id"]).toBe("tenant-123");
+    expect(result).toMatchObject({ invoice: { invoice_id: "invoice-1", total: 1150 } });
+  });
+
+  it("defaults the due date to 30 days after the invoice date", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Invoices": { Invoices: [invoiceFixture] },
+    });
+    await xeroActionHandlers.create_invoice(
+      {
+        tenant_id: "tenant-123",
+        contact_id: "contact-1",
+        date: "2026-08-01",
+        line_items: [{ description: "Consulting", quantity: 1, unit_amount: 100, account_code: "200" }],
+      },
+      { accessToken, fetcher },
+    );
+    const postRequest = requests.find((request) => request.method === "POST");
+    expect(postRequest?.body).toMatchObject({ DueDate: "2026-08-31" });
+  });
+
+  it("rejects when no line items are provided", async () => {
+    const { fetcher } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+    });
+    await expect(
+      xeroActionHandlers.create_invoice(
+        { tenant_id: "tenant-123", contact_id: "contact-1", line_items: [] },
+        { accessToken, fetcher },
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("search_invoices", () => {
+  it("forwards page and Statuses so Xero returns a paged invoice list", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Invoices": { Invoices: [invoiceFixture] },
+    });
+    const result = await xeroActionHandlers.search_invoices(
+      { tenant_id: "tenant-123", status: "DRAFT", page: 2 },
+      { accessToken, fetcher },
+    );
+    const invoicesRequest = requests.find((request) => request.url.includes("/Invoices"));
+    expect(invoicesRequest?.url).toContain("page=2");
+    expect(invoicesRequest?.url).toContain("Statuses=DRAFT");
+    expect(result).toMatchObject({ page: 2, returned: 1, items: [{ invoice_id: "invoice-1" }] });
+  });
+});
+
+describe("update_invoice_status", () => {
+  it("posts only InvoiceID and Status", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Invoices/invoice-1": {
+        Invoices: [{ ...invoiceFixture, Status: "AUTHORISED" }],
+      },
+    });
+    const result = await xeroActionHandlers.update_invoice_status(
+      { tenant_id: "tenant-123", invoice_id: "invoice-1", status: "AUTHORISED" },
+      { accessToken, fetcher },
+    );
+    const postRequest = requests.find((request) => request.method === "POST");
+    expect(postRequest?.body).toEqual({ InvoiceID: "invoice-1", Status: "AUTHORISED" });
+    expect(requests.filter((request) => request.url.includes("/Invoices/invoice-1"))).toHaveLength(1);
+    expect(result).toMatchObject({ invoice: { invoice_id: "invoice-1", status: "AUTHORISED" } });
+  });
+});
+
+describe("get_invoice", () => {
+  it("parses ASP.NET dates with or without a timezone offset", async () => {
+    const { fetcher } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Invoices/invoice-1": {
+        Invoices: [
+          {
+            ...invoiceFixture,
+            Date: "/Date(1754006400000)/",
+            DueDate: "/Date(1756598400000+0000)/",
+            DateString: undefined,
+            DueDateString: undefined,
+          },
+        ],
+      },
+    });
+    await expect(
+      xeroActionHandlers.get_invoice({ tenant_id: "tenant-123", invoice_id: "invoice-1" }, { accessToken, fetcher }),
+    ).resolves.toMatchObject({
+      date: "2025-08-01",
+      due_date: "2025-08-31",
+    });
+  });
+});
+
+describe("get_balance_sheet", () => {
+  it("sends the as-at date query parameter Xero expects", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Reports/BalanceSheet": {
+        Reports: [{ ReportID: "bs-1", ReportName: "BalanceSheet", ReportTitles: ["Balance Sheet"], Rows: [] }],
+      },
+    });
+    await xeroActionHandlers.get_balance_sheet(
+      { tenant_id: "tenant-123", date: "2026-08-01" },
+      { accessToken, fetcher },
+    );
+    const reportRequest = requests.find((request) => request.url.includes("/Reports/BalanceSheet"));
+    expect(reportRequest?.url).toContain("date=2026-08-01");
+    expect(reportRequest?.url).not.toContain("fromDate");
+    expect(reportRequest?.url).not.toContain("toDate");
+  });
+});
+
+describe("get_profit_and_loss", () => {
+  it("parses report sections into labelled rows an agent can summarise", async () => {
+    const reportFixture = {
+      ReportID: "report-1",
+      ReportName: "ProfitAndLoss",
+      ReportTitles: ["Profit and Loss", "Demo Company", "01 August 2026 to 31 August 2026"],
+      ReportDate: "2026-08-13T00:00:00",
+      Rows: [
+        {
+          RowType: "Section",
+          Title: "Revenue",
+          Rows: [
+            { RowType: "Row", Cells: [{ Value: "Sales" }, { Value: "10000.00" }] },
+            { RowType: "SummaryRow", Cells: [{ Value: "Total Revenue" }, { Value: "10000.00" }] },
+          ],
+        },
+        {
+          RowType: "Section",
+          Title: "Expenses",
+          Rows: [
+            { RowType: "Row", Cells: [{ Value: "Rent" }, { Value: "2000.00" }] },
+            { RowType: "SummaryRow", Cells: [{ Value: "Total Expenses" }, { Value: "2000.00" }] },
+          ],
+        },
+      ],
+    };
+    const { fetcher } = createFetcher({
+      "https://api.xero.com/connections": connectionsFixture,
+      "https://api.xero.com/api.xro/2.0/Reports/ProfitAndLoss": { Reports: [reportFixture] },
+    });
+    await expect(
+      xeroActionHandlers.get_profit_and_loss({ tenant_id: "tenant-123" }, { accessToken, fetcher }),
+    ).resolves.toEqual({
+      report_id: "report-1",
+      report_name: "ProfitAndLoss",
+      titles: ["Profit and Loss", "Demo Company", "01 August 2026 to 31 August 2026"],
+      generated_at: "2026-08-13T00:00:00",
+      sections: [
+        {
+          title: "Revenue",
+          rows: [
+            { label: "Sales", value: "10000.00", is_total: false },
+            { label: "Total Revenue", value: "10000.00", is_total: true },
+          ],
+        },
+        {
+          title: "Expenses",
+          rows: [
+            { label: "Rent", value: "2000.00", is_total: false },
+            { label: "Total Expenses", value: "2000.00", is_total: true },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/src/providers/xero/executors.test.ts
+++ b/src/providers/xero/executors.test.ts
@@ -52,7 +52,7 @@ const contactsFixture = [
     IsCustomer: true,
     IsSupplier: false,
     AccountNumber: "AC-1001",
-    Status: "ACTIVE",
+    ContactStatus: "ACTIVE",
   },
 ];
 const invoiceFixture = {
@@ -94,7 +94,7 @@ describe("credentialValidators", () => {
     });
   });
 
-  it("falls back to a neutral profile when no organisation is connected", async () => {
+  it("leaves profile defaults to the connection service when no organisation is connected", async () => {
     const { fetcher } = createFetcher({ "https://api.xero.com/connections": [] });
     await expect(
       credentialValidators.oauth2?.(
@@ -103,9 +103,7 @@ describe("credentialValidators", () => {
           fetcher,
         } as never,
       ),
-    ).resolves.toEqual({
-      profile: { accountId: "xero", displayName: "Xero" },
-    });
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -185,8 +183,33 @@ describe("get_contact", () => {
   });
 });
 
+describe("create_contact", () => {
+  it("posts only writable Xero contact fields", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/api.xro/2.0/Contacts": { Contacts: contactsFixture },
+    });
+    await xeroActionHandlers.create_contact(
+      {
+        tenant_id: "tenant-123",
+        name: "Jane Doe",
+        email_address: "jane@example.com",
+        first_name: "Jane",
+        last_name: "Doe",
+      },
+      { accessToken, fetcher },
+    );
+    const postRequest = requests.find((request) => request.method === "POST");
+    expect(postRequest?.body).toEqual({
+      Name: "Jane Doe",
+      EmailAddress: "jane@example.com",
+      FirstName: "Jane",
+      LastName: "Doe",
+    });
+  });
+});
+
 describe("create_invoice", () => {
-  it("posts the Xero payload shape and returns the created invoice", async () => {
+  it("lets Xero determine both dates when the invoice date is omitted", async () => {
     const { fetcher, requests } = createFetcher({
       "https://api.xero.com/connections": connectionsFixture,
       "https://api.xero.com/api.xro/2.0/Invoices": { Invoices: [invoiceFixture] },
@@ -200,12 +223,9 @@ describe("create_invoice", () => {
       { accessToken, fetcher },
     );
     const postRequest = requests.find((request) => request.method === "POST");
-    const due = new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
-    due.setUTCDate(due.getUTCDate() + 30);
     expect(postRequest?.body).toEqual({
       Type: "ACCREC",
       Contact: { ContactID: "contact-1" },
-      DueDate: due.toISOString().slice(0, 10),
       Status: "DRAFT",
       LineItems: [{ Description: "Consulting", Quantity: 2, UnitAmount: 500, AccountCode: "200" }],
     });
@@ -258,6 +278,101 @@ describe("search_invoices", () => {
     expect(invoicesRequest?.url).toContain("page=2");
     expect(invoicesRequest?.url).toContain("Statuses=DRAFT");
     expect(result).toMatchObject({ page: 2, returned: 1, items: [{ invoice_id: "invoice-1" }] });
+  });
+});
+
+describe("search_bank_transactions", () => {
+  it("normalises transaction, overpayment, and prepayment identifiers", async () => {
+    const bankTransactions = [
+      {
+        BankTransactionID: "bank-1",
+        Type: "RECEIVE-TRANSFER",
+        Status: "DELETED",
+        DateString: "2026-08-01",
+        Total: 100,
+        CurrencyCode: "NZD",
+        Contact: { Name: "Transfer account" },
+        LineItems: [],
+      },
+      {
+        OverpaymentID: "overpayment-1",
+        Type: "RECEIVE-OVERPAYMENT",
+        Status: "PAID",
+        DateString: "2026-08-02",
+        Total: 200,
+        CurrencyCode: "NZD",
+        Contact: { Name: "Jane Doe" },
+        LineItems: [],
+      },
+      {
+        PrepaymentID: "prepayment-1",
+        Type: "SPEND-PREPAYMENT",
+        Status: "VOIDED",
+        DateString: "2026-08-03",
+        Total: 300,
+        CurrencyCode: "NZD",
+        Contact: { Name: "Supplier" },
+        LineItems: [],
+      },
+    ];
+    const { fetcher, requests } = createFetcher({
+      "https://api.xero.com/api.xro/2.0/BankTransactions": { BankTransactions: bankTransactions },
+    });
+    const result = await xeroActionHandlers.search_bank_transactions(
+      { tenant_id: "tenant-123", status: "PAID", page: 2 },
+      { accessToken, fetcher },
+    );
+    const transactionRequest = requests.find((request) => request.url.includes("/BankTransactions"));
+    const query = new URL(transactionRequest?.url ?? "https://invalid.example").searchParams;
+    expect(query.get("where")).toBe('Status=="PAID"');
+    expect(query.get("page")).toBe("2");
+    expect(result).toEqual({
+      items: [
+        {
+          transaction_id: "bank-1",
+          type: "RECEIVE-TRANSFER",
+          status: "DELETED",
+          date: "2026-08-01",
+          total: 100,
+          currency_code: "NZD",
+          contact_name: "Transfer account",
+          line_item_count: 0,
+        },
+        {
+          transaction_id: "overpayment-1",
+          type: "RECEIVE-OVERPAYMENT",
+          status: "PAID",
+          date: "2026-08-02",
+          total: 200,
+          currency_code: "NZD",
+          contact_name: "Jane Doe",
+          line_item_count: 0,
+        },
+        {
+          transaction_id: "prepayment-1",
+          type: "SPEND-PREPAYMENT",
+          status: "VOIDED",
+          date: "2026-08-03",
+          total: 300,
+          currency_code: "NZD",
+          contact_name: "Supplier",
+          line_item_count: 0,
+        },
+      ],
+      page: 2,
+      returned: 3,
+    });
+  });
+
+  it("rejects a Xero transaction without any supported identifier", async () => {
+    const { fetcher } = createFetcher({
+      "https://api.xero.com/api.xro/2.0/BankTransactions": {
+        BankTransactions: [{ Type: "RECEIVE", Status: "AUTHORISED", LineItems: [] }],
+      },
+    });
+    await expect(
+      xeroActionHandlers.search_bank_transactions({ tenant_id: "tenant-123" }, { accessToken, fetcher }),
+    ).rejects.toMatchObject({ status: 502 });
   });
 });
 

--- a/src/providers/xero/executors.test.ts
+++ b/src/providers/xero/executors.test.ts
@@ -130,19 +130,19 @@ describe("tenant resolution", () => {
     await xeroActionHandlers.search_contacts({ search: "Jane" }, { accessToken, fetcher });
     const contactsRequest = requests.find((request) => request.url.includes("/Contacts"));
     expect(contactsRequest?.headers["xero-tenant-id"]).toBe("tenant-123");
-    expect(decodeURIComponent(contactsRequest?.url ?? "")).toContain('Name.Contains("Jane")');
+    expect(new URL(contactsRequest?.url ?? "https://invalid.example").searchParams.get("SearchTerm")).toBe("Jane");
   });
 
-  it("escapes quotes in the contact name filter", async () => {
+  it("sends quoted search terms through SearchTerm instead of a where clause", async () => {
     const { fetcher, requests } = createFetcher(baseRoutes);
     await xeroActionHandlers.search_contacts(
       { tenant_id: "tenant-123", search: 'Acme "Holdings"' },
       { accessToken, fetcher },
     );
     const contactsRequest = requests.find((request) => request.url.includes("/Contacts"));
-    expect(new URL(contactsRequest?.url ?? "https://invalid.example").searchParams.get("where")).toBe(
-      'Name.Contains("Acme ""Holdings""")',
-    );
+    const url = new URL(contactsRequest?.url ?? "https://invalid.example");
+    expect(url.searchParams.get("SearchTerm")).toBe('Acme "Holdings"');
+    expect(url.searchParams.get("where")).toBeNull();
   });
 
   it("uses an explicit tenant_id without calling the connections endpoint", async () => {
@@ -200,9 +200,12 @@ describe("create_invoice", () => {
       { accessToken, fetcher },
     );
     const postRequest = requests.find((request) => request.method === "POST");
+    const due = new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+    due.setUTCDate(due.getUTCDate() + 30);
     expect(postRequest?.body).toEqual({
       Type: "ACCREC",
       Contact: { ContactID: "contact-1" },
+      DueDate: due.toISOString().slice(0, 10),
       Status: "DRAFT",
       LineItems: [{ Description: "Consulting", Quantity: 2, UnitAmount: 500, AccountCode: "200" }],
     });

--- a/src/providers/xero/executors.ts
+++ b/src/providers/xero/executors.ts
@@ -1,12 +1,11 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { OAuthProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
-import { optionalBoolean, optionalInteger, optionalNumber, optionalString, requiredString } from "../../core/cast.ts";
+import { optionalInteger, optionalNumber, optionalString, requiredString } from "../../core/cast.ts";
 import { arrayPayload, definedBody, objectPayload, requestJson } from "../http-json-runtime.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "xero";
-const providerName = "Xero";
 const apiBaseUrl = "https://api.xero.com/api.xro/2.0";
 const identityBaseUrl = "https://api.xero.com";
 const apiPackage = "OpenConnector";
@@ -26,7 +25,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
   async list_organisations(_input, context): Promise<unknown> {
     const connections = arrayPayload(
       await requestJson({
-        providerName,
+        providerName: service,
         baseUrl: identityBaseUrl,
         path: "/connections",
         fetcher: context.fetcher,
@@ -83,9 +82,6 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
         EmailAddress: optionalString(input.email_address),
         FirstName: optionalString(input.first_name),
         LastName: optionalString(input.last_name),
-        IsCustomer: optionalBoolean(input.is_customer),
-        IsSupplier: optionalBoolean(input.is_supplier),
-        Status: "ACTIVE",
       }),
     });
     const contacts = resourceList(payload, "Contacts");
@@ -127,7 +123,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
         Type: optionalString(input.type) ?? "ACCREC",
         Contact: { ContactID: requiredString(input.contact_id, "contact_id") },
         Date: invoiceDate,
-        DueDate: optionalString(input.due_date) ?? defaultDueDate(invoiceDate ?? utcToday()),
+        DueDate: optionalString(input.due_date) ?? defaultDueDate(invoiceDate),
         Reference: optionalString(input.reference),
         LineItems: lineItems,
         Status: "DRAFT",
@@ -208,7 +204,7 @@ export const executors: ProviderExecutors = defineOAuthProviderExecutors(service
 export const credentialValidators: CredentialValidators = {
   async oauth2(input, { fetcher }) {
     const payload = await requestJson({
-      providerName,
+      providerName: service,
       baseUrl: identityBaseUrl,
       path: "/connections",
       fetcher,
@@ -216,10 +212,13 @@ export const credentialValidators: CredentialValidators = {
     });
     const tenants = arrayPayload(payload, "connections");
     const first = tenants.length > 0 ? optionalRecordValue(tenants[0]) : undefined;
+    if (!first) {
+      return;
+    }
     return {
       profile: {
-        accountId: optionalString(first?.tenantId) ?? "xero",
-        displayName: optionalString(first?.tenantName) ?? "Xero",
+        accountId: optionalString(first.tenantId),
+        displayName: optionalString(first.tenantName),
       },
     };
   },
@@ -232,7 +231,7 @@ async function xeroRequest(
   try {
     return objectPayload(
       await requestJson({
-        providerName,
+        providerName: service,
         baseUrl: options.baseUrl ?? apiBaseUrl,
         path: options.path,
         fetcher: context.fetcher,
@@ -305,7 +304,7 @@ async function resolveTenantId(input: Record<string, unknown>, context: OAuthPro
   }
   const connections = arrayPayload(
     await requestJson({
-      providerName,
+      providerName: service,
       baseUrl: identityBaseUrl,
       path: "/connections",
       fetcher: context.fetcher,
@@ -418,8 +417,15 @@ function mapInvoiceDetail(raw: unknown): Record<string, unknown> {
 function mapBankTransactionSummary(raw: unknown): Record<string, unknown> {
   const record = optionalRecordValue(raw);
   const lineItems = Array.isArray(record.LineItems) ? record.LineItems : [];
+  const transactionId =
+    optionalString(record.BankTransactionID) ??
+    optionalString(record.OverpaymentID) ??
+    optionalString(record.PrepaymentID);
+  if (!transactionId) {
+    throw new ProviderRequestError(502, "Xero did not return a bank transaction identifier.");
+  }
   return {
-    bank_transaction_id: record.BankTransactionID ?? null,
+    transaction_id: transactionId,
     type: record.Type ?? "",
     status: record.Status ?? "",
     date: xeroDate(record.DateString ?? record.Date),
@@ -542,8 +548,4 @@ function xeroDate(value: unknown): string | null {
     return new Date(Number(epoch[1])).toISOString().slice(0, 10);
   }
   return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : null;
-}
-
-function utcToday(): string {
-  return new Date().toISOString().slice(0, 10);
 }

--- a/src/providers/xero/executors.ts
+++ b/src/providers/xero/executors.ts
@@ -49,7 +49,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
     const tenantId = await resolveTenantId(input, context);
     const payload = await xeroRequest(context, { path: "/Organisation", tenantId });
     const organisations = resourceList(payload, "Organisations");
-    return organisations.length > 0 ? mapOrganisation(organisations[0]) : null;
+    return mapOrganisation(requireFirst(organisations, "Organisation was not found."));
   },
   async search_contacts(input, context): Promise<unknown> {
     const tenantId = await resolveTenantId(input, context);
@@ -59,7 +59,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
       path: "/Contacts",
       tenantId,
       query: compactQuery({
-        where: search ? xeroContainsFilter("Name", search) : undefined,
+        SearchTerm: search,
         page: String(page),
       }),
     });
@@ -89,7 +89,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
       }),
     });
     const contacts = resourceList(payload, "Contacts");
-    return { contact: contacts.length > 0 ? mapContact(contacts[0]) : null };
+    return { contact: mapContact(requireFirst(contacts, "Xero did not return the created contact.", 502)) };
   },
   async search_invoices(input, context): Promise<unknown> {
     const tenantId = await resolveTenantId(input, context);
@@ -127,14 +127,14 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
         Type: optionalString(input.type) ?? "ACCREC",
         Contact: { ContactID: requiredString(input.contact_id, "contact_id") },
         Date: invoiceDate,
-        DueDate: optionalString(input.due_date) ?? defaultDueDate(invoiceDate),
+        DueDate: optionalString(input.due_date) ?? defaultDueDate(invoiceDate ?? utcToday()),
         Reference: optionalString(input.reference),
         LineItems: lineItems,
         Status: "DRAFT",
       }),
     });
     const invoices = resourceList(payload, "Invoices");
-    return { invoice: invoices.length > 0 ? mapInvoiceDetail(invoices[0]) : null };
+    return { invoice: mapInvoiceDetail(requireFirst(invoices, "Xero did not return the created invoice.", 502)) };
   },
   async update_invoice_status(input, context): Promise<unknown> {
     const tenantId = await resolveTenantId(input, context);
@@ -147,7 +147,7 @@ export const xeroActionHandlers: Record<string, XeroHandler> = {
       body: { InvoiceID: invoiceId, Status: status },
     });
     const invoices = resourceList(updated, "Invoices");
-    return { invoice: invoices.length > 0 ? mapInvoiceSummary(invoices[0]) : null };
+    return { invoice: mapInvoiceSummary(requireFirst(invoices, `Invoice not found: ${invoiceId}`)) };
   },
   async list_accounts(input, context): Promise<unknown> {
     const tenantId = await resolveTenantId(input, context);
@@ -329,17 +329,19 @@ function resourceList(payload: Record<string, unknown>, key: string): unknown[] 
   return Array.isArray(items) ? items : [];
 }
 
+function requireFirst(items: unknown[], message: string, status = 404): unknown {
+  if (items.length === 0) {
+    throw new ProviderRequestError(status, message);
+  }
+  return items[0];
+}
+
 function pageResult<T>(items: unknown[], page: number, map: (raw: unknown) => T): Record<string, unknown> {
   return { items: items.map(map), page, returned: items.length };
 }
 
 function compactQuery(query: Record<string, string | undefined>): Record<string, string> {
   return Object.fromEntries(Object.entries(query).filter(([, value]) => value !== undefined)) as Record<string, string>;
-}
-
-/** Xero where-strings use doubled quotes to escape a literal `"`. */
-function xeroContainsFilter(field: string, value: string): string {
-  return `${field}.Contains("${value.replaceAll('"', '""')}")`;
 }
 
 function optionalRecordValue(value: unknown): Record<string, unknown> {
@@ -528,7 +530,7 @@ async function fetchReport(
     query: compactQuery(query),
   });
   const reports = resourceList(payload, "Reports");
-  return reports.length > 0 ? mapReport(reports[0]) : null;
+  return mapReport(requireFirst(reports, `${report} report was not found.`));
 }
 
 function xeroDate(value: unknown): string | null {
@@ -540,4 +542,8 @@ function xeroDate(value: unknown): string | null {
     return new Date(Number(epoch[1])).toISOString().slice(0, 10);
   }
   return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : null;
+}
+
+function utcToday(): string {
+  return new Date().toISOString().slice(0, 10);
 }

--- a/src/providers/xero/executors.ts
+++ b/src/providers/xero/executors.ts
@@ -1,0 +1,543 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { optionalBoolean, optionalInteger, optionalNumber, optionalString, requiredString } from "../../core/cast.ts";
+import { arrayPayload, definedBody, objectPayload, requestJson } from "../http-json-runtime.ts";
+import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
+
+const service = "xero";
+const providerName = "Xero";
+const apiBaseUrl = "https://api.xero.com/api.xro/2.0";
+const identityBaseUrl = "https://api.xero.com";
+const apiPackage = "OpenConnector";
+
+type XeroHandler = ProviderRuntimeHandler<OAuthProviderContext>;
+
+interface XeroRequestOptions {
+  path: string;
+  baseUrl?: string;
+  method?: string;
+  query?: Record<string, string>;
+  body?: unknown;
+  tenantId?: string;
+}
+
+export const xeroActionHandlers: Record<string, XeroHandler> = {
+  async list_organisations(_input, context): Promise<unknown> {
+    const connections = arrayPayload(
+      await requestJson({
+        providerName,
+        baseUrl: identityBaseUrl,
+        path: "/connections",
+        fetcher: context.fetcher,
+        headers: bearerHeaders(context.accessToken),
+      }),
+      "Xero connections",
+    );
+    return {
+      organisations: connections.map((connection) => {
+        const record = optionalRecordValue(connection);
+        return {
+          tenant_id: record.tenantId,
+          tenant_name: record.tenantName,
+          tenant_type: record.tenantType,
+        };
+      }),
+    };
+  },
+  async get_organisation(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const payload = await xeroRequest(context, { path: "/Organisation", tenantId });
+    const organisations = resourceList(payload, "Organisations");
+    return organisations.length > 0 ? mapOrganisation(organisations[0]) : null;
+  },
+  async search_contacts(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const page = optionalInteger(input.page) ?? 1;
+    const search = optionalString(input.search);
+    const payload = await xeroRequest(context, {
+      path: "/Contacts",
+      tenantId,
+      query: compactQuery({
+        where: search ? xeroContainsFilter("Name", search) : undefined,
+        page: String(page),
+      }),
+    });
+    return pageResult(resourceList(payload, "Contacts"), page, mapContact);
+  },
+  async get_contact(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const contactId = requiredString(input.contact_id, "contact_id");
+    const payload = await xeroRequest(context, { path: `/Contacts/${contactId}`, tenantId });
+    const contacts = resourceList(payload, "Contacts");
+    return contacts.length > 0 ? mapContact(contacts[0]) : null;
+  },
+  async create_contact(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const payload = await xeroRequest(context, {
+      path: "/Contacts",
+      method: "POST",
+      tenantId,
+      body: definedBody({
+        Name: requiredString(input.name, "name"),
+        EmailAddress: optionalString(input.email_address),
+        FirstName: optionalString(input.first_name),
+        LastName: optionalString(input.last_name),
+        IsCustomer: optionalBoolean(input.is_customer),
+        IsSupplier: optionalBoolean(input.is_supplier),
+        Status: "ACTIVE",
+      }),
+    });
+    const contacts = resourceList(payload, "Contacts");
+    return { contact: contacts.length > 0 ? mapContact(contacts[0]) : null };
+  },
+  async search_invoices(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const page = optionalInteger(input.page) ?? 1;
+    const status = optionalString(input.status);
+    const payload = await xeroRequest(context, {
+      path: "/Invoices",
+      tenantId,
+      query: compactQuery({
+        Statuses: status,
+        page: String(page),
+      }),
+    });
+    return pageResult(resourceList(payload, "Invoices"), page, mapInvoiceSummary);
+  },
+  async get_invoice(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const invoiceId = requiredString(input.invoice_id, "invoice_id");
+    const payload = await xeroRequest(context, { path: `/Invoices/${invoiceId}`, tenantId });
+    const invoices = resourceList(payload, "Invoices");
+    return invoices.length > 0 ? mapInvoiceDetail(invoices[0]) : null;
+  },
+  async create_invoice(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const lineItems = Array.isArray(input.line_items) ? input.line_items.map(mapLineItemInput) : [];
+    if (lineItems.length === 0) {
+      throw new ProviderRequestError(400, "At least one line item is required.");
+    }
+    const invoiceDate = optionalString(input.date);
+    const payload = await xeroRequest(context, {
+      path: "/Invoices",
+      method: "POST",
+      tenantId,
+      body: definedBody({
+        Type: optionalString(input.type) ?? "ACCREC",
+        Contact: { ContactID: requiredString(input.contact_id, "contact_id") },
+        Date: invoiceDate,
+        DueDate: optionalString(input.due_date) ?? defaultDueDate(invoiceDate),
+        Reference: optionalString(input.reference),
+        LineItems: lineItems,
+        Status: "DRAFT",
+      }),
+    });
+    const invoices = resourceList(payload, "Invoices");
+    return { invoice: invoices.length > 0 ? mapInvoiceDetail(invoices[0]) : null };
+  },
+  async update_invoice_status(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const invoiceId = requiredString(input.invoice_id, "invoice_id");
+    const status = requiredString(input.status, "status");
+    const updated = await xeroRequest(context, {
+      path: `/Invoices/${invoiceId}`,
+      method: "POST",
+      tenantId,
+      body: { InvoiceID: invoiceId, Status: status },
+    });
+    const invoices = resourceList(updated, "Invoices");
+    return { invoice: invoices.length > 0 ? mapInvoiceSummary(invoices[0]) : null };
+  },
+  async list_accounts(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const status = optionalString(input.status);
+    const payload = await xeroRequest(context, {
+      path: "/Accounts",
+      tenantId,
+      query: compactQuery({ where: status ? `Status=="${status}"` : undefined }),
+    });
+    return { accounts: resourceList(payload, "Accounts").map(mapAccount) };
+  },
+  async get_account(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const accountId = requiredString(input.account_id, "account_id");
+    const payload = await xeroRequest(context, { path: `/Accounts/${accountId}`, tenantId });
+    const accounts = resourceList(payload, "Accounts");
+    return accounts.length > 0 ? mapAccount(accounts[0]) : null;
+  },
+  async search_bank_transactions(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const page = optionalInteger(input.page) ?? 1;
+    const status = optionalString(input.status);
+    const payload = await xeroRequest(context, {
+      path: "/BankTransactions",
+      tenantId,
+      query: compactQuery({
+        where: status ? `Status=="${status}"` : undefined,
+        page: String(page),
+      }),
+    });
+    return pageResult(resourceList(payload, "BankTransactions"), page, mapBankTransactionSummary);
+  },
+  async get_bank_transaction(input, context): Promise<unknown> {
+    const tenantId = await resolveTenantId(input, context);
+    const bankTransactionId = requiredString(input.bank_transaction_id, "bank_transaction_id");
+    const payload = await xeroRequest(context, {
+      path: `/BankTransactions/${bankTransactionId}`,
+      tenantId,
+    });
+    const transactions = resourceList(payload, "BankTransactions");
+    return transactions.length > 0 ? mapBankTransactionDetail(transactions[0]) : null;
+  },
+  async get_profit_and_loss(input, context): Promise<unknown> {
+    return fetchReport(input, context, "ProfitAndLoss", {
+      fromDate: optionalString(input.from_date),
+      toDate: optionalString(input.to_date),
+    });
+  },
+  async get_balance_sheet(input, context): Promise<unknown> {
+    return fetchReport(input, context, "BalanceSheet", {
+      date: optionalString(input.date),
+    });
+  },
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, xeroActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher }) {
+    const payload = await requestJson({
+      providerName,
+      baseUrl: identityBaseUrl,
+      path: "/connections",
+      fetcher,
+      headers: bearerHeaders(input.accessToken),
+    });
+    const tenants = arrayPayload(payload, "connections");
+    const first = tenants.length > 0 ? optionalRecordValue(tenants[0]) : undefined;
+    return {
+      profile: {
+        accountId: optionalString(first?.tenantId) ?? "xero",
+        displayName: optionalString(first?.tenantName) ?? "Xero",
+      },
+    };
+  },
+};
+
+async function xeroRequest(
+  context: OAuthProviderContext,
+  options: XeroRequestOptions,
+): Promise<Record<string, unknown>> {
+  try {
+    return objectPayload(
+      await requestJson({
+        providerName,
+        baseUrl: options.baseUrl ?? apiBaseUrl,
+        path: options.path,
+        fetcher: context.fetcher,
+        method: options.method,
+        query: options.query,
+        body: options.body,
+        headers: bearerHeaders(context.accessToken, options.tenantId),
+      }),
+      `${options.path} response`,
+    );
+  } catch (error) {
+    throw refineXeroError(error);
+  }
+}
+
+/**
+ * Xero wraps actionable validation messages in `Elements[].ValidationErrors`,
+ * while the top-level `Message` is a generic "A validation exception occurred".
+ * Surface the specific messages so agents can act on them.
+ */
+function refineXeroError(error: unknown): unknown {
+  if (!(error instanceof ProviderRequestError)) {
+    return error;
+  }
+  const details = optionalRecordValue(error.details);
+  const elements = Array.isArray(details.Elements) ? details.Elements : [];
+  const messages = new Set<string>();
+  for (const element of elements) {
+    const record = optionalRecordValue(element);
+    if (Array.isArray(record.ValidationErrors)) {
+      for (const item of record.ValidationErrors) {
+        const message = optionalString(optionalRecordValue(item).Message);
+        if (message) {
+          messages.add(message);
+        }
+      }
+    }
+  }
+  if (messages.size === 0) {
+    return error;
+  }
+  return new ProviderRequestError(error.status, `${error.message}: ${[...messages].join("; ")}`, error.details);
+}
+
+/** Xero requires a due date on approved invoices; default to a 30-day term. */
+function defaultDueDate(date: string | undefined): string | undefined {
+  if (!date) {
+    return undefined;
+  }
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  parsed.setUTCDate(parsed.getUTCDate() + 30);
+  return parsed.toISOString().slice(0, 10);
+}
+
+function bearerHeaders(accessToken: string, tenantId?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${accessToken}`,
+    "xero-api-package": apiPackage,
+    ...(tenantId ? { "xero-tenant-id": tenantId } : {}),
+  };
+}
+
+async function resolveTenantId(input: Record<string, unknown>, context: OAuthProviderContext): Promise<string> {
+  const explicit = optionalString(input.tenant_id);
+  if (explicit) {
+    return explicit;
+  }
+  const connections = arrayPayload(
+    await requestJson({
+      providerName,
+      baseUrl: identityBaseUrl,
+      path: "/connections",
+      fetcher: context.fetcher,
+      headers: bearerHeaders(context.accessToken),
+    }),
+    "Xero connections",
+  );
+  const first = optionalRecordValue(connections[0]);
+  const tenantId = optionalString(first.tenantId);
+  if (!tenantId) {
+    throw new ProviderRequestError(
+      400,
+      "No Xero organisation is connected. Pass tenant_id or connect an organisation first.",
+    );
+  }
+  return tenantId;
+}
+
+function resourceList(payload: Record<string, unknown>, key: string): unknown[] {
+  const items = payload[key];
+  return Array.isArray(items) ? items : [];
+}
+
+function pageResult<T>(items: unknown[], page: number, map: (raw: unknown) => T): Record<string, unknown> {
+  return { items: items.map(map), page, returned: items.length };
+}
+
+function compactQuery(query: Record<string, string | undefined>): Record<string, string> {
+  return Object.fromEntries(Object.entries(query).filter(([, value]) => value !== undefined)) as Record<string, string>;
+}
+
+/** Xero where-strings use doubled quotes to escape a literal `"`. */
+function xeroContainsFilter(field: string, value: string): string {
+  return `${field}.Contains("${value.replaceAll('"', '""')}")`;
+}
+
+function optionalRecordValue(value: unknown): Record<string, unknown> {
+  return value != null && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function mapLineItemInput(input: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(input);
+  return definedBody({
+    Description: optionalString(record.description),
+    Quantity: optionalNumber(record.quantity),
+    UnitAmount: optionalNumber(record.unit_amount),
+    AccountCode: optionalString(record.account_code),
+  });
+}
+
+function mapLineItem(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  return {
+    line_item_id: record.LineItemID ?? null,
+    description: record.Description ?? null,
+    quantity: optionalNumber(record.Quantity) ?? 0,
+    unit_amount: optionalNumber(record.UnitAmount) ?? 0,
+    line_amount: optionalNumber(record.LineAmount) ?? 0,
+    account_code: record.AccountCode ?? null,
+  };
+}
+
+function mapContact(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const phones = Array.isArray(record.Phones) ? record.Phones : [];
+  return {
+    contact_id: record.ContactID ?? null,
+    name: record.Name ?? "",
+    first_name: record.FirstName ?? null,
+    last_name: record.LastName ?? null,
+    email_address: record.EmailAddress ?? null,
+    phone: phones.length > 0 ? (optionalRecordValue(phones[0]).PhoneNumber ?? null) : null,
+    is_customer: record.IsCustomer ?? false,
+    is_supplier: record.IsSupplier ?? false,
+    account_number: record.AccountNumber ?? null,
+    status: record.ContactStatus ?? record.Status ?? "",
+  };
+}
+
+function mapInvoiceSummary(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const lineItems = Array.isArray(record.LineItems) ? record.LineItems : [];
+  return {
+    invoice_id: record.InvoiceID ?? null,
+    invoice_number: record.InvoiceNumber ?? "",
+    type: record.Type ?? "",
+    status: record.Status ?? "",
+    date: xeroDate(record.DateString ?? record.Date),
+    due_date: xeroDate(record.DueDateString ?? record.DueDate),
+    total: optionalNumber(record.Total) ?? 0,
+    amount_due: optionalNumber(record.AmountDue) ?? 0,
+    currency_code: record.CurrencyCode ?? "",
+    contact_name: optionalRecordValue(record.Contact).Name ?? null,
+    line_item_count: lineItems.length,
+  };
+}
+
+function mapInvoiceDetail(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const lineItems = Array.isArray(record.LineItems) ? record.LineItems : [];
+  return {
+    ...mapInvoiceSummary(raw),
+    reference: record.Reference ?? null,
+    line_items: lineItems.map(mapLineItem),
+  };
+}
+
+function mapBankTransactionSummary(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const lineItems = Array.isArray(record.LineItems) ? record.LineItems : [];
+  return {
+    bank_transaction_id: record.BankTransactionID ?? null,
+    type: record.Type ?? "",
+    status: record.Status ?? "",
+    date: xeroDate(record.DateString ?? record.Date),
+    total: optionalNumber(record.Total) ?? 0,
+    currency_code: record.CurrencyCode ?? "",
+    contact_name: optionalRecordValue(record.Contact).Name ?? null,
+    line_item_count: lineItems.length,
+  };
+}
+
+function mapBankTransactionDetail(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const lineItems = Array.isArray(record.LineItems) ? record.LineItems : [];
+  return {
+    ...mapBankTransactionSummary(raw),
+    reference: record.Reference ?? null,
+    line_items: lineItems.map(mapLineItem),
+  };
+}
+
+function mapAccount(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  return {
+    account_id: record.AccountID ?? null,
+    code: record.Code ?? "",
+    name: record.Name ?? "",
+    type: record.Type ?? "",
+    status: record.Status ?? "",
+    tax_type: record.TaxType ?? null,
+    currency_code: record.CurrencyCode ?? "",
+  };
+}
+
+function mapOrganisation(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  return {
+    organisation_id: record.OrganisationID ?? null,
+    name: record.Name ?? "",
+    legal_name: record.LegalName ?? "",
+    currency_code: record.BaseCurrency ?? "",
+    country_code: record.CountryCode ?? "",
+    timezone: record.Timezone ?? "",
+    tax_system_type: record.TaxSystemType ?? record.Version ?? "",
+  };
+}
+
+function mapReport(raw: unknown): Record<string, unknown> {
+  const record = optionalRecordValue(raw);
+  const rows = Array.isArray(record.Rows) ? record.Rows : [];
+  return {
+    report_id: record.ReportID ?? "",
+    report_name: record.ReportName ?? "",
+    titles: Array.isArray(record.ReportTitles) ? record.ReportTitles.filter((title) => typeof title === "string") : [],
+    generated_at: record.ReportDate ?? null,
+    sections: parseReportSections(rows),
+  };
+}
+
+function parseReportSections(rows: unknown[]): Record<string, unknown>[] {
+  const sections = rows.filter((row) => optionalRecordValue(row).RowType === "Section");
+  const mapped = sections.map((section) => {
+    const record = optionalRecordValue(section);
+    const sectionRows = Array.isArray(record.Rows) ? record.Rows : [];
+    return {
+      title: optionalString(record.Title) ?? null,
+      rows: sectionRows
+        .map((row) => {
+          const rowRecord = optionalRecordValue(row);
+          const cells = Array.isArray(rowRecord.Cells) ? rowRecord.Cells : [];
+          return {
+            label: cells.length > 0 ? (optionalString(optionalRecordValue(cells[0]).Value) ?? "") : "",
+            value: cells.length > 1 ? (optionalString(optionalRecordValue(cells[1]).Value) ?? null) : null,
+            is_total: rowRecord.RowType === "SummaryRow",
+          };
+        })
+        .filter((row) => row.label !== ""),
+    };
+  });
+  if (mapped.length > 0) {
+    return mapped;
+  }
+  return [
+    {
+      title: null,
+      rows: rows.map((row) => {
+        const rowRecord = optionalRecordValue(row);
+        const cells = Array.isArray(rowRecord.Cells) ? rowRecord.Cells : [];
+        return {
+          label: cells.length > 0 ? (optionalString(optionalRecordValue(cells[0]).Value) ?? "") : "",
+          value: cells.length > 1 ? (optionalString(optionalRecordValue(cells[1]).Value) ?? null) : null,
+          is_total: rowRecord.RowType === "SummaryRow",
+        };
+      }),
+    },
+  ];
+}
+
+async function fetchReport(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+  report: string,
+  query: Record<string, string | undefined>,
+): Promise<unknown> {
+  const tenantId = await resolveTenantId(input, context);
+  const payload = await xeroRequest(context, {
+    path: `/Reports/${report}`,
+    tenantId,
+    query: compactQuery(query),
+  });
+  const reports = resourceList(payload, "Reports");
+  return reports.length > 0 ? mapReport(reports[0]) : null;
+}
+
+function xeroDate(value: unknown): string | null {
+  if (typeof value !== "string" || !value) {
+    return null;
+  }
+  const epoch = /^\/Date\((\d+)(?:[+-]\d{4})?\)\/$/.exec(value);
+  if (epoch) {
+    return new Date(Number(epoch[1])).toISOString().slice(0, 10);
+  }
+  return /^\d{4}-\d{2}-\d{2}/.test(value) ? value.slice(0, 10) : null;
+}

--- a/src/providers/xero/scopes.ts
+++ b/src/providers/xero/scopes.ts
@@ -6,11 +6,10 @@
  * https://developer.xero.com/documentation/guides/oauth2/scopes
  */
 /**
- * The `app.connections` scope grants access to the Identity API connections
- * endpoint, but Xero REJECTS authorization requests that list it explicitly
- * ("Requested wrong apps scopes" / access_denied), even though the scope is
- * part of the app's allowed scope list. The connections endpoint works with a
- * live connection regardless, so this scope is kept out of the request list.
+ * The `app.connections` scope is for client-credentials Custom Connection apps.
+ * It is kept out of this provider's authorization-code request list. Requesting
+ * it on a web-app authorize URL returned access_denied ("Requested wrong apps
+ * scopes") in testing; GET /connections still works with a user access token.
  */
 export const xeroConnectionsScope = "app.connections";
 export const xeroSettingsReadScope = "accounting.settings.read";

--- a/src/providers/xero/scopes.ts
+++ b/src/providers/xero/scopes.ts
@@ -1,0 +1,45 @@
+/**
+ * Xero OAuth2 scopes (granular scope family). Apps created after 2 March 2026
+ * only have access to the granular scopes listed here; the older broad scopes
+ * such as `accounting.transactions.read` and `accounting.reports.read` are
+ * deprecated for new apps and are NOT requested by this provider:
+ * https://developer.xero.com/documentation/guides/oauth2/scopes
+ */
+/**
+ * The `app.connections` scope grants access to the Identity API connections
+ * endpoint, but Xero REJECTS authorization requests that list it explicitly
+ * ("Requested wrong apps scopes" / access_denied), even though the scope is
+ * part of the app's allowed scope list. The connections endpoint works with a
+ * live connection regardless, so this scope is kept out of the request list.
+ */
+export const xeroConnectionsScope = "app.connections";
+export const xeroSettingsReadScope = "accounting.settings.read";
+export const xeroContactsReadScope = "accounting.contacts.read";
+export const xeroInvoicesReadScope = "accounting.invoices.read";
+export const xeroBankTransactionsReadScope = "accounting.banktransactions.read";
+export const xeroProfitAndLossReadScope = "accounting.reports.profitandloss.read";
+export const xeroBalanceSheetReadScope = "accounting.reports.balancesheet.read";
+export const xeroContactsWriteScope = "accounting.contacts";
+export const xeroInvoicesWriteScope = "accounting.invoices";
+/** Required for a refresh token. Without it, Xero access lasts 30 minutes and then dies. */
+export const xeroOfflineAccessScope = "offline_access";
+
+/**
+ * Read-only scopes: safe for an agent that should inspect the books without
+ * modifying them. `app.connections` is intentionally not requested (see above)
+ * even though the tenant resolution calls the Identity API connections endpoint.
+ */
+export const xeroReadOnlyScopes: string[] = [
+  xeroSettingsReadScope,
+  xeroContactsReadScope,
+  xeroInvoicesReadScope,
+  xeroBankTransactionsReadScope,
+  xeroProfitAndLossReadScope,
+  xeroBalanceSheetReadScope,
+];
+
+/** Read-write scopes needed by create/update actions such as creating invoices. */
+export const xeroWriteScopes: string[] = [xeroContactsWriteScope, xeroInvoicesWriteScope];
+
+/** Scopes declared on the OAuth app. `offline_access` is required so the runtime can refresh. */
+export const xeroOAuthScopes: string[] = [...xeroReadOnlyScopes, ...xeroWriteScopes, xeroOfflineAccessScope];


### PR DESCRIPTION
## Summary
- Add a locally executable Xero provider (BYO OAuth app) for organisations, contacts, invoices, bank transactions, chart of accounts, and profit-and-loss / balance-sheet reports.
- Request `offline_access` so Xero's 30-minute access tokens can be refreshed by the runtime.
- Ignore local Xero OAuth credential files so they cannot be committed.

## Test plan
- [x] `npm run fix-check`
- [x] `npm test` (843 passed locally)
- [ ] Create a Xero OAuth **web app** with the granular accounting scopes plus `offline_access`, set the redirect URI to `http://localhost:3000/oauth/callback`, and reconnect (old connections have no refresh token).
- [ ] Run `xero.list_organisations`, then a read action such as `xero.search_contacts`.
- [ ] Confirm a token older than 30 minutes still works after refresh.
- [ ] Confirm Xero web-app OAuth stays without PKCE (Xero rejects PKCE on web apps).

Made with [Cursor](https://cursor.com)