### PR TITLE
feat(googlemeet): add OAuth provider

### DIFF
--- a/src/providers/google-runtime.test.ts
+++ b/src/providers/google-runtime.test.ts
@@ -1,8 +1,8 @@
-import type { ProviderFetch } from "../provider-runtime.ts";
+import type { ProviderFetch } from "./provider-runtime.ts";
 
 import { describe, expect, it } from "vitest";
-import { ProviderRequestError } from "../provider-runtime.ts";
-import { googleRequest } from "./runtime-shared.ts";
+import { googleRequest } from "./google-runtime.ts";
+import { ProviderRequestError } from "./provider-runtime.ts";
 
 const accessToken = "test-token";
 const url = "https://example.googleapis.com/v1/resource";

--- a/src/providers/google-runtime.ts
+++ b/src/providers/google-runtime.ts
@@ -1,0 +1,172 @@
+import type { ProviderFetch } from "./provider-runtime.ts";
+
+import { optionalRecord, optionalString } from "../core/cast.ts";
+import { providerUserAgent, ProviderRequestError } from "./provider-runtime.ts";
+
+export type GoogleQueryValue = string | readonly string[] | undefined;
+
+const defaultService = "googledrive";
+const googleDefaultRequestTimeoutMs = 30_000;
+
+export interface GoogleRequestOptions {
+  accessToken: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+  method?: string;
+  query?: Record<string, GoogleQueryValue>;
+  body?: unknown;
+  rawBody?: BodyInit;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  /**
+   * Provider slug used in the fallback error messages this module generates itself.
+   * Defaults to Google Drive so existing callers keep their current wording.
+   */
+  service?: string;
+}
+
+interface GoogleFetchOptions {
+  fetcher: ProviderFetch;
+  timeoutMs?: number;
+  init?: RequestInit;
+  service: string;
+}
+
+export async function googleJsonRequest<T>(url: string, input: GoogleRequestOptions): Promise<T> {
+  const response = await googleRequest(url, input);
+  return (await response.json()) as T;
+}
+
+export async function googleRequest(url: string, input: GoogleRequestOptions): Promise<Response> {
+  const service = input.service ?? defaultService;
+  const target = new URL(url);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        target.searchParams.append(key, item);
+      }
+      continue;
+    }
+    if (typeof value === "string") {
+      target.searchParams.set(key, value);
+    }
+  }
+
+  const headers = {
+    authorization: `Bearer ${input.accessToken}`,
+    "user-agent": providerUserAgent,
+    ...(input.headers ?? {}),
+  };
+  const hasJsonBody = input.rawBody == null && input.body !== undefined;
+  const hasRequestBody = input.rawBody != null || hasJsonBody;
+  const method = (input.method ?? (hasRequestBody ? "POST" : "GET")).toUpperCase();
+  if ((method === "GET" || method === "HEAD") && hasRequestBody) {
+    throw new ProviderRequestError(400, `${service} ${method} request must not include a body`);
+  }
+
+  const requestInit: RequestInit = {
+    method,
+    headers:
+      hasJsonBody && !hasContentTypeHeader(headers)
+        ? {
+            ...headers,
+            "content-type": "application/json",
+          }
+        : headers,
+    signal: input.signal,
+    ...(input.rawBody != null ? { body: input.rawBody } : hasJsonBody ? { body: JSON.stringify(input.body) } : {}),
+  };
+  const response = await googleFetchWithTimeout(target.toString(), {
+    fetcher: input.fetcher,
+    timeoutMs: input.timeoutMs ?? googleDefaultRequestTimeoutMs,
+    init: requestInit,
+    service,
+  });
+
+  await assertGoogleResponse(response, service);
+  return response;
+}
+
+async function googleFetchWithTimeout(url: string | URL, input: GoogleFetchOptions): Promise<Response> {
+  const timeoutMs = input.timeoutMs ?? googleDefaultRequestTimeoutMs;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return input.fetcher(url, input.init);
+  }
+
+  const controller = new AbortController();
+  const parentSignal = input.init?.signal;
+  let didTimeout = false;
+  const timeoutHandle = globalThis.setTimeout(() => {
+    didTimeout = true;
+    controller.abort();
+  }, timeoutMs);
+  const abortFromParent = (): void => controller.abort(parentSignal?.reason);
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      abortFromParent();
+    } else {
+      parentSignal.addEventListener("abort", abortFromParent, { once: true });
+    }
+  }
+
+  try {
+    return await input.fetcher(url, {
+      ...(input.init ?? {}),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (didTimeout && isAbortLikeError(error)) {
+      const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+      const unit = timeoutSeconds === 1 ? "second" : "seconds";
+      throw new ProviderRequestError(502, `${input.service} request timed out after ${timeoutSeconds} ${unit}`);
+    }
+    throw error;
+  } finally {
+    globalThis.clearTimeout(timeoutHandle);
+    if (parentSignal) {
+      parentSignal.removeEventListener("abort", abortFromParent);
+    }
+  }
+}
+
+function hasContentTypeHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((key) => key.toLowerCase() === "content-type");
+}
+
+async function assertGoogleResponse(response: Response, service: string): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const { message, details } = await extractGoogleError(response, service);
+  throw new ProviderRequestError(response.status, message, details);
+}
+
+async function extractGoogleError(response: Response, service: string): Promise<{ message: string; details: unknown }> {
+  const rawText = await response.text().catch(() => "");
+  if (!rawText) {
+    return {
+      message: `${service} request failed with ${response.status}`,
+      details: { status: response.status },
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(rawText) as Record<string, unknown>;
+    const error = optionalRecord(parsed.error);
+    const message = optionalString(error?.message) ?? optionalString(parsed.error_description) ?? rawText;
+    return {
+      message,
+      details: parsed,
+    };
+  } catch {
+    return {
+      message: rawText,
+      details: rawText,
+    };
+  }
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/src/providers/google_analytics/executors.ts
+++ b/src/providers/google_analytics/executors.ts
@@ -13,7 +13,7 @@ import {
   optionalStringOrNull,
   requiredRecord,
 } from "../../core/cast.ts";
-import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "google_analytics";

--- a/src/providers/google_bigquery/executors.ts
+++ b/src/providers/google_bigquery/executors.ts
@@ -8,7 +8,7 @@ import {
   optionalInteger as asOptionalInteger,
   requiredRecord,
 } from "../../core/cast.ts";
-import { googleJsonRequest, googleRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 const bigQueryApiBaseUrl = "https://bigquery.googleapis.com/bigquery/v2";

--- a/src/providers/google_search_console/executors.ts
+++ b/src/providers/google_search_console/executors.ts
@@ -8,7 +8,7 @@ import {
   pickOptionalInteger,
   pickOptionalString as pickNonEmptyString,
 } from "../../core/cast.ts";
-import { googleJsonRequest, googleRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "google_search_console";

--- a/src/providers/googleads/executors.ts
+++ b/src/providers/googleads/executors.ts
@@ -11,7 +11,7 @@ import {
   optionalScalarString,
   optionalString,
 } from "../../core/cast.ts";
-import { googleJsonRequest, googleRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { defineProviderExecutors, ProviderRequestError, requireOAuthCredential } from "../provider-runtime.ts";
 import { googleAdsScope } from "./scopes.ts";
 

--- a/src/providers/googlechat/executors.ts
+++ b/src/providers/googlechat/executors.ts
@@ -9,7 +9,8 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
-import { asObject, googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
+import { asObject } from "../googledrive/runtime-shared.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 export const googleChatApiBaseUrl = "https://chat.googleapis.com/v1";

--- a/src/providers/googledocs/executors.ts
+++ b/src/providers/googledocs/executors.ts
@@ -9,12 +9,14 @@ import type { GoogledocsActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { integer, objectArray } from "../../core/cast.ts";
 import {
+  googleJsonRequest as googleJsonRequestShared,
+  googleRequest as googleRequestShared,
+} from "../google-runtime.ts";
+import {
   asObject,
   asOptionalObject,
   asStringArray,
   compactObject,
-  googleJsonRequest as googleJsonRequestShared,
-  googleRequest as googleRequestShared,
   optionalBoolean,
 } from "../googledrive/runtime-shared.ts";
 import {

--- a/src/providers/googledrive/executors.ts
+++ b/src/providers/googledrive/executors.ts
@@ -3,6 +3,7 @@ import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { randomUUID } from "node:crypto";
 import { readBoundedResponseBytes } from "../../core/request.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import {
   defineOAuthProviderExecutors,
   defineProviderProxy,
@@ -42,8 +43,6 @@ import {
   asStringRecord,
   compactObject,
   compactUnknownObject,
-  googleJsonRequest,
-  googleRequest,
   optionalBoolean,
   optionalNestedString,
   optionalString,

--- a/src/providers/googledrive/runtime-collaboration.ts
+++ b/src/providers/googledrive/runtime-collaboration.ts
@@ -1,3 +1,4 @@
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { ProviderRequestError } from "../provider-runtime.ts";
 import {
   asObject,
@@ -6,8 +7,6 @@ import {
   asStringRecordOrUndefined,
   compactObject,
   compactUnknownObject,
-  googleJsonRequest,
-  googleRequest,
   optionalBoolean,
   optionalString,
   parseSizeBytes,

--- a/src/providers/googledrive/runtime-shared.ts
+++ b/src/providers/googledrive/runtime-shared.ts
@@ -1,5 +1,3 @@
-import type { ProviderFetch } from "../provider-runtime.ts";
-
 import {
   compactObject,
   optionalBoolean,
@@ -12,7 +10,7 @@ import {
   requiredRecord,
   stringArray,
 } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
 
 export {
   compactObject,
@@ -26,83 +24,6 @@ export {
   requiredRecord,
   stringArray,
 };
-
-export type GoogleQueryValue = string | readonly string[] | undefined;
-
-const defaultService = "googledrive";
-const googleDefaultRequestTimeoutMs = 30_000;
-
-export interface GoogleRequestOptions {
-  accessToken: string;
-  fetcher: ProviderFetch;
-  signal?: AbortSignal;
-  method?: string;
-  query?: Record<string, GoogleQueryValue>;
-  body?: unknown;
-  rawBody?: BodyInit;
-  headers?: Record<string, string>;
-  timeoutMs?: number;
-  /**
-   * Provider slug used in the fallback error messages this module generates itself.
-   * Defaults to Google Drive so existing callers keep their current wording.
-   */
-  service?: string;
-}
-
-export async function googleJsonRequest<T>(url: string, input: GoogleRequestOptions): Promise<T> {
-  const response = await googleRequest(url, input);
-  return (await response.json()) as T;
-}
-
-export async function googleRequest(url: string, input: GoogleRequestOptions): Promise<Response> {
-  const service = input.service ?? defaultService;
-  const target = new URL(url);
-  for (const [key, value] of Object.entries(input.query ?? {})) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        target.searchParams.append(key, item);
-      }
-      continue;
-    }
-    if (typeof value === "string") {
-      target.searchParams.set(key, value);
-    }
-  }
-
-  const headers = {
-    authorization: `Bearer ${input.accessToken}`,
-    "user-agent": providerUserAgent,
-    ...(input.headers ?? {}),
-  };
-  const hasJsonBody = input.rawBody == null && input.body !== undefined;
-  const hasRequestBody = input.rawBody != null || hasJsonBody;
-  const method = (input.method ?? (hasRequestBody ? "POST" : "GET")).toUpperCase();
-  if ((method === "GET" || method === "HEAD") && hasRequestBody) {
-    throw new ProviderRequestError(400, `${service} ${method} request must not include a body`);
-  }
-
-  const requestInit: RequestInit = {
-    method,
-    headers:
-      hasJsonBody && !hasContentTypeHeader(headers)
-        ? {
-            ...headers,
-            "content-type": "application/json",
-          }
-        : headers,
-    signal: input.signal,
-    ...(input.rawBody != null ? { body: input.rawBody } : hasJsonBody ? { body: JSON.stringify(input.body) } : {}),
-  };
-  const response = await googleFetchWithTimeout(target.toString(), {
-    fetcher: input.fetcher,
-    timeoutMs: input.timeoutMs ?? googleDefaultRequestTimeoutMs,
-    init: requestInit,
-    service,
-  });
-
-  await assertGoogleResponse(response, service);
-  return response;
-}
 
 export function resolveFileId(input: Record<string, unknown>): string {
   const value = optionalString(input.fileId);
@@ -164,94 +85,6 @@ export function asStringArray(value: unknown): string[] {
   return stringArray(value, "string array", (message) => new ProviderRequestError(400, message));
 }
 
-async function googleFetchWithTimeout(
-  url: string | URL,
-  input: {
-    fetcher: ProviderFetch;
-    timeoutMs?: number;
-    init?: RequestInit;
-    service: string;
-  },
-): Promise<Response> {
-  const timeoutMs = input.timeoutMs ?? googleDefaultRequestTimeoutMs;
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return input.fetcher(url, input.init);
-  }
-
-  const controller = new AbortController();
-  const parentSignal = input.init?.signal;
-  let didTimeout = false;
-  const timeoutHandle = globalThis.setTimeout(() => {
-    didTimeout = true;
-    controller.abort();
-  }, timeoutMs);
-  const abortFromParent = (): void => controller.abort(parentSignal?.reason);
-  if (parentSignal) {
-    if (parentSignal.aborted) {
-      abortFromParent();
-    } else {
-      parentSignal.addEventListener("abort", abortFromParent, { once: true });
-    }
-  }
-
-  try {
-    return await input.fetcher(url, {
-      ...(input.init ?? {}),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (didTimeout && isAbortLikeError(error)) {
-      const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
-      const unit = timeoutSeconds === 1 ? "second" : "seconds";
-      throw new ProviderRequestError(502, `${input.service} request timed out after ${timeoutSeconds} ${unit}`);
-    }
-    throw error;
-  } finally {
-    globalThis.clearTimeout(timeoutHandle);
-    if (parentSignal) {
-      parentSignal.removeEventListener("abort", abortFromParent);
-    }
-  }
-}
-
-function hasContentTypeHeader(headers: Record<string, string>): boolean {
-  return Object.keys(headers).some((key) => key.toLowerCase() === "content-type");
-}
-
-async function assertGoogleResponse(response: Response, service: string): Promise<void> {
-  if (response.ok) {
-    return;
-  }
-
-  const { message, details } = await extractGoogleError(response, service);
-  throw new ProviderRequestError(response.status, message, details);
-}
-
-async function extractGoogleError(response: Response, service: string): Promise<{ message: string; details: unknown }> {
-  const rawText = await response.text().catch(() => "");
-  if (!rawText) {
-    return {
-      message: `${service} request failed with ${response.status}`,
-      details: { status: response.status },
-    };
-  }
-
-  try {
-    const parsed = JSON.parse(rawText) as Record<string, unknown>;
-    const error = optionalRecord(parsed.error);
-    const message = optionalString(error?.message) ?? optionalString(parsed.error_description) ?? rawText;
-    return {
-      message,
-      details: parsed,
-    };
-  } catch {
-    return {
-      message: rawText,
-      details: rawText,
-    };
-  }
-}
-
 function extractFileId(value: string): string {
   const normalizedValue = value.trim();
   const maybeId = extractIdFromGoogleUrl(normalizedValue);
@@ -274,8 +107,4 @@ function extractIdFromGoogleUrl(value: string): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/googleforms/executors.ts
+++ b/src/providers/googleforms/executors.ts
@@ -10,7 +10,7 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
-import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 export const googleFormsApiBaseUrl = "https://forms.googleapis.com/v1/forms";

--- a/src/providers/googlemeet/actions.ts
+++ b/src/providers/googlemeet/actions.ts
@@ -276,7 +276,9 @@ const actions: GoogleMeetActionSource[] = [
     "end_active_conference",
     "End the active conference currently running in a Google Meet space.",
     googleMeetCreateScopes,
-    resourceNameInput("The space resource name, in the form spaces/{space}."),
+    resourceNameInput(
+      "The canonical space resource name, in the form spaces/{space}; bare IDs and meeting-code aliases are not accepted.",
+    ),
     s.requiredObject("The result of ending the active conference.", {
       success: s.literal(true, { description: "Whether the request completed successfully." }),
     }),

--- a/src/providers/googlemeet/actions.ts
+++ b/src/providers/googlemeet/actions.ts
@@ -244,25 +244,25 @@ const transcriptEntryNameInput = resourceNameInput("The transcript entry resourc
 const smartNoteNameInput = resourceNameInput("The smart-note resource name ending in smartNotes/{smart_note}.");
 
 const actions: GoogleMeetActionSource[] = [
-  action(
-    "create_space",
-    "Create a Google Meet space and return its join URL.",
-    googleMeetCreateScopes,
-    s.actionInput({ space: spaceWrite }),
-    space,
-  ),
-  action(
-    "get_space",
-    "Retrieve a Google Meet space by resource name or meeting code.",
-    googleMeetReadScopes,
-    resourceNameInput("The space name, such as spaces/{space}, or a bare space ID or meeting code."),
-    space,
-  ),
-  action(
-    "update_space",
-    "Update the configuration of a Google Meet space.",
-    googleMeetSettingsScopes,
-    s.actionInput(
+  {
+    name: "create_space",
+    description: "Create a Google Meet space and return its join URL.",
+    requiredScopes: googleMeetCreateScopes,
+    inputSchema: s.actionInput({ space: spaceWrite }),
+    outputSchema: space,
+  },
+  {
+    name: "get_space",
+    description: "Retrieve a Google Meet space by resource name or meeting code.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: resourceNameInput("The space name, such as spaces/{space}, or a bare space ID or meeting code."),
+    outputSchema: space,
+  },
+  {
+    name: "update_space",
+    description: "Update the configuration of a Google Meet space.",
+    requiredScopes: googleMeetSettingsScopes,
+    inputSchema: s.actionInput(
       {
         name: s.nonEmptyString("The space resource name, in the form spaces/{space}."),
         space: spaceWrite,
@@ -270,43 +270,43 @@ const actions: GoogleMeetActionSource[] = [
       },
       ["name", "space"],
     ),
-    space,
-  ),
-  action(
-    "end_active_conference",
-    "End the active conference currently running in a Google Meet space.",
-    googleMeetCreateScopes,
-    resourceNameInput(
+    outputSchema: space,
+  },
+  {
+    name: "end_active_conference",
+    description: "End the active conference currently running in a Google Meet space.",
+    requiredScopes: googleMeetCreateScopes,
+    inputSchema: resourceNameInput(
       "The canonical space resource name, in the form spaces/{space}; bare IDs and meeting-code aliases are not accepted.",
     ),
-    s.requiredObject("The result of ending the active conference.", {
+    outputSchema: s.requiredObject("The result of ending the active conference.", {
       success: s.literal(true, { description: "Whether the request completed successfully." }),
     }),
-  ),
-  action(
-    "list_conference_records",
-    "List accessible Google Meet conference records with optional filtering and pagination.",
-    googleMeetReadScopes,
-    s.actionInput({
+  },
+  {
+    name: "list_conference_records",
+    description: "List accessible Google Meet conference records with optional filtering and pagination.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: s.actionInput({
       filter,
       pageSize: s.integer("The maximum number of conference records to return.", { minimum: 1, maximum: 100 }),
       pageToken,
     }),
-    listOutput("conferenceRecords", "Conference records in the requested page.", conferenceRecord),
-  ),
-  action(
-    "get_conference_record",
-    "Retrieve one Google Meet conference record.",
-    googleMeetReadScopes,
-    conferenceRecordNameInput,
-    conferenceRecord,
-  ),
-  action(
-    "list_participants",
-    "List participants in a Google Meet conference record.",
-    googleMeetReadScopes,
-    filteredListInput("The parent conference record, such as conferenceRecords/{conference_record}.", 250),
-    s.object(
+    outputSchema: listOutput("conferenceRecords", "Conference records in the requested page.", conferenceRecord),
+  },
+  {
+    name: "get_conference_record",
+    description: "Retrieve one Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: conferenceRecordNameInput,
+    outputSchema: conferenceRecord,
+  },
+  {
+    name: "list_participants",
+    description: "List participants in a Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: filteredListInput("The parent conference record, such as conferenceRecords/{conference_record}.", 250),
+    outputSchema: s.object(
       "A page of Google Meet participants.",
       {
         participants: s.array("Participants in the requested page.", participant),
@@ -315,81 +315,90 @@ const actions: GoogleMeetActionSource[] = [
       },
       { required: ["participants", "nextPageToken"] },
     ),
-  ),
-  action(
-    "get_participant",
-    "Retrieve one participant from a Google Meet conference record.",
-    googleMeetReadScopes,
-    participantNameInput,
-    participant,
-  ),
-  action(
-    "list_participant_sessions",
-    "List join-to-leave sessions for a Google Meet participant.",
-    googleMeetReadScopes,
-    filteredListInput(
+  },
+  {
+    name: "get_participant",
+    description: "Retrieve one participant from a Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: participantNameInput,
+    outputSchema: participant,
+  },
+  {
+    name: "list_participant_sessions",
+    description: "List join-to-leave sessions for a Google Meet participant.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: filteredListInput(
       "The parent participant, such as conferenceRecords/{conference_record}/participants/{participant}.",
       250,
     ),
-    listOutput("participantSessions", "Participant sessions in the requested page.", participantSession),
-  ),
-  action(
-    "get_participant_session",
-    "Retrieve one Google Meet participant session.",
-    googleMeetReadScopes,
-    participantSessionNameInput,
-    participantSession,
-  ),
-  action(
-    "list_recordings",
-    "List recordings generated for a Google Meet conference record.",
-    googleMeetReadScopes,
-    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
-    listOutput("recordings", "Recordings in the requested page.", recording),
-  ),
-  action("get_recording", "Retrieve one Google Meet recording.", googleMeetReadScopes, recordingNameInput, recording),
-  action(
-    "list_transcripts",
-    "List transcripts generated for a Google Meet conference record.",
-    googleMeetReadScopes,
-    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
-    listOutput("transcripts", "Transcripts in the requested page.", transcript),
-  ),
-  action(
-    "get_transcript",
-    "Retrieve one Google Meet transcript.",
-    googleMeetReadScopes,
-    transcriptNameInput,
-    transcript,
-  ),
-  action(
-    "list_transcript_entries",
-    "List speaker segments in a Google Meet transcript.",
-    googleMeetReadScopes,
-    listInput("The parent transcript, such as conferenceRecords/{conference_record}/transcripts/{transcript}.", 100),
-    listOutput("transcriptEntries", "Transcript entries in the requested page.", transcriptEntry),
-  ),
-  action(
-    "get_transcript_entry",
-    "Retrieve one speaker segment from a Google Meet transcript.",
-    googleMeetReadScopes,
-    transcriptEntryNameInput,
-    transcriptEntry,
-  ),
-  action(
-    "list_smart_notes",
-    "List smart notes generated for a Google Meet conference record.",
-    googleMeetReadScopes,
-    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
-    listOutput("smartNotes", "Smart notes in the requested page.", smartNote),
-  ),
-  action(
-    "get_smart_note",
-    "Retrieve one Google Meet smart-note artifact.",
-    googleMeetReadScopes,
-    smartNoteNameInput,
-    smartNote,
-  ),
+    outputSchema: listOutput("participantSessions", "Participant sessions in the requested page.", participantSession),
+  },
+  {
+    name: "get_participant_session",
+    description: "Retrieve one Google Meet participant session.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: participantSessionNameInput,
+    outputSchema: participantSession,
+  },
+  {
+    name: "list_recordings",
+    description: "List recordings generated for a Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    outputSchema: listOutput("recordings", "Recordings in the requested page.", recording),
+  },
+  {
+    name: "get_recording",
+    description: "Retrieve one Google Meet recording.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: recordingNameInput,
+    outputSchema: recording,
+  },
+  {
+    name: "list_transcripts",
+    description: "List transcripts generated for a Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    outputSchema: listOutput("transcripts", "Transcripts in the requested page.", transcript),
+  },
+  {
+    name: "get_transcript",
+    description: "Retrieve one Google Meet transcript.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: transcriptNameInput,
+    outputSchema: transcript,
+  },
+  {
+    name: "list_transcript_entries",
+    description: "List speaker segments in a Google Meet transcript.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: listInput(
+      "The parent transcript, such as conferenceRecords/{conference_record}/transcripts/{transcript}.",
+      100,
+    ),
+    outputSchema: listOutput("transcriptEntries", "Transcript entries in the requested page.", transcriptEntry),
+  },
+  {
+    name: "get_transcript_entry",
+    description: "Retrieve one speaker segment from a Google Meet transcript.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: transcriptEntryNameInput,
+    outputSchema: transcriptEntry,
+  },
+  {
+    name: "list_smart_notes",
+    description: "List smart notes generated for a Google Meet conference record.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    outputSchema: listOutput("smartNotes", "Smart notes in the requested page.", smartNote),
+  },
+  {
+    name: "get_smart_note",
+    description: "Retrieve one Google Meet smart-note artifact.",
+    requiredScopes: googleMeetReadScopes,
+    inputSchema: smartNoteNameInput,
+    outputSchema: smartNote,
+  },
 ];
 
 export const googleMeetActions: ActionDefinition[] = actions.map((source) =>
@@ -398,22 +407,6 @@ export const googleMeetActions: ActionDefinition[] = actions.map((source) =>
     providerPermissions: source.requiredScopes,
   }),
 );
-
-function action(
-  name: string,
-  description: string,
-  requiredScopes: string[],
-  inputSchema: JsonSchema,
-  outputSchema: JsonSchema,
-): GoogleMeetActionSource {
-  return {
-    name,
-    description,
-    requiredScopes,
-    inputSchema,
-    outputSchema,
-  };
-}
 
 function resourceNameInput(description: string): JsonSchema {
   return s.actionInput({ name: s.nonEmptyString(description) }, ["name"]);

--- a/src/providers/googlemeet/actions.ts
+++ b/src/providers/googlemeet/actions.ts
@@ -1,0 +1,454 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { googleMeetCreateScopes, googleMeetReadScopes, googleMeetSettingsScopes } from "./scopes.ts";
+
+const service = "googlemeet";
+
+interface GoogleMeetActionSource {
+  name: string;
+  description: string;
+  requiredScopes: string[];
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}
+
+const autoGenerationType = s.stringEnum("Whether Google Meet should automatically generate the artifact.", [
+  "AUTO_GENERATION_TYPE_UNSPECIFIED",
+  "ON",
+  "OFF",
+]);
+
+const recordingConfig = s.object("Automatic recording settings for the meeting space.", {
+  autoRecordingGeneration: autoGenerationType,
+});
+
+const transcriptionConfig = s.object("Automatic transcription settings for the meeting space.", {
+  autoTranscriptionGeneration: autoGenerationType,
+});
+
+const smartNotesConfig = s.object("Automatic smart-note settings for the meeting space.", {
+  autoSmartNotesGeneration: autoGenerationType,
+});
+
+const artifactConfig = s.object("Automatic artifact generation settings for the meeting space.", {
+  recordingConfig,
+  transcriptionConfig,
+  smartNotesConfig,
+});
+
+const restrictionType = s.stringEnum("Who can use the moderated meeting feature.", [
+  "RESTRICTION_TYPE_UNSPECIFIED",
+  "HOSTS_ONLY",
+  "NO_RESTRICTION",
+]);
+
+const moderationRestrictions = s.object("Feature restrictions applied while moderation is enabled.", {
+  chatRestriction: restrictionType,
+  presentRestriction: restrictionType,
+  reactionRestriction: restrictionType,
+  defaultJoinAsViewerType: s.stringEnum("Whether participants join as viewers by default.", [
+    "DEFAULT_JOIN_AS_VIEWER_TYPE_UNSPECIFIED",
+    "ON",
+    "OFF",
+  ]),
+});
+
+const spaceConfig = s.object("Configuration for a Google Meet space.", {
+  accessType: s.stringEnum("Who can join the meeting without knocking.", [
+    "ACCESS_TYPE_UNSPECIFIED",
+    "OPEN",
+    "TRUSTED",
+    "RESTRICTED",
+  ]),
+  entryPointAccess: s.stringEnum("Which entry points can join the meeting.", [
+    "ENTRY_POINT_ACCESS_UNSPECIFIED",
+    "ALL",
+    "CREATOR_APP_ONLY",
+  ]),
+  moderation: s.stringEnum("Whether meeting moderation is enabled.", ["MODERATION_UNSPECIFIED", "OFF", "ON"]),
+  moderationRestrictions,
+  attendanceReportGenerationType: s.stringEnum("Whether the meeting generates an attendance report.", [
+    "ATTENDANCE_REPORT_GENERATION_TYPE_UNSPECIFIED",
+    "GENERATE_REPORT",
+    "DO_NOT_GENERATE",
+  ]),
+  artifactConfig,
+});
+
+const spaceWrite = s.object("Writable Google Meet space fields.", {
+  config: spaceConfig,
+});
+
+const activeConference = s.object("The conference currently active in the meeting space.", {
+  conferenceRecord: s.nonEmptyString("The active conference record resource name."),
+});
+
+const phoneAccess = s.object("A regional dial-in option for the meeting space.", {
+  regionCode: s.string("The regional country code."),
+  phoneNumber: s.string("The E.164 phone number used to dial in."),
+  pin: s.string("The numeric PIN entered after dialing."),
+  languageCode: s.string("The language code associated with the dial-in option."),
+});
+
+const gatewaySipAccess = s.object("A SIP gateway option for joining the meeting space.", {
+  uri: s.string("The SIP or SIPS URI used to join."),
+  sipAccessCode: s.string("The numeric SIP access code."),
+});
+
+const space = s.object(
+  "A Google Meet meeting space.",
+  {
+    name: s.nonEmptyString("The resource name, in the form spaces/{space}."),
+    meetingUri: s.url("The URL participants use to join the meeting."),
+    meetingCode: s.string("The human-readable meeting code."),
+    config: spaceConfig,
+    activeConference,
+    phoneAccess: s.array("Regional phone dial-in options.", phoneAccess),
+    gatewaySipAccess: s.array("SIP gateway access options.", gatewaySipAccess),
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const conferenceRecord = s.object(
+  "One instance of a conference held in a Google Meet space.",
+  {
+    name: s.nonEmptyString("The conference record resource name."),
+    space: s.string("The meeting space resource name."),
+    startTime: s.dateTime("When the conference started."),
+    endTime: s.dateTime("When the conference ended, when finished."),
+    expireTime: s.dateTime("When Google deletes the conference record resource."),
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const signedInUser = s.object("A participant signed in with a Google account.", {
+  user: s.string("The Google user resource name."),
+  displayName: s.string("The participant display name."),
+});
+
+const anonymousUser = s.object("A participant who joined without signing in.", {
+  displayName: s.string("The name supplied when joining."),
+});
+
+const phoneUser = s.object("A participant who joined by phone.", {
+  displayName: s.string("The partially redacted phone number shown by Google Meet."),
+});
+
+const participant = s.object(
+  "A user who attended a Google Meet conference.",
+  {
+    name: s.nonEmptyString("The participant resource name."),
+    earliestStartTime: s.dateTime("When the participant first joined."),
+    latestEndTime: s.dateTime("When the participant most recently left."),
+    signedinUser: signedInUser,
+    anonymousUser,
+    phoneUser,
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const participantSession = s.object(
+  "One join-to-leave session for a conference participant.",
+  {
+    name: s.nonEmptyString("The participant session resource name."),
+    startTime: s.dateTime("When the participant session started."),
+    endTime: s.dateTime("When the participant session ended."),
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const driveDestination = s.object("The Google Drive destination of a recording.", {
+  file: s.string("The Google Drive file ID of the MP4 recording."),
+  exportUri: s.url("The browser URL for the recording."),
+});
+
+const docsDestination = s.object("The Google Docs destination of a generated artifact.", {
+  document: s.string("The Google Docs document ID."),
+  exportUri: s.url("The browser URL for the document."),
+});
+
+const artifactState = s.stringEnum("The current artifact generation state.", [
+  "STATE_UNSPECIFIED",
+  "STARTED",
+  "ENDED",
+  "FILE_GENERATED",
+]);
+
+const recording = s.object(
+  "Metadata for a recording generated during a Google Meet conference.",
+  {
+    name: s.nonEmptyString("The recording resource name."),
+    state: artifactState,
+    startTime: s.dateTime("When recording started."),
+    endTime: s.dateTime("When recording ended."),
+    driveDestination,
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const transcript = s.object(
+  "Metadata for a transcript generated during a Google Meet conference.",
+  {
+    name: s.nonEmptyString("The transcript resource name."),
+    state: artifactState,
+    startTime: s.dateTime("When transcription started."),
+    endTime: s.dateTime("When transcription ended."),
+    docsDestination,
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const transcriptEntry = s.object(
+  "One speaker segment from a Google Meet transcript.",
+  {
+    name: s.nonEmptyString("The transcript entry resource name."),
+    participant: s.string("The participant resource name for the speaker."),
+    text: s.string("The transcribed speech."),
+    languageCode: s.string("The BCP 47 language code of the speech."),
+    startTime: s.dateTime("When the spoken segment started."),
+    endTime: s.dateTime("When the spoken segment ended."),
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const smartNote = s.object(
+  "Metadata for smart notes generated during a Google Meet conference.",
+  {
+    name: s.nonEmptyString("The smart-note resource name."),
+    state: artifactState,
+    startTime: s.dateTime("When smart-note generation started."),
+    endTime: s.dateTime("When smart-note generation ended."),
+    docsDestination,
+  },
+  { required: ["name"], additionalProperties: true },
+);
+
+const pageToken = s.nonEmptyString("A pagination token returned by a previous list call.");
+const nextPageToken = s.nullableString("A pagination token for the next page, or null when the page is final.");
+const filter = s.nonEmptyString("A Google Meet API filter expression for this resource collection.");
+
+const conferenceRecordNameInput = resourceNameInput(
+  "The conference record resource name, such as conferenceRecords/{conference_record}.",
+);
+const participantNameInput = resourceNameInput(
+  "The participant resource name, such as conferenceRecords/{conference_record}/participants/{participant}.",
+);
+const participantSessionNameInput = resourceNameInput(
+  "The participant session resource name ending in participantSessions/{participant_session}.",
+);
+const recordingNameInput = resourceNameInput("The recording resource name ending in recordings/{recording}.");
+const transcriptNameInput = resourceNameInput("The transcript resource name ending in transcripts/{transcript}.");
+const transcriptEntryNameInput = resourceNameInput("The transcript entry resource name ending in entries/{entry}.");
+const smartNoteNameInput = resourceNameInput("The smart-note resource name ending in smartNotes/{smart_note}.");
+
+const actions: GoogleMeetActionSource[] = [
+  action(
+    "create_space",
+    "Create a Google Meet space and return its join URL.",
+    googleMeetCreateScopes,
+    s.actionInput({ space: spaceWrite }),
+    space,
+  ),
+  action(
+    "get_space",
+    "Retrieve a Google Meet space by resource name or meeting code.",
+    googleMeetReadScopes,
+    resourceNameInput("The space name, such as spaces/{space}, or a bare space ID or meeting code."),
+    space,
+  ),
+  action(
+    "update_space",
+    "Update the configuration of a Google Meet space.",
+    googleMeetSettingsScopes,
+    s.actionInput(
+      {
+        name: s.nonEmptyString("The space resource name, in the form spaces/{space}."),
+        space: spaceWrite,
+        updateMask: s.nonEmptyString("A comma-separated Google field mask, such as config.accessType."),
+      },
+      ["name", "space"],
+    ),
+    space,
+  ),
+  action(
+    "end_active_conference",
+    "End the active conference currently running in a Google Meet space.",
+    googleMeetCreateScopes,
+    resourceNameInput("The space resource name, in the form spaces/{space}."),
+    s.requiredObject("The result of ending the active conference.", {
+      success: s.literal(true, { description: "Whether the request completed successfully." }),
+    }),
+  ),
+  action(
+    "list_conference_records",
+    "List accessible Google Meet conference records with optional filtering and pagination.",
+    googleMeetReadScopes,
+    s.actionInput({
+      filter,
+      pageSize: s.integer("The maximum number of conference records to return.", { minimum: 1, maximum: 100 }),
+      pageToken,
+    }),
+    listOutput("conferenceRecords", "Conference records in the requested page.", conferenceRecord),
+  ),
+  action(
+    "get_conference_record",
+    "Retrieve one Google Meet conference record.",
+    googleMeetReadScopes,
+    conferenceRecordNameInput,
+    conferenceRecord,
+  ),
+  action(
+    "list_participants",
+    "List participants in a Google Meet conference record.",
+    googleMeetReadScopes,
+    filteredListInput("The parent conference record, such as conferenceRecords/{conference_record}.", 250),
+    s.object(
+      "A page of Google Meet participants.",
+      {
+        participants: s.array("Participants in the requested page.", participant),
+        nextPageToken,
+        totalSize: s.integer("The total participant count when requested through a field mask."),
+      },
+      { required: ["participants", "nextPageToken"] },
+    ),
+  ),
+  action(
+    "get_participant",
+    "Retrieve one participant from a Google Meet conference record.",
+    googleMeetReadScopes,
+    participantNameInput,
+    participant,
+  ),
+  action(
+    "list_participant_sessions",
+    "List join-to-leave sessions for a Google Meet participant.",
+    googleMeetReadScopes,
+    filteredListInput(
+      "The parent participant, such as conferenceRecords/{conference_record}/participants/{participant}.",
+      250,
+    ),
+    listOutput("participantSessions", "Participant sessions in the requested page.", participantSession),
+  ),
+  action(
+    "get_participant_session",
+    "Retrieve one Google Meet participant session.",
+    googleMeetReadScopes,
+    participantSessionNameInput,
+    participantSession,
+  ),
+  action(
+    "list_recordings",
+    "List recordings generated for a Google Meet conference record.",
+    googleMeetReadScopes,
+    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    listOutput("recordings", "Recordings in the requested page.", recording),
+  ),
+  action("get_recording", "Retrieve one Google Meet recording.", googleMeetReadScopes, recordingNameInput, recording),
+  action(
+    "list_transcripts",
+    "List transcripts generated for a Google Meet conference record.",
+    googleMeetReadScopes,
+    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    listOutput("transcripts", "Transcripts in the requested page.", transcript),
+  ),
+  action(
+    "get_transcript",
+    "Retrieve one Google Meet transcript.",
+    googleMeetReadScopes,
+    transcriptNameInput,
+    transcript,
+  ),
+  action(
+    "list_transcript_entries",
+    "List speaker segments in a Google Meet transcript.",
+    googleMeetReadScopes,
+    listInput("The parent transcript, such as conferenceRecords/{conference_record}/transcripts/{transcript}.", 100),
+    listOutput("transcriptEntries", "Transcript entries in the requested page.", transcriptEntry),
+  ),
+  action(
+    "get_transcript_entry",
+    "Retrieve one speaker segment from a Google Meet transcript.",
+    googleMeetReadScopes,
+    transcriptEntryNameInput,
+    transcriptEntry,
+  ),
+  action(
+    "list_smart_notes",
+    "List smart notes generated for a Google Meet conference record.",
+    googleMeetReadScopes,
+    listInput("The parent conference record, such as conferenceRecords/{conference_record}.", 100),
+    listOutput("smartNotes", "Smart notes in the requested page.", smartNote),
+  ),
+  action(
+    "get_smart_note",
+    "Retrieve one Google Meet smart-note artifact.",
+    googleMeetReadScopes,
+    smartNoteNameInput,
+    smartNote,
+  ),
+];
+
+export const googleMeetActions: ActionDefinition[] = actions.map((source) =>
+  defineProviderAction(service, {
+    ...source,
+    providerPermissions: source.requiredScopes,
+  }),
+);
+
+function action(
+  name: string,
+  description: string,
+  requiredScopes: string[],
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+): GoogleMeetActionSource {
+  return {
+    name,
+    description,
+    requiredScopes,
+    inputSchema,
+    outputSchema,
+  };
+}
+
+function resourceNameInput(description: string): JsonSchema {
+  return s.actionInput({ name: s.nonEmptyString(description) }, ["name"]);
+}
+
+function listInput(parentDescription: string, maximumPageSize: number): JsonSchema {
+  return s.actionInput(
+    {
+      parent: s.nonEmptyString(parentDescription),
+      pageSize: s.integer("The maximum number of resources to return.", {
+        minimum: 1,
+        maximum: maximumPageSize,
+      }),
+      pageToken,
+    },
+    ["parent"],
+  );
+}
+
+function filteredListInput(parentDescription: string, maximumPageSize: number): JsonSchema {
+  return s.actionInput(
+    {
+      parent: s.nonEmptyString(parentDescription),
+      filter,
+      pageSize: s.integer("The maximum number of resources to return.", {
+        minimum: 1,
+        maximum: maximumPageSize,
+      }),
+      pageToken,
+    },
+    ["parent"],
+  );
+}
+
+function listOutput(field: string, description: string, itemSchema: JsonSchema): JsonSchema {
+  return s.requiredObject(`A paginated Google Meet ${field} response.`, {
+    [field]: s.array(description, itemSchema),
+    nextPageToken,
+  });
+}

--- a/src/providers/googlemeet/constants.ts
+++ b/src/providers/googlemeet/constants.ts
@@ -1,0 +1,6 @@
+export const googleMeetAuthorizationUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+export const googleMeetTokenUrl = "https://oauth2.googleapis.com/token";
+export const googleMeetApiOrigin = "https://meet.googleapis.com";
+export const googleMeetApiBaseUrl: string = `${googleMeetApiOrigin}/v2`;
+export const googleMeetUserInfoUrl = "https://www.googleapis.com/oauth2/v3/userinfo";
+export const googleMeetHomepageUrl = "https://workspace.google.com/products/meet/";

--- a/src/providers/googlemeet/definition.ts
+++ b/src/providers/googlemeet/definition.ts
@@ -1,0 +1,34 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { googleMeetActions } from "./actions.ts";
+import { googleMeetAuthorizationUrl, googleMeetHomepageUrl, googleMeetTokenUrl } from "./constants.ts";
+import { googleMeetOAuthScopes } from "./scopes.ts";
+
+const service = "googlemeet";
+
+/**
+ * Google Meet provider backed by the Meet REST API and a user-provided Google OAuth app.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Google Meet",
+  description:
+    "Create and manage Google Meet spaces, then read conference records, participants, recordings, transcripts, and smart notes.",
+  categories: ["Communication", "Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: googleMeetAuthorizationUrl,
+      tokenUrl: googleMeetTokenUrl,
+      scopes: googleMeetOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      authorizationParams: {
+        access_type: "offline",
+        prompt: "consent",
+      },
+    },
+  ],
+  homepageUrl: googleMeetHomepageUrl,
+  actions: googleMeetActions,
+};

--- a/src/providers/googlemeet/executors.test.ts
+++ b/src/providers/googlemeet/executors.test.ts
@@ -1,0 +1,166 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { credentialValidators, googleMeetActionHandlers, proxy } from "./executors.ts";
+
+const accessToken = "google-meet-access-token";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Google Meet OAuth execution", () => {
+  it("validates the credential through Google user info", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url, init) => {
+      expect(url.toString()).toBe("https://www.googleapis.com/oauth2/v3/userinfo");
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${accessToken}`);
+      return Response.json({ sub: "google-user-1", email: "meet@example.com", name: "Meet User" });
+    });
+
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken,
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: {},
+      },
+      { fetcher },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "meet@example.com", displayName: "Meet User" },
+      metadata: { currentAccount: { sub: "google-user-1", email: "meet@example.com" } },
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("creates a meeting space with Bearer authentication", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url, init) => {
+      expect(url.toString()).toBe("https://meet.googleapis.com/v2/spaces");
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${accessToken}`);
+      expect(JSON.parse(String(init?.body))).toEqual({ config: { accessType: "TRUSTED" } });
+      return Response.json({
+        name: "spaces/space-1",
+        meetingCode: "abc-mnop-xyz",
+        meetingUri: "https://meet.google.com/abc-mnop-xyz",
+      });
+    });
+
+    await expect(
+      googleMeetActionHandlers.create_space({ space: { config: { accessType: "TRUSTED" } } }, { accessToken, fetcher }),
+    ).resolves.toMatchObject({ name: "spaces/space-1", meetingCode: "abc-mnop-xyz" });
+  });
+
+  it("constructs participant list paths and pagination query values", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url) => {
+      const target = new URL(url);
+      expect(target.origin + target.pathname).toBe(
+        "https://meet.googleapis.com/v2/conferenceRecords/record-1/participants",
+      );
+      expect(Object.fromEntries(target.searchParams)).toEqual({
+        filter: "latest_end_time IS NULL",
+        pageSize: "250",
+        pageToken: "next-1",
+      });
+      return Response.json({ participants: [{ name: "conferenceRecords/record-1/participants/person-1" }] });
+    });
+
+    await expect(
+      googleMeetActionHandlers.list_participants(
+        {
+          parent: "record-1",
+          filter: "latest_end_time IS NULL",
+          pageSize: 250,
+          pageToken: "next-1",
+        },
+        { accessToken, fetcher },
+      ),
+    ).resolves.toEqual({
+      participants: [{ name: "conferenceRecords/record-1/participants/person-1" }],
+      nextPageToken: null,
+    });
+  });
+});
+
+describe("Google Meet resource names", () => {
+  const fetcher: ProviderFetch = async () => {
+    throw new Error("invalid resource names must not be fetched");
+  };
+  const context = { accessToken, fetcher };
+
+  it.each([
+    ["space traversal", "get_space", { name: "spaces/.." }],
+    ["conference record traversal", "get_conference_record", { name: "conferenceRecords/%2e%2e" }],
+    ["participant traversal", "get_participant", { name: "conferenceRecords/record-1/participants/.." }],
+    [
+      "participant session with a missing participant",
+      "get_participant_session",
+      { name: "conferenceRecords/record-1/participantSessions/session-1" },
+    ],
+    [
+      "recording with extra path segments",
+      "get_recording",
+      { name: "conferenceRecords/record-1/recordings/recording-1/file" },
+    ],
+    [
+      "transcript entry traversal",
+      "get_transcript_entry",
+      { name: "conferenceRecords/record-1/transcripts/transcript-1/entries/%2E%2E" },
+    ],
+  ])("rejects %s", async (_description, action, input) => {
+    await expect(googleMeetActionHandlers[action](input, context)).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("Google Meet proxy", () => {
+  const credential: ResolvedCredential = {
+    authType: "oauth2",
+    accessToken,
+    tokenType: "Bearer",
+    profile: { accountId: "meet@example.com", displayName: "Meet User", grantedScopes: [] },
+    metadata: {},
+  };
+  const context: ExecutionContext = {
+    getCredential: async () => credential,
+  };
+
+  it("routes only v2 requests with the stored OAuth credential", async () => {
+    const fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("https://meet.googleapis.com/v2/conferenceRecords?pageSize=1");
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${accessToken}`);
+      return Response.json({ conferenceRecords: [] });
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await proxy(
+      {
+        method: "GET",
+        endpoint: "/v2/conferenceRecords",
+        query: { pageSize: 1 },
+        headers: { authorization: "Bearer caller-supplied-token" },
+      },
+      context,
+    );
+
+    expect(result).toMatchObject({ ok: true, response: { status: 200, data: { conferenceRecords: [] } } });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects endpoints outside the Meet v2 API", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(proxy({ method: "GET", endpoint: "/oauth2/v2/userinfo" }, context)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_input" },
+    });
+    await expect(proxy({ method: "GET", endpoint: "/v2beta/conferenceRecords" }, context)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_input" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/googlemeet/executors.test.ts
+++ b/src/providers/googlemeet/executors.test.ts
@@ -65,7 +65,10 @@ describe("Google Meet OAuth execution", () => {
         pageSize: "250",
         pageToken: "next-1",
       });
-      return Response.json({ participants: [{ name: "conferenceRecords/record-1/participants/person-1" }] });
+      return Response.json({
+        participants: [{ name: "conferenceRecords/record-1/participants/person-1" }],
+        totalSize: 1,
+      });
     });
 
     await expect(
@@ -81,6 +84,7 @@ describe("Google Meet OAuth execution", () => {
     ).resolves.toEqual({
       participants: [{ name: "conferenceRecords/record-1/participants/person-1" }],
       nextPageToken: null,
+      totalSize: 1,
     });
   });
 
@@ -154,6 +158,7 @@ describe("Google Meet resource names", () => {
 
   it.each([
     ["space traversal", "get_space", { name: "spaces/.." }],
+    ["bare space ID for end active conference", "end_active_conference", { name: "space-1" }],
     ["conference record traversal", "get_conference_record", { name: "conferenceRecords/%2e%2e" }],
     ["participant traversal", "get_participant", { name: "conferenceRecords/record-1/participants/.." }],
     [

--- a/src/providers/googlemeet/executors.test.ts
+++ b/src/providers/googlemeet/executors.test.ts
@@ -83,6 +83,67 @@ describe("Google Meet OAuth execution", () => {
       nextPageToken: null,
     });
   });
+
+  it("omits unsupported filters from transcript list requests", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url) => {
+      const target = new URL(url);
+      expect(target.origin + target.pathname).toBe(
+        "https://meet.googleapis.com/v2/conferenceRecords/record-1/transcripts",
+      );
+      expect(Object.fromEntries(target.searchParams)).toEqual({ pageSize: "10", pageToken: "next-1" });
+      return Response.json({ transcripts: [], nextPageToken: "next-2" });
+    });
+
+    await expect(
+      googleMeetActionHandlers.list_transcripts(
+        {
+          parent: "record-1",
+          filter: "start_time > 2026-01-01T00:00:00Z",
+          pageSize: 10,
+          pageToken: "next-1",
+        },
+        { accessToken, fetcher },
+      ),
+    ).resolves.toEqual({ transcripts: [], nextPageToken: "next-2" });
+  });
+
+  it("updates a meeting space with an update mask", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url, init) => {
+      const target = new URL(url);
+      expect(target.origin + target.pathname).toBe("https://meet.googleapis.com/v2/spaces/space-1");
+      expect(Object.fromEntries(target.searchParams)).toEqual({ updateMask: "config.accessType" });
+      expect(init?.method).toBe("PATCH");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        name: "spaces/space-1",
+        config: { accessType: "OPEN" },
+      });
+      return Response.json({ name: "spaces/space-1", config: { accessType: "OPEN" } });
+    });
+
+    await expect(
+      googleMeetActionHandlers.update_space(
+        {
+          name: "space-1",
+          space: { config: { accessType: "OPEN" } },
+          updateMask: "config.accessType",
+        },
+        { accessToken, fetcher },
+      ),
+    ).resolves.toMatchObject({ name: "spaces/space-1", config: { accessType: "OPEN" } });
+  });
+
+  it("ends an active conference through the custom method", async () => {
+    const fetcher: ProviderFetch = vi.fn(async (url, init) => {
+      expect(url.toString()).toBe("https://meet.googleapis.com/v2/spaces/space-1:endActiveConference");
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(String(init?.body))).toEqual({});
+      return Response.json({});
+    });
+
+    await expect(
+      googleMeetActionHandlers.end_active_conference({ name: "spaces/space-1" }, { accessToken, fetcher }),
+    ).resolves.toEqual({ success: true });
+  });
 });
 
 describe("Google Meet resource names", () => {

--- a/src/providers/googlemeet/executors.test.ts
+++ b/src/providers/googlemeet/executors.test.ts
@@ -127,7 +127,7 @@ describe("Google Meet OAuth execution", () => {
     await expect(
       googleMeetActionHandlers.update_space(
         {
-          name: "space-1",
+          name: "spaces/space-1",
           space: { config: { accessType: "OPEN" } },
           updateMask: "config.accessType",
         },
@@ -158,7 +158,10 @@ describe("Google Meet resource names", () => {
 
   it.each([
     ["space traversal", "get_space", { name: "spaces/.." }],
+    ["bare space ID for update", "update_space", { name: "space-1" }],
+    ["meeting-code alias for update", "update_space", { name: "spaces/abc-mnop-xyz" }],
     ["bare space ID for end active conference", "end_active_conference", { name: "space-1" }],
+    ["meeting-code alias for end active conference", "end_active_conference", { name: "spaces/abc-mnop-xyz" }],
     ["conference record traversal", "get_conference_record", { name: "conferenceRecords/%2e%2e" }],
     ["participant traversal", "get_participant", { name: "conferenceRecords/record-1/participants/.." }],
     [

--- a/src/providers/googlemeet/executors.ts
+++ b/src/providers/googlemeet/executors.ts
@@ -2,7 +2,7 @@ import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } f
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
-import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
 import {
   defineOAuthProviderExecutors,
   defineProviderProxy,
@@ -80,6 +80,40 @@ interface GoogleMeetListPayload {
   nextPageToken?: unknown;
   totalSize?: unknown;
 }
+
+interface GoogleMeetChildListSpec {
+  parentRule: ResourceNameRule;
+  collection: string;
+  responseField: keyof GoogleMeetListPayload;
+  supportsFilter?: boolean;
+}
+
+const participantSessionsListSpec: GoogleMeetChildListSpec = {
+  parentRule: participantNameRule,
+  collection: "participantSessions",
+  responseField: "participantSessions",
+  supportsFilter: true,
+};
+const recordingsListSpec: GoogleMeetChildListSpec = {
+  parentRule: conferenceRecordNameRule,
+  collection: "recordings",
+  responseField: "recordings",
+};
+const transcriptsListSpec: GoogleMeetChildListSpec = {
+  parentRule: conferenceRecordNameRule,
+  collection: "transcripts",
+  responseField: "transcripts",
+};
+const transcriptEntriesListSpec: GoogleMeetChildListSpec = {
+  parentRule: transcriptNameRule,
+  collection: "entries",
+  responseField: "transcriptEntries",
+};
+const smartNotesListSpec: GoogleMeetChildListSpec = {
+  parentRule: conferenceRecordNameRule,
+  collection: "smartNotes",
+  responseField: "smartNotes",
+};
 
 export const googleMeetActionHandlers: Record<string, GoogleMeetActionHandler> = {
   create_space: createSpace,
@@ -217,22 +251,8 @@ async function getParticipant(input: Record<string, unknown>, context: GoogleMee
   return getResource(input.name, participantNameRule, context);
 }
 
-async function listParticipantSessions(
-  input: Record<string, unknown>,
-  context: GoogleMeetRuntimeContext,
-): Promise<unknown> {
-  const parent = resolveParent(input.parent, participantNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/participantSessions`,
-    {
-      context,
-      query: listQuery(input, true),
-    },
-  );
-  return {
-    participantSessions: arrayOrEmpty(payload.participantSessions),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listParticipantSessions(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listChildResources(input, context, participantSessionsListSpec);
 }
 
 async function getParticipantSession(
@@ -242,79 +262,32 @@ async function getParticipantSession(
   return getResource(input.name, participantSessionNameRule, context);
 }
 
-async function listRecordings(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  const parent = resolveParent(input.parent, conferenceRecordNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/recordings`,
-    {
-      context,
-      query: listQuery(input),
-    },
-  );
-  return {
-    recordings: arrayOrEmpty(payload.recordings),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listRecordings(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listChildResources(input, context, recordingsListSpec);
 }
 
 async function getRecording(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
   return getResource(input.name, recordingNameRule, context);
 }
 
-async function listTranscripts(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  const parent = resolveParent(input.parent, conferenceRecordNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/transcripts`,
-    {
-      context,
-      query: listQuery(input),
-    },
-  );
-  return {
-    transcripts: arrayOrEmpty(payload.transcripts),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listTranscripts(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listChildResources(input, context, transcriptsListSpec);
 }
 
 async function getTranscript(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
   return getResource(input.name, transcriptNameRule, context);
 }
 
-async function listTranscriptEntries(
-  input: Record<string, unknown>,
-  context: GoogleMeetRuntimeContext,
-): Promise<unknown> {
-  const parent = resolveParent(input.parent, transcriptNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/entries`,
-    {
-      context,
-      query: listQuery(input),
-    },
-  );
-  return {
-    transcriptEntries: arrayOrEmpty(payload.transcriptEntries),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listTranscriptEntries(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listChildResources(input, context, transcriptEntriesListSpec);
 }
 
 async function getTranscriptEntry(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
   return getResource(input.name, transcriptEntryNameRule, context);
 }
 
-async function listSmartNotes(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  const parent = resolveParent(input.parent, conferenceRecordNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/smartNotes`,
-    {
-      context,
-      query: listQuery(input),
-    },
-  );
-  return {
-    smartNotes: arrayOrEmpty(payload.smartNotes),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listSmartNotes(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listChildResources(input, context, smartNotesListSpec);
 }
 
 async function getSmartNote(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -324,6 +297,25 @@ async function getSmartNote(input: Record<string, unknown>, context: GoogleMeetR
 function getResource(value: unknown, rule: ResourceNameRule, context: GoogleMeetRuntimeContext): Promise<unknown> {
   const name = resolveResourceName(value, rule);
   return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}`, { context });
+}
+
+async function listChildResources(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+  spec: GoogleMeetChildListSpec,
+): Promise<unknown> {
+  const parent = resolveParent(input.parent, spec.parentRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/${spec.collection}`,
+    {
+      context,
+      query: listQuery(input, spec.supportsFilter),
+    },
+  );
+  return {
+    [spec.responseField]: arrayOrEmpty(payload[spec.responseField]),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
 }
 
 function googleMeetJsonRequest<T = unknown>(url: string, input: GoogleMeetRequestOptions): Promise<T> {

--- a/src/providers/googlemeet/executors.ts
+++ b/src/providers/googlemeet/executors.ts
@@ -18,7 +18,7 @@ const spaceNameRule: ResourceNameRule = {
   expected: "spaces/{space}",
   barePrefix: "spaces",
 };
-const strictSpaceNameRule: ResourceNameRule = {
+const canonicalSpaceNameRule: ResourceNameRule = {
   pattern: spaceNameRule.pattern,
   expected: spaceNameRule.expected,
 };
@@ -81,35 +81,48 @@ interface GoogleMeetListPayload {
   totalSize?: unknown;
 }
 
-interface GoogleMeetChildListSpec {
-  parentRule: ResourceNameRule;
+interface GoogleMeetListSpec {
+  parentRule?: ResourceNameRule;
   collection: string;
   responseField: keyof GoogleMeetListPayload;
   supportsFilter?: boolean;
+  supportsTotalSize?: boolean;
 }
 
-const participantSessionsListSpec: GoogleMeetChildListSpec = {
+const conferenceRecordsListSpec: GoogleMeetListSpec = {
+  collection: "conferenceRecords",
+  responseField: "conferenceRecords",
+  supportsFilter: true,
+};
+const participantsListSpec: GoogleMeetListSpec = {
+  parentRule: conferenceRecordNameRule,
+  collection: "participants",
+  responseField: "participants",
+  supportsFilter: true,
+  supportsTotalSize: true,
+};
+const participantSessionsListSpec: GoogleMeetListSpec = {
   parentRule: participantNameRule,
   collection: "participantSessions",
   responseField: "participantSessions",
   supportsFilter: true,
 };
-const recordingsListSpec: GoogleMeetChildListSpec = {
+const recordingsListSpec: GoogleMeetListSpec = {
   parentRule: conferenceRecordNameRule,
   collection: "recordings",
   responseField: "recordings",
 };
-const transcriptsListSpec: GoogleMeetChildListSpec = {
+const transcriptsListSpec: GoogleMeetListSpec = {
   parentRule: conferenceRecordNameRule,
   collection: "transcripts",
   responseField: "transcripts",
 };
-const transcriptEntriesListSpec: GoogleMeetChildListSpec = {
+const transcriptEntriesListSpec: GoogleMeetListSpec = {
   parentRule: transcriptNameRule,
   collection: "entries",
   responseField: "transcriptEntries",
 };
-const smartNotesListSpec: GoogleMeetChildListSpec = {
+const smartNotesListSpec: GoogleMeetListSpec = {
   parentRule: conferenceRecordNameRule,
   collection: "smartNotes",
   responseField: "smartNotes",
@@ -201,7 +214,7 @@ async function endActiveConference(
   input: Record<string, unknown>,
   context: GoogleMeetRuntimeContext,
 ): Promise<unknown> {
-  const name = resolveResourceName(input.name, strictSpaceNameRule);
+  const name = resolveResourceName(input.name, canonicalSpaceNameRule);
   await googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}:endActiveConference`, {
     context,
     method: "POST",
@@ -210,18 +223,8 @@ async function endActiveConference(
   return { success: true };
 }
 
-async function listConferenceRecords(
-  input: Record<string, unknown>,
-  context: GoogleMeetRuntimeContext,
-): Promise<unknown> {
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(`${googleMeetApiBaseUrl}/conferenceRecords`, {
-    context,
-    query: listQuery(input, true),
-  });
-  return {
-    conferenceRecords: arrayOrEmpty(payload.conferenceRecords),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+function listConferenceRecords(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listResources(input, context, conferenceRecordsListSpec);
 }
 
 async function getConferenceRecord(
@@ -231,20 +234,8 @@ async function getConferenceRecord(
   return getResource(input.name, conferenceRecordNameRule, context);
 }
 
-async function listParticipants(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  const parent = resolveParent(input.parent, conferenceRecordNameRule);
-  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/participants`,
-    {
-      context,
-      query: listQuery(input, true),
-    },
-  );
-  return compactObject({
-    participants: arrayOrEmpty(payload.participants),
-    nextPageToken: optionalString(payload.nextPageToken) ?? null,
-    totalSize: optionalInteger(payload.totalSize),
-  });
+function listParticipants(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return listResources(input, context, participantsListSpec);
 }
 
 async function getParticipant(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -252,7 +243,7 @@ async function getParticipant(input: Record<string, unknown>, context: GoogleMee
 }
 
 function listParticipantSessions(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  return listChildResources(input, context, participantSessionsListSpec);
+  return listResources(input, context, participantSessionsListSpec);
 }
 
 async function getParticipantSession(
@@ -263,7 +254,7 @@ async function getParticipantSession(
 }
 
 function listRecordings(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  return listChildResources(input, context, recordingsListSpec);
+  return listResources(input, context, recordingsListSpec);
 }
 
 async function getRecording(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -271,7 +262,7 @@ async function getRecording(input: Record<string, unknown>, context: GoogleMeetR
 }
 
 function listTranscripts(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  return listChildResources(input, context, transcriptsListSpec);
+  return listResources(input, context, transcriptsListSpec);
 }
 
 async function getTranscript(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -279,7 +270,7 @@ async function getTranscript(input: Record<string, unknown>, context: GoogleMeet
 }
 
 function listTranscriptEntries(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  return listChildResources(input, context, transcriptEntriesListSpec);
+  return listResources(input, context, transcriptEntriesListSpec);
 }
 
 async function getTranscriptEntry(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -287,7 +278,7 @@ async function getTranscriptEntry(input: Record<string, unknown>, context: Googl
 }
 
 function listSmartNotes(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  return listChildResources(input, context, smartNotesListSpec);
+  return listResources(input, context, smartNotesListSpec);
 }
 
 async function getSmartNote(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
@@ -299,23 +290,24 @@ function getResource(value: unknown, rule: ResourceNameRule, context: GoogleMeet
   return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}`, { context });
 }
 
-async function listChildResources(
+async function listResources(
   input: Record<string, unknown>,
   context: GoogleMeetRuntimeContext,
-  spec: GoogleMeetChildListSpec,
+  spec: GoogleMeetListSpec,
 ): Promise<unknown> {
-  const parent = resolveParent(input.parent, spec.parentRule);
+  const parent = spec.parentRule ? `${encodeResourceName(resolveParent(input.parent, spec.parentRule))}/` : "";
   const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
-    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/${spec.collection}`,
+    `${googleMeetApiBaseUrl}/${parent}${spec.collection}`,
     {
       context,
       query: listQuery(input, spec.supportsFilter),
     },
   );
-  return {
+  return compactObject({
     [spec.responseField]: arrayOrEmpty(payload[spec.responseField]),
     nextPageToken: optionalString(payload.nextPageToken) ?? null,
-  };
+    totalSize: spec.supportsTotalSize ? optionalInteger(payload.totalSize) : undefined,
+  });
 }
 
 function googleMeetJsonRequest<T = unknown>(url: string, input: GoogleMeetRequestOptions): Promise<T> {

--- a/src/providers/googlemeet/executors.ts
+++ b/src/providers/googlemeet/executors.ts
@@ -20,8 +20,9 @@ const spaceNameRule: ResourceNameRule = {
 };
 const canonicalSpaceNameRule: ResourceNameRule = {
   pattern: spaceNameRule.pattern,
-  expected: spaceNameRule.expected,
+  expected: "canonical spaces/{space} resource ID",
 };
+const meetingCodePattern = /^[a-z]+-[a-z]+-[a-z]+$/iu;
 const conferenceRecordNameRule: ResourceNameRule = {
   pattern: /^conferenceRecords\/[^/]+$/u,
   expected: "conferenceRecords/{conference_record}",
@@ -195,7 +196,7 @@ async function getSpace(input: Record<string, unknown>, context: GoogleMeetRunti
 }
 
 async function updateSpace(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
-  const name = resolveResourceName(input.name, spaceNameRule);
+  const name = resolveCanonicalSpaceName(input.name);
   const space = requiredRecord(input.space, "space", (message) => new ProviderRequestError(400, message));
   return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}`, {
     context,
@@ -214,7 +215,7 @@ async function endActiveConference(
   input: Record<string, unknown>,
   context: GoogleMeetRuntimeContext,
 ): Promise<unknown> {
-  const name = resolveResourceName(input.name, canonicalSpaceNameRule);
+  const name = resolveCanonicalSpaceName(input.name);
   await googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}:endActiveConference`, {
     context,
     method: "POST",
@@ -324,6 +325,14 @@ function googleMeetJsonRequest<T = unknown>(url: string, input: GoogleMeetReques
 
 function resolveParent(value: unknown, rule: ResourceNameRule): string {
   return resolveResourceName(value, rule, "parent");
+}
+
+function resolveCanonicalSpaceName(value: unknown): string {
+  const name = resolveResourceName(value, canonicalSpaceNameRule);
+  if (meetingCodePattern.test(name.slice("spaces/".length))) {
+    throw new ProviderRequestError(400, "name must use the canonical spaces/{space} resource ID format");
+  }
+  return name;
 }
 
 function resolveResourceName(value: unknown, rule: ResourceNameRule, fieldName = "name"): string {

--- a/src/providers/googlemeet/executors.ts
+++ b/src/providers/googlemeet/executors.ts
@@ -1,0 +1,392 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+import type { OAuthProviderContext } from "../provider-runtime.ts";
+
+import { compactObject, optionalInteger, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
+import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import {
+  defineOAuthProviderExecutors,
+  defineProviderProxy,
+  providerProxyEndpointPrefixes,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
+import { googleMeetApiBaseUrl, googleMeetApiOrigin, googleMeetUserInfoUrl } from "./constants.ts";
+
+const service = "googlemeet";
+
+const spaceNameRule: ResourceNameRule = {
+  pattern: /^spaces\/[^/]+$/u,
+  expected: "spaces/{space}",
+  barePrefix: "spaces",
+};
+const strictSpaceNameRule: ResourceNameRule = {
+  pattern: spaceNameRule.pattern,
+  expected: spaceNameRule.expected,
+};
+const conferenceRecordNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}",
+  barePrefix: "conferenceRecords",
+};
+const participantNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/participants\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}/participants/{participant}",
+};
+const participantSessionNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/participants\/[^/]+\/participantSessions\/[^/]+$/u,
+  expected:
+    "conferenceRecords/{conference_record}/participants/{participant}/participantSessions/{participant_session}",
+};
+const recordingNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/recordings\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}/recordings/{recording}",
+};
+const transcriptNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/transcripts\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}/transcripts/{transcript}",
+};
+const transcriptEntryNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/transcripts\/[^/]+\/entries\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}/transcripts/{transcript}/entries/{entry}",
+};
+const smartNoteNameRule: ResourceNameRule = {
+  pattern: /^conferenceRecords\/[^/]+\/smartNotes\/[^/]+$/u,
+  expected: "conferenceRecords/{conference_record}/smartNotes/{smart_note}",
+};
+
+type GoogleMeetRuntimeContext = OAuthProviderContext;
+type GoogleMeetActionHandler = (input: Record<string, unknown>, context: GoogleMeetRuntimeContext) => Promise<unknown>;
+
+interface GoogleMeetRequestOptions {
+  context: Pick<GoogleMeetRuntimeContext, "accessToken" | "fetcher" | "signal">;
+  method?: string;
+  query?: Record<string, string | undefined>;
+  body?: unknown;
+}
+
+interface ResourceNameRule {
+  pattern: RegExp;
+  expected: string;
+  barePrefix?: string;
+}
+
+interface GoogleMeetListPayload {
+  conferenceRecords?: unknown;
+  participants?: unknown;
+  participantSessions?: unknown;
+  recordings?: unknown;
+  transcripts?: unknown;
+  transcriptEntries?: unknown;
+  smartNotes?: unknown;
+  nextPageToken?: unknown;
+  totalSize?: unknown;
+}
+
+export const googleMeetActionHandlers: Record<string, GoogleMeetActionHandler> = {
+  create_space: createSpace,
+  get_space: getSpace,
+  update_space: updateSpace,
+  end_active_conference: endActiveConference,
+  list_conference_records: listConferenceRecords,
+  get_conference_record: getConferenceRecord,
+  list_participants: listParticipants,
+  get_participant: getParticipant,
+  list_participant_sessions: listParticipantSessions,
+  get_participant_session: getParticipantSession,
+  list_recordings: listRecordings,
+  get_recording: getRecording,
+  list_transcripts: listTranscripts,
+  get_transcript: getTranscript,
+  list_transcript_entries: listTranscriptEntries,
+  get_transcript_entry: getTranscriptEntry,
+  list_smart_notes: listSmartNotes,
+  get_smart_note: getSmartNote,
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, googleMeetActionHandlers);
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: googleMeetApiOrigin,
+  auth: { type: "oauth_bearer" },
+  allowedEndpoint: providerProxyEndpointPrefixes("/v2"),
+});
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const profile = await googleJsonRequest<{
+      email?: string;
+      name?: string;
+      sub?: string;
+    }>(googleMeetUserInfoUrl, {
+      accessToken: input.accessToken,
+      fetcher,
+      signal,
+      service,
+    });
+    return {
+      profile: {
+        accountId: profile.email ?? profile.sub ?? "googlemeet:oauth2",
+        displayName: profile.name ?? profile.email ?? "Google Meet User",
+      },
+      metadata: {
+        currentAccount: profile,
+      },
+    };
+  },
+};
+
+async function createSpace(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/spaces`, {
+    context,
+    method: "POST",
+    body: optionalRecord(input.space) ?? {},
+  });
+}
+
+async function getSpace(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, spaceNameRule, context);
+}
+
+async function updateSpace(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const name = resolveResourceName(input.name, spaceNameRule);
+  const space = requiredRecord(input.space, "space", (message) => new ProviderRequestError(400, message));
+  return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}`, {
+    context,
+    method: "PATCH",
+    query: compactObject({
+      updateMask: optionalString(input.updateMask),
+    }),
+    body: {
+      ...space,
+      name,
+    },
+  });
+}
+
+async function endActiveConference(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  const name = resolveResourceName(input.name, strictSpaceNameRule);
+  await googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}:endActiveConference`, {
+    context,
+    method: "POST",
+    body: {},
+  });
+  return { success: true };
+}
+
+async function listConferenceRecords(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(`${googleMeetApiBaseUrl}/conferenceRecords`, {
+    context,
+    query: listQuery(input, true),
+  });
+  return {
+    conferenceRecords: arrayOrEmpty(payload.conferenceRecords),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getConferenceRecord(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  return getResource(input.name, conferenceRecordNameRule, context);
+}
+
+async function listParticipants(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const parent = resolveParent(input.parent, conferenceRecordNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/participants`,
+    {
+      context,
+      query: listQuery(input, true),
+    },
+  );
+  return compactObject({
+    participants: arrayOrEmpty(payload.participants),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+    totalSize: optionalInteger(payload.totalSize),
+  });
+}
+
+async function getParticipant(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, participantNameRule, context);
+}
+
+async function listParticipantSessions(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  const parent = resolveParent(input.parent, participantNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/participantSessions`,
+    {
+      context,
+      query: listQuery(input, true),
+    },
+  );
+  return {
+    participantSessions: arrayOrEmpty(payload.participantSessions),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getParticipantSession(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  return getResource(input.name, participantSessionNameRule, context);
+}
+
+async function listRecordings(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const parent = resolveParent(input.parent, conferenceRecordNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/recordings`,
+    {
+      context,
+      query: listQuery(input),
+    },
+  );
+  return {
+    recordings: arrayOrEmpty(payload.recordings),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getRecording(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, recordingNameRule, context);
+}
+
+async function listTranscripts(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const parent = resolveParent(input.parent, conferenceRecordNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/transcripts`,
+    {
+      context,
+      query: listQuery(input),
+    },
+  );
+  return {
+    transcripts: arrayOrEmpty(payload.transcripts),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getTranscript(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, transcriptNameRule, context);
+}
+
+async function listTranscriptEntries(
+  input: Record<string, unknown>,
+  context: GoogleMeetRuntimeContext,
+): Promise<unknown> {
+  const parent = resolveParent(input.parent, transcriptNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/entries`,
+    {
+      context,
+      query: listQuery(input),
+    },
+  );
+  return {
+    transcriptEntries: arrayOrEmpty(payload.transcriptEntries),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getTranscriptEntry(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, transcriptEntryNameRule, context);
+}
+
+async function listSmartNotes(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const parent = resolveParent(input.parent, conferenceRecordNameRule);
+  const payload = await googleMeetJsonRequest<GoogleMeetListPayload>(
+    `${googleMeetApiBaseUrl}/${encodeResourceName(parent)}/smartNotes`,
+    {
+      context,
+      query: listQuery(input),
+    },
+  );
+  return {
+    smartNotes: arrayOrEmpty(payload.smartNotes),
+    nextPageToken: optionalString(payload.nextPageToken) ?? null,
+  };
+}
+
+async function getSmartNote(input: Record<string, unknown>, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  return getResource(input.name, smartNoteNameRule, context);
+}
+
+function getResource(value: unknown, rule: ResourceNameRule, context: GoogleMeetRuntimeContext): Promise<unknown> {
+  const name = resolveResourceName(value, rule);
+  return googleMeetJsonRequest(`${googleMeetApiBaseUrl}/${encodeResourceName(name)}`, { context });
+}
+
+function googleMeetJsonRequest<T = unknown>(url: string, input: GoogleMeetRequestOptions): Promise<T> {
+  return googleJsonRequest<T>(url, {
+    accessToken: input.context.accessToken,
+    fetcher: input.context.fetcher,
+    signal: input.context.signal,
+    method: input.method,
+    query: input.query,
+    body: input.body,
+    service,
+  });
+}
+
+function resolveParent(value: unknown, rule: ResourceNameRule): string {
+  return resolveResourceName(value, rule, "parent");
+}
+
+function resolveResourceName(value: unknown, rule: ResourceNameRule, fieldName = "name"): string {
+  const raw = optionalString(value);
+  if (!raw) {
+    throw new ProviderRequestError(400, `${fieldName} is required`);
+  }
+
+  const trimmed = raw.replace(/^\/+|\/+$/gu, "");
+  const name = rule.barePrefix && !trimmed.includes("/") ? `${rule.barePrefix}/${trimmed}` : trimmed;
+  if (!rule.pattern.test(name) || hasUnsafeResourceSegment(name)) {
+    throw new ProviderRequestError(400, `${fieldName} must use the ${rule.expected} format`);
+  }
+  return name;
+}
+
+function hasUnsafeResourceSegment(name: string): boolean {
+  return name.split("/").some((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\");
+    } catch {
+      return true;
+    }
+  });
+}
+
+function encodeResourceName(name: string): string {
+  return name
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function listQuery(input: Record<string, unknown>, supportsFilter = false): Record<string, string | undefined> {
+  return compactObject({
+    filter: supportsFilter ? optionalString(input.filter) : undefined,
+    pageSize: integerQuery(input.pageSize),
+    pageToken: optionalString(input.pageToken),
+  });
+}
+
+function integerQuery(value: unknown): string | undefined {
+  const resolved = optionalInteger(value);
+  return resolved === undefined ? undefined : String(resolved);
+}
+
+function arrayOrEmpty(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/src/providers/googlemeet/scopes.ts
+++ b/src/providers/googlemeet/scopes.ts
@@ -1,0 +1,19 @@
+export const googleMeetSpaceCreatedScope = "https://www.googleapis.com/auth/meetings.space.created";
+export const googleMeetSpaceReadonlyScope = "https://www.googleapis.com/auth/meetings.space.readonly";
+export const googleMeetSpaceSettingsScope = "https://www.googleapis.com/auth/meetings.space.settings";
+export const googleOpenIdScope = "openid";
+export const googleEmailScope = "email";
+export const googleProfileScope = "profile";
+
+export const googleMeetCreateScopes: string[] = [googleMeetSpaceCreatedScope];
+export const googleMeetReadScopes: string[] = [googleMeetSpaceReadonlyScope];
+export const googleMeetSettingsScopes: string[] = [googleMeetSpaceSettingsScope];
+
+export const googleMeetOAuthScopes: string[] = [
+  googleMeetSpaceCreatedScope,
+  googleMeetSpaceReadonlyScope,
+  googleMeetSpaceSettingsScope,
+  googleOpenIdScope,
+  googleEmailScope,
+  googleProfileScope,
+];

--- a/src/providers/googleslides/executors.ts
+++ b/src/providers/googleslides/executors.ts
@@ -3,7 +3,7 @@ import type { OAuthProviderContext } from "../provider-runtime.ts";
 import type { GoogleSlidesActionName } from "./actions.ts";
 
 import { compactObject, objectArray, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 
 export const slidesApiBaseUrl = "https://slides.googleapis.com/v1";

--- a/src/providers/googletasks/executors.ts
+++ b/src/providers/googletasks/executors.ts
@@ -10,7 +10,7 @@ import {
   pickOptionalInteger,
   pickOptionalString,
 } from "../../core/cast.ts";
-import { googleJsonRequest, googleRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 export const googleTasksApiBaseUrl = "https://tasks.googleapis.com/tasks/v1";

--- a/src/providers/youtube/executors.ts
+++ b/src/providers/youtube/executors.ts
@@ -1,6 +1,6 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
-import { googleJsonRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest } from "../google-runtime.ts";
 import {
   defineOAuthProviderExecutors,
   defineProviderProxy,

--- a/src/providers/youtube/runtime.ts
+++ b/src/providers/youtube/runtime.ts
@@ -4,7 +4,7 @@ import type { YoutubeActionName } from "./actions.ts";
 import { randomUUID } from "node:crypto";
 import { compactObject, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
-import { googleJsonRequest, googleRequest } from "../googledrive/runtime-shared.ts";
+import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const youtubeApiBaseUrl = "https://www.googleapis.com/youtube/v3";


### PR DESCRIPTION
## Summary

- add a locally executable `googlemeet` provider using Google OAuth 2.0
- cover the complete current Meet REST API v2 surface with 18 actions for spaces, conference records, participants, participant sessions, recordings, transcripts, transcript entries, and smart notes
- add OAuth credential validation through Google user info and a guarded proxy restricted to `/v2`
- preserve provider-native scopes in action metadata and request offline access for refresh tokens
- move the generic Google request transport to a shared runtime module used by Google providers

## OAuth and API behavior

- authorization endpoint: `https://accounts.google.com/o/oauth2/v2/auth`
- token endpoint: `https://oauth2.googleapis.com/token`
- Meet scopes: `meetings.space.created`, `meetings.space.readonly`, and `meetings.space.settings`
- identity scopes: `openid`, `email`, and `profile`
- API origin: `https://meet.googleapis.com`

The implementation follows the official [Google Meet REST API v2 reference](https://developers.google.com/workspace/meet/api/reference/rest/v2) and [Google OAuth authorization guide](https://developers.google.com/workspace/meet/api/guides/authenticate-authorize).

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npx vitest run src/providers/googlemeet/executors.test.ts` (15 tests)
- `npm test` (97 files, 928 tests)

## Third-party assets

No provider logo is included. The repository contribution policy requires distribution rights for third-party brand assets, and current upstream intentionally does not keep local provider SVGs.
