### PR TITLE
feat(heygen): add OAuth authentication

### DIFF
--- a/src/providers/heygen/definition.ts
+++ b/src/providers/heygen/definition.ts
@@ -11,8 +11,22 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "HeyGen",
   categories: ["AI", "Design & Media"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://app.heygen.com/oauth/authorize",
+      tokenUrl: "https://api2.heygen.com/v1/oauth/token",
+      refreshTokenUrl: "https://api2.heygen.com/v1/oauth/refresh_token",
+      scopes: [],
+      tokenEndpointAuthMethod: "none",
+      pkce: {
+        method: "S256",
+      },
+      authorizationRequestFields: {
+        scope: false,
+      },
+    },
     {
       type: "api_key",
       label: "API Key",

--- a/src/providers/heygen/definition.ts
+++ b/src/providers/heygen/definition.ts
@@ -3,6 +3,9 @@ import type { ProviderDefinition } from "../../core/types.ts";
 import { heygenActions } from "./actions.ts";
 
 const service = "heygen";
+const heygenOAuthAuthorizationUrl = "https://app.heygen.com/oauth/authorize";
+const heygenOAuthTokenUrl = "https://api2.heygen.com/v1/oauth/token";
+const heygenOAuthRefreshTokenUrl = "https://api2.heygen.com/v1/oauth/refresh_token";
 
 /**
  * HeyGen provider backed by the HeyGen REST API.
@@ -15,9 +18,9 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://app.heygen.com/oauth/authorize",
-      tokenUrl: "https://api2.heygen.com/v1/oauth/token",
-      refreshTokenUrl: "https://api2.heygen.com/v1/oauth/refresh_token",
+      authorizationUrl: heygenOAuthAuthorizationUrl,
+      tokenUrl: heygenOAuthTokenUrl,
+      refreshTokenUrl: heygenOAuthRefreshTokenUrl,
       scopes: [],
       tokenEndpointAuthMethod: "none",
       pkce: {

--- a/src/providers/heygen/executors.test.ts
+++ b/src/providers/heygen/executors.test.ts
@@ -17,7 +17,7 @@ describe("HeyGen authentication", () => {
   it("validates OAuth credentials against the OAuth API origin", async () => {
     const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(input.toString()).toBe("https://api2.heygen.com/v1/user/me");
+      expect(input.toString()).toBe("https://api.heygen.com/v3/users/me");
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer heygen-access-token");
       expect(headers.has("x-api-key")).toBe(false);
@@ -38,9 +38,9 @@ describe("HeyGen authentication", () => {
       },
       grantedScopes: [],
       metadata: {
-        apiBaseUrl: "https://api2.heygen.com",
+        apiBaseUrl: "https://api.heygen.com",
         authHeaderName: "Authorization",
-        validationEndpoint: "/v1/user/me",
+        validationEndpoint: "/v3/users/me",
       },
     });
   });
@@ -48,7 +48,7 @@ describe("HeyGen authentication", () => {
   it("executes OAuth actions with Bearer authentication", async () => {
     const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(input.toString()).toBe("https://api2.heygen.com/v1/user/me");
+      expect(input.toString()).toBe("https://api.heygen.com/v3/users/me");
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer heygen-access-token");
       return Response.json({ data: { username: "owner" } });
     });
@@ -64,10 +64,15 @@ describe("HeyGen authentication", () => {
   it("routes OAuth asset uploads through the OAuth API origin", async () => {
     const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
     const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(input.toString()).toBe("https://api2.heygen.com/v1/asset");
+      expect(input.toString()).toBe("https://api.heygen.com/v3/assets");
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer heygen-access-token");
       expect(headers.has("x-api-key")).toBe(false);
+      expect(headers.has("content-type")).toBe(false);
+      const body = init?.body;
+      expect(body).toBeInstanceOf(FormData);
+      if (!(body instanceof FormData)) throw new Error("Expected multipart form data");
+      expect(body.get("file")).toBeInstanceOf(Blob);
       return Response.json({ data: { id: "asset-1", url: "https://files.heygen.com/asset-1" } });
     });
 

--- a/src/providers/heygen/executors.test.ts
+++ b/src/providers/heygen/executors.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxy } from "./executors.ts";
 import {
   createHeygenApiKeyAuth,
   createHeygenOAuthAuth,
   heygenActionHandlers,
   validateHeygenCredential,
 } from "./runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("HeyGen authentication", () => {
   it("validates OAuth credentials against the OAuth API origin", async () => {
@@ -52,6 +59,58 @@ describe("HeyGen authentication", () => {
       user: { username: "owner" },
       raw: { username: "owner" },
     });
+  });
+
+  it("routes OAuth asset uploads through the OAuth API origin", async () => {
+    const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api2.heygen.com/v1/asset");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer heygen-access-token");
+      expect(headers.has("x-api-key")).toBe(false);
+      return Response.json({ data: { id: "asset-1", url: "https://files.heygen.com/asset-1" } });
+    });
+
+    const result = await heygenActionHandlers.upload_asset(
+      { contentBase64: "YXNzZXQ=", mimeType: "image/png" },
+      { auth, fetcher },
+    );
+
+    expect(result).toMatchObject({
+      assetId: "asset-1",
+      url: "https://files.heygen.com/asset-1",
+    });
+  });
+
+  it("removes caller authorization when proxying with an API key", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBeNull();
+      expect(headers.get("x-api-key")).toBe("heygen-api-key");
+      return Response.json({ data: { username: "owner" } });
+    });
+    vi.stubGlobal("fetch", fetcher);
+    const credential: ResolvedCredential = {
+      authType: "api_key",
+      apiKey: "heygen-api-key",
+      values: {},
+      profile: { accountId: "api_key", displayName: "API Key", grantedScopes: [] },
+      metadata: {},
+    };
+    const context: ExecutionContext = {
+      getCredential: async () => credential,
+    };
+
+    const result = await proxy(
+      {
+        method: "GET",
+        endpoint: "/v1/user/me",
+        headers: { authorization: "Bearer caller-supplied-token" },
+      },
+      context,
+    );
+
+    expect(result.ok).toBe(true);
   });
 
   it("keeps API key credentials on the public API origin", () => {

--- a/src/providers/heygen/executors.test.ts
+++ b/src/providers/heygen/executors.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createHeygenApiKeyAuth,
+  createHeygenOAuthAuth,
+  heygenActionHandlers,
+  validateHeygenCredential,
+} from "./runtime.ts";
+
+describe("HeyGen authentication", () => {
+  it("validates OAuth credentials against the OAuth API origin", async () => {
+    const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api2.heygen.com/v1/user/me");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer heygen-access-token");
+      expect(headers.has("x-api-key")).toBe(false);
+      return Response.json({
+        data: {
+          email: "owner@example.com",
+          username: "owner",
+        },
+      });
+    });
+
+    const result = await validateHeygenCredential(auth, { fetcher }, { grantedScopes: [] });
+
+    expect(result).toMatchObject({
+      profile: {
+        accountId: "owner@example.com",
+        displayName: "owner@example.com",
+      },
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl: "https://api2.heygen.com",
+        authHeaderName: "Authorization",
+        validationEndpoint: "/v1/user/me",
+      },
+    });
+  });
+
+  it("executes OAuth actions with Bearer authentication", async () => {
+    const auth = createHeygenOAuthAuth("heygen-access-token", "Bearer");
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api2.heygen.com/v1/user/me");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer heygen-access-token");
+      return Response.json({ data: { username: "owner" } });
+    });
+
+    const result = await heygenActionHandlers.get_current_user({}, { auth, fetcher });
+
+    expect(result).toEqual({
+      user: { username: "owner" },
+      raw: { username: "owner" },
+    });
+  });
+
+  it("keeps API key credentials on the public API origin", () => {
+    expect(createHeygenApiKeyAuth("heygen-api-key")).toEqual({
+      apiBaseUrl: "https://api.heygen.com",
+      headerName: "X-Api-Key",
+      headerValue: "heygen-api-key",
+    });
+  });
+});

--- a/src/providers/heygen/executors.ts
+++ b/src/providers/heygen/executors.ts
@@ -45,6 +45,7 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
   auth: { type: "none" },
   async customizeRequest({ context, headers }) {
     const auth = await resolveHeygenAuth(context);
+    headers.delete("authorization");
     headers.delete("x-api-key");
     headers.set(auth.headerName, auth.headerValue);
   },

--- a/src/providers/heygen/executors.ts
+++ b/src/providers/heygen/executors.ts
@@ -1,18 +1,62 @@
-import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+import type {
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { HeygenActionContext } from "./runtime.ts";
 
-import { defineApiKeyProviderExecutors, defineProviderProxy } from "../provider-runtime.ts";
-import { heygenActionHandlers, validateHeygenCredential } from "./runtime.ts";
+import { defineProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createHeygenApiKeyAuth,
+  createHeygenOAuthAuth,
+  heygenActionHandlers,
+  validateHeygenCredential,
+} from "./runtime.ts";
 
 const service = "heygen";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, heygenActionHandlers);
+export const executors: ProviderExecutors = defineProviderExecutors<HeygenActionContext>({
+  service,
+  handlers: heygenActionHandlers,
+  async createContext(context, fetcher): Promise<HeygenActionContext> {
+    return {
+      auth: await resolveHeygenAuth(context),
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
 
 export const credentialValidators: CredentialValidators = {
-  apiKey: validateHeygenCredential,
+  apiKey(input, options) {
+    return validateHeygenCredential(createHeygenApiKeyAuth(input.apiKey), options);
+  },
+  oauth2(input, options) {
+    return validateHeygenCredential(createHeygenOAuthAuth(input.accessToken, input.tokenType), options, {
+      grantedScopes: input.profile.grantedScopes,
+    });
+  },
 };
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  baseUrl: "https://api.heygen.com",
-  auth: { type: "api_key_header", name: "x-api-key" },
+  baseUrl: async (context) => (await resolveHeygenAuth(context)).apiBaseUrl,
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    const auth = await resolveHeygenAuth(context);
+    headers.delete("x-api-key");
+    headers.set(auth.headerName, auth.headerValue);
+  },
 });
+
+async function resolveHeygenAuth(context: ExecutionContext) {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "oauth2") {
+    return createHeygenOAuthAuth(credential.accessToken, credential.tokenType);
+  }
+  if (credential?.authType === "api_key") {
+    return createHeygenApiKeyAuth(credential.apiKey);
+  }
+  throw new ProviderRequestError(401, "Configure HeyGen OAuth or API key credentials first.");
+}

--- a/src/providers/heygen/runtime.ts
+++ b/src/providers/heygen/runtime.ts
@@ -1,18 +1,29 @@
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import type { HeygenActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { ProviderRequestError } from "../provider-runtime.ts";
 
 const heygenApiBaseUrl = "https://api.heygen.com";
+const heygenOAuthApiBaseUrl = "https://api2.heygen.com";
 const heygenUploadBaseUrl = "https://upload.heygen.com";
 
-type HeygenActionContext = ApiKeyProviderContext;
+export interface HeygenAuth {
+  apiBaseUrl: string;
+  headerName: "Authorization" | "X-Api-Key";
+  headerValue: string;
+}
+
+export interface HeygenActionContext {
+  auth: HeygenAuth;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
 type HeygenActionHandler = (input: Record<string, unknown>, context: HeygenActionContext) => Promise<unknown>;
 type HeygenRequestMode = "validate" | "execute";
 
 interface HeygenRequestInput {
-  apiKey: string;
+  auth: HeygenAuth;
   baseUrl?: string;
   path: string;
   method?: "GET" | "POST" | "DELETE";
@@ -78,8 +89,9 @@ export const heygenActionHandlers: Record<HeygenActionName, HeygenActionHandler>
 };
 
 export async function validateHeygenCredential(
-  input: { apiKey: string },
+  auth: HeygenAuth,
   options: { fetcher: typeof fetch; signal?: AbortSignal },
+  credential: { grantedScopes?: string[] } = {},
 ): Promise<{
   profile: { accountId: string; displayName: string };
   grantedScopes: string[];
@@ -87,7 +99,7 @@ export async function validateHeygenCredential(
 }> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: input.apiKey,
+      auth,
       fetcher: options.fetcher,
       signal: options.signal,
       path: "/v1/user/me",
@@ -98,22 +110,41 @@ export async function validateHeygenCredential(
   const label = readAccountLabel(data);
   return {
     profile: {
-      accountId: optionalString(data.email) ?? optionalString(data.username) ?? "api_key",
+      accountId:
+        optionalString(data.email) ??
+        optionalString(data.username) ??
+        (auth.headerName === "Authorization" ? "oauth2" : "api_key"),
       displayName: label,
     },
-    grantedScopes: [],
+    grantedScopes: credential.grantedScopes ?? [],
     metadata: {
-      apiBaseUrl: heygenApiBaseUrl,
-      authHeaderName: "X-Api-Key",
+      apiBaseUrl: auth.apiBaseUrl,
+      authHeaderName: auth.headerName,
       validationEndpoint: "/v1/user/me",
     },
+  };
+}
+
+export function createHeygenApiKeyAuth(apiKey: string): HeygenAuth {
+  return {
+    apiBaseUrl: heygenApiBaseUrl,
+    headerName: "X-Api-Key",
+    headerValue: apiKey,
+  };
+}
+
+export function createHeygenOAuthAuth(accessToken: string, tokenType: string): HeygenAuth {
+  return {
+    apiBaseUrl: heygenOAuthApiBaseUrl,
+    headerName: "Authorization",
+    headerValue: `${tokenType} ${accessToken}`,
   };
 }
 
 async function heygenGetCurrentUser(context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/user/me",
@@ -130,7 +161,7 @@ async function heygenGetCurrentUser(context: HeygenActionContext): Promise<unkno
 async function heygenGetRemainingQuota(context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v2/user/remaining_quota",
@@ -147,7 +178,7 @@ async function heygenGetRemainingQuota(context: HeygenActionContext): Promise<un
 async function heygenListAvatars(context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v2/avatars",
@@ -166,7 +197,7 @@ async function heygenGetAvatar(input: Record<string, unknown>, context: HeygenAc
   const avatarId = readInputString(input.avatarId, "avatarId");
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: `/v2/avatar/${encodeURIComponent(avatarId)}/details`,
@@ -183,7 +214,7 @@ async function heygenGetAvatar(input: Record<string, unknown>, context: HeygenAc
 async function heygenListVoices(context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v2/voices",
@@ -201,7 +232,7 @@ async function heygenListVoices(context: HeygenActionContext): Promise<unknown> 
 async function heygenListTemplates(context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v2/templates",
@@ -219,7 +250,7 @@ async function heygenGetTemplate(input: Record<string, unknown>, context: Heygen
   const templateId = readInputString(input.templateId, "templateId");
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: `/v3/template/${encodeURIComponent(templateId)}`,
@@ -236,7 +267,7 @@ async function heygenGetTemplate(input: Record<string, unknown>, context: Heygen
 async function heygenGenerateVideo(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v2/video/generate",
@@ -266,7 +297,7 @@ async function heygenGenerateTemplateVideo(
   const templateId = readInputString(input.templateId, "templateId");
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: `/v2/template/${encodeURIComponent(templateId)}/generate`,
@@ -294,7 +325,7 @@ async function heygenGenerateTemplateVideo(
 async function heygenGetVideoStatus(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/video_status.get",
@@ -321,7 +352,7 @@ async function heygenGetShareableVideoUrl(
 ): Promise<unknown> {
   const data = await heygenRequest<unknown>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/video/share",
@@ -342,7 +373,7 @@ async function heygenGetShareableVideoUrl(
 async function heygenUploadAsset(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       baseUrl: heygenUploadBaseUrl,
@@ -372,7 +403,7 @@ async function heygenUploadAsset(input: Record<string, unknown>, context: Heygen
 async function heygenListAssets(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/asset/list",
@@ -398,7 +429,7 @@ async function heygenDeleteAsset(input: Record<string, unknown>, context: Heygen
   const assetId = readInputString(input.assetId, "assetId");
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: `/v1/asset/${encodeURIComponent(assetId)}/delete`,
@@ -418,7 +449,7 @@ async function heygenDeleteAsset(input: Record<string, unknown>, context: Heygen
 async function heygenListVideos(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/video.list",
@@ -444,7 +475,7 @@ async function heygenDeleteVideo(input: Record<string, unknown>, context: Heygen
   const videoId = readInputString(input.videoId, "videoId");
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/video.delete",
@@ -471,7 +502,7 @@ async function heygenDeleteVideo(input: Record<string, unknown>, context: Heygen
 async function heygenListFolders(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
   const data = await heygenRequest<Record<string, unknown>>(
     {
-      apiKey: context.apiKey,
+      auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
       path: "/v1/folders",
@@ -498,7 +529,7 @@ async function heygenRequest<T>(
   input: HeygenRequestInput & { fetcher: typeof fetch },
   mode: HeygenRequestMode,
 ): Promise<T> {
-  const url = new URL(input.path, input.baseUrl ?? heygenApiBaseUrl);
+  const url = new URL(input.path, input.baseUrl ?? input.auth.apiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined && value !== null && value !== "") {
       url.searchParams.set(key, String(value));
@@ -511,7 +542,7 @@ async function heygenRequest<T>(
       method: input.method ?? "GET",
       headers: {
         accept: "application/json",
-        "X-Api-Key": input.apiKey,
+        [input.auth.headerName]: input.auth.headerValue,
         ...(input.body ? { "content-type": "application/json" } : {}),
         ...input.headers,
       },

--- a/src/providers/heygen/runtime.ts
+++ b/src/providers/heygen/runtime.ts
@@ -4,7 +4,6 @@ import { compactObject, optionalInteger, optionalRecord, optionalString, require
 import { ProviderRequestError } from "../provider-runtime.ts";
 
 const heygenApiBaseUrl = "https://api.heygen.com";
-const heygenOAuthApiBaseUrl = "https://api2.heygen.com";
 const heygenUploadBaseUrl = "https://upload.heygen.com";
 
 export interface HeygenAuth {
@@ -97,12 +96,13 @@ export async function validateHeygenCredential(
   grantedScopes: string[];
   metadata: Record<string, unknown>;
 }> {
+  const validationEndpoint = auth.headerName === "Authorization" ? "/v3/users/me" : "/v1/user/me";
   const data = await heygenRequest<Record<string, unknown>>(
     {
       auth,
       fetcher: options.fetcher,
       signal: options.signal,
-      path: "/v1/user/me",
+      path: validationEndpoint,
     },
     "validate",
   );
@@ -120,7 +120,7 @@ export async function validateHeygenCredential(
     metadata: {
       apiBaseUrl: auth.apiBaseUrl,
       authHeaderName: auth.headerName,
-      validationEndpoint: "/v1/user/me",
+      validationEndpoint,
     },
   };
 }
@@ -135,7 +135,7 @@ export function createHeygenApiKeyAuth(apiKey: string): HeygenAuth {
 
 export function createHeygenOAuthAuth(accessToken: string, tokenType: string): HeygenAuth {
   return {
-    apiBaseUrl: heygenOAuthApiBaseUrl,
+    apiBaseUrl: heygenApiBaseUrl,
     headerName: "Authorization",
     headerValue: `${tokenType} ${accessToken}`,
   };
@@ -147,7 +147,7 @@ async function heygenGetCurrentUser(context: HeygenActionContext): Promise<unkno
       auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
-      path: "/v1/user/me",
+      path: context.auth.headerName === "Authorization" ? "/v3/users/me" : "/v1/user/me",
     },
     "execute",
   );
@@ -371,18 +371,19 @@ async function heygenGetShareableVideoUrl(
 }
 
 async function heygenUploadAsset(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {
+  const mimeType = readInputString(input.mimeType, "mimeType");
+  const content = toArrayBuffer(Buffer.from(readInputString(input.contentBase64, "contentBase64"), "base64"));
+  const isOAuth = context.auth.headerName === "Authorization";
   const data = await heygenRequest<Record<string, unknown>>(
     {
       auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
-      baseUrl: context.auth.headerName === "Authorization" ? context.auth.apiBaseUrl : heygenUploadBaseUrl,
-      path: "/v1/asset",
+      baseUrl: isOAuth ? context.auth.apiBaseUrl : heygenUploadBaseUrl,
+      path: isOAuth ? "/v3/assets" : "/v1/asset",
       method: "POST",
-      rawBody: toArrayBuffer(Buffer.from(readInputString(input.contentBase64, "contentBase64"), "base64")),
-      headers: {
-        "content-type": readInputString(input.mimeType, "mimeType"),
-      },
+      rawBody: isOAuth ? createHeygenOAuthAssetForm(content, mimeType) : content,
+      headers: isOAuth ? undefined : { "content-type": mimeType },
     },
     "execute",
   );
@@ -398,6 +399,12 @@ async function heygenUploadAsset(input: Record<string, unknown>, context: Heygen
     asset: data,
     raw: data,
   };
+}
+
+function createHeygenOAuthAssetForm(content: ArrayBuffer, mimeType: string): FormData {
+  const form = new FormData();
+  form.append("file", new Blob([content], { type: mimeType }), "asset");
+  return form;
 }
 
 async function heygenListAssets(input: Record<string, unknown>, context: HeygenActionContext): Promise<unknown> {

--- a/src/providers/heygen/runtime.ts
+++ b/src/providers/heygen/runtime.ts
@@ -376,7 +376,7 @@ async function heygenUploadAsset(input: Record<string, unknown>, context: Heygen
       auth: context.auth,
       fetcher: context.fetcher,
       signal: context.signal,
-      baseUrl: heygenUploadBaseUrl,
+      baseUrl: context.auth.headerName === "Authorization" ? context.auth.apiBaseUrl : heygenUploadBaseUrl,
       path: "/v1/asset",
       method: "POST",
       rawBody: toArrayBuffer(Buffer.from(readInputString(input.contentBase64, "contentBase64"), "base64")),


### PR DESCRIPTION
## Summary

- add HeyGen OAuth 2.0 authorization-code support with PKCE using the documented app authorization and api2 token endpoints
- preserve API-key authentication while sending OAuth Bearer credentials to the supported api.heygen.com business API
- use current v3 routes for OAuth credential validation and multipart asset uploads, while retaining legacy API-key routes
- strip caller-supplied auth headers in proxy requests and add focused OAuth/API-key regression coverage

## Verification

- npm run generate:catalog
- npx vitest run src/providers/heygen/executors.test.ts
- npm run fix-check
- npm test