### PR TITLE
feat(shopify): add OAuth authentication

### DIFF
--- a/src/providers/shopify/actions.ts
+++ b/src/providers/shopify/actions.ts
@@ -2,9 +2,9 @@ import type { ActionDefinition } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { shopifyReadContentScope } from "./scopes.ts";
 
 const service = "shopify" as const;
-const contentScope = "content";
 
 const shopifyIdSchema = (description: string) => s.integer(description, { minimum: 1 });
 const nullableStringSchema = (description: string) => s.nullable(s.string(description));
@@ -127,7 +127,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_blogs",
     description: "List Shopify REST blogs with optional handle filtering and pagination.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for listing Shopify REST blogs.",
       {
@@ -146,7 +147,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_blog",
     description: "Retrieve one Shopify REST blog by numeric ID.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object("The input payload for retrieving one Shopify REST blog.", {
       blog_id: shopifyIdSchema("The Shopify blog ID."),
     }),
@@ -157,7 +159,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "count_blogs",
     description: "Count Shopify REST blogs in the connected shop.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object("No input is required to count Shopify REST blogs.", {}),
     outputSchema: s.object("The Shopify REST blog count response.", {
       count: countSchema,
@@ -166,7 +169,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_pages",
     description: "List Shopify REST pages with optional filters and pagination.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for listing Shopify REST pages.",
       {
@@ -203,7 +207,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_page",
     description: "Retrieve one Shopify REST page by numeric ID.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object("The input payload for retrieving one Shopify REST page.", {
       page_id: shopifyIdSchema("The Shopify page ID."),
     }),
@@ -214,7 +219,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "count_pages",
     description: "Count Shopify REST pages with optional filters.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for counting Shopify REST pages.",
       {
@@ -242,7 +248,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_articles",
     description: "List Shopify REST articles in a blog with optional filters and pagination.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for listing Shopify REST articles.",
       {
@@ -282,7 +289,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_article",
     description: "Retrieve one Shopify REST article by blog ID and article ID.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object("The input payload for retrieving one Shopify REST article.", {
       blog_id: shopifyIdSchema("The Shopify blog ID."),
       article_id: shopifyIdSchema("The Shopify article ID."),
@@ -294,7 +302,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "count_articles",
     description: "Count Shopify REST articles in a blog with optional filters.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for counting Shopify REST articles.",
       {
@@ -321,7 +330,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_article_tags",
     description: "List Shopify REST article tags across all articles in the connected shop.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for listing Shopify REST article tags.",
       {
@@ -337,7 +347,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_blog_article_tags",
     description: "List Shopify REST article tags for one blog.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object(
       "The input payload for listing Shopify REST article tags in one blog.",
       {
@@ -354,7 +365,8 @@ export const shopifyActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_article_authors",
     description: "List Shopify REST article authors across the connected shop.",
-    requiredScopes: [contentScope],
+    requiredScopes: [shopifyReadContentScope],
+    providerPermissions: [shopifyReadContentScope],
     inputSchema: s.object("No input is required to list Shopify REST article authors.", {}),
     outputSchema: s.object("The Shopify REST article authors response.", {
       authors: s.array("Article authors returned by Shopify.", s.string("One article author.")),

--- a/src/providers/shopify/definition.ts
+++ b/src/providers/shopify/definition.ts
@@ -4,6 +4,8 @@ import { shopifyActions } from "./actions.ts";
 import { shopifyOAuthScopes } from "./scopes.ts";
 
 const service = "shopify";
+const shopifyAuthorizationUrl = "https://{shopSubdomain}.myshopify.com/admin/oauth/authorize";
+const shopifyTokenUrl = "https://{shopSubdomain}.myshopify.com/admin/oauth/access_token";
 
 export const provider: ProviderDefinition = {
   service,
@@ -13,20 +15,20 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://{shopDomain}/admin/oauth/authorize",
-      tokenUrl: "https://{shopDomain}/admin/oauth/access_token",
+      authorizationUrl: shopifyAuthorizationUrl,
+      tokenUrl: shopifyTokenUrl,
       scopes: shopifyOAuthScopes,
       scopeSeparator: ",",
       tokenEndpointAuthMethod: "client_secret_post",
       clientConfigFields: [
         {
-          key: "shopDomain",
-          label: "Shop domain",
+          key: "shopSubdomain",
+          label: "Shop subdomain",
           inputType: "text",
           required: true,
           secret: false,
-          placeholder: "acme.myshopify.com",
-          description: "The exact myshopify.com domain of the store to authorize, such as acme.myshopify.com.",
+          placeholder: "acme",
+          description: "The store-specific part before .myshopify.com, such as acme for acme.myshopify.com.",
         },
       ],
     },

--- a/src/providers/shopify/definition.ts
+++ b/src/providers/shopify/definition.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { shopifyActions } from "./actions.ts";
+import { shopifyOAuthScopes } from "./scopes.ts";
 
 const service = "shopify";
 
@@ -8,8 +9,27 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Shopify REST Admin (Legacy)",
   categories: ["Marketing", "Data"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://{shopDomain}/admin/oauth/authorize",
+      tokenUrl: "https://{shopDomain}/admin/oauth/access_token",
+      scopes: shopifyOAuthScopes,
+      scopeSeparator: ",",
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientConfigFields: [
+        {
+          key: "shopDomain",
+          label: "Shop domain",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "acme.myshopify.com",
+          description: "The exact myshopify.com domain of the store to authorize, such as acme.myshopify.com.",
+        },
+      ],
+    },
     {
       type: "api_key",
       label: "Admin API access token",

--- a/src/providers/shopify/executors.test.ts
+++ b/src/providers/shopify/executors.test.ts
@@ -1,6 +1,21 @@
+import type { IOAuthClientConfigStore } from "../../oauth/oauth-client-config-service.ts";
+
 import { describe, expect, it } from "vitest";
+import { createCatalogStore } from "../../catalog-store.ts";
+import { OAuthClientConfigService } from "../../oauth/oauth-client-config-service.ts";
 import { provider } from "./definition.ts";
 import { credentialValidators } from "./executors.ts";
+
+const oauthConfigStore: IOAuthClientConfigStore = {
+  async get() {
+    return undefined;
+  },
+  async set() {},
+  async delete() {},
+  async list() {
+    return [];
+  },
+};
 
 function shopifyCredentialFetcher(expectedToken: string): typeof fetch {
   return async (url, init) => {
@@ -68,12 +83,29 @@ describe("Shopify credentials", () => {
     if (!oauth || oauth.type !== "oauth2") {
       throw new Error("expected Shopify OAuth definition");
     }
+    const clientConfigs = new OAuthClientConfigService({
+      catalog: createCatalogStore([provider]),
+      origin: "http://localhost:3000",
+      store: oauthConfigStore,
+    });
+    const config = clientConfigs.normalizeConfig("shopify", {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      extra: { shopSubdomain: "acme" },
+    });
 
-    const attackerInput = encodeURIComponent("attacker.example");
-    const authorizationUrl = new URL(oauth.authorizationUrl.replace("{shopSubdomain}", attackerInput));
-    const tokenUrl = new URL(oauth.tokenUrl.replace("{shopSubdomain}", attackerInput));
+    expect(new URL(clientConfigs.resolveEndpointUrl("shopify", oauth.authorizationUrl, config)).origin).toBe(
+      "https://acme.myshopify.com",
+    );
+    expect(new URL(clientConfigs.resolveEndpointUrl("shopify", oauth.tokenUrl, config)).origin).toBe(
+      "https://acme.myshopify.com",
+    );
 
-    expect(authorizationUrl.hostname).toBe("attacker.example.myshopify.com");
-    expect(tokenUrl.hostname).toBe("attacker.example.myshopify.com");
+    expect(() =>
+      clientConfigs.resolveEndpointUrl("shopify", oauth.tokenUrl, {
+        ...config,
+        extra: { shopSubdomain: "attacker.example/evil" },
+      }),
+    ).toThrow();
   });
 });

--- a/src/providers/shopify/executors.test.ts
+++ b/src/providers/shopify/executors.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+function shopifyCredentialFetcher(expectedToken: string): typeof fetch {
+  return async (url, init) => {
+    const requestUrl = new URL(url.toString());
+    expect(requestUrl.origin).toBe("https://acme.myshopify.com");
+    expect(new Headers(init?.headers).get("x-shopify-access-token")).toBe(expectedToken);
+    if (requestUrl.pathname.endsWith("/shop.json")) {
+      return Response.json({
+        shop: {
+          id: 123,
+          name: "Acme Store",
+          myshopify_domain: "acme.myshopify.com",
+        },
+      });
+    }
+    expect(requestUrl.pathname).toMatch(/\/blogs\/count\.json$/u);
+    return Response.json({ count: 1 });
+  };
+}
+
+describe("Shopify credentials", () => {
+  it("validates OAuth credentials against the configured shop", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "shopify-oauth-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: {
+          scope: "read_content",
+          oauthClientExtra: { shopDomain: "acme.myshopify.com" },
+        },
+      },
+      { fetcher: shopifyCredentialFetcher("shopify-oauth-token") },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "shopify:acme.myshopify.com", displayName: "Acme Store" },
+      grantedScopes: ["read_content"],
+      metadata: {
+        apiBaseUrl: "https://acme.myshopify.com/admin/api/2026-04",
+        shopDomain: "acme.myshopify.com",
+        shopId: 123,
+      },
+    });
+  });
+
+  it("keeps custom-app access token validation compatible", async () => {
+    const result = await credentialValidators.apiKey!(
+      {
+        apiKey: "shpat_custom_token",
+        values: { shopDomain: "https://acme.myshopify.com/admin" },
+      },
+      { fetcher: shopifyCredentialFetcher("shpat_custom_token") },
+    );
+
+    expect(result).toMatchObject({
+      profile: { displayName: "Acme Store" },
+      grantedScopes: ["read_content"],
+    });
+  });
+});

--- a/src/providers/shopify/executors.test.ts
+++ b/src/providers/shopify/executors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
 import { credentialValidators } from "./executors.ts";
 
 function shopifyCredentialFetcher(expectedToken: string): typeof fetch {
@@ -30,7 +31,7 @@ describe("Shopify credentials", () => {
         profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
         metadata: {
           scope: "read_content",
-          oauthClientExtra: { shopDomain: "acme.myshopify.com" },
+          oauthClientExtra: { shopSubdomain: "acme" },
         },
       },
       { fetcher: shopifyCredentialFetcher("shopify-oauth-token") },
@@ -60,5 +61,19 @@ describe("Shopify credentials", () => {
       profile: { displayName: "Acme Store" },
       grantedScopes: ["read_content"],
     });
+  });
+
+  it("keeps every resolved OAuth endpoint under myshopify.com", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+    if (!oauth || oauth.type !== "oauth2") {
+      throw new Error("expected Shopify OAuth definition");
+    }
+
+    const attackerInput = encodeURIComponent("attacker.example");
+    const authorizationUrl = new URL(oauth.authorizationUrl.replace("{shopSubdomain}", attackerInput));
+    const tokenUrl = new URL(oauth.tokenUrl.replace("{shopSubdomain}", attackerInput));
+
+    expect(authorizationUrl.hostname).toBe("attacker.example.myshopify.com");
+    expect(tokenUrl.hostname).toBe("attacker.example.myshopify.com");
   });
 });

