### PR TITLE
feat(mailchimp): add OAuth authentication

### DIFF
--- a/src/providers/mailchimp/definition.ts
+++ b/src/providers/mailchimp/definition.ts
@@ -8,8 +8,18 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Mailchimp",
   categories: ["Communication", "Marketing"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",
+      tokenUrl: "https://login.mailchimp.com/oauth2/token",
+      scopes: [],
+      tokenEndpointAuthMethod: "client_secret_post",
+      authorizationRequestFields: {
+        scope: false,
+      },
+    },
     {
       type: "api_key",
       label: "API Key",

--- a/src/providers/mailchimp/executors.test.ts
+++ b/src/providers/mailchimp/executors.test.ts
@@ -1,0 +1,68 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("Mailchimp credentials", () => {
+  it("resolves OAuth account identity and data center from metadata", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "mailchimp-oauth-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: {},
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://login.mailchimp.com/oauth2/metadata");
+          expect(new Headers(init?.headers).get("authorization")).toBe("OAuth mailchimp-oauth-token");
+          return Response.json({
+            dc: "us21",
+            role: "owner",
+            accountname: "Example Audience",
+            user_id: 42,
+            api_endpoint: "https://us21.api.mailchimp.com/3.0/",
+            login: { email: "owner@example.com", login_id: 7 },
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "42", displayName: "Example Audience" },
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl: "https://us21.api.mailchimp.com/3.0",
+        dataCenter: "us21",
+        email: "owner@example.com",
+        role: "owner",
+      },
+    });
+  });
+
+  it("keeps API key validation compatible with Basic authentication", async () => {
+    const apiKey = "0123456789abcdef-us6";
+    const result = await credentialValidators.apiKey!(
+      { apiKey, values: {} },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://us6.api.mailchimp.com/3.0/");
+          expect(new Headers(init?.headers).get("authorization")).toBe(
+            `Basic ${Buffer.from(`connect:${apiKey}`).toString("base64")}`,
+          );
+          return Response.json({
+            account_id: "account-1",
+            account_name: "Example Account",
+            email: "owner@example.com",
+            role: "owner",
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "account-1", displayName: "Example Account" },
+      metadata: { dataCenter: "us6" },
+    });
+  });
+});

--- a/src/providers/mailchimp/executors.test.ts
+++ b/src/providers/mailchimp/executors.test.ts
@@ -1,6 +1,12 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
 import { Buffer } from "node:buffer";
-import { describe, expect, it } from "vitest";
-import { credentialValidators } from "./executors.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { credentialValidators, executors } from "./executors.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Mailchimp credentials", () => {
   it("resolves OAuth account identity and data center from metadata", async () => {
@@ -64,5 +70,65 @@ describe("Mailchimp credentials", () => {
       profile: { accountId: "account-1", displayName: "Example Account" },
       metadata: { dataCenter: "us6" },
     });
+  });
+
+  it("executes OAuth actions with the stored token type and data center", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://us21.api.mailchimp.com/3.0/lists");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer mailchimp-oauth-token");
+      return Response.json({ lists: [] });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const credential: ResolvedCredential = {
+      authType: "oauth2",
+      accessToken: "mailchimp-oauth-token",
+      tokenType: "Bearer",
+      profile: { accountId: "42", displayName: "Example Audience", grantedScopes: [] },
+      metadata: { dataCenter: "us21" },
+    };
+    const context: ExecutionContext = { getCredential: async () => credential };
+
+    const result = await executors["mailchimp.list_lists"]!({}, context);
+
+    expect(result).toMatchObject({ ok: true, output: { lists: [] } });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an OAuth metadata endpoint that disagrees with its data center", async () => {
+    await expect(
+      credentialValidators.oauth2!(
+        {
+          authType: "oauth2",
+          accessToken: "mailchimp-oauth-token",
+          tokenType: "Bearer",
+          profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+          metadata: {},
+        },
+        {
+          fetcher: async () =>
+            Response.json({
+              dc: "us21",
+              api_endpoint: "https://us22.api.mailchimp.com/3.0",
+            }),
+        },
+      ),
+    ).rejects.toThrow("unexpected API endpoint");
+  });
+
+  it("rejects an invalid OAuth metadata data center", async () => {
+    await expect(
+      credentialValidators.oauth2!(
+        {
+          authType: "oauth2",
+          accessToken: "mailchimp-oauth-token",
+          tokenType: "Bearer",
+          profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+          metadata: {},
+        },
+        {
+          fetcher: async () => Response.json({ dc: "us-21" }),
+        },
+      ),
+    ).rejects.toThrow("invalid data center");
   });
 });

