### PR TITLE
feat(dropbox-sign): add OAuth authentication

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -116,6 +116,8 @@ export type OAuth2AuthDefinition = {
       grantType?: string | false;
       code?: string;
       redirectUri?: string | false;
+      /** Provider-specific field name for forwarding the original OAuth state during code exchange. */
+      state?: string | false;
     };
     refresh?: {
       grantType?: string | false;

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -90,6 +90,7 @@ const customOAuthProvider: ProviderDefinition = {
         authorizationCode: {
           grantType: false,
           redirectUri: false,
+          state: "state",
         },
       },
       tokenResponseEnvelope: {
@@ -587,6 +588,7 @@ describe("OAuthFlowService", () => {
       app_id: "client-id",
       auth_code: "code",
       secret: "client-secret",
+      state: started.state,
     });
     await expect(services.connections.getCredential("custom_oauth")).resolves.toMatchObject({
       authType: "oauth2",

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -151,6 +151,7 @@ export class OAuthFlowService {
 
     let tokenResponse = await requestAuthorizationCodeToken({
       code: input.code,
+      state: pending.state,
       clientId: config.clientId,
       clientSecret: config.clientSecret,
       redirectUri: this.clientConfigs.expectedRedirectUri(pending.service),

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -23,6 +23,7 @@ export interface OAuthTokenRequestOptions {
 
 interface AuthorizationCodeTokenRequest extends OAuthTokenRequestOptions {
   code: string;
+  state?: string;
   redirectUri: string;
   extraFields?: Record<string, string>;
   createError: OAuthTokenErrorFactory;
@@ -253,6 +254,10 @@ function createAuthorizationCodeFields(input: AuthorizationCodeTokenRequest): Re
     "redirect_uri",
     input.redirectUri,
   );
+  const stateField = fieldMap?.authorizationCode?.state;
+  if (input.state !== undefined && stateField !== undefined) {
+    setMappedField(fields, stateField, "state", input.state);
+  }
   return {
     ...fields,
     ...(input.extraFields ?? {}),

--- a/src/providers/dropbox_sign/definition.ts
+++ b/src/providers/dropbox_sign/definition.ts
@@ -3,6 +3,9 @@ import type { ProviderDefinition } from "../../core/types.ts";
 import { dropboxSignActions } from "./actions.ts";
 
 const service = "dropbox_sign";
+const dropboxSignAuthorizationUrl = "https://app.hellosign.com/oauth/authorize";
+const dropboxSignTokenUrl = "https://app.hellosign.com/oauth/token";
+const dropboxSignRefreshTokenUrl = "https://app.hellosign.com/oauth/token?refresh";
 
 export const provider: ProviderDefinition = {
   service,
@@ -12,11 +15,16 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://app.hellosign.com/oauth/authorize",
-      tokenUrl: "https://app.hellosign.com/oauth/token",
-      refreshTokenUrl: "https://app.hellosign.com/oauth/token?refresh",
+      authorizationUrl: dropboxSignAuthorizationUrl,
+      tokenUrl: dropboxSignTokenUrl,
+      refreshTokenUrl: dropboxSignRefreshTokenUrl,
       scopes: [],
       tokenEndpointAuthMethod: "client_secret_post",
+      tokenRequestFields: {
+        authorizationCode: {
+          state: "state",
+        },
+      },
       authorizationRequestFields: {
         scope: false,
       },

--- a/src/providers/dropbox_sign/definition.ts
+++ b/src/providers/dropbox_sign/definition.ts
@@ -8,8 +8,19 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Dropbox Sign",
   categories: ["Productivity"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://app.hellosign.com/oauth/authorize",
+      tokenUrl: "https://app.hellosign.com/oauth/token",
+      refreshTokenUrl: "https://app.hellosign.com/oauth/token?refresh",
+      scopes: [],
+      tokenEndpointAuthMethod: "client_secret_post",
+      authorizationRequestFields: {
+        scope: false,
+      },
+    },
     {
       type: "api_key",
       label: "API Key",

--- a/src/providers/dropbox_sign/executors.test.ts
+++ b/src/providers/dropbox_sign/executors.test.ts
@@ -1,0 +1,74 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it, vi } from "vitest";
+import { buildDropboxSignApiKeyAuthorization, credentialValidators, dropboxSignActionHandlers } from "./executors.ts";
+
+describe("Dropbox Sign authentication", () => {
+  it("validates OAuth credentials with Bearer authentication", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api.hellosign.com/v3/account");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer dropbox-sign-token");
+      return Response.json({
+        account: {
+          account_id: "account-1",
+          email_address: "owner@example.com",
+        },
+      });
+    });
+
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "dropbox-sign-token",
+        tokenType: "Bearer",
+        profile: {
+          accountId: "oauth2",
+          displayName: "OAuth Credential",
+          grantedScopes: ["signature_request_access"],
+        },
+        metadata: {},
+      },
+      { fetcher },
+    );
+
+    expect(result).toMatchObject({
+      profile: {
+        accountId: "dropbox_sign:account-1",
+        displayName: "owner@example.com",
+      },
+      grantedScopes: ["signature_request_access"],
+      metadata: {
+        apiBaseUrl: "https://api.hellosign.com/v3",
+        accountId: "account-1",
+        emailAddress: "owner@example.com",
+        validationEndpoint: "/account",
+      },
+    });
+  });
+
+  it("executes actions with OAuth Bearer authentication", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api.hellosign.com/v3/signature_request/list?page=2");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer dropbox-sign-token");
+      return Response.json({ signature_requests: [], list_info: { page: 2 } });
+    });
+
+    const result = await dropboxSignActionHandlers.list_signature_requests(
+      { page: 2 },
+      {
+        authorization: "Bearer dropbox-sign-token",
+        fetcher,
+      },
+    );
+
+    expect(result).toMatchObject({
+      signatureRequests: [],
+      listInfo: { page: 2 },
+    });
+  });
+
+  it("keeps API key credentials on Dropbox Sign Basic authentication", () => {
+    expect(buildDropboxSignApiKeyAuthorization("dropbox-sign-api-key")).toBe(
+      `Basic ${Buffer.from("dropbox-sign-api-key:").toString("base64")}`,
+    );
+  });
+});

