### PR TITLE
fix: request only necessary Google OAuth scopes

### DIFF
--- a/src/providers/gmail/definition.test.ts
+++ b/src/providers/gmail/definition.test.ts
@@ -3,12 +3,20 @@ import { provider } from "./definition.ts";
 
 const gmailSettingsSharingScope = "https://www.googleapis.com/auth/gmail.settings.sharing";
 const gmailSettingsBasicScope = "https://www.googleapis.com/auth/gmail.settings.basic";
+const gmailLabelsScope = "https://www.googleapis.com/auth/gmail.labels";
+const gmailModifyScope = "https://www.googleapis.com/auth/gmail.modify";
 
 describe("Gmail provider definition", () => {
   it("does not request the Workspace administrator-only sharing scope for user OAuth", () => {
     const oauth = provider.auth.find((auth) => auth.type === "oauth2");
 
     expect(oauth?.scopes).not.toContain(gmailSettingsSharingScope);
+  });
+
+  it("requests only the least scopes that cover the full Gmail action catalog", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth?.scopes).toEqual([gmailModifyScope, gmailLabelsScope, gmailSettingsBasicScope]);
   });
 
   it("uses a user-authorizable scope for forwarding read actions", () => {

--- a/src/providers/gmail/scopes.ts
+++ b/src/providers/gmail/scopes.ts
@@ -12,11 +12,4 @@ export const gmailSendScopes: string[] = [gmailSendScope];
 export const gmailLabelScopes: string[] = [gmailLabelsScope];
 export const gmailSettingsBasicScopes: string[] = [gmailSettingsBasicScope];
 
-export const gmailOAuthScopes: string[] = [
-  gmailReadonlyScope,
-  gmailModifyScope,
-  gmailComposeScope,
-  gmailSendScope,
-  gmailLabelsScope,
-  gmailSettingsBasicScope,
-];
+export const gmailOAuthScopes: string[] = [gmailModifyScope, gmailLabelsScope, gmailSettingsBasicScope];

--- a/src/providers/googlecalendar/definition.test.ts
+++ b/src/providers/googlecalendar/definition.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+const expectedOAuthScopes = [
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.calendars",
+  "https://www.googleapis.com/auth/calendar.calendarlist",
+  "https://www.googleapis.com/auth/calendar.settings.readonly",
+  "https://www.googleapis.com/auth/calendar.acls",
+  "https://www.googleapis.com/auth/calendar.acls.readonly",
+];
+
+describe("Google Calendar provider definition", () => {
+  it("does not request the redundant full-calendar scope alongside narrower scopes", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth?.scopes).toEqual(expectedOAuthScopes);
+  });
+});

--- a/src/providers/googlecalendar/scopes.ts
+++ b/src/providers/googlecalendar/scopes.ts
@@ -1,4 +1,3 @@
-export const googleCalendarFullScope = "https://www.googleapis.com/auth/calendar";
 export const googleCalendarReadonlyScope = "https://www.googleapis.com/auth/calendar.readonly";
 export const googleCalendarEventsScope = "https://www.googleapis.com/auth/calendar.events";
 export const googleCalendarCalendarsScope = "https://www.googleapis.com/auth/calendar.calendars";
@@ -18,7 +17,6 @@ export const googlecalendarAclReadScopes: string[] = [googleCalendarAclsReadonly
 export const googlecalendarAclWriteScopes: string[] = [googleCalendarAclsScope];
 
 export const googlecalendarOAuthScopes: string[] = [
-  googleCalendarFullScope,
   googleCalendarReadonlyScope,
   googleCalendarEventsScope,
   googleCalendarCalendarsScope,

--- a/src/providers/googledrive/definition.test.ts
+++ b/src/providers/googledrive/definition.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+const googleDriveFullScope = "https://www.googleapis.com/auth/drive";
+
+describe("Google Drive provider definition", () => {
+  it("requests only the full Drive scope required by the write action catalog", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(oauth?.scopes).toEqual([googleDriveFullScope]);
+  });
+});

--- a/src/providers/googledrive/scopes.ts
+++ b/src/providers/googledrive/scopes.ts
@@ -2,8 +2,4 @@ export const googleDriveReadonlyScope = "https://www.googleapis.com/auth/drive.r
 export const googleDriveMetadataReadonlyScope = "https://www.googleapis.com/auth/drive.metadata.readonly";
 export const googleDriveFullScope = "https://www.googleapis.com/auth/drive";
 
-export const googledriveOAuthScopes: string[] = [
-  googleDriveReadonlyScope,
-  googleDriveMetadataReadonlyScope,
-  googleDriveFullScope,
-];
+export const googledriveOAuthScopes: string[] = [googleDriveFullScope];


### PR DESCRIPTION
## What changed

- remove OAuth scopes already covered by the stronger Gmail and Drive scopes requested by each provider
- stop requesting the broad Calendar scope alongside the provider’s narrower action-specific scopes
- add provider-definition regression tests for the exact OAuth scope sets

## Why

The current OAuth authorization URLs request redundant Google scopes. That makes the consent surface harder to understand and increases production verification work without enabling any additional actions. The action catalog and executor behavior are unchanged.

## Verification

- `npm test` — 76 files, 789 tests passed
- `npm run generate:catalog`
- `npm run fix-check`