--- a/src/providers/mailchimp/executors.ts
+++ b/src/providers/mailchimp/executors.ts
@@ -1,10 +1,10 @@
 import type {
   CredentialValidationResult,
   CredentialValidators,
+  ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
 } from "../../core/types.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import type { MailchimpActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
@@ -19,24 +19,29 @@ import {
 } from "../../core/cast.ts";
 import {
   createProviderProxyUrl,
-  defineApiKeyProviderExecutors,
+  defineProviderExecutors,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
-  requireApiKeyCredential,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
 type MailchimpJsonObject = Record<string, unknown>;
 type MailchimpRequestMode = "validate" | "execute";
-type MailchimpActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+type MailchimpActionHandler = (input: Record<string, unknown>, context: MailchimpActionContext) => Promise<unknown>;
+
+interface MailchimpActionContext {
+  apiBaseUrl: string;
+  authorization: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
 
 interface MailchimpRequestOptions {
-  apiKey: string;
-  context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
+  context: MailchimpActionContext;
   path: string;
   mode: MailchimpRequestMode;
   method?: string;
@@ -46,11 +51,11 @@ interface MailchimpRequestOptions {
 
 const service = "mailchimp";
 const mailchimpValidationPath = "/";
+const mailchimpOAuthMetadataUrl = "https://login.mailchimp.com/oauth2/metadata";
 
 export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActionHandler> = {
   list_lists(input, context) {
     return requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: "/lists",
       query: compactObject({
@@ -62,7 +67,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async get_list(input, context) {
     const payload = await requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: `/lists/${encodeURIComponent(requireInputString(input.list_id, "list_id"))}`,
       mode: "execute",
@@ -72,7 +76,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   list_members(input, context) {
     return requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: `/lists/${encodeURIComponent(requireInputString(input.list_id, "list_id"))}/members`,
       query: compactObject({
@@ -85,7 +88,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async get_member(input, context) {
     const payload = await requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: memberPath(input),
       mode: "execute",
@@ -96,7 +98,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   async upsert_member(input, context) {
     const emailAddress = requireInputString(input.email_address, "email_address");
     const payload = await requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: `/lists/${encodeURIComponent(requireInputString(input.list_id, "list_id"))}/members/${subscriberHash(
         emailAddress,
@@ -121,7 +122,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async update_member(input, context) {
     const payload = await requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: memberPath(input),
       method: "PATCH",
@@ -142,7 +142,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async archive_member(input, context) {
     await requestMailchimpNoContent({
-      apiKey: context.apiKey,
       context,
       path: memberPath(input),
       method: "DELETE",
@@ -153,7 +152,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async delete_member_permanently(input, context) {
     await requestMailchimpNoContent({
-      apiKey: context.apiKey,
       context,
       path: `${memberPath(input)}/actions/delete-permanent`,
       method: "POST",
@@ -164,7 +162,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   list_member_tags(input, context) {
     return requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: `${memberPath(input)}/tags`,
       mode: "execute",
@@ -172,7 +169,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   async update_member_tags(input, context) {
     await requestMailchimpNoContent({
-      apiKey: context.apiKey,
       context,
       path: `${memberPath(input)}/tags`,
       method: "POST",
@@ -186,7 +182,6 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
   list_merge_fields(input, context) {
     return requestMailchimpJson({
-      apiKey: context.apiKey,
       context,
       path: `/lists/${encodeURIComponent(requireInputString(input.list_id, "list_id"))}/merge-fields`,
       query: compactObject({
@@ -198,14 +193,20 @@ export const mailchimpActionHandlers: Record<MailchimpActionName, MailchimpActio
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, mailchimpActionHandlers);
+export const executors: ProviderExecutors = defineProviderExecutors<MailchimpActionContext>({
+  service,
+  handlers: mailchimpActionHandlers,
+  createContext(context, fetcher) {
+    return resolveMailchimpActionContext(context, fetcher);
+  },
+});
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
-    const credential = await requireApiKeyCredential(context, service);
-    const url = createProviderProxyUrl(mailchimpApiBaseUrl(credential.apiKey), input.endpoint, input.query);
+    const providerContext = await resolveMailchimpActionContext(context, providerFetch);
+    const url = createProviderProxyUrl(providerContext.apiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
-    for (const [name, value] of Object.entries(mailchimpHeaders(credential.apiKey, input.body !== undefined))) {
+    for (const [name, value] of Object.entries(mailchimpHeaders(providerContext, input.body !== undefined))) {
       headers.set(name, value);
     }
 
@@ -232,24 +233,31 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
-    return validateMailchimpCredential(input.apiKey, fetcher, signal);
+    return validateMailchimpApiKeyCredential(input.apiKey, fetcher, signal);
+  },
+  async oauth2(input, { fetcher, signal }) {
+    return validateMailchimpOAuthCredential(input.accessToken, fetcher, signal);
   },
 };
 
-async function validateMailchimpCredential(
+async function validateMailchimpApiKeyCredential(
   apiKey: string,
   fetcher: typeof fetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
+  const dataCenter = extractMailchimpDataCenter(apiKey);
+  const apiBaseUrl = mailchimpApiBaseUrl(dataCenter);
   const payload = await requestMailchimpJson({
-    apiKey,
-    context: { fetcher, signal },
+    context: {
+      apiBaseUrl,
+      authorization: mailchimpApiKeyAuthorization(apiKey),
+      fetcher,
+      signal,
+    },
     path: mailchimpValidationPath,
     mode: "validate",
   });
 
-  const dataCenter = extractMailchimpDataCenter(apiKey);
-  const apiBaseUrl = mailchimpApiBaseUrl(apiKey);
   const accountId = optionalString(payload.account_id);
   const loginId = optionalString(payload.login_id);
   const accountName = optionalString(payload.account_name);
@@ -268,6 +276,36 @@ async function validateMailchimpCredential(
       validationEndpoint: mailchimpValidationPath,
       email,
       role,
+    }),
+  };
+}
+
+async function validateMailchimpOAuthCredential(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const metadata = await requestMailchimpOAuthMetadata(accessToken, fetcher, signal);
+  const dataCenter = readMailchimpDataCenter(metadata.dc);
+  const apiBaseUrl = mailchimpApiBaseUrl(dataCenter);
+  assertMailchimpApiEndpoint(metadata.api_endpoint, apiBaseUrl);
+  const login = optionalRecord(metadata.login);
+  const accountId = readMailchimpIdentifier(metadata.user_id) ?? readMailchimpIdentifier(login?.login_id);
+  const accountName = optionalString(metadata.accountname) ?? optionalString(metadata.account_name);
+  const email = optionalString(login?.email) ?? optionalString(login?.login_email);
+
+  return {
+    profile: {
+      accountId: accountId ?? `mailchimp:${dataCenter}`,
+      displayName: accountName ?? email ?? `Mailchimp ${dataCenter}`,
+    },
+    grantedScopes: [],
+    metadata: compactObject({
+      apiBaseUrl,
+      dataCenter,
+      validationEndpoint: mailchimpOAuthMetadataUrl,
+      email,
+      role: optionalString(metadata.role),
     }),
   };
 }
@@ -295,13 +333,13 @@ async function requestMailchimpNoContent(input: MailchimpRequestOptions): Promis
 }
 
 async function mailchimpFetch(input: MailchimpRequestOptions): Promise<Response> {
-  const url = buildMailchimpUrl(input.apiKey, input.path, input.query);
+  const url = buildMailchimpUrl(input.context.apiBaseUrl, input.path, input.query);
   const method = input.method ?? "GET";
 
   try {
     return await input.context.fetcher(url, {
       method,
-      headers: mailchimpHeaders(input.apiKey, input.body !== undefined),
+      headers: mailchimpHeaders(input.context, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
       signal: input.context.signal,
     });
@@ -311,8 +349,7 @@ async function mailchimpFetch(input: MailchimpRequestOptions): Promise<Response>
   }
 }
 
-function buildMailchimpUrl(apiKey: string, path: string, query?: MailchimpRequestOptions["query"]): URL {
-  const apiBaseUrl = mailchimpApiBaseUrl(apiKey);
+function buildMailchimpUrl(apiBaseUrl: string, path: string, query?: MailchimpRequestOptions["query"]): URL {
   const url = new URL(path.startsWith("/") ? `${apiBaseUrl}${path}` : `${apiBaseUrl}/${path}`);
 
   for (const [key, value] of Object.entries(query ?? {})) {
@@ -324,10 +361,10 @@ function buildMailchimpUrl(apiKey: string, path: string, query?: MailchimpReques
   return url;
 }
 
-function mailchimpHeaders(apiKey: string, hasBody: boolean): Record<string, string> {
+function mailchimpHeaders(context: MailchimpActionContext, hasBody: boolean): Record<string, string> {
   return {
     accept: "application/json",
-    authorization: `Basic ${Buffer.from(`connect:${apiKey}`).toString("base64")}`,
+    authorization: context.authorization,
     ...(hasBody ? { "content-type": "application/json" } : {}),
     "user-agent": providerUserAgent,
   };
@@ -421,9 +458,12 @@ function extractMailchimpErrorMessage(payload: MailchimpJsonObject): string | un
   return undefined;
 }
 
-function mailchimpApiBaseUrl(apiKey: string): string {
-  const dataCenter = extractMailchimpDataCenter(apiKey);
+function mailchimpApiBaseUrl(dataCenter: string): string {
   return `https://${dataCenter}.api.mailchimp.com/3.0`;
+}
+
+function mailchimpApiKeyAuthorization(apiKey: string): string {
+  return `Basic ${Buffer.from(`connect:${apiKey}`).toString("base64")}`;
 }
 
 function extractMailchimpDataCenter(apiKey: string): string {
@@ -433,12 +473,83 @@ function extractMailchimpDataCenter(apiKey: string): string {
     throw new ProviderRequestError(400, "Mailchimp apiKey must include a data center suffix such as us1");
   }
 
-  const dataCenter = trimmed.slice(separatorIndex + 1);
-  if (!/^[a-z0-9]+$/i.test(dataCenter)) {
-    throw new ProviderRequestError(400, "Mailchimp apiKey has an invalid data center suffix");
-  }
+  return readMailchimpDataCenter(
+    trimmed.slice(separatorIndex + 1),
+    "Mailchimp apiKey has an invalid data center suffix",
+  );
+}
 
-  return dataCenter.toLowerCase();
+async function resolveMailchimpActionContext(
+  context: ExecutionContext,
+  fetcher: typeof fetch,
+): Promise<MailchimpActionContext> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "api_key") {
+    const dataCenter = extractMailchimpDataCenter(credential.apiKey);
+    return {
+      apiBaseUrl: mailchimpApiBaseUrl(dataCenter),
+      authorization: mailchimpApiKeyAuthorization(credential.apiKey),
+      fetcher,
+      signal: context.signal,
+    };
+  }
+  if (credential?.authType === "oauth2") {
+    const storedDataCenter = optionalString(credential.metadata.dataCenter);
+    const dataCenter = storedDataCenter
+      ? readMailchimpDataCenter(storedDataCenter)
+      : readMailchimpDataCenter(
+          (await requestMailchimpOAuthMetadata(credential.accessToken, fetcher, context.signal)).dc,
+        );
+    return {
+      apiBaseUrl: mailchimpApiBaseUrl(dataCenter),
+      authorization: `${credential.tokenType} ${credential.accessToken}`,
+      fetcher,
+      signal: context.signal,
+    };
+  }
+  throw new ProviderRequestError(401, "Configure Mailchimp credentials first.");
+}
+
+async function requestMailchimpOAuthMetadata(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<MailchimpJsonObject> {
+  const response = await fetcher(mailchimpOAuthMetadataUrl, {
+    headers: {
+      accept: "application/json",
+      authorization: `OAuth ${accessToken}`,
+      "user-agent": providerUserAgent,
+    },
+    signal,
+  });
+  const payload = await parseMailchimpJson(response);
+  if (!response.ok) {
+    throw toMailchimpError(response, payload, "validate");
+  }
+  return payload;
+}
+
+function readMailchimpDataCenter(
+  value: unknown,
+  message = "Mailchimp OAuth metadata has an invalid data center",
+): string {
+  const dataCenter = optionalString(value)?.toLowerCase();
+  if (!dataCenter || !/^[a-z0-9]+$/u.test(dataCenter)) {
+    throw new ProviderRequestError(400, message);
+  }
+  return dataCenter;
+}
+
+function assertMailchimpApiEndpoint(value: unknown, expectedApiBaseUrl: string): void {
+  const endpoint = optionalString(value)?.replace(/\/+$/u, "");
+  if (endpoint && endpoint !== expectedApiBaseUrl) {
+    throw new ProviderRequestError(400, "Mailchimp OAuth metadata returned an unexpected API endpoint");
+  }
+}
+
+function readMailchimpIdentifier(value: unknown): string | undefined {
+  return typeof value === "string" || typeof value === "number" ? String(value) : undefined;
 }
 
 function memberPath(input: Record<string, unknown>): string {


### PR DESCRIPTION
## What

- add the Mailchimp OAuth 2 authorization-code flow alongside API keys
- resolve and validate the account data center through the OAuth metadata endpoint
- use Bearer auth for Marketing API calls while preserving API-key Basic auth
- support OAuth credentials in actions and proxy requests

## Why

Mailchimp recommends OAuth when an integration accesses accounts on behalf of other users, and access tokens require a metadata lookup before API requests can be routed to the correct data center.

## Checks

- npm run generate:catalog
- npx vitest run src/providers/mailchimp/executors.test.ts
- npm run fix-check
- npm test (90 files, 889 tests)