--- a/src/providers/dropbox_sign/executors.ts
+++ b/src/providers/dropbox_sign/executors.ts
@@ -1,11 +1,17 @@
-import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+  ResolvedCredential,
+} from "../../core/types.ts";
 import type { DropboxSignActionName } from "./actions.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  defineApiKeyProviderExecutors,
+  defineProviderExecutors,
   defineProviderProxy,
   providerUserAgent,
   ProviderRequestError,
@@ -15,7 +21,14 @@ const service = "dropbox_sign";
 export const dropboxSignApiBaseUrl = "https://api.hellosign.com/v3";
 
 type DropboxSignRequestPhase = "validate" | "execute";
-type DropboxSignActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+
+interface DropboxSignContext {
+  authorization: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+type DropboxSignActionHandler = (input: Record<string, unknown>, context: DropboxSignContext) => Promise<unknown>;
 
 export const dropboxSignActionHandlers: Record<DropboxSignActionName, DropboxSignActionHandler> = {
   get_account(input, context) {
@@ -35,43 +48,81 @@ export const dropboxSignActionHandlers: Record<DropboxSignActionName, DropboxSig
   },
 };
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, dropboxSignActionHandlers);
+export const executors: ProviderExecutors = defineProviderExecutors<DropboxSignContext>({
+  service,
+  handlers: dropboxSignActionHandlers,
+  createContext(context, fetcher) {
+    return resolveDropboxSignContext(context, fetcher);
+  },
+});
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: dropboxSignApiBaseUrl,
-  auth: { type: "api_key_basic", suffix: ":" },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    headers.set("authorization", await resolveDropboxSignAuthorization(context));
+  },
 });
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
-    const payload = await dropboxSignRequest("/account", {
-      apiKey: input.apiKey,
+    return validateDropboxSignCredential({
+      authorization: buildDropboxSignApiKeyAuthorization(input.apiKey),
+      fallbackAccountId: "dropbox_sign:api_key",
+      fallbackDisplayName: "Dropbox Sign API Key",
       fetcher,
-      method: "GET",
-      phase: "validate",
       signal,
     });
-    const account = normalizeAccount(readWrappedObject(payload, "account"));
-    return {
-      profile: {
-        accountId: account.accountId ? `dropbox_sign:${account.accountId}` : "dropbox_sign:api_key",
-        displayName: account.emailAddress ?? account.accountId ?? "Dropbox Sign API Key",
-      },
-      grantedScopes: [],
-      metadata: compactObject({
-        apiBaseUrl: dropboxSignApiBaseUrl,
-        accountId: account.accountId ?? undefined,
-        emailAddress: account.emailAddress ?? undefined,
-        validationEndpoint: "/account",
-      }),
-    };
+  },
+  async oauth2(input, { fetcher, signal }) {
+    return validateDropboxSignCredential({
+      authorization: `${input.tokenType} ${input.accessToken}`,
+      fallbackAccountId: "dropbox_sign:oauth2",
+      fallbackDisplayName: "Dropbox Sign OAuth",
+      fetcher,
+      grantedScopes: input.profile.grantedScopes,
+      signal,
+    });
   },
 };
 
