### PR TITLE
feat(coinbase): add OAuth authentication

### DIFF
--- a/src/providers/coinbase/actions.ts
+++ b/src/providers/coinbase/actions.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { coinbaseAccountReadScope } from "./scopes.ts";
 
 const service = "coinbase";
 
@@ -19,7 +20,8 @@ const getAccountOutputSchema = s.object("Single brokerage account payload return
 export const coinbaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_accounts",
-    description: "List Coinbase Advanced Trade brokerage accounts that the connected API key can access.",
+    description: "List Coinbase Advanced Trade brokerage accounts that the connected credential can access.",
+    requiredScopes: [coinbaseAccountReadScope],
     inputSchema: s.object(
       "Input parameters for listing Coinbase brokerage accounts.",
       {
@@ -33,6 +35,7 @@ export const coinbaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_account",
     description: "Get one Coinbase Advanced Trade brokerage account by UUID.",
+    requiredScopes: [coinbaseAccountReadScope],
     inputSchema: s.object(
       "Input parameters for retrieving one Coinbase brokerage account.",
       {

--- a/src/providers/coinbase/definition.ts
+++ b/src/providers/coinbase/definition.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { coinbaseActions } from "./actions.ts";
+import { coinbaseOAuthScopes } from "./scopes.ts";
 
 const service = "coinbase";
 
@@ -8,8 +9,19 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Coinbase",
   categories: ["Finance"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://login.coinbase.com/oauth2/auth",
+      tokenUrl: "https://login.coinbase.com/oauth2/token",
+      scopes: coinbaseOAuthScopes,
+      scopeSeparator: ",",
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkce: {
+        method: "S256",
+      },
+    },
     {
       type: "api_key",
       label: "API Private Key",

--- a/src/providers/coinbase/executors.test.ts
+++ b/src/providers/coinbase/executors.test.ts
@@ -60,19 +60,41 @@ describe("Coinbase credentials", () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
-  it("keeps API key validation on the Coinbase JWT authentication path", async () => {
+  it("keeps API key validation and action execution on the Coinbase JWT authentication path", async () => {
     const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
     const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+    const keyName = "organizations/org/apiKeys/key";
 
-    await credentialValidators.apiKey!(
-      { apiKey: pem, values: { keyName: "organizations/org/apiKeys/key" } },
+    const validation = await credentialValidators.apiKey!(
+      { apiKey: pem, values: { keyName } },
       {
         fetcher: async (_url, init) => {
           const authorization = new Headers(init?.headers).get("authorization");
           expect(authorization).toMatch(/^Bearer [^.]+\.[^.]+\.[^.]+$/u);
-          return Response.json({ accounts: [] });
+          return Response.json({ accounts: [{ uuid: "account-1", name: "Primary" }] });
         },
       },
     );
+    expect(validation).toMatchObject({ profile: { accountId: "account-1", displayName: "Primary" } });
+
+    const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("authorization");
+      expect(authorization).toMatch(/^Bearer [^.]+\.[^.]+\.[^.]+$/u);
+      return Response.json({ accounts: [], has_next: false, size: 0 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const credential: ResolvedCredential = {
+      authType: "api_key",
+      apiKey: pem,
+      values: { keyName },
+      profile: { accountId: "account-1", displayName: "Primary", grantedScopes: [] },
+      metadata: {},
+    };
+    const context: ExecutionContext = { getCredential: async () => credential };
+
+    const result = await executors["coinbase.list_accounts"]!({ limit: 10 }, context);
+
+    expect(result).toMatchObject({ ok: true, output: { accounts: [], has_next: false, size: 0 } });
+    expect(fetch).toHaveBeenCalledOnce();
   });
 });

--- a/src/providers/coinbase/executors.test.ts
+++ b/src/providers/coinbase/executors.test.ts
@@ -1,0 +1,78 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { credentialValidators, executors } from "./executors.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Coinbase credentials", () => {
+  it("validates OAuth credentials with a bearer token and records granted scopes", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "coinbase-oauth-token",
+        tokenType: "Bearer",
+        refreshToken: "coinbase-refresh-token",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: { scope: "wallet:accounts:read,offline_access" },
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://api.coinbase.com/api/v3/brokerage/accounts");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer coinbase-oauth-token");
+          return Response.json({
+            accounts: [{ uuid: "account-1", name: "Primary" }],
+            has_next: false,
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "account-1", displayName: "Primary" },
+      grantedScopes: ["wallet:accounts:read", "offline_access"],
+      metadata: { accountCount: 1 },
+    });
+  });
+
+  it("executes account actions with OAuth bearer credentials", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://api.coinbase.com/api/v3/brokerage/accounts?limit=10");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer coinbase-oauth-token");
+      return Response.json({ accounts: [], has_next: false, size: 0 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const credential: ResolvedCredential = {
+      authType: "oauth2",
+      accessToken: "coinbase-oauth-token",
+      tokenType: "Bearer",
+      profile: { accountId: "account-1", displayName: "Primary", grantedScopes: ["wallet:accounts:read"] },
+      metadata: { scope: "wallet:accounts:read" },
+    };
+    const context: ExecutionContext = { getCredential: async () => credential };
+
+    const result = await executors["coinbase.list_accounts"]!({ limit: 10 }, context);
+
+    expect(result).toMatchObject({ ok: true, output: { accounts: [], has_next: false, size: 0 } });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("keeps API key validation on the Coinbase JWT authentication path", async () => {
+    const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+
+    await credentialValidators.apiKey!(
+      { apiKey: pem, values: { keyName: "organizations/org/apiKeys/key" } },
+      {
+        fetcher: async (_url, init) => {
+          const authorization = new Headers(init?.headers).get("authorization");
+          expect(authorization).toMatch(/^Bearer [^.]+\.[^.]+\.[^.]+$/u);
+          return Response.json({ accounts: [] });
+        },
+      },
+    );
+  });
+});

--- a/src/providers/coinbase/executors.ts
+++ b/src/providers/coinbase/executors.ts
@@ -1,10 +1,12 @@
 import type {
+  CredentialValidationResult,
   CredentialValidators,
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
+  ResolvedCredential,
 } from "../../core/types.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { createPrivateKey, createSign, randomBytes } from "node:crypto";
@@ -19,9 +21,9 @@ import {
   providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
-  requireApiKeyCredential,
   toProviderProxyError,
 } from "../provider-runtime.ts";
+import { readCoinbaseGrantedScopes } from "./scopes.ts";
 
 const service = "coinbase";
 const coinbaseApiBaseUrl = "https://api.coinbase.com";
@@ -30,8 +32,10 @@ const coinbaseFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CoinbaseRequestPhase = "validate" | "execute";
 type CoinbaseJwtBuilder = (input: { method: string; path: string }) => string;
-interface CoinbaseActionContext extends ApiKeyProviderContext {
-  keyName: string;
+interface CoinbaseActionContext {
+  authorization(method: string, path: string): string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
 }
 type CoinbaseActionHandler = (input: Record<string, unknown>, context: CoinbaseActionContext) => Promise<unknown>;
 
@@ -64,16 +68,10 @@ export const executors: ProviderExecutors = defineProviderExecutors<CoinbaseActi
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {
-    const credential = await requireApiKeyCredential(context, service);
-    const jwtBuilder = createCoinbaseJwtBuilder({
-      apiKey: credential.apiKey,
-      keyName: requiredString(credential.values.keyName, "keyName", providerInputError),
-      now: () => Date.now(),
-      nonce: () => randomBytes(16).toString("hex"),
-    });
+    const providerContext = await createCoinbaseContext(context, coinbaseFetch);
     const url = createProviderProxyUrl(coinbaseApiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `Bearer ${jwtBuilder({ method: input.method, path: url.pathname + url.search })}`);
+    headers.set("authorization", providerContext.authorization(input.method, url.pathname + url.search));
     headers.set("user-agent", providerUserAgent);
 
     const init: RequestInit = {
@@ -102,27 +100,18 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {
-    const context: CoinbaseActionContext = {
-      apiKey: input.apiKey,
-      keyName: requiredString(input.values.keyName, "keyName", providerInputError),
-      fetcher,
-      signal,
-    };
-    const payload = await coinbaseGetJson(accountsPath, {}, context, "validate");
-    const accounts = readAccountsArray(payload);
-    const firstAccount = accounts[0];
-    return {
-      profile: {
-        accountId: optionalString(firstAccount?.uuid),
-        displayName: optionalString(firstAccount?.name) ?? "Coinbase API Key",
-      },
-      grantedScopes: [],
-      metadata: {
-        validationEndpoint: accountsPath,
-        apiBaseUrl: coinbaseApiBaseUrl,
-        accountCount: accounts.length,
-      },
-    };
+    return validateCoinbaseCredential(
+      createCoinbaseApiKeyContext(input.apiKey, input.values.keyName, fetcher, signal),
+      [],
+      "Coinbase API Key",
+    );
+  },
+  async oauth2(input, { fetcher, signal }) {
+    return validateCoinbaseCredential(
+      createCoinbaseOAuthContext(input, fetcher, signal),
+      readCoinbaseGrantedScopes(input.metadata.scope),
+      "Coinbase OAuth",
+    );
   },
 };
 
@@ -132,12 +121,6 @@ async function coinbaseGetJson(
   context: CoinbaseActionContext,
   phase: CoinbaseRequestPhase,
 ): Promise<unknown> {
-  const jwtBuilder = createCoinbaseJwtBuilder({
-    apiKey: context.apiKey,
-    keyName: context.keyName,
-    now: () => Date.now(),
-    nonce: () => randomBytes(16).toString("hex"),
-  });
   const url = new URL(path, coinbaseApiBaseUrl);
   for (const [key, value] of Object.entries(query)) {
     url.searchParams.set(key, value);
@@ -150,7 +133,7 @@ async function coinbaseGetJson(
       method: "GET",
       headers: {
         accept: "application/json",
-        authorization: `Bearer ${jwtBuilder({ method: "GET", path: requestPath })}`,
+        authorization: context.authorization("GET", requestPath),
         "user-agent": providerUserAgent,
       },
       signal: context.signal,
@@ -171,17 +154,71 @@ async function coinbaseGetJson(
 }
 
 async function createCoinbaseContext(context: ExecutionContext, fetcher: typeof fetch): Promise<CoinbaseActionContext> {
-  const credential = await requireApiKeyCredential(context, service);
-  const providerContext: CoinbaseActionContext = {
-    apiKey: credential.apiKey,
-    keyName: requiredString(credential.values.keyName, "keyName", providerInputError),
-    fetcher,
-    signal: context.signal,
-  };
-  if (context.transitFiles) {
-    providerContext.transitFiles = context.transitFiles;
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "api_key") {
+    return createCoinbaseApiKeyContext(credential.apiKey, credential.values.keyName, fetcher, context.signal);
   }
-  return providerContext;
+  if (credential?.authType === "oauth2") {
+    return createCoinbaseOAuthContext(credential, fetcher, context.signal);
+  }
+  throw new ProviderRequestError(401, "Configure Coinbase credentials first.");
+}
+
+function createCoinbaseApiKeyContext(
+  apiKey: string,
+  keyNameInput: unknown,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): CoinbaseActionContext {
+  const jwtBuilder = createCoinbaseJwtBuilder({
+    apiKey,
+    keyName: requiredString(keyNameInput, "keyName", providerInputError),
+    now: () => Date.now(),
+    nonce: () => randomBytes(16).toString("hex"),
+  });
+  return {
+    authorization(method, path) {
+      return `Bearer ${jwtBuilder({ method, path })}`;
+    },
+    fetcher,
+    signal,
+  };
+}
+
+function createCoinbaseOAuthContext(
+  credential: Extract<ResolvedCredential, { authType: "oauth2" }>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): CoinbaseActionContext {
+  return {
+    authorization() {
+      return `${credential.tokenType} ${credential.accessToken}`;
+    },
+    fetcher,
+    signal,
+  };
+}
+
+async function validateCoinbaseCredential(
+  context: CoinbaseActionContext,
+  grantedScopes: string[],
+  fallbackDisplayName: string,
+): Promise<CredentialValidationResult> {
+  const payload = await coinbaseGetJson(accountsPath, {}, context, "validate");
+  const accounts = readAccountsArray(payload);
+  const firstAccount = accounts[0];
+  return {
+    profile: {
+      accountId: optionalString(firstAccount?.uuid),
+      displayName: optionalString(firstAccount?.name) ?? fallbackDisplayName,
+    },
+    grantedScopes,
+    metadata: {
+      validationEndpoint: accountsPath,
+      apiBaseUrl: coinbaseApiBaseUrl,
+      accountCount: accounts.length,
+    },
+  };
 }
 
 function createCoinbaseJwtBuilder(input: {

--- a/src/providers/coinbase/scopes.ts
+++ b/src/providers/coinbase/scopes.ts
@@ -1,0 +1,13 @@
+import { optionalString } from "../../core/cast.ts";
+
+export const coinbaseAccountReadScope = "wallet:accounts:read";
+export const coinbaseOfflineAccessScope = "offline_access";
+
+/** OAuth scopes needed by the currently exposed Coinbase account actions. */
+export const coinbaseOAuthScopes: string[] = [coinbaseAccountReadScope, coinbaseOfflineAccessScope];
+
+/** Read Coinbase's token scope, which may use spaces or commas as separators. */
+export function readCoinbaseGrantedScopes(value: unknown): string[] {
+  const scope = optionalString(value);
+  return scope ? [...new Set(scope.split(/[\s,]+/u).filter(Boolean))] : [...coinbaseOAuthScopes];
+}


### PR DESCRIPTION
## What changed

- add Coinbase OAuth 2.0 authorization with PKCE
- request `wallet:accounts:read` and `offline_access`, using Coinbase's comma-delimited scope format
- support OAuth bearer tokens across the existing account actions and proxy while preserving CDP API key JWT signing
- validate OAuth credentials and expose granted scopes
- add focused OAuth and API key regression tests

## Why

Coinbase supports third-party account delegation through OAuth 2.0, but the provider previously required a CDP API key. This lets self-hosted users connect Coinbase accounts with their own approved Coinbase OAuth application.

## Validation

- `npm exec vitest run src/providers/coinbase/executors.test.ts`
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (97 files, 908 tests)