### PR TITLE
feat(okta): add OAuth authentication

### DIFF
--- a/src/providers/okta/actions.ts
+++ b/src/providers/okta/actions.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { oktaGroupsManageScope, oktaGroupsReadScope, oktaUsersManageScope, oktaUsersReadScope } from "./constants.ts";
 
 const service = "okta";
 
@@ -101,7 +102,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_users",
     description: "List Okta users with search, filtering, sorting, field projection, and cursor pagination.",
-    requiredScopes: ["okta.users.read"],
+    requiredScopes: [oktaUsersReadScope],
     inputSchema: s.object(
       "Options for listing Okta users.",
       {
@@ -133,14 +134,14 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_user",
     description: "Get one Okta user by ID, login, or login shortname.",
-    requiredScopes: ["okta.users.read"],
+    requiredScopes: [oktaUsersReadScope],
     inputSchema: s.object("The user to retrieve.", { userId }),
     outputSchema: userOutputSchema,
   }),
   defineProviderAction(service, {
     name: "create_user",
     description: "Create an Okta user with profile, credentials, group assignments, and activation options.",
-    requiredScopes: ["okta.users.manage"],
+    requiredScopes: [oktaUsersManageScope],
     inputSchema: s.object(
       "The Okta user creation request.",
       {
@@ -161,7 +162,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "update_user",
     description: "Partially update an Okta user's profile or credentials.",
-    requiredScopes: ["okta.users.manage"],
+    requiredScopes: [oktaUsersManageScope],
     inputSchema: s.object(
       "The Okta user partial update request.",
       {
@@ -177,7 +178,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "delete_user",
     description: "Deactivate an active Okta user, or permanently delete a user that is already deactivated.",
-    requiredScopes: ["okta.users.manage"],
+    requiredScopes: [oktaUsersManageScope],
     inputSchema: s.object(
       "The Okta user deletion request.",
       {
@@ -198,7 +199,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "lifecycle_user",
     description: "Activate, reactivate, deactivate, suspend, unsuspend, unlock, or expire an Okta user's password.",
-    requiredScopes: ["okta.users.manage"],
+    requiredScopes: [oktaUsersManageScope],
     inputSchema: s.object(
       "The Okta user lifecycle request.",
       {
@@ -232,7 +233,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_groups",
     description: "List Okta groups with search, filtering, sorting, expansion, and cursor pagination.",
-    requiredScopes: ["okta.groups.read"],
+    requiredScopes: [oktaGroupsReadScope],
     inputSchema: s.object(
       "Options for listing Okta groups.",
       {
@@ -260,28 +261,28 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_group",
     description: "Get one Okta group by ID.",
-    requiredScopes: ["okta.groups.read"],
+    requiredScopes: [oktaGroupsReadScope],
     inputSchema: s.object("The group to retrieve.", { groupId }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "create_group",
     description: "Create an Okta-managed group.",
-    requiredScopes: ["okta.groups.manage"],
+    requiredScopes: [oktaGroupsManageScope],
     inputSchema: s.object("The Okta group creation request.", { profile: groupProfile }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "update_group",
     description: "Replace an Okta-managed group's profile.",
-    requiredScopes: ["okta.groups.manage"],
+    requiredScopes: [oktaGroupsManageScope],
     inputSchema: s.object("The Okta group replacement request.", { groupId, profile: groupProfile }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "delete_group",
     description: "Delete an Okta-managed group by ID.",
-    requiredScopes: ["okta.groups.manage"],
+    requiredScopes: [oktaGroupsManageScope],
     inputSchema: s.object("The group to delete.", { groupId }),
     outputSchema: s.object("The Okta group deletion result.", {
       groupId: s.string("The deleted Okta group ID."),
@@ -291,7 +292,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_group_users",
     description: "List the users that are members of an Okta group.",
-    requiredScopes: ["okta.groups.read"],
+    requiredScopes: [oktaGroupsReadScope],
     inputSchema: s.object(
       "Options for listing Okta group members.",
       {
@@ -306,7 +307,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "add_user_to_group",
     description: "Assign an Okta user to an Okta-managed group.",
-    requiredScopes: ["okta.groups.manage"],
+    requiredScopes: [oktaGroupsManageScope],
     inputSchema: s.object("The Okta group membership to create.", { groupId, userId }),
     outputSchema: s.object("The Okta group membership assignment result.", {
       groupId: s.string("The Okta group ID."),
@@ -317,7 +318,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "remove_user_from_group",
     description: "Unassign an Okta user from an Okta-managed group.",
-    requiredScopes: ["okta.groups.manage"],
+    requiredScopes: [oktaGroupsManageScope],
     inputSchema: s.object("The Okta group membership to remove.", { groupId, userId }),
     outputSchema: s.object("The Okta group membership removal result.", {
       groupId: s.string("The Okta group ID."),

--- a/src/providers/okta/actions.ts
+++ b/src/providers/okta/actions.ts
@@ -101,6 +101,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_users",
     description: "List Okta users with search, filtering, sorting, field projection, and cursor pagination.",
+    requiredScopes: ["okta.users.read"],
     inputSchema: s.object(
       "Options for listing Okta users.",
       {
@@ -132,12 +133,14 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_user",
     description: "Get one Okta user by ID, login, or login shortname.",
+    requiredScopes: ["okta.users.read"],
     inputSchema: s.object("The user to retrieve.", { userId }),
     outputSchema: userOutputSchema,
   }),
   defineProviderAction(service, {
     name: "create_user",
     description: "Create an Okta user with profile, credentials, group assignments, and activation options.",
+    requiredScopes: ["okta.users.manage"],
     inputSchema: s.object(
       "The Okta user creation request.",
       {
@@ -158,6 +161,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "update_user",
     description: "Partially update an Okta user's profile or credentials.",
+    requiredScopes: ["okta.users.manage"],
     inputSchema: s.object(
       "The Okta user partial update request.",
       {
@@ -173,6 +177,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "delete_user",
     description: "Deactivate an active Okta user, or permanently delete a user that is already deactivated.",
+    requiredScopes: ["okta.users.manage"],
     inputSchema: s.object(
       "The Okta user deletion request.",
       {
@@ -193,6 +198,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "lifecycle_user",
     description: "Activate, reactivate, deactivate, suspend, unsuspend, unlock, or expire an Okta user's password.",
+    requiredScopes: ["okta.users.manage"],
     inputSchema: s.object(
       "The Okta user lifecycle request.",
       {
@@ -226,6 +232,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_groups",
     description: "List Okta groups with search, filtering, sorting, expansion, and cursor pagination.",
+    requiredScopes: ["okta.groups.read"],
     inputSchema: s.object(
       "Options for listing Okta groups.",
       {
@@ -253,24 +260,28 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_group",
     description: "Get one Okta group by ID.",
+    requiredScopes: ["okta.groups.read"],
     inputSchema: s.object("The group to retrieve.", { groupId }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "create_group",
     description: "Create an Okta-managed group.",
+    requiredScopes: ["okta.groups.manage"],
     inputSchema: s.object("The Okta group creation request.", { profile: groupProfile }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "update_group",
     description: "Replace an Okta-managed group's profile.",
+    requiredScopes: ["okta.groups.manage"],
     inputSchema: s.object("The Okta group replacement request.", { groupId, profile: groupProfile }),
     outputSchema: groupOutputSchema,
   }),
   defineProviderAction(service, {
     name: "delete_group",
     description: "Delete an Okta-managed group by ID.",
+    requiredScopes: ["okta.groups.manage"],
     inputSchema: s.object("The group to delete.", { groupId }),
     outputSchema: s.object("The Okta group deletion result.", {
       groupId: s.string("The deleted Okta group ID."),
@@ -280,6 +291,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_group_users",
     description: "List the users that are members of an Okta group.",
+    requiredScopes: ["okta.groups.read"],
     inputSchema: s.object(
       "Options for listing Okta group members.",
       {
@@ -294,6 +306,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "add_user_to_group",
     description: "Assign an Okta user to an Okta-managed group.",
+    requiredScopes: ["okta.groups.manage"],
     inputSchema: s.object("The Okta group membership to create.", { groupId, userId }),
     outputSchema: s.object("The Okta group membership assignment result.", {
       groupId: s.string("The Okta group ID."),
@@ -304,6 +317,7 @@ export const oktaActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "remove_user_from_group",
     description: "Unassign an Okta user from an Okta-managed group.",
+    requiredScopes: ["okta.groups.manage"],
     inputSchema: s.object("The Okta group membership to remove.", { groupId, userId }),
     outputSchema: s.object("The Okta group membership removal result.", {
       groupId: s.string("The Okta group ID."),

--- a/src/providers/okta/constants.ts
+++ b/src/providers/okta/constants.ts
@@ -1,0 +1,9 @@
+export const oktaOAuthAuthorizationUrl = "https://{subdomain}.okta.com/oauth2/v1/authorize";
+export const oktaOAuthTokenUrl = "https://{subdomain}.okta.com/oauth2/v1/token";
+
+export const oktaOpenIdScope = "openid";
+export const oktaOfflineAccessScope = "offline_access";
+export const oktaUsersReadScope = "okta.users.read";
+export const oktaUsersManageScope = "okta.users.manage";
+export const oktaGroupsReadScope = "okta.groups.read";
+export const oktaGroupsManageScope = "okta.groups.manage";

--- a/src/providers/okta/definition.ts
+++ b/src/providers/okta/definition.ts
@@ -9,8 +9,40 @@ export const provider: ProviderDefinition = {
   displayName: "Okta",
   description: "Manage Okta directory users, groups, memberships, and user lifecycle operations.",
   categories: ["Security"],
-  authTypes: ["custom_credential"],
+  authTypes: ["oauth2", "custom_credential"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://{subdomain}.okta.com/oauth2/v1/authorize",
+      tokenUrl: "https://{subdomain}.okta.com/oauth2/v1/token",
+      scopes: [
+        "openid",
+        "offline_access",
+        "okta.users.read",
+        "okta.users.manage",
+        "okta.groups.read",
+        "okta.groups.manage",
+      ],
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkce: {
+        method: "S256",
+      },
+      authorizationParams: {
+        response_mode: "query",
+      },
+      clientConfigFields: [
+        {
+          key: "subdomain",
+          label: "Okta subdomain",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "dev-12345678",
+          description:
+            "The subdomain from your Okta organization URL. For https://dev-12345678.okta.com, enter dev-12345678.",
+        },
+      ],
+    },
     {
       type: "custom_credential",
       fields: [

--- a/src/providers/okta/definition.ts
+++ b/src/providers/okta/definition.ts
@@ -1,6 +1,16 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { oktaActions } from "./actions.ts";
+import {
+  oktaGroupsManageScope,
+  oktaGroupsReadScope,
+  oktaOAuthAuthorizationUrl,
+  oktaOAuthTokenUrl,
+  oktaOfflineAccessScope,
+  oktaOpenIdScope,
+  oktaUsersManageScope,
+  oktaUsersReadScope,
+} from "./constants.ts";
 
 const service = "okta";
 
@@ -13,15 +23,15 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://{subdomain}.okta.com/oauth2/v1/authorize",
-      tokenUrl: "https://{subdomain}.okta.com/oauth2/v1/token",
+      authorizationUrl: oktaOAuthAuthorizationUrl,
+      tokenUrl: oktaOAuthTokenUrl,
       scopes: [
-        "openid",
-        "offline_access",
-        "okta.users.read",
-        "okta.users.manage",
-        "okta.groups.read",
-        "okta.groups.manage",
+        oktaOpenIdScope,
+        oktaOfflineAccessScope,
+        oktaUsersReadScope,
+        oktaUsersManageScope,
+        oktaGroupsReadScope,
+        oktaGroupsManageScope,
       ],
       tokenEndpointAuthMethod: "client_secret_post",
       pkce: {

--- a/src/providers/okta/executors.test.ts
+++ b/src/providers/okta/executors.test.ts
@@ -24,9 +24,10 @@ describe("Okta authentication", () => {
         profile: {
           accountId: "oauth2",
           displayName: "OAuth Credential",
-          grantedScopes: ["okta.users.read"],
+          grantedScopes: [],
         },
         metadata: {
+          scope: "okta.users.read okta.groups.read",
           oauthClientExtra: {
             subdomain: "dev-12345678",
           },
@@ -40,7 +41,7 @@ describe("Okta authentication", () => {
         accountId: "okta:dev-12345678.okta.com:user-1",
         displayName: "admin@example.com",
       },
-      grantedScopes: ["okta.users.read"],
+      grantedScopes: ["okta.users.read", "okta.groups.read"],
       metadata: {
         orgUrl: "https://dev-12345678.okta.com",
         validationEndpoint: "/api/v1/users/me",

--- a/src/providers/okta/executors.test.ts
+++ b/src/providers/okta/executors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { credentialValidators } from "./executors.ts";
+import { oktaActionHandlers } from "./runtime.ts";
+
+describe("Okta authentication", () => {
+  it("validates OAuth credentials against the configured Okta organization", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://dev-12345678.okta.com/api/v1/users/me");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer okta-access-token");
+      return Response.json({
+        id: "user-1",
+        profile: {
+          email: "admin@example.com",
+          login: "admin@example.com",
+        },
+      });
+    });
+
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "okta-access-token",
+        tokenType: "Bearer",
+        profile: {
+          accountId: "oauth2",
+          displayName: "OAuth Credential",
+          grantedScopes: ["okta.users.read"],
+        },
+        metadata: {
+          oauthClientExtra: {
+            subdomain: "dev-12345678",
+          },
+        },
+      },
+      { fetcher },
+    );
+
+    expect(result).toMatchObject({
+      profile: {
+        accountId: "okta:dev-12345678.okta.com:user-1",
+        displayName: "admin@example.com",
+      },
+      grantedScopes: ["okta.users.read"],
+      metadata: {
+        orgUrl: "https://dev-12345678.okta.com",
+        validationEndpoint: "/api/v1/users/me",
+        userId: "user-1",
+        userLogin: "admin@example.com",
+      },
+    });
+  });
+
+  it("executes OAuth actions with Bearer authentication", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://dev-12345678.okta.com/api/v1/users?limit=1&sortOrder=asc");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer okta-access-token");
+      return Response.json([{ id: "user-1", profile: { email: "admin@example.com" } }]);
+    });
+
+    const result = await oktaActionHandlers.list_users(
+      { limit: 1 },
+      {
+        orgUrl: "https://dev-12345678.okta.com",
+        authorization: "Bearer okta-access-token",
+        fetcher,
+      },
+    );
+
+    expect(result).toMatchObject({
+      users: [{ id: "user-1", profile: { email: "admin@example.com" } }],
+      nextAfter: null,
+    });
+  });
+
+  it("keeps API tokens on the SSWS authorization scheme", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe("SSWS okta-api-token");
+      return Response.json({ id: "user-1", profile: { login: "admin@example.com" } });
+    });
+
+    await credentialValidators.customCredential!(
+      {
+        values: {
+          orgUrl: "https://example.okta.com",
+          apiToken: "okta-api-token",
+        },
+      },
+      { fetcher },
+    );
+  });
+});

--- a/src/providers/okta/executors.ts
+++ b/src/providers/okta/executors.ts
@@ -7,26 +7,30 @@ import type {
 } from "../../core/types.ts";
 import type { OktaContext } from "./runtime.ts";
 
-import { optionalString, requiredString } from "../../core/cast.ts";
+import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
   defineProviderProxy,
   providerUserAgent,
   ProviderRequestError,
-  requireCustomCredential,
 } from "../provider-runtime.ts";
-import { normalizeOktaOrgUrl, oktaActionHandlers, validateOktaCredential } from "./runtime.ts";
+import { normalizeOktaOrgUrl, oktaActionHandlers, oktaApiTokenHelpUrl, validateOktaCredential } from "./runtime.ts";
 
 const service = "okta";
+const oktaOAuthHelpUrl = "https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/";
+
+interface OktaAuthorization {
+  orgUrl: string;
+  authorization: string;
+}
 
 export const executors: ProviderExecutors = defineProviderExecutors<OktaContext>({
   service,
   handlers: oktaActionHandlers,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<OktaContext> {
-    const credential = await requireCustomCredential(context, service);
+    const auth = await resolveOktaAuthorization(context);
     return {
-      orgUrl: normalizeOktaOrgUrl(optionalString(credential.metadata.orgUrl) ?? credential.values.orgUrl),
-      apiToken: requiredString(credential.values.apiToken, "apiToken", providerInputError),
+      ...auth,
       fetcher,
       signal: context.signal,
     };
@@ -35,25 +39,71 @@ export const executors: ProviderExecutors = defineProviderExecutors<OktaContext>
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  baseUrl: async (context) => {
-    const credential = await requireCustomCredential(context, service);
-    return normalizeOktaOrgUrl(optionalString(credential.metadata.orgUrl) ?? credential.values.orgUrl);
-  },
+  baseUrl: async (context) => (await resolveOktaAuthorization(context)).orgUrl,
   auth: { type: "none" },
   async customizeRequest({ context, headers }) {
-    const credential = await requireCustomCredential(context, service);
-    const apiToken = requiredString(credential.values.apiToken, "apiToken", providerInputError);
+    const auth = await resolveOktaAuthorization(context);
     headers.set("accept", "application/json");
-    headers.set("authorization", `SSWS ${apiToken}`);
+    headers.set("authorization", auth.authorization);
     headers.set("user-agent", providerUserAgent);
   },
 });
 
 export const credentialValidators: CredentialValidators = {
   customCredential(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    return validateOktaCredential(input.values, fetcher, signal);
+    return validateOktaCredential(
+      {
+        orgUrl: input.values.orgUrl,
+        authorization: `SSWS ${requiredString(input.values.apiToken, "apiToken", providerInputError)}`,
+        credentialHelpUrl: oktaApiTokenHelpUrl,
+      },
+      fetcher,
+      signal,
+    );
+  },
+  oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateOktaCredential(
+      {
+        orgUrl: resolveOktaOAuthOrgUrl(input.metadata),
+        authorization: `${input.tokenType} ${input.accessToken}`,
+        grantedScopes: input.profile.grantedScopes,
+        credentialHelpUrl: oktaOAuthHelpUrl,
+      },
+      fetcher,
+      signal,
+    );
   },
 };
+
+async function resolveOktaAuthorization(context: ExecutionContext): Promise<OktaAuthorization> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "oauth2") {
+    return {
+      orgUrl: resolveOktaOAuthOrgUrl(credential.metadata),
+      authorization: `${credential.tokenType} ${credential.accessToken}`,
+    };
+  }
+  if (credential?.authType === "custom_credential") {
+    return {
+      orgUrl: normalizeOktaOrgUrl(optionalString(credential.metadata.orgUrl) ?? credential.values.orgUrl),
+      authorization: `SSWS ${requiredString(credential.values.apiToken, "apiToken", providerInputError)}`,
+    };
+  }
+  throw new ProviderRequestError(401, "Configure Okta OAuth or API token credentials first.");
+}
+
+function resolveOktaOAuthOrgUrl(metadata: Record<string, unknown>): string {
+  const storedOrgUrl = optionalString(metadata.orgUrl);
+  if (storedOrgUrl) {
+    return normalizeOktaOrgUrl(storedOrgUrl);
+  }
+  const extra = optionalRecord(metadata.oauthClientExtra);
+  const subdomain = requiredString(extra?.subdomain, "subdomain", providerInputError).toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(subdomain)) {
+    throw new ProviderRequestError(400, "subdomain must be a valid Okta organization subdomain");
+  }
+  return `https://${subdomain}.okta.com`;
+}
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);

--- a/src/providers/okta/executors.ts
+++ b/src/providers/okta/executors.ts
@@ -66,7 +66,7 @@ export const credentialValidators: CredentialValidators = {
       {
         orgUrl: resolveOktaOAuthOrgUrl(input.metadata),
         authorization: `${input.tokenType} ${input.accessToken}`,
-        grantedScopes: input.profile.grantedScopes,
+        grantedScopes: readOktaGrantedScopes(input.metadata.scope, input.profile.grantedScopes),
         credentialHelpUrl: oktaOAuthHelpUrl,
       },
       fetcher,
@@ -103,6 +103,11 @@ function resolveOktaOAuthOrgUrl(metadata: Record<string, unknown>): string {
     throw new ProviderRequestError(400, "subdomain must be a valid Okta organization subdomain");
   }
   return `https://${subdomain}.okta.com`;
+}
+
+function readOktaGrantedScopes(value: unknown, fallback: string[]): string[] {
+  const scope = optionalString(value);
+  return scope ? [...new Set(scope.split(/\s+/u).filter(Boolean))] : fallback;
 }
 
 function providerInputError(message: string): ProviderRequestError {

--- a/src/providers/okta/runtime.ts
+++ b/src/providers/okta/runtime.ts
@@ -18,7 +18,7 @@ import { assertPublicHttpUrl, queryParams } from "../../core/request.ts";
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const oktaRequestTimeoutMs = 30_000;
-const oktaCredentialHelpUrl = "https://developer.okta.com/docs/guides/create-an-api-token/main/";
+export const oktaApiTokenHelpUrl = "https://developer.okta.com/docs/guides/create-an-api-token/main/";
 const oktaLifecycleOperations: Set<string> = new Set([
   "activate",
   "reactivate",
@@ -42,9 +42,16 @@ type OktaLifecycleOperation =
 
 export interface OktaContext {
   orgUrl: string;
-  apiToken: string;
+  authorization: string;
   fetcher: ProviderFetch;
   signal?: AbortSignal;
+}
+
+export interface OktaCredentialValidationInput {
+  orgUrl: unknown;
+  authorization: string;
+  grantedScopes?: string[];
+  credentialHelpUrl?: string;
 }
 
 interface OktaRequestInput extends OktaContext {
@@ -310,15 +317,14 @@ export const oktaActionHandlers: Record<OktaActionName, ProviderRuntimeHandler<O
 };
 
 export async function validateOktaCredential(
-  values: Record<string, string>,
+  input: OktaCredentialValidationInput,
   fetcher: ProviderFetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
-  const orgUrl = normalizeOktaOrgUrl(values.orgUrl);
-  const apiToken = requiredString(values.apiToken, "apiToken", inputError);
+  const orgUrl = normalizeOktaOrgUrl(input.orgUrl);
   const response = await requestOkta({
     orgUrl,
-    apiToken,
+    authorization: input.authorization,
     path: "/api/v1/users/me",
     method: "GET",
     phase: "validate",
@@ -334,11 +340,11 @@ export async function validateOktaCredential(
       accountId: `okta:${host}:${user.id}`,
       displayName: login ?? host,
     },
-    grantedScopes: [],
+    grantedScopes: input.grantedScopes ?? [],
     metadata: compactObject({
       orgUrl,
       validationEndpoint: "/api/v1/users/me",
-      credentialHelpUrl: oktaCredentialHelpUrl,
+      credentialHelpUrl: input.credentialHelpUrl,
       userId: user.id,
       userLogin: login,
     }),
@@ -373,7 +379,7 @@ async function requestOkta(input: OktaRequestInput): Promise<OktaResponse> {
   try {
     const response = await input.fetcher(buildOktaUrl(input), {
       method: input.method,
-      headers: buildOktaHeaders(input.apiToken, input.body !== undefined),
+      headers: buildOktaHeaders(input.authorization, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
       signal: timeout.signal,
     });
@@ -407,10 +413,10 @@ function buildOktaUrl(input: OktaRequestInput): URL {
   return url;
 }
 
-function buildOktaHeaders(apiToken: string, hasBody: boolean): Record<string, string> {
+function buildOktaHeaders(authorization: string, hasBody: boolean): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
-    authorization: `SSWS ${apiToken}`,
+    authorization,
     "user-agent": providerUserAgent,
   };
   if (hasBody) {


### PR DESCRIPTION
## Summary

- add tenant-aware Okta OAuth 2.0 authorization-code flow with PKCE and refresh-token scopes
- preserve SSWS API-token authentication while supporting OAuth Bearer credentials across actions, proxy requests, and validation
- declare Okta user/group read and manage scopes on the corresponding actions
- add focused OAuth action/validation and SSWS compatibility coverage

## Verification

- npm run generate:catalog
- npx vitest run src/providers/okta/executors.test.ts
- npm run fix-check
- npm test