### PR TITLE
feat(airtable): add OAuth authentication

### DIFF
--- a/src/providers/airtable/actions.ts
+++ b/src/providers/airtable/actions.ts
@@ -2,12 +2,21 @@ import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import {
+  airtableBaseSchemaReadScope,
+  airtableBaseSchemaWriteScope,
+  airtableRecordsReadScope,
+  airtableRecordsWriteScope,
+  airtableWorkspacesAndBasesManageScope,
+  airtableWorkspacesAndBasesReadScope,
+} from "./scopes.ts";
 
 const service = "airtable";
 
 interface AirtableActionSource {
   name: AirtableActionName;
   description: string;
+  requiredScopes: string[];
   inputSchema: JsonSchema;
   outputSchema: JsonSchema;
   followUpActions?: string[];
@@ -244,7 +253,8 @@ const updateRecordInput = s.object(
 const actions: AirtableActionSource[] = [
   action({
     name: "list_bases",
-    description: "List Airtable bases accessible to the authenticated personal access token.",
+    description: "List Airtable bases accessible to the authenticated credential.",
+    requiredScopes: [airtableBaseSchemaReadScope],
     followUpActions: ["airtable.get_base_collaborators", "airtable.get_base_schema"],
     inputSchema: input({ offset }),
     outputSchema: output({
@@ -257,6 +267,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "get_base_collaborators",
     description: "Read Airtable base metadata, including workspaceId and optional collaborator details.",
+    requiredScopes: [airtableBaseSchemaReadScope, airtableWorkspacesAndBasesReadScope],
     followUpActions: ["airtable.create_base", "airtable.get_base_schema"],
     inputSchema: input(
       {
@@ -273,6 +284,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "get_base_schema",
     description: "Read Airtable table, field, and view schema for a specific base.",
+    requiredScopes: [airtableBaseSchemaReadScope],
     followUpActions: ["airtable.create_table", "airtable.create_field", "airtable.list_records"],
     inputSchema: input(
       {
@@ -292,6 +304,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "create_base",
     description: "Create an Airtable base in a workspace with the provided initial table and field schema.",
+    requiredScopes: [airtableBaseSchemaWriteScope],
     followUpActions: ["airtable.get_base_schema", "airtable.delete_base"],
     inputSchema: input(
       {
@@ -309,12 +322,14 @@ const actions: AirtableActionSource[] = [
   action({
     name: "delete_base",
     description: "Delete an Airtable base. Airtable restricts this endpoint to enterprise admins.",
+    requiredScopes: [airtableWorkspacesAndBasesManageScope],
     inputSchema: input({ baseId }, ["baseId"]),
     outputSchema: airtableDeletedBase,
   }),
   action({
     name: "create_table",
     description: "Create a table in an Airtable base with the provided field schema.",
+    requiredScopes: [airtableBaseSchemaWriteScope],
     followUpActions: ["airtable.create_records", "airtable.update_table", "airtable.create_field"],
     inputSchema: input(
       {
@@ -333,6 +348,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "update_table",
     description: "Update an Airtable table name, description, or date dependency settings.",
+    requiredScopes: [airtableBaseSchemaWriteScope],
     followUpActions: ["airtable.get_base_schema"],
     inputSchema: input(
       {
@@ -349,6 +365,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "create_field",
     description: "Create a field in an Airtable table.",
+    requiredScopes: [airtableBaseSchemaWriteScope],
     followUpActions: ["airtable.update_field", "airtable.create_records"],
     inputSchema: input(
       {
@@ -366,6 +383,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "update_field",
     description: "Update an Airtable field name, description, or type-specific options.",
+    requiredScopes: [airtableBaseSchemaWriteScope],
     followUpActions: ["airtable.get_base_schema"],
     inputSchema: input(
       {
@@ -384,6 +402,7 @@ const actions: AirtableActionSource[] = [
     name: "list_records",
     description:
       "List Airtable records from a table with optional fields, sorting, view filters, formula filters, and pagination.",
+    requiredScopes: [airtableRecordsReadScope],
     followUpActions: ["airtable.get_record", "airtable.update_records"],
     inputSchema: recordReadInput({
       view,
@@ -405,6 +424,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "get_record",
     description: "Read a single Airtable record by record ID.",
+    requiredScopes: [airtableRecordsReadScope],
     followUpActions: ["airtable.update_records", "airtable.delete_records"],
     inputSchema: recordReadInput({ recordId }, ["recordId"]),
     outputSchema: output({ record: airtableRecord }),
@@ -412,6 +432,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "create_records",
     description: "Create one or more Airtable records in a table.",
+    requiredScopes: [airtableRecordsWriteScope],
     followUpActions: ["airtable.list_records"],
     inputSchema: input(
       {
@@ -434,6 +455,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "update_records",
     description: "Update one or more existing Airtable records by record ID.",
+    requiredScopes: [airtableRecordsWriteScope],
     followUpActions: ["airtable.get_record"],
     inputSchema: input(
       {
@@ -456,6 +478,7 @@ const actions: AirtableActionSource[] = [
   action({
     name: "delete_records",
     description: "Delete one or more Airtable records by record ID.",
+    requiredScopes: [airtableRecordsWriteScope],
     inputSchema: input(
       {
         baseId,
@@ -496,7 +519,7 @@ export const airtableActions: ActionDefinition[] = actions.map((source) =>
   defineProviderAction(service, {
     name: source.name,
     description: source.description,
-    requiredScopes: [],
+    requiredScopes: source.requiredScopes,
     providerPermissions: [],
     followUpActions: source.followUpActions,
     inputSchema: source.inputSchema,

--- a/src/providers/airtable/definition.ts
+++ b/src/providers/airtable/definition.ts
@@ -1,18 +1,29 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { airtableActions } from "./actions.ts";
+import { airtableOAuthScopes } from "./scopes.ts";
 
 const service = "airtable";
 
 /**
- * Airtable provider backed by Airtable Web API personal access tokens.
+ * Airtable provider backed by the Airtable Web API.
  */
 export const provider: ProviderDefinition = {
   service,
   displayName: "Airtable",
   categories: ["Productivity", "Data"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://airtable.com/oauth2/v1/authorize",
+      tokenUrl: "https://airtable.com/oauth2/v1/token",
+      scopes: airtableOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_basic",
+      pkce: {
+        method: "S256",
+      },
+    },
     {
       type: "api_key",
       label: "Personal Access Token",

--- a/src/providers/airtable/executors.test.ts
+++ b/src/providers/airtable/executors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("Airtable credentials", () => {
+  it("validates OAuth credentials and records the granted scopes", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "airtable-oauth-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: {},
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(new URL(url.toString()).pathname).toBe("/v0/meta/whoami");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer airtable-oauth-token");
+          return Response.json({
+            id: "usr123",
+            scopes: ["data.records:read", "schema.bases:read"],
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "usr123", displayName: "usr123" },
+      grantedScopes: ["data.records:read", "schema.bases:read"],
+      metadata: {
+        validationEndpoint: "/v0/meta/whoami",
+        currentUser: { id: "usr123" },
+      },
+    });
+  });
+
+  it("keeps personal access token validation compatible with the same identity endpoint", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "airtable-pat", values: {} },
+      {
+        fetcher: async (url, init) => {
+          expect(new URL(url.toString()).pathname).toBe("/v0/meta/whoami");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer airtable-pat");
+          return Response.json({ id: "usr456" });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "usr456", displayName: "usr456" },
+      grantedScopes: [],
+    });
+  });
+});

--- a/src/providers/airtable/executors.ts
+++ b/src/providers/airtable/executors.ts
@@ -1,4 +1,5 @@
-import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { BearerProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { AirtableActionName } from "./actions.ts";
 
 import {
@@ -8,26 +9,22 @@ import {
   optionalInteger,
   optionalRecord,
   optionalString,
+  optionalStringArray,
   requiredRecord,
 } from "../../core/cast.ts";
-import {
-  ProviderRequestError,
-  defineProviderExecutors,
-  providerUserAgent,
-  requireApiKeyCredential,
-} from "../provider-runtime.ts";
+import { defineBearerProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 type AirtableRequestMode = "validate" | "execute";
 type AirtableActionInput = Record<string, unknown>;
-type AirtableActionHandler = (input: AirtableActionInput, context: AirtableActionContext) => Promise<unknown>;
+type AirtableActionHandler = ProviderRuntimeHandler<BearerProviderContext>;
 
-interface AirtableActionContext {
-  apiKey: string;
-  fetcher: typeof fetch;
+interface AirtableAuth {
+  accessToken: string;
+  tokenType?: string;
 }
 
 interface AirtableRequestOptions {
-  apiKey: string;
+  auth: AirtableAuth;
   path: string;
   fetcher: typeof fetch;
   mode: AirtableRequestMode;
@@ -40,7 +37,8 @@ interface AirtableRequestOptions {
 export const airtableApiBaseUrl = "https://api.airtable.com";
 
 const service = "airtable";
-const airtableValidationPath = "/v0/meta/bases";
+const airtableValidationPath = "/v0/meta/whoami";
+const airtableListBasesPath = "/v0/meta/bases";
 const airtableGetUrlLengthSoftLimit = 15_000;
 
 export const airtableActionHandlers: Record<AirtableActionName, AirtableActionHandler> = {
@@ -88,38 +86,24 @@ export const airtableActionHandlers: Record<AirtableActionName, AirtableActionHa
   },
 };
 
-export const executors: ProviderExecutors = defineProviderExecutors<AirtableActionContext>({
-  service,
-  handlers: airtableActionHandlers,
-  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AirtableActionContext> {
-    const credential = await requireApiKeyCredential(context, service);
-    return {
-      apiKey: credential.apiKey,
-      fetcher,
-    };
-  },
-});
+export const executors: ProviderExecutors = defineBearerProviderExecutors(service, airtableActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher }) {
-    return validateAirtableCredential(input.apiKey, fetcher);
+    return validateAirtableCredential({ accessToken: input.apiKey, tokenType: "Bearer" }, fetcher);
+  },
+  async oauth2(input, { fetcher }) {
+    return validateAirtableCredential({ accessToken: input.accessToken, tokenType: input.tokenType }, fetcher);
   },
 };
 
 async function validateAirtableCredential(
-  apiKey: string,
+  auth: AirtableAuth,
   fetcher: typeof fetch,
-): Promise<{
-  profile: {
-    accountId: string;
-    displayName: string;
-  };
-  grantedScopes: string[];
-  metadata: Record<string, unknown>;
-}> {
+): Promise<CredentialValidationResult> {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey,
+      auth,
       path: airtableValidationPath,
       fetcher,
       mode: "validate",
@@ -127,30 +111,31 @@ async function validateAirtableCredential(
     "airtable validation response",
   );
 
-  const bases = readBaseArray(payload.bases);
-  const firstBase = bases[0];
+  const accountId = optionalString(payload.id);
+  if (!accountId) {
+    throw new ProviderRequestError(502, "airtable validation response is missing user id", payload);
+  }
+  const grantedScopes = optionalStringArray(payload.scopes) ?? [];
 
   return {
     profile: {
-      accountId: firstBase ? `airtable:base:${firstBase.id}` : "airtable:token",
-      displayName: optionalString(firstBase?.name) ?? "Airtable API Token",
+      accountId,
+      displayName: optionalString(payload.email) ?? accountId,
     },
-    grantedScopes: [],
+    grantedScopes,
     metadata: compactObject({
       apiBaseUrl: `${airtableApiBaseUrl}/v0`,
       validationEndpoint: airtableValidationPath,
-      accessibleBaseCount: bases.length,
-      firstBaseId: optionalString(firstBase?.id),
-      firstBaseName: optionalString(firstBase?.name),
+      currentUser: payload,
     }),
   };
 }
 
-async function listBases(input: AirtableActionInput, context: AirtableActionContext) {
+async function listBases(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
-      path: airtableValidationPath,
+      auth: context,
+      path: airtableListBasesPath,
       query: buildListBasesQuery(input),
       fetcher: context.fetcher,
       mode: "execute",
@@ -164,10 +149,10 @@ async function listBases(input: AirtableActionInput, context: AirtableActionCont
   };
 }
 
-async function getBaseCollaborators(input: AirtableActionInput, context: AirtableActionContext) {
+async function getBaseCollaborators(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}`,
       query: buildBaseCollaboratorsQuery(input),
       fetcher: context.fetcher,
@@ -182,10 +167,10 @@ async function getBaseCollaborators(input: AirtableActionInput, context: Airtabl
   };
 }
 
-async function getBaseSchema(input: AirtableActionInput, context: AirtableActionContext) {
+async function getBaseSchema(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}/tables`,
       query: buildBaseSchemaQuery(input),
       fetcher: context.fetcher,
@@ -200,10 +185,10 @@ async function getBaseSchema(input: AirtableActionInput, context: AirtableAction
   };
 }
 
-async function createBase(input: AirtableActionInput, context: AirtableActionContext) {
+async function createBase(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: "/v0/meta/bases",
       method: "POST",
       body: {
@@ -218,10 +203,10 @@ async function createBase(input: AirtableActionInput, context: AirtableActionCon
   );
 }
 
-async function deleteBase(input: AirtableActionInput, context: AirtableActionContext) {
+async function deleteBase(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}`,
       method: "DELETE",
       fetcher: context.fetcher,
@@ -232,10 +217,10 @@ async function deleteBase(input: AirtableActionInput, context: AirtableActionCon
   );
 }
 
-async function createTable(input: AirtableActionInput, context: AirtableActionContext) {
+async function createTable(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}/tables`,
       method: "POST",
       body: compactObject({
@@ -251,10 +236,10 @@ async function createTable(input: AirtableActionInput, context: AirtableActionCo
   );
 }
 
-async function updateTable(input: AirtableActionInput, context: AirtableActionContext) {
+async function updateTable(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}/tables/${encodeURIComponent(requireString(input.tableIdOrName, "tableIdOrName"))}`,
       method: "PATCH",
       body: compactObject({
@@ -270,10 +255,10 @@ async function updateTable(input: AirtableActionInput, context: AirtableActionCo
   );
 }
 
-async function createField(input: AirtableActionInput, context: AirtableActionContext) {
+async function createField(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}/tables/${encodeURIComponent(requireString(input.tableId, "tableId"))}/fields`,
       method: "POST",
       body: readCreateFieldConfig(input, "field"),
@@ -285,10 +270,10 @@ async function createField(input: AirtableActionInput, context: AirtableActionCo
   );
 }
 
-async function updateField(input: AirtableActionInput, context: AirtableActionContext) {
+async function updateField(input: AirtableActionInput, context: BearerProviderContext) {
   return readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `/v0/meta/bases/${encodeURIComponent(requireString(input.baseId, "baseId"))}/tables/${encodeURIComponent(requireString(input.tableId, "tableId"))}/fields/${encodeURIComponent(requireString(input.columnId, "columnId"))}`,
       method: "PATCH",
       body: compactObject({
@@ -304,14 +289,14 @@ async function updateField(input: AirtableActionInput, context: AirtableActionCo
   );
 }
 
-async function listRecords(input: AirtableActionInput, context: AirtableActionContext) {
+async function listRecords(input: AirtableActionInput, context: BearerProviderContext) {
   const path = buildRecordCollectionPath(input);
   const query = buildRecordReadQuery(input);
   const usePostEndpoint = buildAirtableUrl(path, query).toString().length >= airtableGetUrlLengthSoftLimit;
 
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: usePostEndpoint ? `${path}/listRecords` : path,
       method: usePostEndpoint ? "POST" : undefined,
       query: usePostEndpoint ? undefined : query,
@@ -329,10 +314,10 @@ async function listRecords(input: AirtableActionInput, context: AirtableActionCo
   };
 }
 
-async function getRecord(input: AirtableActionInput, context: AirtableActionContext) {
+async function getRecord(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: `${buildRecordCollectionPath(input)}/${encodeURIComponent(requireString(input.recordId, "recordId"))}`,
       query: buildRecordDetailQuery(input),
       fetcher: context.fetcher,
@@ -347,10 +332,10 @@ async function getRecord(input: AirtableActionInput, context: AirtableActionCont
   };
 }
 
-async function createRecords(input: AirtableActionInput, context: AirtableActionContext) {
+async function createRecords(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: buildRecordCollectionPath(input),
       method: "POST",
       body: compactObject({
@@ -370,10 +355,10 @@ async function createRecords(input: AirtableActionInput, context: AirtableAction
   };
 }
 
-async function updateRecords(input: AirtableActionInput, context: AirtableActionContext) {
+async function updateRecords(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: buildRecordCollectionPath(input),
       method: "PATCH",
       body: compactObject({
@@ -393,10 +378,10 @@ async function updateRecords(input: AirtableActionInput, context: AirtableAction
   };
 }
 
-async function deleteRecords(input: AirtableActionInput, context: AirtableActionContext) {
+async function deleteRecords(input: AirtableActionInput, context: BearerProviderContext) {
   const payload = readObject(
     await requestAirtableJson({
-      apiKey: context.apiKey,
+      auth: context,
       path: buildRecordCollectionPath(input),
       method: "DELETE",
       query: buildDeleteRecordsQuery(input),
@@ -419,7 +404,7 @@ async function requestAirtableJson(input: AirtableRequestOptions): Promise<unkno
   try {
     response = await input.fetcher(url, {
       method: input.method ?? "GET",
-      headers: airtableHeaders(input.apiKey, input.body === undefined ? undefined : "application/json"),
+      headers: airtableHeaders(input.auth, input.body === undefined ? undefined : "application/json"),
       ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
     });
   } catch (error) {
@@ -448,10 +433,10 @@ function buildAirtableUrl(path: string, query?: ReadonlyArray<readonly [string, 
   return url;
 }
 
-function airtableHeaders(apiKey: string, contentType?: string): Record<string, string> {
+function airtableHeaders(auth: AirtableAuth, contentType?: string): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: "application/json",
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `${auth.tokenType ?? "Bearer"} ${auth.accessToken}`,
     "User-Agent": providerUserAgent,
   };
   if (contentType) {

--- a/src/providers/airtable/scopes.ts
+++ b/src/providers/airtable/scopes.ts
@@ -1,0 +1,20 @@
+export const airtableRecordsReadScope = "data.records:read";
+export const airtableRecordsWriteScope = "data.records:write";
+export const airtableBaseSchemaReadScope = "schema.bases:read";
+export const airtableBaseSchemaWriteScope = "schema.bases:write";
+export const airtableWorkspacesAndBasesReadScope = "workspacesAndBases:read";
+export const airtableWorkspacesAndBasesManageScope = "workspacesAndBases:manage";
+
+/**
+ * Scopes available to regular Airtable OAuth integrations for the provider's
+ * record, schema, and collaborator actions. The enterprise-admin-only
+ * `workspacesAndBases:manage` scope stays out of the default authorization so
+ * non-enterprise users can connect; it is still declared on `delete_base`.
+ */
+export const airtableOAuthScopes: string[] = [
+  airtableRecordsReadScope,
+  airtableRecordsWriteScope,
+  airtableBaseSchemaReadScope,
+  airtableBaseSchemaWriteScope,
+  airtableWorkspacesAndBasesReadScope,
+];


### PR DESCRIPTION
## Summary

- add Airtable OAuth 2.0 authorization-code support with PKCE S256 and Basic client authentication
- keep personal access tokens working through the shared bearer executor path
- validate both credential types with `GET /v0/meta/whoami` and persist OAuth granted scopes
- declare the official Airtable scope required by each action

## Scope decisions

The default OAuth request includes the regular record, schema, and base collaborator scopes. The enterprise-admin-only `workspacesAndBases:manage` scope remains declared on `delete_base`, but is intentionally excluded from the default OAuth request so regular Airtable users can authorize the connector.

Protocol and scope details follow the official [OAuth reference](https://airtable.com/developers/web/api/oauth-reference) and [scope reference](https://airtable.com/developers/web/api/scopes).

## Verification

- `npx vitest run src/providers/airtable/executors.test.ts`
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (79 files, 848 tests)
