### PR TITLE
fix: explain OAuth completion in plain language

### DIFF
--- a/src/server/api/oauth-completion-page.test.ts
+++ b/src/server/api/oauth-completion-page.test.ts
@@ -5,12 +5,13 @@ describe("renderOAuthCompletionPage", () => {
   it("renders escaped completion content and the broadcast payload", () => {
     const html = renderOAuthCompletionPage('oauth_<example>"');
 
-    expect(html).toContain("Connection ready");
-    expect(html).toContain("<code>oauth_&lt;example&gt;&quot;</code>");
+    expect(html).toContain("Connection complete");
+    expect(html).toContain("Close this window to continue where you started.");
     expect(html).toContain('"type":"oauth.completed"');
     expect(html).toContain('"service":"oauth_\\u003cexample>\\""');
     expect(html).toContain("BroadcastChannel");
-    expect(html).not.toContain('<code>oauth_<example>"</code>');
+    expect(html).not.toContain("OOMOL Connect");
+    expect(html).not.toContain("OAuth finished");
   });
 
   it("embeds client-side translations and a manual-close fallback", () => {
@@ -21,8 +22,8 @@ describe("renderOAuthCompletionPage", () => {
     expect(html).toContain('data-t="title"');
     expect(html).toContain("data-close-note");
     // Bundled locales (English default plus at least one non-English locale).
-    expect(html).toContain("连接已就绪");
-    expect(html).toContain("接続の準備が完了しました");
+    expect(html).toContain("连接完成");
+    expect(html).toContain("接続が完了しました");
     // Honest close handling: a manual-close hint replaces the countdown when
     // window.close() is blocked on a user-navigated tab.
     expect(html).toContain("现在可以手动关闭此窗口。");

--- a/src/server/api/oauth-completion-page.ts
+++ b/src/server/api/oauth-completion-page.ts
@@ -1,45 +1,38 @@
-import { escapeHtml } from "./http-utils.ts";
-
 const oauthCompletionChannelName = "oomol-connect-oauth";
 const oauthCompletedType = "oauth.completed";
 
 // Client-side translations. English is also the server-rendered default in the
-// markup below, so the page stays meaningful without JavaScript. `bodyBefore`
-// and `bodyAfter` wrap the (already-escaped) service <code> element, which the
-// script never rewrites, so no service value is ever injected as HTML.
+// markup below, so the page stays meaningful without JavaScript. The copy stays
+// host-neutral because this runtime can be embedded by more than one product.
 const oauthCompletionStrings = {
   en: {
     badge: "Connected",
-    title: "Connection ready",
-    bodyBefore: "OAuth finished for ",
-    bodyAfter: ". Return to OOMOL Connect to continue.",
+    title: "Connection complete",
+    body: "Close this window to continue where you started.",
     closeButton: "Close window",
     autoClose: "Automatically closing in %N% seconds.",
     manualClose: "You can now close this window.",
   },
   "zh-CN": {
     badge: "已连接",
-    title: "连接已就绪",
-    bodyBefore: "已完成 ",
-    bodyAfter: " 的授权，返回 OOMOL Connect 继续。",
+    title: "连接完成",
+    body: "关闭此窗口，然后回到刚才的应用继续。",
     closeButton: "关闭窗口",
     autoClose: "%N% 秒后自动关闭。",
     manualClose: "现在可以手动关闭此窗口。",
   },
   "zh-TW": {
     badge: "已連線",
-    title: "連線已就緒",
-    bodyBefore: "已完成 ",
-    bodyAfter: " 的授權，返回 OOMOL Connect 繼續。",
+    title: "連線完成",
+    body: "關閉此視窗，然後回到剛才的應用繼續。",
     closeButton: "關閉視窗",
     autoClose: "%N% 秒後自動關閉。",
     manualClose: "現在可以手動關閉此視窗。",
   },
   ja: {
     badge: "接続済み",
-    title: "接続の準備が完了しました",
-    bodyBefore: "",
-    bodyAfter: " の認証が完了しました。OOMOL Connect に戻って続行してください。",
+    title: "接続が完了しました",
+    body: "このウィンドウを閉じて、元のアプリに戻って続行してください。",
     closeButton: "ウィンドウを閉じる",
     autoClose: "%N% 秒後に自動的に閉じます。",
     manualClose: "このウィンドウを閉じても問題ありません。",
@@ -51,13 +44,12 @@ export function renderOAuthCompletionPage(service: string): string {
     type: oauthCompletedType,
     service,
   });
-  const escapedService = escapeHtml(service);
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Connected ${escapedService}</title>
+<title>Connection complete</title>
 <style>
 :root {
   --background: hsl(0 0% 100%);
@@ -169,8 +161,8 @@ code {
 <main class="card" role="status" aria-live="polite">
   <div class="header">
     <span class="badge" data-t="badge">Connected</span>
-    <h1 data-t="title">Connection ready</h1>
-    <p><span data-t="bodyBefore">OAuth finished for </span><code>${escapedService}</code><span data-t="bodyAfter">. Return to OOMOL Connect to continue.</span></p>
+    <h1 data-t="title">Connection complete</h1>
+    <p data-t="body">Close this window to continue where you started.</p>
   </div>
   <div class="actions">
     <button class="button" type="button" data-t="closeButton">Close window</button>

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -1210,7 +1210,11 @@ describe("ConnectServer", () => {
     expect(callbackText).toContain('"service":"oauth_example"');
     expect(callbackText).not.toContain("window.opener");
     expect(callbackText).not.toContain('postMessage(message,"*"');
-    expect(callbackText).toContain("Connection ready");
+    expect(callbackText).toContain("Connection complete");
+    expect(callbackText).toContain(
+      "Close this window to continue where you started."
+    );
+    expect(callbackText).not.toContain("OOMOL Connect");
     expect(callbackText).toContain("card");
     expect(callbackText).toContain("badge");
     expect(callbackText).toContain("Automatically closing in 5 seconds.");


### PR DESCRIPTION
## Summary\n- make the OAuth completion page host-neutral for embedded runtimes\n- replace internal OAuth and product-specific wording with a clear next action\n- keep all bundled locales and the existing auto-close behavior\n\n## Validation\n- npm run fix-check\n- npm test -- --run src/server/api/oauth-completion-page.test.ts src/server/connect-server.test.ts