### PR TITLE
feat(stripe): add Connect OAuth authentication

### DIFF
--- a/src/providers/stripe/actions.ts
+++ b/src/providers/stripe/actions.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { stripeConnectReadWriteScope } from "./scopes.ts";
 
 const service = "stripe";
 
@@ -392,8 +393,8 @@ export const stripeActions: ActionDefinition[] = actions.map((source) =>
   defineProviderAction(service, {
     name: source.name,
     description: source.description,
-    requiredScopes: [],
-    providerPermissions: [],
+    requiredScopes: [stripeConnectReadWriteScope],
+    providerPermissions: [stripeConnectReadWriteScope],
     inputSchema: source.inputSchema,
     outputSchema: source.outputSchema,
   }),

--- a/src/providers/stripe/definition.ts
+++ b/src/providers/stripe/definition.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { stripeActions } from "./actions.ts";
+import { stripeConnectOAuthScopes } from "./scopes.ts";
 
 const service = "stripe";
 
@@ -11,8 +12,18 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Stripe",
   categories: ["Finance", "Developer Tools"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://connect.stripe.com/oauth/authorize",
+      tokenUrl: "https://connect.stripe.com/oauth/token",
+      scopes: stripeConnectOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      tokenRequestFields: {
+        clientId: false,
+      },
+    },
     {
       type: "api_key",
       label: "Secret API Key",

--- a/src/providers/stripe/executors.test.ts
+++ b/src/providers/stripe/executors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+const account = {
+  id: "acct_123",
+  email: "owner@example.com",
+  country: "US",
+  default_currency: "usd",
+};
+
+describe("Stripe credentials", () => {
+  it("validates a Stripe Connect OAuth credential with bearer authentication", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "sk_live_connected",
+        tokenType: "bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: { scope: "read_write", stripe_user_id: "acct_123" },
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://api.stripe.com/v1/account");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer sk_live_connected");
+          return Response.json(account);
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "acct_123", displayName: "owner@example.com" },
+      grantedScopes: ["read_write"],
+      metadata: { accountId: "acct_123", country: "US", defaultCurrency: "usd" },
+    });
+  });
+
+  it("keeps secret API key validation compatible", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "sk_test_platform", values: {} },
+      {
+        fetcher: async (_url, init) => {
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer sk_test_platform");
+          return Response.json(account);
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "acct_123", displayName: "owner@example.com" },
+      grantedScopes: [],
+    });
+  });
+});

