### PR TITLE
feat(cloudflare): let Browser Run connect with OAuth

### DIFF
--- a/src/providers/cloudflare_browser_rendering/actions.ts
+++ b/src/providers/cloudflare_browser_rendering/actions.ts
@@ -52,6 +52,9 @@ const waitForSelectorSchema = s.object(
 );
 
 const commonQuickActionFields: Record<string, JsonSchema> = {
+  accountId: s.nonEmptyString(
+    "The Cloudflare account ID. OAuth connections that can access multiple accounts must provide this value.",
+  ),
   url: s.string({
     format: "uri",
     minLength: 1,
@@ -72,6 +75,7 @@ const commonQuickActionFields: Record<string, JsonSchema> = {
 };
 
 const commonQuickActionOptionalFields = [
+  "accountId",
   "url",
   "html",
   "cacheTtl",
@@ -147,14 +151,14 @@ export const cloudflareBrowserRenderingActions: ProviderActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_accounts",
     description:
-      "List Cloudflare accounts accessible to the API token so callers can confirm account IDs used by Browser Run actions.",
+      "List Cloudflare accounts accessible to the current connection so callers can confirm account IDs used by Browser Run actions.",
     inputSchema: paginationInputSchema,
     outputSchema: s.actionOutput(
       {
-        accounts: s.array("Cloudflare accounts visible to the API token.", cloudflareAccountSchema),
+        accounts: s.array("Cloudflare accounts visible to the current connection.", cloudflareAccountSchema),
         resultInfo: cloudflareResultInfoSchema,
       },
-      "The Cloudflare accounts visible to the API token.",
+      "The Cloudflare accounts visible to the current connection.",
     ),
   }),
   defineProviderAction(service, {

--- a/src/providers/cloudflare_browser_rendering/definition.test.ts
+++ b/src/providers/cloudflare_browser_rendering/definition.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { provider } from "./definition.ts";
+
+describe("Cloudflare Browser Run provider definition", () => {
+  it("offers Cloudflare OAuth with the Browser Run scopes", () => {
+    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+
+    expect(provider.authTypes).toEqual(["api_key", "oauth2"]);
+    expect(oauth).toMatchObject({
+      authorizationUrl: "https://dash.cloudflare.com/oauth2/auth",
+      tokenUrl: "https://dash.cloudflare.com/oauth2/token",
+      refreshTokenUrl: "https://dash.cloudflare.com/oauth2/token",
+      scopes: ["browser-rendering.read", "browser-rendering.write"],
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+  });
+});

--- a/src/providers/cloudflare_browser_rendering/definition.test.ts
+++ b/src/providers/cloudflare_browser_rendering/definition.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { provider } from "./definition.ts";
 
 describe("Cloudflare Browser Run provider definition", () => {
-  it("offers Cloudflare OAuth with the Browser Run scopes", () => {
+  it("offers Cloudflare OAuth with account discovery and Browser Run scopes", () => {
     const oauth = provider.auth.find((auth) => auth.type === "oauth2");
 
     expect(provider.authTypes).toEqual(["api_key", "oauth2"]);
@@ -10,7 +10,7 @@ describe("Cloudflare Browser Run provider definition", () => {
       authorizationUrl: "https://dash.cloudflare.com/oauth2/auth",
       tokenUrl: "https://dash.cloudflare.com/oauth2/token",
       refreshTokenUrl: "https://dash.cloudflare.com/oauth2/token",
-      scopes: ["browser-rendering.read", "browser-rendering.write"],
+      scopes: ["memberships.read", "browser-rendering.read", "browser-rendering.write"],
       tokenEndpointAuthMethod: "client_secret_basic",
     });
   });

--- a/src/providers/cloudflare_browser_rendering/definition.ts
+++ b/src/providers/cloudflare_browser_rendering/definition.ts
@@ -8,7 +8,7 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Cloudflare Browser Run",
   categories: ["Developer Tools", "Data"],
-  authTypes: ["api_key"],
+  authTypes: ["api_key", "oauth2"],
   auth: [
     {
       type: "api_key",
@@ -28,6 +28,14 @@ export const provider: ProviderDefinition = {
             "Cloudflare account ID used in Browser Run API paths. Find it from https://developers.cloudflare.com/fundamentals/account/find-account-and-zone-ids/.",
         },
       ],
+    },
+    {
+      type: "oauth2",
+      authorizationUrl: "https://dash.cloudflare.com/oauth2/auth",
+      tokenUrl: "https://dash.cloudflare.com/oauth2/token",
+      refreshTokenUrl: "https://dash.cloudflare.com/oauth2/token",
+      scopes: ["browser-rendering.read", "browser-rendering.write"],
+      tokenEndpointAuthMethod: "client_secret_basic",
     },
   ],
   homepageUrl: "https://developers.cloudflare.com/browser-run/",

--- a/src/providers/cloudflare_browser_rendering/definition.ts
+++ b/src/providers/cloudflare_browser_rendering/definition.ts
@@ -34,7 +34,7 @@ export const provider: ProviderDefinition = {
       authorizationUrl: "https://dash.cloudflare.com/oauth2/auth",
       tokenUrl: "https://dash.cloudflare.com/oauth2/token",
       refreshTokenUrl: "https://dash.cloudflare.com/oauth2/token",
-      scopes: ["browser-rendering.read", "browser-rendering.write"],
+      scopes: ["memberships.read", "browser-rendering.read", "browser-rendering.write"],
       tokenEndpointAuthMethod: "client_secret_basic",
     },
   ],

--- a/src/providers/cloudflare_browser_rendering/executors.test.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.test.ts
@@ -12,7 +12,7 @@ function oauthCredential(metadata: Record<string, unknown>): Extract<ResolvedCre
     profile: {
       accountId: "cloudflare:test",
       displayName: "Cloudflare Browser Run",
-      grantedScopes: ["browser-rendering.read", "browser-rendering.write"],
+      grantedScopes: ["memberships.read", "browser-rendering.read", "browser-rendering.write"],
     },
     metadata,
   };
@@ -46,7 +46,13 @@ describe("Cloudflare Browser Run OAuth", () => {
     const fetch = vi.fn(async () =>
       Response.json({
         success: true,
-        result: [{ id: "account-1", name: "Amplift", type: "standard" }],
+        result: [
+          {
+            id: "membership-1",
+            account: { id: "account-1", name: "Amplift", type: "standard" },
+            status: "accepted",
+          },
+        ],
         result_info: { page: 1, per_page: 50, count: 1, total_count: 1, total_pages: 1 },
       }),
     );
@@ -54,13 +60,48 @@ describe("Cloudflare Browser Run OAuth", () => {
     const result = await credentialValidators.oauth2!(oauthCredential({}), { fetcher: fetch });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.cloudflare.com/client/v4/accounts?page=1&per_page=50",
+      "https://api.cloudflare.com/client/v4/memberships?page=1&per_page=50&status=accepted",
       expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer oauth-access-token" }) }),
     );
     expect(result).toMatchObject({
       profile: { accountId: "account-1", displayName: "Amplift" },
       metadata: { accountId: "account-1", accountName: "Amplift", accountType: "standard" },
     });
+  });
+
+  it("lists OAuth accounts through Cloudflare memberships", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        success: true,
+        result: [
+          {
+            id: "membership-1",
+            account: { id: "account-1", name: "Amplift", type: "standard" },
+            status: "accepted",
+          },
+        ],
+        result_info: { page: 1, per_page: 50, count: 1, total_count: 1 },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+
+    const result = await executors["cloudflare_browser_rendering.list_accounts"]!(
+      {},
+      executionContext(oauthCredential({ accountId: "account-1" })),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        accounts: [{ id: "account-1", name: "Amplift", type: "standard" }],
+        resultInfo: { page: 1, perPage: 50, count: 1, totalCount: 1 },
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/memberships?page=1&per_page=50&status=accepted",
+      expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer oauth-access-token" }) }),
+    );
   });
 
   it("executes Browser Run with the OAuth bearer token and resolved account", async () => {

--- a/src/providers/cloudflare_browser_rendering/executors.test.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.test.ts
@@ -1,0 +1,147 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { credentialValidators, executors, proxy } from "./executors.ts";
+
+function oauthCredential(metadata: Record<string, unknown>): Extract<ResolvedCredential, { authType: "oauth2" }> {
+  return {
+    authType: "oauth2",
+    accessToken: "oauth-access-token",
+    tokenType: "Bearer",
+    profile: {
+      accountId: "cloudflare:test",
+      displayName: "Cloudflare Browser Run",
+      grantedScopes: ["browser-rendering.read", "browser-rendering.write"],
+    },
+    metadata,
+  };
+}
+
+function executionContext(credential: ResolvedCredential): ExecutionContext {
+  return { getCredential: async () => credential };
+}
+
+function apiKeyCredential(): Extract<ResolvedCredential, { authType: "api_key" }> {
+  return {
+    authType: "api_key",
+    apiKey: "api-key-token",
+    values: { accountId: "account-1" },
+    profile: {
+      accountId: "account-1",
+      displayName: "Cloudflare Browser Run",
+      grantedScopes: [],
+    },
+    metadata: { accountId: "account-1" },
+  };
+}
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("Cloudflare Browser Run OAuth", () => {
+  it("validates OAuth by resolving the one accessible Cloudflare account", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({
+        success: true,
+        result: [{ id: "account-1", name: "Amplift", type: "standard" }],
+        result_info: { page: 1, per_page: 50, count: 1, total_count: 1, total_pages: 1 },
+      }),
+    );
+
+    const result = await credentialValidators.oauth2!(oauthCredential({}), { fetcher: fetch });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts?page=1&per_page=50",
+      expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer oauth-access-token" }) }),
+    );
+    expect(result).toMatchObject({
+      profile: { accountId: "account-1", displayName: "Amplift" },
+      metadata: { accountId: "account-1", accountName: "Amplift", accountType: "standard" },
+    });
+  });
+
+  it("executes Browser Run with the OAuth bearer token and resolved account", async () => {
+    const fetch = vi.fn(async () => Response.json({ success: true, result: "# OpenMeld" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+
+    const result = await executors["cloudflare_browser_rendering.get_markdown"]!(
+      { url: "https://openmeld.ai" },
+      executionContext(oauthCredential({ accountId: "account-1" })),
+    );
+
+    expect(result).toEqual({ ok: true, output: { markdown: "# OpenMeld" } });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts/account-1/browser-rendering/markdown",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ authorization: "Bearer oauth-access-token" }),
+      }),
+    );
+  });
+
+  it("uses OAuth for raw proxy requests", async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ success: true, result: [] }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+
+    const result = await proxy(
+      { method: "GET", endpoint: "/accounts" },
+      executionContext(oauthCredential({ accountId: "account-1" })),
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    expect(fetch.mock.calls[0]?.[0]).toBe("https://api.cloudflare.com/client/v4/accounts");
+    expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get("authorization")).toBe("Bearer oauth-access-token");
+  });
+
+  it("keeps API token actions working", async () => {
+    const fetch = vi.fn(async () => Response.json({ success: true, result: "# OpenMeld" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+
+    const result = await executors["cloudflare_browser_rendering.get_markdown"]!(
+      { url: "https://openmeld.ai" },
+      executionContext(apiKeyCredential()),
+    );
+
+    expect(result).toEqual({ ok: true, output: { markdown: "# OpenMeld" } });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.cloudflare.com/client/v4/accounts/account-1/browser-rendering/markdown",
+      expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer api-key-token" }) }),
+    );
+  });
+
+  it("requires an explicit accessible account when OAuth can reach more than one", async () => {
+    const fetch = vi.fn(async () => Response.json({ success: true, result: "# OpenMeld" }));
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(null);
+    const credential = oauthCredential({
+      availableAccounts: [
+        { id: "account-1", name: "Amplift" },
+        { id: "account-2", name: "Personal" },
+      ],
+    });
+
+    const missingAccount = await executors["cloudflare_browser_rendering.get_markdown"]!(
+      { url: "https://openmeld.ai" },
+      executionContext(credential),
+    );
+    const selectedAccount = await executors["cloudflare_browser_rendering.get_markdown"]!(
+      { accountId: "account-1", url: "https://openmeld.ai" },
+      executionContext(credential),
+    );
+
+    expect(missingAccount).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("accountId is required") },
+    });
+    expect(selectedAccount).toEqual({ ok: true, output: { markdown: "# OpenMeld" } });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/providers/cloudflare_browser_rendering/executors.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.ts
@@ -146,7 +146,12 @@ export const credentialValidators: CredentialValidators = {
     };
   },
   async oauth2(input, { fetcher, signal }) {
-    const result = await requestAccounts(input.accessToken, { fetcher, signal }, { page: 1, perPage: 50 });
+    const result = await requestOAuthAccounts(
+      input.accessToken,
+      { fetcher, signal },
+      { page: 1, perPage: 50 },
+      "validate",
+    );
     if (result.accounts.length === 0) {
       throw new ProviderRequestError(400, "Cloudflare OAuth cannot access any accounts.");
     }
@@ -164,7 +169,7 @@ export const credentialValidators: CredentialValidators = {
         grantedScopes: input.profile.grantedScopes,
         metadata: compactObject({
           apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
-          validationEndpoint: "/accounts?page=1&per_page=50",
+          validationEndpoint: "/memberships?page=1&per_page=50&status=accepted",
           accountId,
           accountName,
           accountType: optionalString(account.type),
@@ -180,7 +185,7 @@ export const credentialValidators: CredentialValidators = {
       grantedScopes: input.profile.grantedScopes,
       metadata: {
         apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
-        validationEndpoint: "/accounts?page=1&per_page=50",
+        validationEndpoint: "/memberships?page=1&per_page=50&status=accepted",
         availableAccounts: result.accounts,
       },
     };
@@ -191,10 +196,39 @@ async function listAccounts(
   input: Record<string, unknown>,
   context: CloudflareBrowserRenderingContext,
 ): Promise<unknown> {
-  return requestAccounts(context.accessToken, context, {
+  const pagination = {
     page: optionalInteger(input.page),
     perPage: optionalInteger(input.perPage),
-  });
+  };
+  return context.authType === "oauth2"
+    ? requestOAuthAccounts(context.accessToken, context, pagination)
+    : requestAccounts(context.accessToken, context, pagination);
+}
+
+async function requestOAuthAccounts(
+  accessToken: string,
+  context: Pick<CloudflareBrowserRenderingContext, "fetcher" | "signal">,
+  input: { page?: number; perPage?: number } = {},
+  phase: CloudflareRequestPhase = "execute",
+): Promise<{ accounts: Array<Record<string, unknown>>; resultInfo: Record<string, unknown> }> {
+  const envelope = await cloudflareRequestEnvelope(
+    accessToken,
+    {
+      path: "/memberships",
+      query: {
+        page: input.page ?? 1,
+        per_page: input.perPage ?? 50,
+        status: "accepted",
+      },
+    },
+    context,
+    phase,
+  );
+
+  return {
+    accounts: normalizeMembershipAccountList(envelope.result),
+    resultInfo: normalizeResultInfo(envelope.result_info),
+  };
 }
 
 async function requestAccounts(
@@ -563,6 +597,16 @@ function normalizeAccountList(value: unknown): Array<Record<string, unknown>> {
     throw new ProviderRequestError(502, "malformed cloudflare accounts response");
   }
   return value.map((item) => normalizeAccount(item));
+}
+
+function normalizeMembershipAccountList(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(502, "malformed cloudflare memberships response");
+  }
+  return value.map((item) => {
+    const membership = readObject(item, "cloudflare membership");
+    return normalizeAccount(membership.account);
+  });
 }
 
 function normalizeAccount(value: unknown): Record<string, unknown> {

--- a/src/providers/cloudflare_browser_rendering/executors.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.ts
@@ -17,7 +17,6 @@ import {
   defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  requireApiKeyCredential,
 } from "../provider-runtime.ts";
 
 const service = "cloudflare_browser_rendering";
@@ -36,8 +35,10 @@ interface CloudflareEnvelope {
 }
 
 interface CloudflareBrowserRenderingContext {
-  apiToken: string;
-  accountId: string;
+  authType: "api_key" | "oauth2";
+  accessToken: string;
+  accountId?: string;
+  metadata: Record<string, unknown>;
   fetcher: ProviderFetch;
   signal?: AbortSignal;
 }
@@ -75,20 +76,35 @@ export const executors: ProviderExecutors = defineProviderExecutors<CloudflareBr
   service,
   handlers: cloudflareBrowserRenderingActionHandlers,
   async createContext(context, fetcher): Promise<CloudflareBrowserRenderingContext> {
-    const credential = await requireApiKeyCredential(context, service);
-    return {
-      apiToken: credential.apiKey,
-      accountId: requireAccountId(credential.values),
-      fetcher,
-      signal: context.signal,
-    };
+    const credential = await context.getCredential(service);
+    if (credential?.authType === "api_key") {
+      return {
+        authType: "api_key",
+        accessToken: credential.apiKey,
+        accountId: requireAccountId(credential.values),
+        metadata: credential.metadata,
+        fetcher,
+        signal: context.signal,
+      };
+    }
+    if (credential?.authType === "oauth2") {
+      return {
+        authType: "oauth2",
+        accessToken: credential.accessToken,
+        accountId: optionalString(credential.metadata.accountId),
+        metadata: credential.metadata,
+        fetcher,
+        signal: context.signal,
+      };
+    }
+    throw new ProviderRequestError(401, "Connect Cloudflare Browser Run first.");
   },
 });
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: cloudflareBrowserRenderingApiBaseUrl,
-  auth: { type: "api_key_authorization", prefix: "Bearer " },
+  auth: { type: "bearer" },
 });
 
 export const credentialValidators: CredentialValidators = {
@@ -129,20 +145,71 @@ export const credentialValidators: CredentialValidators = {
       }),
     };
   },
+  async oauth2(input, { fetcher, signal }) {
+    const result = await requestAccounts(input.accessToken, { fetcher, signal }, { page: 1, perPage: 50 });
+    if (result.accounts.length === 0) {
+      throw new ProviderRequestError(400, "Cloudflare OAuth cannot access any accounts.");
+    }
+
+    const totalCount = optionalInteger(result.resultInfo.totalCount);
+    if (result.accounts.length === 1 && totalCount === 1) {
+      const account = result.accounts[0]!;
+      const accountId = readRequiredString(account, "id");
+      const accountName = readRequiredString(account, "name");
+      return {
+        profile: {
+          accountId,
+          displayName: accountName,
+        },
+        grantedScopes: input.profile.grantedScopes,
+        metadata: compactObject({
+          apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
+          validationEndpoint: "/accounts?page=1&per_page=50",
+          accountId,
+          accountName,
+          accountType: optionalString(account.type),
+        }),
+      };
+    }
+
+    return {
+      profile: {
+        accountId: input.profile.accountId,
+        displayName: "Cloudflare Browser Run",
+      },
+      grantedScopes: input.profile.grantedScopes,
+      metadata: {
+        apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
+        validationEndpoint: "/accounts?page=1&per_page=50",
+        availableAccounts: result.accounts,
+      },
+    };
+  },
 };
 
 async function listAccounts(
   input: Record<string, unknown>,
   context: CloudflareBrowserRenderingContext,
 ): Promise<unknown> {
+  return requestAccounts(context.accessToken, context, {
+    page: optionalInteger(input.page),
+    perPage: optionalInteger(input.perPage),
+  });
+}
+
+async function requestAccounts(
+  accessToken: string,
+  context: Pick<CloudflareBrowserRenderingContext, "fetcher" | "signal">,
+  input: { page?: number; perPage?: number } = {},
+): Promise<{ accounts: Array<Record<string, unknown>>; resultInfo: Record<string, unknown> }> {
   const envelope = await cloudflareRequestEnvelope(
-    context.apiToken,
+    accessToken,
     {
       path: "/accounts",
-      query: compactObject({
-        page: optionalInteger(input.page),
-        per_page: optionalInteger(input.perPage),
-      }),
+      query: {
+        page: input.page ?? 1,
+        per_page: input.perPage ?? 50,
+      },
     },
     context,
     "execute",
@@ -251,11 +318,13 @@ async function runQuickAction(
     assertJsonExtractionInstruction(input);
   }
 
+  const accountId = resolveAccountId(input, context);
+
   return cloudflareRequestEnvelope(
-    context.apiToken,
+    context.accessToken,
     {
       method: "POST",
-      path: `/accounts/${encodeURIComponent(context.accountId)}/browser-rendering/${endpoint}`,
+      path: `/accounts/${encodeURIComponent(accountId)}/browser-rendering/${endpoint}`,
       query: compactObject({
         cacheTTL: optionalNumber(input.cacheTtl),
       }),
@@ -264,6 +333,37 @@ async function runQuickAction(
     context,
     "execute",
   );
+}
+
+function resolveAccountId(input: Record<string, unknown>, context: CloudflareBrowserRenderingContext): string {
+  const inputAccountId = optionalString(input.accountId);
+  const accountId = context.accountId ?? optionalString(context.metadata.accountId) ?? inputAccountId;
+  if (!accountId) {
+    throw new ProviderRequestError(
+      400,
+      Array.isArray(context.metadata.availableAccounts)
+        ? "accountId is required for this Cloudflare Browser Run action because the OAuth connection can access multiple accounts."
+        : "accountId is required in the connected Cloudflare Browser Run credential.",
+    );
+  }
+  if (context.authType === "api_key" && inputAccountId && inputAccountId !== accountId) {
+    throw new ProviderRequestError(400, "accountId must match the connected Cloudflare Browser Run credential.");
+  }
+  ensureAccountIsAvailable(accountId, context.metadata);
+  return accountId;
+}
+
+function ensureAccountIsAvailable(accountId: string, metadata: Record<string, unknown>): void {
+  if (!Array.isArray(metadata.availableAccounts)) {
+    return;
+  }
+  const matched = metadata.availableAccounts.some((item) => optionalString(optionalRecord(item)?.id) === accountId);
+  if (!matched) {
+    throw new ProviderRequestError(
+      400,
+      "accountId must be one of the Cloudflare accounts accessible through this OAuth connection.",
+    );
+  }
 }
 
 function buildQuickActionBody(input: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- advertise Cloudflare OAuth for Browser Run with the official read/write scopes
- resolve a single accessible account automatically and require explicit account selection when OAuth reaches multiple accounts
- use OAuth bearer credentials for actions and proxy requests while preserving API-token support

## Tests
- focused Browser Run definition and executor tests (6 passed)
- full test suite (98 files, 911 tests passed)
- `npm run fix-check`

## Notes
The implementation follows the existing Cloudflare Worker and R2 account-selection contract. It does not choose an arbitrary account when an OAuth connection can access more than one.