-async function executeGetAccount(input: Record<string, unknown>, context: ApiKeyProviderContext) {
+interface DropboxSignValidationInput {
+  authorization: string;
+  fallbackAccountId: string;
+  fallbackDisplayName: string;
+  fetcher: typeof fetch;
+  grantedScopes?: string[];
+  signal?: AbortSignal;
+}
+
+async function validateDropboxSignCredential(input: DropboxSignValidationInput): Promise<CredentialValidationResult> {
   const payload = await dropboxSignRequest("/account", {
-    apiKey: context.apiKey,
+    authorization: input.authorization,
+    fetcher: input.fetcher,
+    method: "GET",
+    phase: "validate",
+    signal: input.signal,
+  });
+  const account = normalizeAccount(readWrappedObject(payload, "account"));
+  return {
+    profile: {
+      accountId: account.accountId ? `dropbox_sign:${account.accountId}` : input.fallbackAccountId,
+      displayName: account.emailAddress ?? account.accountId ?? input.fallbackDisplayName,
+    },
+    grantedScopes: input.grantedScopes ?? [],
+    metadata: compactObject({
+      apiBaseUrl: dropboxSignApiBaseUrl,
+      accountId: account.accountId ?? undefined,
+      emailAddress: account.emailAddress ?? undefined,
+      validationEndpoint: "/account",
+    }),
+  };
+}
+
+async function executeGetAccount(input: Record<string, unknown>, context: DropboxSignContext) {
+  const payload = await dropboxSignRequest("/account", {
+    authorization: context.authorization,
     fetcher: context.fetcher,
     method: "GET",
     phase: "execute",
@@ -87,9 +138,9 @@ async function executeGetAccount(input: Record<string, unknown>, context: ApiKey
   };
 }
 
-async function executeListSignatureRequests(input: Record<string, unknown>, context: ApiKeyProviderContext) {
+async function executeListSignatureRequests(input: Record<string, unknown>, context: DropboxSignContext) {
   const payload = await dropboxSignRequest("/signature_request/list", {
-    apiKey: context.apiKey,
+    authorization: context.authorization,
     fetcher: context.fetcher,
     method: "GET",
     phase: "execute",
@@ -105,10 +156,10 @@ async function executeListSignatureRequests(input: Record<string, unknown>, cont
   };
 }
 
-async function executeGetSignatureRequest(input: Record<string, unknown>, context: ApiKeyProviderContext) {
+async function executeGetSignatureRequest(input: Record<string, unknown>, context: DropboxSignContext) {
   const signatureRequestId = readRequiredTrimmedString(input.signatureRequestId, "signatureRequestId");
   const payload = await dropboxSignRequest(`/signature_request/${encodeURIComponent(signatureRequestId)}`, {
-    apiKey: context.apiKey,
+    authorization: context.authorization,
     fetcher: context.fetcher,
     method: "GET",
     phase: "execute",
@@ -120,9 +171,9 @@ async function executeGetSignatureRequest(input: Record<string, unknown>, contex
   };
 }
 
-async function executeListTemplates(input: Record<string, unknown>, context: ApiKeyProviderContext) {
+async function executeListTemplates(input: Record<string, unknown>, context: DropboxSignContext) {
   const payload = await dropboxSignRequest("/template/list", {
-    apiKey: context.apiKey,
+    authorization: context.authorization,
     fetcher: context.fetcher,
     method: "GET",
     phase: "execute",
@@ -138,10 +189,10 @@ async function executeListTemplates(input: Record<string, unknown>, context: Api
   };
 }
 
-async function executeGetTemplate(input: Record<string, unknown>, context: ApiKeyProviderContext) {
+async function executeGetTemplate(input: Record<string, unknown>, context: DropboxSignContext) {
   const templateId = readRequiredTrimmedString(input.templateId, "templateId");
   const payload = await dropboxSignRequest(`/template/${encodeURIComponent(templateId)}`, {
-    apiKey: context.apiKey,
+    authorization: context.authorization,
     fetcher: context.fetcher,
     method: "GET",
     phase: "execute",
@@ -156,7 +207,7 @@ async function executeGetTemplate(input: Record<string, unknown>, context: ApiKe
 async function dropboxSignRequest(
   path: string,
   input: {
-    apiKey: string;
+    authorization: string;
     fetcher: typeof fetch;
     method: "GET";
     phase: DropboxSignRequestPhase;
@@ -176,7 +227,7 @@ async function dropboxSignRequest(
   try {
     response = await input.fetcher(url, {
       method: input.method,
-      headers: dropboxSignHeaders(input.apiKey),
+      headers: dropboxSignHeaders(input.authorization),
       signal: input.signal,
     });
     payload = await readDropboxSignPayload(response);
@@ -194,16 +245,41 @@ async function dropboxSignRequest(
   return payload;
 }
 
-function dropboxSignHeaders(apiKey: string) {
+function dropboxSignHeaders(authorization: string) {
   return {
     accept: "application/json",
-    authorization: buildDropboxSignAuthorizationHeader(apiKey),
+    authorization,
     "user-agent": providerUserAgent,
   };
 }
 
-export function buildDropboxSignAuthorizationHeader(apiKey: string) {
+export function buildDropboxSignApiKeyAuthorization(apiKey: string): string {
   return `Basic ${Buffer.from(`${apiKey}:`).toString("base64")}`;
+}
+
+async function resolveDropboxSignContext(
+  context: ExecutionContext,
+  fetcher: typeof fetch,
+): Promise<DropboxSignContext> {
+  return {
+    authorization: await resolveDropboxSignAuthorization(context),
+    fetcher,
+    signal: context.signal,
+  };
+}
+
+async function resolveDropboxSignAuthorization(context: ExecutionContext): Promise<string> {
+  return buildDropboxSignCredentialAuthorization(await context.getCredential(service));
+}
+
+function buildDropboxSignCredentialAuthorization(credential: ResolvedCredential | undefined): string {
+  if (credential?.authType === "oauth2") {
+    return `${credential.tokenType} ${credential.accessToken}`;
+  }
+  if (credential?.authType === "api_key") {
+    return buildDropboxSignApiKeyAuthorization(credential.apiKey);
+  }
+  throw new ProviderRequestError(401, "Configure Dropbox Sign OAuth or API key credentials first.");
 }
 
 function buildDropboxSignUrl(path: string) {


### PR DESCRIPTION
## Summary

- add Dropbox Sign OAuth 2.0 authorization-code and refresh-token configuration
- preserve API-key Basic authentication while supporting OAuth Bearer credentials across actions, proxy requests, and validation
- add focused coverage for OAuth validation/action authentication and API-key compatibility

## Verification

- npm run generate:catalog
- npx vitest run src/providers/dropbox_sign/executors.test.ts
- npm run fix-check
- npm test