--- a/src/providers/shopify/executors.ts
+++ b/src/providers/shopify/executors.ts
@@ -3,16 +3,18 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
+  ResolvedCredential,
 } from "../../core/types.ts";
 
-import { optionalString } from "../../core/cast.ts";
-import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
+import { optionalRecord, optionalString } from "../../core/cast.ts";
+import { defineProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 import {
   buildShopifyRestApiBaseUrl,
   normalizeShopDomain,
   shopifyActionHandlers,
   validateShopifyCredential,
 } from "./runtime.ts";
+import { shopifyReadContentScope } from "./scopes.ts";
 
 const service = "shopify";
 
@@ -20,10 +22,10 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: shopifyActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
-    const credential = await requireApiKeyCredential(context, service);
+    const credential = await requireShopifyCredential(context);
     return {
-      apiKey: credential.apiKey,
-      shopDomain: normalizeShopDomain(optionalString(credential.values.shopDomain)),
+      accessToken: shopifyAccessToken(credential),
+      shopDomain: shopifyCredentialDomain(credential),
       fetcher,
       signal: context.signal,
     };
@@ -33,14 +35,60 @@ export const executors: ProviderExecutors = defineProviderExecutors({
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: async (context) => {
-    const credential = await requireApiKeyCredential(context, service);
-    return buildShopifyRestApiBaseUrl(normalizeShopDomain(optionalString(credential.values.shopDomain)));
+    return buildShopifyRestApiBaseUrl(shopifyCredentialDomain(await requireShopifyCredential(context)));
   },
-  auth: { type: "api_key_header", name: "x-shopify-access-token" },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    headers.set("x-shopify-access-token", shopifyAccessToken(await requireShopifyCredential(context)));
+  },
 });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {
-    return validateShopifyCredential(input, fetcher, signal);
+    return validateShopifyCredential(
+      input.apiKey,
+      normalizeShopDomain(optionalString(input.values.shopDomain)),
+      [shopifyReadContentScope],
+      fetcher,
+      signal,
+    );
+  },
+  oauth2(input, { fetcher, signal }) {
+    return validateShopifyCredential(
+      input.accessToken,
+      shopifyCredentialDomain(input),
+      parseShopifyScopes(input.metadata.scope),
+      fetcher,
+      signal,
+    );
   },
 };