--- a/src/providers/stripe/executors.ts
+++ b/src/providers/stripe/executors.ts
@@ -1,16 +1,16 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type { BearerProviderContext } from "../provider-runtime.ts";
 import type { StripeActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
-import { ProviderRequestError, defineApiKeyProviderExecutors, providerUserAgent } from "../provider-runtime.ts";
+import { ProviderRequestError, defineBearerProviderExecutors, providerUserAgent } from "../provider-runtime.ts";
 
-type StripeActionContext = ApiKeyProviderContext;
+type StripeActionContext = BearerProviderContext;
 
 type StripeActionHandler = (input: Record<string, unknown>, context: StripeActionContext) => Promise<unknown>;
 
 interface StripeRequestInput {
-  apiKey: string;
+  accessToken: string;
   fetcher: typeof fetch;
   method: "GET" | "POST" | "DELETE";
   query?: Record<string, unknown>;
@@ -110,17 +110,20 @@ export const stripeActionHandlers: Record<StripeActionName, StripeActionHandler>
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, stripeActionHandlers);
+export const executors: ProviderExecutors = defineBearerProviderExecutors(service, stripeActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher }) {
-    const profile = await validateStripeCredential(input.apiKey, fetcher);
-    return profile;
+    return validateStripeCredential(input.apiKey, [], fetcher);
+  },
+  async oauth2(input, { fetcher }) {
+    return validateStripeCredential(input.accessToken, parseStripeScopes(input.metadata.scope), fetcher);
   },
 };
 
 async function validateStripeCredential(
-  apiKey: string,
+  accessToken: string,
+  grantedScopes: string[],
   fetcher: typeof fetch,
 ): Promise<{
   profile: {
@@ -132,7 +135,7 @@ async function validateStripeCredential(
 }> {
   const payload = readObject(
     await stripeRequest(stripeAccountPath, {
-      apiKey,
+      accessToken,
       fetcher,
       method: "GET",
     }),
@@ -148,7 +151,7 @@ async function validateStripeCredential(
       accountId,
       displayName: email ?? accountId ?? "Stripe API Key",
     },
-    grantedScopes: [],
+    grantedScopes,
     metadata: compactObject({
       apiBaseUrl: stripeApiBaseUrl,
       apiVersion: stripeApiVersion,
@@ -164,7 +167,7 @@ async function validateStripeCredential(
 async function executeIdentifyAccount(context: StripeActionContext) {
   const payload = readObject(
     await stripeRequest(stripeAccountPath, {
-      apiKey: context.apiKey,
+      accessToken: context.accessToken,
       fetcher: context.fetcher,
       method: "GET",
     }),
@@ -182,7 +185,7 @@ async function executeIdentifyAccount(context: StripeActionContext) {
 
 async function executeCustomerMutation(path: string, input: Record<string, unknown>, context: StripeActionContext) {
   const customer = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "POST",
     body: input,
@@ -192,7 +195,7 @@ async function executeCustomerMutation(path: string, input: Record<string, unkno
 
 async function executeCustomerRead(path: string, context: StripeActionContext) {
   const customer = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "GET",
   });
@@ -201,7 +204,7 @@ async function executeCustomerRead(path: string, context: StripeActionContext) {
 
 async function executeProductMutation(path: string, input: Record<string, unknown>, context: StripeActionContext) {
   const product = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "POST",
     body: input,
@@ -211,7 +214,7 @@ async function executeProductMutation(path: string, input: Record<string, unknow
 
 async function executeProductRead(path: string, context: StripeActionContext) {
   const product = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "GET",
   });
@@ -220,7 +223,7 @@ async function executeProductRead(path: string, context: StripeActionContext) {
 
 async function executePriceMutation(path: string, input: Record<string, unknown>, context: StripeActionContext) {
   const price = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "POST",
     body: input,
@@ -230,7 +233,7 @@ async function executePriceMutation(path: string, input: Record<string, unknown>
 
 async function executePriceRead(path: string, context: StripeActionContext) {
   const price = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "GET",
   });
@@ -244,7 +247,7 @@ async function executeStripeList(
   context: StripeActionContext,
 ) {
   const payload = await stripeRequest(path, {
-    apiKey: context.apiKey,
+    accessToken: context.accessToken,
     fetcher: context.fetcher,
     method: "GET",
     query: input,
@@ -255,7 +258,7 @@ async function executeStripeList(
 async function executeStripeDelete(path: string, context: StripeActionContext) {
   const payload = readObject(
     await stripeRequest(path, {
-      apiKey: context.apiKey,
+      accessToken: context.accessToken,
       fetcher: context.fetcher,
       method: "DELETE",
     }),
@@ -274,7 +277,7 @@ async function stripeRequest(path: string, input: StripeRequestInput): Promise<u
   appendStripeParams(url.searchParams, input.query);
 
   const headers: Record<string, string> = {
-    authorization: `Bearer ${input.apiKey}`,
+    authorization: `Bearer ${input.accessToken}`,
     "stripe-version": stripeApiVersion,
     "user-agent": providerUserAgent,
   };
@@ -372,6 +375,13 @@ function mapStripeError(status: number, message: string): ProviderRequestError {
   }
 
   return new ProviderRequestError(502, message, status);
+}
+
+function parseStripeScopes(value: unknown): string[] {
+  return (optionalString(value) ?? "")
+    .split(/[ ,]+/u)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
 }
 
 function readObject(value: unknown, context: string): Record<string, unknown> {

--- a/src/providers/stripe/scopes.ts
+++ b/src/providers/stripe/scopes.ts
@@ -1,0 +1,4 @@
+export const stripeConnectReadWriteScope = "read_write";
+
+/** Stripe Connect access required by the provider's read and mutation actions. */
+export const stripeConnectOAuthScopes: string[] = [stripeConnectReadWriteScope];


### PR DESCRIPTION
## What

- add Stripe Connect OAuth 2 authorization alongside secret API keys
- use the official read_write scope and Connect token request shape
- share bearer execution and credential validation across both auth modes

## Why

Stripe Connect users should be able to authorize Standard accounts without copying account API keys.

## Checks

- npm run generate:catalog
- npx vitest run src/providers/stripe/executors.test.ts
- npm run fix-check
- npm test (90 files, 889 tests)