### PR TITLE
feat(bamboohr): add OAuth authentication

### DIFF
--- a/src/providers/bamboohr/actions.ts
+++ b/src/providers/bamboohr/actions.ts
@@ -62,7 +62,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_company_information",
     description: "Retrieve basic BambooHR company profile information for the connected tenant.",
-    requiredScopes: [],
+    requiredScopes: ["company:info"],
     inputSchema: s.object("No input is required for this BambooHR action.", {}),
     outputSchema: s.object("BambooHR company information output.", {
       company: companySchema,
@@ -72,7 +72,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_fields",
     description: "List BambooHR employee fields available to the connected account.",
-    requiredScopes: [],
+    requiredScopes: ["employee", "field"],
     inputSchema: s.object("No input is required for this BambooHR action.", {}),
     outputSchema: s.object("BambooHR field list output.", {
       fields: s.array("BambooHR field definitions.", fieldSchema),
@@ -82,7 +82,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_employees",
     description: "List BambooHR employees with optional additional field aliases and cursor paging.",
-    requiredScopes: [],
+    requiredScopes: ["employee"],
     inputSchema: s.object(
       "Input for listing BambooHR employees.",
       {
@@ -103,7 +103,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_employee",
     description: "Retrieve one BambooHR employee by ID with optional field aliases.",
-    requiredScopes: [],
+    requiredScopes: ["employee"],
     inputSchema: s.object(
       "Input for retrieving one BambooHR employee.",
       {

--- a/src/providers/bamboohr/actions.ts
+++ b/src/providers/bamboohr/actions.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { bamboohrCompanyInfoScope, bamboohrEmployeeScope, bamboohrFieldScope } from "./constants.ts";
 
 const service = "bamboohr";
 
@@ -62,7 +63,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_company_information",
     description: "Retrieve basic BambooHR company profile information for the connected tenant.",
-    requiredScopes: ["company:info"],
+    requiredScopes: [bamboohrCompanyInfoScope],
     inputSchema: s.object("No input is required for this BambooHR action.", {}),
     outputSchema: s.object("BambooHR company information output.", {
       company: companySchema,
@@ -72,7 +73,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_fields",
     description: "List BambooHR employee fields available to the connected account.",
-    requiredScopes: ["employee", "field"],
+    requiredScopes: [bamboohrEmployeeScope, bamboohrFieldScope],
     inputSchema: s.object("No input is required for this BambooHR action.", {}),
     outputSchema: s.object("BambooHR field list output.", {
       fields: s.array("BambooHR field definitions.", fieldSchema),
@@ -82,7 +83,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_employees",
     description: "List BambooHR employees with optional additional field aliases and cursor paging.",
-    requiredScopes: ["employee"],
+    requiredScopes: [bamboohrEmployeeScope],
     inputSchema: s.object(
       "Input for listing BambooHR employees.",
       {
@@ -103,7 +104,7 @@ export const bamboohrActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_employee",
     description: "Retrieve one BambooHR employee by ID with optional field aliases.",
-    requiredScopes: ["employee"],
+    requiredScopes: [bamboohrEmployeeScope],
     inputSchema: s.object(
       "Input for retrieving one BambooHR employee.",
       {

--- a/src/providers/bamboohr/constants.ts
+++ b/src/providers/bamboohr/constants.ts
@@ -1,0 +1,7 @@
+export const bamboohrOAuthAuthorizationUrl = "https://{companyDomain}.bamboohr.com/authorize.php";
+export const bamboohrOAuthTokenUrl = "https://{companyDomain}.bamboohr.com/token.php?request=token";
+
+export const bamboohrOfflineAccessScope = "offline_access";
+export const bamboohrCompanyInfoScope = "company:info";
+export const bamboohrEmployeeScope = "employee";
+export const bamboohrFieldScope = "field";

--- a/src/providers/bamboohr/definition.ts
+++ b/src/providers/bamboohr/definition.ts
@@ -1,6 +1,14 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { bamboohrActions } from "./actions.ts";
+import {
+  bamboohrCompanyInfoScope,
+  bamboohrEmployeeScope,
+  bamboohrFieldScope,
+  bamboohrOAuthAuthorizationUrl,
+  bamboohrOAuthTokenUrl,
+  bamboohrOfflineAccessScope,
+} from "./constants.ts";
 
 const service = "bamboohr";
 
@@ -12,10 +20,10 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://{companyDomain}.bamboohr.com/authorize.php",
-      tokenUrl: "https://{companyDomain}.bamboohr.com/token.php?request=token",
-      refreshTokenUrl: "https://{companyDomain}.bamboohr.com/token.php?request=token",
-      scopes: ["offline_access", "company:info", "employee", "field"],
+      authorizationUrl: bamboohrOAuthAuthorizationUrl,
+      tokenUrl: bamboohrOAuthTokenUrl,
+      refreshTokenUrl: bamboohrOAuthTokenUrl,
+      scopes: [bamboohrOfflineAccessScope, bamboohrCompanyInfoScope, bamboohrEmployeeScope, bamboohrFieldScope],
       tokenEndpointAuthMethod: "client_secret_post",
       authorizationParams: {
         request: "authorize",

--- a/src/providers/bamboohr/definition.ts
+++ b/src/providers/bamboohr/definition.ts
@@ -8,8 +8,30 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "BambooHR",
   categories: ["Productivity", "Data"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://{companyDomain}.bamboohr.com/authorize.php",
+      tokenUrl: "https://{companyDomain}.bamboohr.com/token.php?request=token",
+      refreshTokenUrl: "https://{companyDomain}.bamboohr.com/token.php?request=token",
+      scopes: ["offline_access", "company:info", "employee", "field"],
+      tokenEndpointAuthMethod: "client_secret_post",
+      authorizationParams: {
+        request: "authorize",
+      },
+      clientConfigFields: [
+        {
+          key: "companyDomain",
+          label: "Company Domain",
+          inputType: "text",
+          placeholder: "acme",
+          description: "The subdomain from your BambooHR company URL. For https://acme.bamboohr.com, enter acme.",
+          required: true,
+          secret: false,
+        },
+      ],
+    },
     {
       type: "api_key",
       label: "API Key",

--- a/src/providers/bamboohr/executors.test.ts
+++ b/src/providers/bamboohr/executors.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { bamboohrActionHandlers, credentialValidators } from "./executors.ts";
+
+describe("BambooHR authentication", () => {
+  it("validates OAuth credentials against the configured company", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://acme.bamboohr.com/api/v1/company_information");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer bamboohr-access-token");
+      return Response.json({ displayName: "Acme" });
+    });
+
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "bamboohr-access-token",
+        tokenType: "Bearer",
+        profile: {
+          accountId: "oauth2",
+          displayName: "OAuth Credential",
+          grantedScopes: ["company:info", "employee"],
+        },
+        metadata: {
+          oauthClientExtra: {
+            companyDomain: "acme",
+          },
+        },
+      },
+      { fetcher },
+    );
+
+    expect(result).toMatchObject({
+      profile: {
+        accountId: "acme",
+        displayName: "Acme",
+      },
+      grantedScopes: ["company:info", "employee"],
+      metadata: {
+        companyDomain: "acme",
+        apiBaseUrl: "https://acme.bamboohr.com",
+      },
+    });
+  });
+
+  it("executes OAuth actions with Bearer authentication", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://acme.bamboohr.com/api/v1/employees?page%5Blimit%5D=1");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer bamboohr-access-token");
+      return Response.json({ data: [], meta: {}, _links: {} });
+    });
+
+    const result = await bamboohrActionHandlers.list_employees(
+      { limit: 1 },
+      {
+        authorization: "Bearer bamboohr-access-token",
+        companyDomain: "acme",
+        fetcher,
+      },
+    );
+
+    expect(result).toMatchObject({
+      employees: [],
+      meta: {},
+      links: {},
+    });
+  });
+
+  it("keeps API key credentials on Basic authentication", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe("Basic YXBpLWtleTp4");
+      return Response.json({ legalName: "Acme Inc." });
+    });
+
+    await credentialValidators.apiKey!(
+      {
+        apiKey: "api-key",
+        values: { companyDomain: "acme" },
+      },
+      { fetcher },
+    );
+  });
+});

--- a/src/providers/bamboohr/executors.test.ts
+++ b/src/providers/bamboohr/executors.test.ts
@@ -17,9 +17,10 @@ describe("BambooHR authentication", () => {
         profile: {
           accountId: "oauth2",
           displayName: "OAuth Credential",
-          grantedScopes: ["company:info", "employee"],
+          grantedScopes: [],
         },
         metadata: {
+          scope: "company:info employee",
           oauthClientExtra: {
             companyDomain: "acme",
           },

--- a/src/providers/bamboohr/executors.ts
+++ b/src/providers/bamboohr/executors.ts
@@ -1,5 +1,10 @@
-import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
 
 import { Buffer } from "node:buffer";
 import { optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -8,12 +13,19 @@ import {
   defineProviderExecutors,
   ProviderRequestError,
   providerUserAgent,
-  requireApiKeyCredential,
 } from "../provider-runtime.ts";
 
 const service = "bamboohr";
 
-interface BamboohrContext extends ApiKeyProviderContext {
+interface BamboohrContext {
+  authorization: string;
+  companyDomain: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+interface BamboohrAuthorization {
+  authorization: string;
   companyDomain: string;
 }
 
@@ -86,55 +98,110 @@ export const bamboohrActionHandlers: Record<string, BamboohrActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<BamboohrContext>({
   service,
   handlers: bamboohrActionHandlers,
-  async createContext(context, fetcher): Promise<BamboohrContext> {
-    const credential = await requireApiKeyCredential(context, service);
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<BamboohrContext> {
+    const auth = await resolveBamboohrAuthorization(context);
     return {
-      apiKey: credential.apiKey,
-      companyDomain: readBamboohrCompanyDomain(credential.values.companyDomain ?? credential.metadata.companyDomain),
+      ...auth,
       fetcher,
       signal: context.signal,
-      transitFiles: context.transitFiles,
     };
   },
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  baseUrl: async (context) => {
-    const credential = await requireApiKeyCredential(context, service);
-    return buildBamboohrApiBaseUrl(credential.values.companyDomain ?? credential.metadata.companyDomain);
+  baseUrl: async (context): Promise<string> => {
+    const auth = await resolveBamboohrAuthorization(context);
+    return buildBamboohrApiBaseUrl(auth.companyDomain);
   },
-  auth: { type: "api_key_basic", suffix: ":x" },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    const auth = await resolveBamboohrAuthorization(context);
+    headers.set("accept", "application/json");
+    headers.set("authorization", auth.authorization);
+    headers.set("user-agent", providerUserAgent);
+  },
 });
 
 export const credentialValidators: CredentialValidators = {
-  async apiKey(input, { fetcher, signal }) {
-    const companyDomain = normalizeBamboohrCompanyDomain(input.values.companyDomain);
-    const raw = await requestBamboohrJson({
-      context: {
-        apiKey: input.apiKey,
-        companyDomain,
-        fetcher,
-        signal,
+  apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateBamboohrCredential(
+      {
+        authorization: buildBamboohrApiKeyAuthorization(input.apiKey),
+        companyDomain: normalizeBamboohrCompanyDomain(input.values.companyDomain),
+        grantedScopes: [],
       },
-      path: "/api/v1/company_information",
-    });
-    const company = asRecord(raw);
-    const label = readFirstString(company, ["displayName", "legalName", "name"]) ?? "BambooHR Account";
-
-    return {
-      profile: {
-        accountId: companyDomain,
-        displayName: label,
+      fetcher,
+      signal,
+    );
+  },
+  oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    return validateBamboohrCredential(
+      {
+        authorization: `${input.tokenType} ${input.accessToken}`,
+        companyDomain: resolveBamboohrOAuthCompanyDomain(input.metadata),
+        grantedScopes: input.profile.grantedScopes,
       },
-      grantedScopes: [],
-      metadata: {
-        companyDomain,
-        apiBaseUrl: buildBamboohrApiBaseUrl(companyDomain),
-      },
-    };
+      fetcher,
+      signal,
+    );
   },
 };
+
+async function validateBamboohrCredential(
+  auth: BamboohrAuthorization & { grantedScopes: string[] },
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const raw = await requestBamboohrJson({
+    context: {
+      authorization: auth.authorization,
+      companyDomain: auth.companyDomain,
+      fetcher,
+      signal,
+    },
+    path: "/api/v1/company_information",
+  });
+  const company = asRecord(raw);
+  const label = readFirstString(company, ["displayName", "legalName", "name"]) ?? "BambooHR Account";
+
+  return {
+    profile: {
+      accountId: auth.companyDomain,
+      displayName: label,
+    },
+    grantedScopes: auth.grantedScopes,
+    metadata: {
+      companyDomain: auth.companyDomain,
+      apiBaseUrl: buildBamboohrApiBaseUrl(auth.companyDomain),
+    },
+  };
+}
+
+async function resolveBamboohrAuthorization(context: ExecutionContext): Promise<BamboohrAuthorization> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "oauth2") {
+    return {
+      authorization: `${credential.tokenType} ${credential.accessToken}`,
+      companyDomain: resolveBamboohrOAuthCompanyDomain(credential.metadata),
+    };
+  }
+  if (credential?.authType === "api_key") {
+    return {
+      authorization: buildBamboohrApiKeyAuthorization(credential.apiKey),
+      companyDomain: readBamboohrCompanyDomain(credential.values.companyDomain ?? credential.metadata.companyDomain),
+    };
+  }
+  throw new ProviderRequestError(401, "Configure BambooHR OAuth or API key credentials first.");
+}
+
+function resolveBamboohrOAuthCompanyDomain(metadata: Record<string, unknown>): string {
+  const storedCompanyDomain = optionalString(metadata.companyDomain);
+  if (storedCompanyDomain) {
+    return normalizeBamboohrCompanyDomain(storedCompanyDomain);
+  }
+  return readBamboohrCompanyDomain(optionalRecord(metadata.oauthClientExtra)?.companyDomain);
+}
 
 function readBamboohrCompanyDomain(value: unknown): string {
   if (typeof value !== "string") {
@@ -154,6 +221,9 @@ function normalizeBamboohrCompanyDomain(value: unknown): string {
   if (trimmed.includes("://") || trimmed.includes("/") || trimmed.includes(".")) {
     throw new ProviderRequestError(400, "companyDomain must be the BambooHR company subdomain, not a full URL");
   }
+  if (!/^[a-z0-9](?:[a-z0-9_-]{0,61}[a-z0-9])?$/u.test(trimmed)) {
+    throw new ProviderRequestError(400, "companyDomain must be a valid BambooHR company subdomain");
+  }
   return trimmed;
 }
 
@@ -162,14 +232,14 @@ function buildBamboohrApiBaseUrl(companyDomain: string): string {
 }
 
 async function requestBamboohrJson(input: {
-  context: Pick<BamboohrContext, "apiKey" | "companyDomain" | "fetcher" | "signal">;
+  context: Pick<BamboohrContext, "authorization" | "companyDomain" | "fetcher" | "signal">;
   path: string;
   query?: Record<string, string | number | boolean | undefined>;
 }): Promise<unknown> {
   let response: Response;
   try {
     response = await input.context.fetcher(buildBamboohrUrl(input.context.companyDomain, input.path, input.query), {
-      headers: buildBamboohrHeaders(input.context.apiKey),
+      headers: buildBamboohrHeaders(input.context.authorization),
       signal: input.context.signal,
     });
   } catch (error) {
@@ -208,12 +278,16 @@ function buildBamboohrUrl(
   return url;
 }
 
-function buildBamboohrHeaders(apiKey: string): Record<string, string> {
+function buildBamboohrHeaders(authorization: string): Record<string, string> {
   return {
     accept: "application/json",
-    authorization: `Basic ${Buffer.from(`${apiKey}:x`).toString("base64")}`,
+    authorization,
     "user-agent": providerUserAgent,
   };
+}
+
+function buildBamboohrApiKeyAuthorization(apiKey: string): string {
+  return `Basic ${Buffer.from(`${apiKey}:x`).toString("base64")}`;
 }
 
 async function throwBamboohrError(response: Response): Promise<never> {

--- a/src/providers/bamboohr/executors.ts
+++ b/src/providers/bamboohr/executors.ts
@@ -140,7 +140,7 @@ export const credentialValidators: CredentialValidators = {
       {
         authorization: `${input.tokenType} ${input.accessToken}`,
         companyDomain: resolveBamboohrOAuthCompanyDomain(input.metadata),
-        grantedScopes: input.profile.grantedScopes,
+        grantedScopes: readBamboohrGrantedScopes(input.metadata.scope, input.profile.grantedScopes),
       },
       fetcher,
       signal,
@@ -201,6 +201,11 @@ function resolveBamboohrOAuthCompanyDomain(metadata: Record<string, unknown>): s
     return normalizeBamboohrCompanyDomain(storedCompanyDomain);
   }
   return readBamboohrCompanyDomain(optionalRecord(metadata.oauthClientExtra)?.companyDomain);
+}
+
+function readBamboohrGrantedScopes(value: unknown, fallback: string[]): string[] {
+  const scope = optionalString(value);
+  return scope ? [...new Set(scope.split(/\s+/u).filter(Boolean))] : fallback;
 }
 
 function readBamboohrCompanyDomain(value: unknown): string {


### PR DESCRIPTION
## Summary

- add tenant-aware BambooHR OAuth 2.0 authorization-code and refresh-token configuration
- preserve API-key Basic authentication while supporting OAuth Bearer credentials across actions, proxy requests, and validation
- declare the official BambooHR scopes required by the existing company, field, and employee actions
- add focused OAuth action/validation and API-key compatibility coverage

## Verification

- npm run generate:catalog
- npm test -- src/providers/bamboohr/executors.test.ts
- npm run fix-check
- npm test