### PR TITLE
feat(miro): add OAuth provider

### DIFF
--- a/src/providers/miro/actions.ts
+++ b/src/providers/miro/actions.ts
@@ -1,0 +1,227 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { miroBoardsReadScope, miroBoardsWriteScope } from "./scopes.ts";
+
+const service = "miro";
+
+const boardIdSchema = s.nonEmptyString("Unique identifier of the Miro board.");
+const itemIdSchema = s.nonEmptyString("Unique identifier of the Miro board item.");
+const looseRecordSchema = s.unknownObject("Additional provider fields returned by Miro.");
+
+const userReferenceSchema = s.looseObject("A Miro user reference.", {
+  id: s.string("Miro user identifier."),
+  name: s.string("Miro user display name."),
+  type: s.string("Miro resource type."),
+});
+
+const boardSchema = s.looseObject("A Miro board.", {
+  id: s.string("Miro board identifier."),
+  type: s.string("Miro resource type."),
+  name: s.string("Miro board name."),
+  description: s.string("Miro board description."),
+  viewLink: s.url("URL for opening the board in Miro."),
+  createdAt: s.dateTime("When the board was created."),
+  modifiedAt: s.dateTime("When the board was last modified."),
+  createdBy: userReferenceSchema,
+  modifiedBy: userReferenceSchema,
+  owner: userReferenceSchema,
+  policy: looseRecordSchema,
+});
+
+const itemSchema = s.looseObject("A Miro board item.", {
+  id: s.string("Miro item identifier."),
+  type: s.string("Miro item type."),
+  createdAt: s.dateTime("When the item was created."),
+  modifiedAt: s.dateTime("When the item was last modified."),
+  createdBy: userReferenceSchema,
+  modifiedBy: userReferenceSchema,
+  data: looseRecordSchema,
+  style: looseRecordSchema,
+  position: looseRecordSchema,
+  geometry: looseRecordSchema,
+  parent: s.nullable(looseRecordSchema),
+});
+
+const boardPaginationSchema = s.object("Offset pagination returned with Miro boards.", {
+  limit: s.integer("Requested page size."),
+  offset: s.nonNegativeInteger("Zero-based offset of the page."),
+  size: s.nonNegativeInteger("Number of boards returned."),
+});
+
+const itemPaginationSchema = s.object("Cursor pagination returned with Miro board items.", {
+  cursor: s.nullableString("Cursor for the next page, or null when no next page is available."),
+});
+
+const itemDataSchema = s.looseRequiredObject(
+  "Miro item data.",
+  {
+    content: s.nonEmptyString("Text or HTML content displayed by the item.", { maxLength: 6000 }),
+  },
+  { optional: [] },
+);
+
+const stickyNoteDataSchema = s.looseRequiredObject(
+  "Miro sticky note data.",
+  {
+    content: s.nonEmptyString("Text or supported HTML displayed by the sticky note.", { maxLength: 6000 }),
+    shape: s.stringEnum("Sticky note shape.", ["square", "rectangle"]),
+  },
+  { optional: ["shape"] },
+);
+
+const itemStyleSchema = s.looseObject("Provider-native Miro item style fields.", {
+  color: s.string("Text color."),
+  fillColor: s.string("Item fill color."),
+  fillOpacity: s.number("Fill opacity from 0 to 1.", { minimum: 0, maximum: 1 }),
+  fontFamily: s.string("Font family used by a text item."),
+  fontSize: s.number("Font size used by a text item.", { exclusiveMinimum: 0 }),
+  textAlign: s.stringEnum("Horizontal text alignment.", ["left", "center", "right"]),
+  textAlignVertical: s.stringEnum("Vertical text alignment.", ["top", "middle", "bottom"]),
+});
+
+const itemPositionSchema = s.looseObject("Position of the item on the board.", {
+  x: s.number("Horizontal coordinate relative to the origin."),
+  y: s.number("Vertical coordinate relative to the origin."),
+  origin: s.stringEnum("Coordinate origin used by Miro.", ["center"]),
+});
+
+const itemGeometrySchema = s.looseObject("Geometry of the Miro item.", {
+  width: s.number("Item width.", { exclusiveMinimum: 0 }),
+  height: s.number("Item height.", { exclusiveMinimum: 0 }),
+  rotation: s.number("Clockwise item rotation in degrees."),
+});
+
+const itemParentSchema = s.looseObject("Optional parent frame for the item.", {
+  id: s.nonEmptyString("Identifier of the parent frame."),
+});
+
+export const miroActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_boards",
+    description: "List Miro boards visible to the connected user with optional team, project, owner, or text filters.",
+    requiredScopes: [miroBoardsReadScope],
+    inputSchema: s.object(
+      "Filters and pagination for listing Miro boards.",
+      {
+        teamId: s.nonEmptyString("Return boards visible in this Miro team."),
+        projectId: s.nonEmptyString("Return boards in this Miro project or space."),
+        query: s.string("Search text matched against board names and descriptions.", { maxLength: 500 }),
+        owner: s.nonEmptyString("Return boards owned by this Miro user ID."),
+        limit: s.integer("Maximum number of boards to return.", { minimum: 1, maximum: 50 }),
+        offset: s.nonNegativeInteger("Zero-based offset of the first board to return."),
+        sort: s.stringEnum("Miro board sort order.", [
+          "default",
+          "last_modified",
+          "last_opened",
+          "last_created",
+          "alphabetically",
+        ]),
+      },
+      { optional: ["teamId", "projectId", "query", "owner", "limit", "offset", "sort"] },
+    ),
+    outputSchema: s.object("Miro boards and pagination metadata.", {
+      boards: s.array("Boards returned by Miro.", boardSchema),
+      pagination: boardPaginationSchema,
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_board",
+    description: "Get one Miro board by ID.",
+    requiredScopes: [miroBoardsReadScope],
+    inputSchema: s.object("Miro board identifier.", { boardId: boardIdSchema }),
+    outputSchema: s.object("The requested Miro board.", { board: boardSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "create_board",
+    description: "Create a Miro board with optional team, project, and sharing policy settings.",
+    requiredScopes: [miroBoardsWriteScope],
+    inputSchema: s.object(
+      "Properties for the new Miro board.",
+      {
+        name: s.nonEmptyString("Board name.", { maxLength: 60 }),
+        description: s.string("Board description.", { maxLength: 300 }),
+        teamId: s.nonEmptyString("Team where the board will be created."),
+        projectId: s.nonEmptyString("Project or space where the board will be created."),
+        policy: s.unknownObject("Provider-native Miro board policy object."),
+      },
+      { optional: ["description", "teamId", "projectId", "policy"] },
+    ),
+    outputSchema: s.object("The created Miro board.", { board: boardSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "list_items",
+    description: "List items on a Miro board with cursor pagination and an optional item-type filter.",
+    requiredScopes: [miroBoardsReadScope],
+    inputSchema: s.object(
+      "Board, pagination, and type filter for listing Miro items.",
+      {
+        boardId: boardIdSchema,
+        limit: s.integer("Maximum number of items to return.", { minimum: 10, maximum: 50 }),
+        cursor: s.nonEmptyString("Opaque pagination cursor returned by Miro."),
+        type: s.nonEmptyString("Miro item type, such as sticky_note, text, shape, frame, card, or image."),
+      },
+      { optional: ["limit", "cursor", "type"] },
+    ),
+    outputSchema: s.object("Miro board items and pagination metadata.", {
+      items: s.array("Items returned by Miro.", itemSchema),
+      pagination: itemPaginationSchema,
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_item",
+    description: "Get one item from a Miro board.",
+    requiredScopes: [miroBoardsReadScope],
+    inputSchema: s.object("Miro board and item identifiers.", {
+      boardId: boardIdSchema,
+      itemId: itemIdSchema,
+    }),
+    outputSchema: s.object("The requested Miro board item.", { item: itemSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "create_sticky_note",
+    description: "Create a sticky note on a Miro board with optional style, position, geometry, and parent frame.",
+    requiredScopes: [miroBoardsWriteScope],
+    inputSchema: s.object(
+      "Properties for a new Miro sticky note.",
+      {
+        boardId: boardIdSchema,
+        data: stickyNoteDataSchema,
+        style: itemStyleSchema,
+        position: itemPositionSchema,
+        geometry: itemGeometrySchema,
+        parent: itemParentSchema,
+      },
+      { optional: ["style", "position", "geometry", "parent"] },
+    ),
+    outputSchema: s.object("The created Miro sticky note.", { item: itemSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "create_text",
+    description: "Create a text item on a Miro board with optional style, position, geometry, and parent frame.",
+    requiredScopes: [miroBoardsWriteScope],
+    inputSchema: s.object(
+      "Properties for a new Miro text item.",
+      {
+        boardId: boardIdSchema,
+        data: itemDataSchema,
+        style: itemStyleSchema,
+        position: itemPositionSchema,
+        geometry: itemGeometrySchema,
+        parent: itemParentSchema,
+      },
+      { optional: ["style", "position", "geometry", "parent"] },
+    ),
+    outputSchema: s.object("The created Miro text item.", { item: itemSchema }),
+  }),
+];
+
+export type MiroActionName =
+  | "list_boards"
+  | "get_board"
+  | "create_board"
+  | "list_items"
+  | "get_item"
+  | "create_sticky_note"
+  | "create_text";

--- a/src/providers/miro/actions.ts
+++ b/src/providers/miro/actions.ts
@@ -9,6 +9,20 @@ const service = "miro";
 const boardIdSchema = s.nonEmptyString("Unique identifier of the Miro board.");
 const itemIdSchema = s.nonEmptyString("Unique identifier of the Miro board item.");
 const looseRecordSchema = s.unknownObject("Additional provider fields returned by Miro.");
+const miroItemTypes = [
+  "text",
+  "shape",
+  "sticky_note",
+  "image",
+  "document",
+  "card",
+  "app_card",
+  "preview",
+  "frame",
+  "embed",
+  "doc_format",
+  "data_table_format",
+];
 
 const userReferenceSchema = s.looseObject("A Miro user reference.", {
   id: s.string("Miro user identifier."),
@@ -87,11 +101,20 @@ const itemPositionSchema = s.looseObject("Position of the item on the board.", {
   origin: s.stringEnum("Coordinate origin used by Miro.", ["center"]),
 });
 
-const itemGeometrySchema = s.looseObject("Geometry of the Miro item.", {
+const stickyNoteGeometrySchema = s.looseObject("Geometry of the Miro sticky note.", {
   width: s.number("Item width.", { exclusiveMinimum: 0 }),
   height: s.number("Item height.", { exclusiveMinimum: 0 }),
   rotation: s.number("Clockwise item rotation in degrees."),
 });
+
+const textGeometrySchema = s.object(
+  "Geometry of the Miro text item. Miro calculates text height from its content and width.",
+  {
+    width: s.number("Text item width.", { exclusiveMinimum: 0 }),
+    rotation: s.number("Clockwise text item rotation in degrees."),
+  },
+  { optional: ["width", "rotation"] },
+);
 
 const itemParentSchema = s.looseObject("Optional parent frame for the item.", {
   id: s.nonEmptyString("Identifier of the parent frame."),
@@ -160,7 +183,7 @@ export const miroActions: ActionDefinition[] = [
         boardId: boardIdSchema,
         limit: s.integer("Maximum number of items to return.", { minimum: 10, maximum: 50 }),
         cursor: s.nonEmptyString("Opaque pagination cursor returned by Miro."),
-        type: s.nonEmptyString("Miro item type, such as sticky_note, text, shape, frame, card, or image."),
+        type: s.stringEnum("Miro item type.", miroItemTypes),
       },
       { optional: ["limit", "cursor", "type"] },
     ),
@@ -190,7 +213,7 @@ export const miroActions: ActionDefinition[] = [
         data: stickyNoteDataSchema,
         style: itemStyleSchema,
         position: itemPositionSchema,
-        geometry: itemGeometrySchema,
+        geometry: stickyNoteGeometrySchema,
         parent: itemParentSchema,
       },
       { optional: ["style", "position", "geometry", "parent"] },
@@ -208,7 +231,7 @@ export const miroActions: ActionDefinition[] = [
         data: itemDataSchema,
         style: itemStyleSchema,
         position: itemPositionSchema,
-        geometry: itemGeometrySchema,
+        geometry: textGeometrySchema,
         parent: itemParentSchema,
       },
       { optional: ["style", "position", "geometry", "parent"] },
@@ -216,12 +239,3 @@ export const miroActions: ActionDefinition[] = [
     outputSchema: s.object("The created Miro text item.", { item: itemSchema }),
   }),
 ];
-
-export type MiroActionName =
-  | "list_boards"
-  | "get_board"
-  | "create_board"
-  | "list_items"
-  | "get_item"
-  | "create_sticky_note"
-  | "create_text";

--- a/src/providers/miro/definition.ts
+++ b/src/providers/miro/definition.ts
@@ -28,5 +28,6 @@ export const provider: ProviderDefinition = {
     },
   ],
   homepageUrl: "https://miro.com",
+  iconUrl: "/provider-icons/miro.svg",
   actions: miroActions,
 };

--- a/src/providers/miro/definition.ts
+++ b/src/providers/miro/definition.ts
@@ -1,0 +1,32 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { miroActions } from "./actions.ts";
+import { miroOAuthScopes } from "./scopes.ts";
+
+const service = "miro";
+
+/**
+ * Miro provider backed by the public Miro REST API v2.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Miro",
+  description: "Read Miro boards and create lightweight board content.",
+  categories: ["Design", "Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://miro.com/oauth/authorize",
+      tokenUrl: "https://api.miro.com/v1/oauth/token",
+      scopes: miroOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      tokenRequestFormat: "form",
+      authorizationRequestFields: {
+        scope: false,
+      },
+    },
+  ],
+  homepageUrl: "https://miro.com",
+  actions: miroActions,
+};

--- a/src/providers/miro/executors.test.ts
+++ b/src/providers/miro/executors.test.ts
@@ -73,7 +73,7 @@ describe("Miro board actions", () => {
     };
 
     await expect(
-      miroActionHandlers.list_boards(
+      miroActionHandlers.list_boards!(
         { teamId: "team-123", query: "roadmap", limit: 5, offset: 10, sort: "last_modified" },
         { ...actionContext, fetcher },
       ),
@@ -99,7 +99,7 @@ describe("Miro item actions", () => {
     };
 
     await expect(
-      miroActionHandlers.create_sticky_note(
+      miroActionHandlers.create_sticky_note!(
         {
           boardId: "board-123",
           data: { content: "Ship it", shape: "square" },
@@ -119,7 +119,7 @@ describe("Miro item actions", () => {
       throw new Error("fetch should not run");
     };
     await expect(
-      miroActionHandlers.create_sticky_note(
+      miroActionHandlers.create_sticky_note!(
         {
           boardId: "board-123",
           data: { content: "Ship it" },
@@ -128,5 +128,22 @@ describe("Miro item actions", () => {
         { ...actionContext, fetcher },
       ),
     ).rejects.toMatchObject({ status: 400, message: expect.stringContaining("either width or height") });
+  });
+
+  it("rejects text-item height before making a request", async () => {
+    const fetcher: ProviderFetch = async () => {
+      throw new Error("fetch should not run");
+    };
+
+    await expect(
+      miroActionHandlers.create_text!(
+        {
+          boardId: "board-123",
+          data: { content: "Ship it" },
+          geometry: { width: 240, height: 120 },
+        },
+        { ...actionContext, fetcher },
+      ),
+    ).rejects.toMatchObject({ status: 400, message: expect.stringContaining("geometry.height") });
   });
 });

--- a/src/providers/miro/executors.test.ts
+++ b/src/providers/miro/executors.test.ts
@@ -1,0 +1,132 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { credentialValidators, miroActionHandlers } from "./executors.ts";
+
+const actionContext = {
+  accessToken: "miro-access-token",
+  tokenType: "Bearer",
+};
+
+describe("Miro OAuth credentials", () => {
+  it("validates the token through its access-token context", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "miro-access-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: {},
+      },
+      {
+        fetcher: async (input, init) => {
+          expect(input.toString()).toBe("https://api.miro.com/v1/oauth-token");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer miro-access-token");
+          return Response.json({
+            id: "token-123",
+            scopes: ["boards:read", "boards:write"],
+            user: { id: "user-123", name: "Alice", type: "user" },
+            team: { id: "team-123", name: "Product", type: "team" },
+            createdAt: "2026-08-13T12:00:00Z",
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: {
+        accountId: "user-123",
+        displayName: "Alice (Product)",
+        grantedScopes: ["boards:read", "boards:write"],
+      },
+      grantedScopes: ["boards:read", "boards:write"],
+      metadata: {
+        apiBaseUrl: "https://api.miro.com",
+        validationEndpoint: "/v1/oauth-token",
+        tokenId: "token-123",
+        currentUser: { id: "user-123", name: "Alice" },
+        team: { id: "team-123", name: "Product" },
+      },
+    });
+  });
+});
+
+describe("Miro board actions", () => {
+  it("maps board filters and offset pagination to the v2 API", async () => {
+    const fetcher: ProviderFetch = async (input, init) => {
+      const url = new URL(input.toString());
+      expect(url.pathname).toBe("/v2/boards");
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        team_id: "team-123",
+        query: "roadmap",
+        limit: "5",
+        offset: "10",
+        sort: "last_modified",
+      });
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer miro-access-token");
+      return Response.json({
+        size: 1,
+        limit: 5,
+        offset: 10,
+        data: [{ id: "board-123", name: "Roadmap", type: "board" }],
+      });
+    };
+
+    await expect(
+      miroActionHandlers.list_boards(
+        { teamId: "team-123", query: "roadmap", limit: 5, offset: 10, sort: "last_modified" },
+        { ...actionContext, fetcher },
+      ),
+    ).resolves.toEqual({
+      boards: [{ id: "board-123", name: "Roadmap", type: "board" }],
+      pagination: { limit: 5, offset: 10, size: 1 },
+    });
+  });
+});
+
+describe("Miro item actions", () => {
+  it("creates a sticky note with provider-native nested fields", async () => {
+    const fetcher: ProviderFetch = async (input, init) => {
+      expect(new URL(input.toString()).pathname).toBe("/v2/boards/board-123/sticky_notes");
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        data: { content: "Ship it", shape: "square" },
+        style: { fillColor: "light_yellow" },
+        position: { x: 10, y: 20 },
+        geometry: { width: 240 },
+      });
+      return Response.json({ id: "item-123", type: "sticky_note", data: { content: "Ship it" } });
+    };
+
+    await expect(
+      miroActionHandlers.create_sticky_note(
+        {
+          boardId: "board-123",
+          data: { content: "Ship it", shape: "square" },
+          style: { fillColor: "light_yellow" },
+          position: { x: 10, y: 20 },
+          geometry: { width: 240 },
+        },
+        { ...actionContext, fetcher },
+      ),
+    ).resolves.toEqual({
+      item: { id: "item-123", type: "sticky_note", data: { content: "Ship it" } },
+    });
+  });
+
+  it("rejects conflicting sticky-note dimensions before making a request", async () => {
+    const fetcher: ProviderFetch = async () => {
+      throw new Error("fetch should not run");
+    };
+    await expect(
+      miroActionHandlers.create_sticky_note(
+        {
+          boardId: "board-123",
+          data: { content: "Ship it" },
+          geometry: { width: 240, height: 120 },
+        },
+        { ...actionContext, fetcher },
+      ),
+    ).rejects.toMatchObject({ status: 400, message: expect.stringContaining("either width or height") });
+  });
+});

--- a/src/providers/miro/executors.ts
+++ b/src/providers/miro/executors.ts
@@ -1,0 +1,313 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { MiroActionName } from "./actions.ts";
+
+import {
+  compactObject,
+  objectArray,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import { queryParams } from "../../core/request.ts";
+import {
+  defineOAuthProviderExecutors,
+  defineProviderProxy,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+  setSearchParams,
+} from "../provider-runtime.ts";
+
+const service = "miro";
+const miroApiBaseUrl = "https://api.miro.com";
+const miroValidationPath = "/v1/oauth-token";
+const defaultBoardLimit = 20;
+const defaultItemLimit = 10;
+
+type MiroRequestPhase = "validate" | "execute";
+type MiroActionHandler = ProviderRuntimeHandler<OAuthProviderContext>;
+
+interface MiroRequestOptions {
+  accessToken: string;
+  tokenType?: string;
+  fetcher: typeof fetch;
+  path: string;
+  phase: MiroRequestPhase;
+  signal?: AbortSignal;
+  method?: "GET" | "POST";
+  query?: Record<string, string>;
+  body?: Record<string, unknown>;
+}
+
+export const miroActionHandlers: Record<MiroActionName, MiroActionHandler> = {
+  async list_boards(input, context): Promise<unknown> {
+    const limit = optionalInteger(input.limit) ?? defaultBoardLimit;
+    const offset = optionalInteger(input.offset) ?? 0;
+    const payload = requireMiroObject(
+      await requestMiroJson({
+        ...context,
+        path: "/v2/boards",
+        phase: "execute",
+        query: queryParams({
+          team_id: optionalString(input.teamId),
+          project_id: optionalString(input.projectId),
+          query: optionalString(input.query),
+          owner: optionalString(input.owner),
+          limit,
+          offset,
+          sort: optionalString(input.sort),
+        }),
+      }),
+      "boards response",
+    );
+    const boards = objectArray(payload.data, "Miro board", providerResponseError);
+    return {
+      boards,
+      pagination: {
+        limit: optionalInteger(payload.limit) ?? limit,
+        offset: optionalInteger(payload.offset) ?? offset,
+        size: optionalInteger(payload.size) ?? boards.length,
+      },
+    };
+  },
+  async get_board(input, context): Promise<unknown> {
+    const boardId = requireInputString(input.boardId, "boardId");
+    return {
+      board: requireMiroObject(
+        await requestMiroJson({
+          ...context,
+          path: `/v2/boards/${encodeURIComponent(boardId)}`,
+          phase: "execute",
+        }),
+        "board response",
+      ),
+    };
+  },
+  async create_board(input, context): Promise<unknown> {
+    const policy = optionalRecord(input.policy);
+    return {
+      board: requireMiroObject(
+        await requestMiroJson({
+          ...context,
+          method: "POST",
+          path: "/v2/boards",
+          phase: "execute",
+          body: compactObject({
+            name: requireInputString(input.name, "name"),
+            description: optionalString(input.description),
+            teamId: optionalString(input.teamId),
+            projectId: optionalString(input.projectId),
+            policy,
+          }),
+        }),
+        "create board response",
+      ),
+    };
+  },
+  async list_items(input, context): Promise<unknown> {
+    const boardId = requireInputString(input.boardId, "boardId");
+    const payload = requireMiroObject(
+      await requestMiroJson({
+        ...context,
+        path: `/v2/boards/${encodeURIComponent(boardId)}/items`,
+        phase: "execute",
+        query: queryParams({
+          limit: optionalInteger(input.limit) ?? defaultItemLimit,
+          cursor: optionalString(input.cursor),
+          type: optionalString(input.type),
+        }),
+      }),
+      "board items response",
+    );
+    return {
+      items: objectArray(payload.data, "Miro board item", providerResponseError),
+      pagination: {
+        cursor: optionalString(payload.cursor) ?? null,
+      },
+    };
+  },
+  async get_item(input, context): Promise<unknown> {
+    const boardId = requireInputString(input.boardId, "boardId");
+    const itemId = requireInputString(input.itemId, "itemId");
+    return {
+      item: requireMiroObject(
+        await requestMiroJson({
+          ...context,
+          path: `/v2/boards/${encodeURIComponent(boardId)}/items/${encodeURIComponent(itemId)}`,
+          phase: "execute",
+        }),
+        "board item response",
+      ),
+    };
+  },
+  async create_sticky_note(input, context): Promise<unknown> {
+    return createBoardItem(input, context, "sticky_notes", "sticky note");
+  },
+  async create_text(input, context): Promise<unknown> {
+    return createBoardItem(input, context, "texts", "text item");
+  },
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, miroActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: miroApiBaseUrl,
+  auth: { type: "oauth_bearer" },
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const payload = requireMiroObject(
+      await requestMiroJson({
+        accessToken: input.accessToken,
+        tokenType: input.tokenType,
+        fetcher,
+        signal,
+        path: miroValidationPath,
+        phase: "validate",
+      }),
+      "access token context",
+    );
+    return normalizeMiroCredential(payload, input.metadata.scope);
+  },
+};
+
+async function createBoardItem(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+  endpoint: "sticky_notes" | "texts",
+  resourceName: string,
+): Promise<{ item: Record<string, unknown> }> {
+  const boardId = requireInputString(input.boardId, "boardId");
+  const data = requiredRecord(input.data, "data", providerInputError);
+  requiredString(data.content, "data.content", providerInputError);
+  const geometry = optionalRecord(input.geometry);
+  if (endpoint === "sticky_notes" && geometry?.width !== undefined && geometry.height !== undefined) {
+    throw new ProviderRequestError(400, "geometry must specify either width or height, not both");
+  }
+
+  const item = requireMiroObject(
+    await requestMiroJson({
+      ...context,
+      method: "POST",
+      path: `/v2/boards/${encodeURIComponent(boardId)}/${endpoint}`,
+      phase: "execute",
+      body: compactObject({
+        data,
+        style: optionalRecord(input.style),
+        position: optionalRecord(input.position),
+        geometry,
+        parent: optionalRecord(input.parent),
+      }),
+    }),
+    `create ${resourceName} response`,
+  );
+  return { item };
+}
+
+async function requestMiroJson(input: MiroRequestOptions): Promise<unknown> {
+  const url = new URL(input.path.replace(/^\//u, ""), `${miroApiBaseUrl}/`);
+  setSearchParams(url, input.query ?? {});
+  const headers: Record<string, string> = {
+    authorization: `${input.tokenType ?? "Bearer"} ${input.accessToken}`,
+    accept: "application/json",
+    "user-agent": providerUserAgent,
+  };
+  if (input.body !== undefined) {
+    headers["content-type"] = "application/json";
+  }
+
+  const response = await input.fetcher(url, {
+    method: input.method ?? "GET",
+    headers,
+    body: input.body === undefined ? undefined : JSON.stringify(input.body),
+    signal: input.signal,
+  });
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "Miro response must be valid JSON",
+    invalidJsonFallback: response.ok ? undefined : (text) => text,
+  });
+  if (!response.ok) {
+    throw createMiroResponseError(response, payload, input.phase);
+  }
+  return payload;
+}
+
+function normalizeMiroCredential(payload: Record<string, unknown>, tokenScope: unknown): CredentialValidationResult {
+  const user = requiredRecord(payload.user, "Miro token context user", providerResponseError);
+  const accountId = requiredString(user.id, "Miro user id", providerResponseError);
+  const team = optionalRecord(payload.team);
+  const userName = optionalString(user.name) ?? accountId;
+  const teamName = optionalString(team?.name);
+  const grantedScopes = optionalStringArray(payload.scopes) ?? parseScopeString(tokenScope);
+
+  return {
+    profile: {
+      accountId,
+      displayName: teamName ? `${userName} (${teamName})` : userName,
+      grantedScopes,
+    },
+    grantedScopes,
+    metadata: compactObject({
+      apiBaseUrl: miroApiBaseUrl,
+      validationEndpoint: miroValidationPath,
+      tokenId: optionalString(payload.id),
+      currentUser: user,
+      team,
+      createdAt: optionalString(payload.createdAt),
+      createdBy: optionalRecord(payload.createdBy),
+    }),
+  };
+}
+
+function parseScopeString(value: unknown): string[] {
+  return optionalString(value)?.split(/\s+/u).filter(Boolean) ?? [];
+}
+
+function createMiroResponseError(response: Response, payload: unknown, phase: MiroRequestPhase): ProviderRequestError {
+  const message = extractMiroErrorMessage(payload) ?? response.statusText ?? "Miro request failed";
+  const status = phase === "validate" && (response.status === 400 || response.status === 401) ? 400 : response.status;
+  return new ProviderRequestError(status || 502, message, payload);
+}
+
+function extractMiroErrorMessage(payload: unknown): string | undefined {
+  if (typeof payload === "string" && payload.trim()) {
+    return payload.trim();
+  }
+  const object = optionalRecord(payload);
+  return optionalString(object?.message) ?? optionalString(object?.error_description) ?? optionalString(object?.error);
+}
+
+function requireMiroObject(value: unknown, source: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (!object) {
+    throw new ProviderRequestError(502, `Miro ${source} must be an object`, value);
+  }
+  return object;
+}
+
+function requireInputString(value: unknown, field: string): string {
+  return requiredString(value, field, providerInputError);
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerResponseError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/miro/executors.ts
+++ b/src/providers/miro/executors.ts
@@ -5,7 +5,6 @@ import type {
   ProviderProxyExecutor,
 } from "../../core/types.ts";
 import type { OAuthProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
-import type { MiroActionName } from "./actions.ts";
 
 import {
   compactObject,
@@ -48,7 +47,7 @@ interface MiroRequestOptions {
   body?: Record<string, unknown>;
 }
 
-export const miroActionHandlers: Record<MiroActionName, MiroActionHandler> = {
+export const miroActionHandlers: Record<string, MiroActionHandler> = {
   async list_boards(input, context): Promise<unknown> {
     const limit = optionalInteger(input.limit) ?? defaultBoardLimit;
     const offset = optionalInteger(input.offset) ?? 0;
@@ -197,6 +196,9 @@ async function createBoardItem(
   const geometry = optionalRecord(input.geometry);
   if (endpoint === "sticky_notes" && geometry?.width !== undefined && geometry.height !== undefined) {
     throw new ProviderRequestError(400, "geometry must specify either width or height, not both");
+  }
+  if (endpoint === "texts" && geometry?.height !== undefined) {
+    throw new ProviderRequestError(400, "geometry.height is not supported for text items");
   }
 
   const item = requireMiroObject(

--- a/src/providers/miro/scopes.ts
+++ b/src/providers/miro/scopes.ts
@@ -1,0 +1,4 @@
+export const miroBoardsReadScope = "boards:read";
+export const miroBoardsWriteScope = "boards:write";
+
+export const miroOAuthScopes: string[] = [miroBoardsReadScope, miroBoardsWriteScope];

--- a/web/public/provider-icons/miro.svg
+++ b/web/public/provider-icons/miro.svg
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- Source: https://thesvg.org/icon/miro; Miro is a trademark of its respective owner. -->
+<svg fill="#050038" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Miro</title>
+  <path d="M17.392 0H13.9L17 4.808 10.444 0H6.949l3.102 6.3L3.494 0H0l3.05 8.131L0 24h3.494L10.05 6.985 6.949 24h3.494L17 5.494 13.899 24h3.493L24 3.672 17.392 0z"/>
+</svg>


### PR DESCRIPTION
## Summary

- add an OAuth-only Miro provider backed by the public REST API v2
- configure Miro's authorization-code flow and refresh-capable token endpoint using form-encoded `client_secret_post`
- keep `scope` out of the authorization URL because Miro permissions are configured on the app itself, while still exposing `boards:read` and `boards:write` as provider-native action requirements
- add locally executable actions for listing, reading, and creating boards; listing and reading board items; and creating sticky-note and text items
- validate credentials through Miro's access-token context and expose the connected user, team, and granted scopes
- add an OAuth bearer proxy and targeted tests for credential identity, pagination, request shaping, and item geometry validation

## Why

The catalog did not include a Miro provider, so self-hosted users could not connect a Miro OAuth app or execute common board workflows locally.

## Developer impact

Open-source deployments can configure their own Miro OAuth application with `boards:read` and `boards:write`. All seven catalog actions have local executors and use the shared guarded provider fetch path.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (80 files, 852 tests)