### PR TITLE
fix(actions): keep run-log summary alive when a URL-like value won't parse

### DIFF
--- a/src/server/actions/run-log-summary.test.ts
+++ b/src/server/actions/run-log-summary.test.ts
@@ -94,3 +94,31 @@ describe("safeRunLogError", () => {
     ).toEqual({ errorCode: "provider_error", errorMessage: "The provider request failed." });
   });
 });
+
+describe("summarizeForRunLog with malformed URL-like strings", () => {
+  it("keeps parseable values and sibling fields instead of collapsing to [unavailable]", () => {
+    expect(summarizeForRunLog({ url: "https://", items: ["https://ok.example/x"] })).toEqual({
+      url: "https://",
+      items: ["https://ok.example"],
+    });
+  });
+
+  it("keeps a URL containing a space as a plain string", () => {
+    expect(summarizeForRunLog({ url: "http://exa mple.com/x" })).toEqual({ url: "http://exa mple.com/x" });
+  });
+
+  it("redacts malformed URLs in sensitive contexts", () => {
+    expect(summarizeForRunLog({ webhookUrl: "http://exa mple.com/hooks" })).toEqual({ webhookUrl: "[redacted-url]" });
+  });
+
+  it("redacts malformed URLs carrying sensitive query params", () => {
+    expect(summarizeForRunLog({ url: "http://exa mple.com/x?token=abc" })).toEqual({ url: "[redacted-url]" });
+  });
+
+  it("truncates long malformed URL-like strings like any other long string", () => {
+    const long = "http://exa mple.com/" + "x".repeat(300);
+    expect(summarizeForRunLog({ url: long })).toEqual({
+      url: "http://exa mple.com/" + "x".repeat(236) + "[truncated]",
+    });
+  });
+});

--- a/src/server/actions/run-log-summary.ts
+++ b/src/server/actions/run-log-summary.ts
@@ -97,19 +97,44 @@ function summarizeObject(value: object, path: string[], depth: number, state: Su
   }
 }
 
+function truncateString(value: string): string {
+  return value.length > maxStringLength ? `${value.slice(0, maxStringLength)}[truncated]` : value;
+}
+
+function hasSensitiveQueryParam(value: string): boolean {
+  const query = value.split("?")[1];
+  if (!query) {
+    return false;
+  }
+  return query
+    .split("&")
+    .map((part) => part.split("=")[0])
+    .some((name) => sensitiveKeyPattern.test(name));
+}
+
 function summarizeString(value: string, path: string[]): string {
   if (credentialValuePattern.test(value)) {
     return "[redacted]";
   }
   if (/^https?:\/\//i.test(value)) {
-    const url = new URL(value);
-    if (
-      sensitiveUrlContextPattern.test(path.join(".")) ||
-      [...url.searchParams.keys()].some((name) => sensitiveKeyPattern.test(name))
-    ) {
-      return "[redacted-url]";
+    try {
+      const url = new URL(value);
+      if (
+        sensitiveUrlContextPattern.test(path.join(".")) ||
+        [...url.searchParams.keys()].some((name) => sensitiveKeyPattern.test(name))
+      ) {
+        return "[redacted-url]";
+      }
+      return url.origin;
+    } catch {
+      // The value only looks like a URL. Keep the rest of the summary alive
+      // instead of letting a single bad string collapse it to "[unavailable]".
+      // Redaction still applies when the context or the raw query says so.
+      if (sensitiveUrlContextPattern.test(path.join(".")) || hasSensitiveQueryParam(value)) {
+        return "[redacted-url]";
+      }
+      return truncateString(value);
     }
-    return url.origin;
   }
-  return value.length > maxStringLength ? `${value.slice(0, maxStringLength)}[truncated]` : value;
+  return truncateString(value);
 }


### PR DESCRIPTION
Fixes #331

## What's wrong

`summarizeForRunLog()` throws when a value that only *looks* like a URL won't parse — `"https://"`, or a URL with a space in it. Since the whole summarization is wrapped in one try/catch, a single bad string turns the entire input/output record into `"[unavailable]"`, wiping the fields that parsed fine.

Repro from the issue:

```ts
summarizeForRunLog({ url: "https://", items: ["https://ok.example/x"] })
// before: "[unavailable]"
```

## What I changed

In `summarizeString()`, wrap the `new URL()` call so a parse failure doesn't escape. On failure the value falls back to the normal bounded string path (still length-truncated), with two carve-outs that keep redaction intact:

- fields in a sensitive URL context (`webhook`, `download`, `callback`, ...) still return `"[redacted-url]"`
- a raw query string that carries sensitive keys (e.g. `?token=...`) is still redacted, even though we can't parse the URL structurally

Also extracted the truncation logic into a small helper since it's now used on both paths.

## Validation

- `npx vitest run src/server/actions/run-log-summary.test.ts` — 13 passed (5 new regression cases)
- `npm test` — 96 files, 910 tests passed
- `npm run lint` — 0 warnings / 0 errors
- `npm run typecheck` — clean
- `npx oxfmt --check` on changed files — clean