+
+type ShopifyCredential = Exclude<ResolvedCredential, { authType: "no_auth" | "custom_credential" }>;
+
+async function requireShopifyCredential(context: ExecutionContext): Promise<ShopifyCredential> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "api_key" || credential?.authType === "oauth2") {
+    return credential;
+  }
+  throw new ProviderRequestError(401, "Configure Shopify credentials first.");
+}
+
+function shopifyAccessToken(credential: ShopifyCredential): string {
+  return credential.authType === "api_key" ? credential.apiKey : credential.accessToken;
+}
+
+function shopifyCredentialDomain(credential: ShopifyCredential): string {
+  if (credential.authType === "api_key") {
+    return normalizeShopDomain(optionalString(credential.values.shopDomain));
+  }
+  const clientExtra = optionalRecord(credential.metadata.oauthClientExtra);
+  return normalizeShopDomain(optionalString(credential.metadata.shopDomain) ?? optionalString(clientExtra?.shopDomain));
+}
+
+function parseShopifyScopes(value: unknown): string[] {
+  return (optionalString(value) ?? "")
+    .split(/[ ,]+/u)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}

--- a/src/providers/shopify/executors.ts
+++ b/src/providers/shopify/executors.ts
@@ -83,7 +83,12 @@ function shopifyCredentialDomain(credential: ShopifyCredential): string {
     return normalizeShopDomain(optionalString(credential.values.shopDomain));
   }
   const clientExtra = optionalRecord(credential.metadata.oauthClientExtra);
