### PR TITLE
fix(run-log): keep summaries intact when a URL-like value cannot be parsed

### DIFF
--- a/src/server/actions/run-log-summary.test.ts
+++ b/src/server/actions/run-log-summary.test.ts
@@ -114,6 +114,18 @@ describe("summarizeForRunLog", () => {
     const long = `https://exa mple.com/${"a".repeat(300)}`;
     expect(summarizeForRunLog({ url: long })).toEqual({ url: `${long.slice(0, 256)}[truncated]` });
   });
+
+  it("redacts unparseable URL-like strings with sensitive raw query keys", () => {
+    expect(
+      summarizeForRunLog({
+        url: "https://exa mple.com/?token=abc",
+        items: ["https://?api_key=SECRET", "https://exa mple.com/?safe=1"],
+      }),
+    ).toEqual({
+      url: "[redacted-url]",
+      items: ["[redacted-url]", "https://exa mple.com/?safe=1"],
+    });
+  });
 });
 
 describe("safeRunLogError", () => {

--- a/src/server/actions/run-log-summary.test.ts
+++ b/src/server/actions/run-log-summary.test.ts
@@ -85,6 +85,35 @@ describe("summarizeForRunLog", () => {
   it("does not enumerate large typed arrays", () => {
     expect(summarizeForRunLog(new Uint8Array(1_000_000))).toBe("[unavailable]");
   });
+
+  it("keeps summarizing the rest of the value when a URL-like string cannot be parsed", () => {
+    expect(
+      summarizeForRunLog({
+        url: "https://",
+        items: ["https://ok.example/x", "http://exa mple.com/y"],
+      }),
+    ).toEqual({
+      url: "https://",
+      items: ["https://ok.example", "http://exa mple.com/y"],
+    });
+  });
+
+  it("redacts unparseable URL-like strings in sensitive contexts", () => {
+    expect(
+      summarizeForRunLog({
+        webhook: { url: "https://hooks.slack.com/services/T000/B000/ SECRET" },
+        downloadUrl: "https://",
+      }),
+    ).toEqual({
+      webhook: { url: "[redacted-url]" },
+      downloadUrl: "[redacted-url]",
+    });
+  });
+
+  it("truncates long unparseable URL-like strings", () => {
+    const long = `https://exa mple.com/${"a".repeat(300)}`;
+    expect(summarizeForRunLog({ url: long })).toEqual({ url: `${long.slice(0, 256)}[truncated]` });
+  });
 });
 
 describe("safeRunLogError", () => {

--- a/src/server/actions/run-log-summary.ts
+++ b/src/server/actions/run-log-summary.ts
@@ -114,11 +114,33 @@ function summarizeString(value: string, path: string[]): string {
     } catch {
       // Not a parseable URL. Keep the rest of the audit record intact instead
       // of letting one malformed value collapse the whole summary, but still
-      // redact when the value sits in a sensitive URL context.
-      if (sensitiveUrlContextPattern.test(path.join("."))) {
+      // redact when the value sits in a sensitive URL context or carries a
+      // sensitive query key.
+      if (sensitiveUrlContextPattern.test(path.join(".")) || hasSensitiveQueryKey(value)) {
         return "[redacted-url]";
       }
     }
   }
   return value.length > maxStringLength ? `${value.slice(0, maxStringLength)}[truncated]` : value;
+}
+
+/** Whether the raw query of an unparseable URL-like value contains a sensitive key. */
+function hasSensitiveQueryKey(value: string): boolean {
+  const queryStart = value.indexOf("?");
+  if (queryStart === -1) {
+    return false;
+  }
+  return value
+    .slice(queryStart + 1)
+    .split("&")
+    .some((pair) => {
+      const [encodedName] = pair.split("=");
+      let name = encodedName;
+      try {
+        name = decodeURIComponent(encodedName);
+      } catch {
+        // Keep the raw name when the encoding is malformed.
+      }
+      return sensitiveKeyPattern.test(name);
+    });
 }

--- a/src/server/actions/run-log-summary.ts
+++ b/src/server/actions/run-log-summary.ts
@@ -102,14 +102,23 @@ function summarizeString(value: string, path: string[]): string {
     return "[redacted]";
   }
   if (/^https?:\/\//i.test(value)) {
-    const url = new URL(value);
-    if (
-      sensitiveUrlContextPattern.test(path.join(".")) ||
-      [...url.searchParams.keys()].some((name) => sensitiveKeyPattern.test(name))
-    ) {
-      return "[redacted-url]";
+    try {
+      const url = new URL(value);
+      if (
+        sensitiveUrlContextPattern.test(path.join(".")) ||
+        [...url.searchParams.keys()].some((name) => sensitiveKeyPattern.test(name))
+      ) {
+        return "[redacted-url]";
+      }
+      return url.origin;
+    } catch {
+      // Not a parseable URL. Keep the rest of the audit record intact instead
+      // of letting one malformed value collapse the whole summary, but still
+      // redact when the value sits in a sensitive URL context.
+      if (sensitiveUrlContextPattern.test(path.join("."))) {
+        return "[redacted-url]";
+      }
     }
-    return url.origin;
   }
   return value.length > maxStringLength ? `${value.slice(0, maxStringLength)}[truncated]` : value;
 }


### PR DESCRIPTION
Closes #331

### Problem

`summarizeForRunLog()` collapses the whole input/output summary to `"[unavailable]"` whenever a value that looks like a URL can't be parsed (`new URL()` throws on e.g. `"https://"` or URLs with spaces). Since the summarizer is wrapped in a single try/catch, one bad string also wipes valid sibling fields, so the run audit trail loses the actual (redacted) details.

### Change

- `summarizeString()` catches the parse failure and falls back to plain-string handling (still length-truncated).
- Values in sensitive URL contexts (`webhook`, `download`, `callback`, ...) are still redacted as `"[redacted-url]"` even when unparseable.
- Unparseable values that carry a sensitive query key (`token`, `api_key`, ...) are redacted too, so the fallback can't leak a credential that a malformed URL would otherwise hide.

### Tests

Added regression tests covering:

- unparseable URL-like values no longer poison sibling fields
- sensitive contexts still redact unparseable values
- unparseable values with sensitive raw query keys are redacted
- long unparseable values are still truncated

Verified with `npm test` (909 passing), `npm run lint`, `npx oxfmt --check` on the touched files, and `npm run typecheck`.