-  return normalizeShopDomain(optionalString(credential.metadata.shopDomain) ?? optionalString(clientExtra?.shopDomain));
+  const storedDomain = optionalString(credential.metadata.shopDomain);
+  if (storedDomain) {
+    return normalizeShopDomain(storedDomain);
+  }
+  const shopSubdomain = optionalString(clientExtra?.shopSubdomain);
+  return normalizeShopDomain(shopSubdomain ? `${shopSubdomain}.myshopify.com` : undefined);
 }
 
 function parseShopifyScopes(value: unknown): string[] {

--- a/src/providers/shopify/runtime.ts
+++ b/src/providers/shopify/runtime.ts
@@ -1,5 +1,5 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
-import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { ShopifyActionName } from "./actions.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
@@ -9,7 +9,6 @@ import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts"
 export const shopifyRestApiVersion = "2026-04";
 
 const credentialHelpUrl = "https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens";
-const shopifyContentScope = "content";
 const shopPath = "/shop.json";
 const contentValidationPath = "/blogs/count.json";
 
@@ -26,8 +25,11 @@ interface ShopifyRestResult {
   pagination: ShopifyPagination;
 }
 
-export interface ShopifyActionContext extends ApiKeyProviderContext {
+export interface ShopifyActionContext {
+  accessToken: string;
   shopDomain: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
 }
 
 export const shopifyActionHandlers: Record<ShopifyActionName, ShopifyActionHandler> = {
@@ -176,13 +178,14 @@ export const shopifyActionHandlers: Record<ShopifyActionName, ShopifyActionHandl
 };
 
 export async function validateShopifyCredential(
-  input: { apiKey: string; values: Record<string, string> },
+  accessToken: string,
+  shopDomain: string,
+  grantedScopes: string[],
   fetcher: typeof fetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
-  const shopDomain = normalizeShopDomain(optionalString(input.values.shopDomain));
   const context: ShopifyActionContext = {
-    apiKey: input.apiKey,
+    accessToken,
     shopDomain,
     fetcher,
     signal,
@@ -204,7 +207,7 @@ export async function validateShopifyCredential(
       accountId: `shopify:${shopDomain}`,
       displayName: optionalString(shop.name) ?? shopDomain,
     },
-    grantedScopes: [shopifyContentScope],
+    grantedScopes,
     metadata: compactObject({
       shopDomain,
       apiBaseUrl: buildShopifyRestApiBaseUrl(shopDomain),
@@ -286,7 +289,7 @@ async function requestShopifyRest(input: {
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
-        "x-shopify-access-token": input.context.apiKey,
+        "x-shopify-access-token": input.context.accessToken,
       },
       signal: input.context.signal,
     });

--- a/src/providers/shopify/scopes.ts
+++ b/src/providers/shopify/scopes.ts
@@ -1,0 +1,4 @@
+export const shopifyReadContentScope = "read_content";
+
+/** Shopify Admin scope required by the REST content actions in this provider. */
+export const shopifyOAuthScopes: string[] = [shopifyReadContentScope];


### PR DESCRIPTION
## What

- add Shopify authorization-code OAuth alongside custom-app access tokens
- resolve authorization and token endpoints from the connection shop domain
- share X-Shopify-Access-Token execution across actions and proxy requests
- replace the internal content alias with the provider-native read_content scope

## Why

Shopify OAuth apps authorize one store at a time and require shop-specific endpoints. This enables that flow without removing existing custom-app token support.

## Checks

- npm run generate:catalog
- npx vitest run src/providers/shopify/executors.test.ts
- npm run fix-check
- npm test (90 files, 889 tests)