### PR TITLE
feat(alpaca): add OAuth authentication

### DIFF
--- a/src/providers/alpaca/actions.ts
+++ b/src/providers/alpaca/actions.ts
@@ -2,6 +2,7 @@ import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { alpacaDataScope } from "./scopes.ts";
 
 const service = "alpaca";
 
@@ -386,6 +387,7 @@ const getMarketCalendarAction = defineProviderAction(service, {
 const listCorporateActionsAction = defineProviderAction(service, {
   name: "list_corporate_actions",
   description: "List Alpaca corporate actions for symbols, CUSIPs, types, or IDs.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: corporateActionFilterSchema,
   outputSchema: s.object(
     "Alpaca corporate actions response.",
@@ -400,6 +402,7 @@ const listCorporateActionsAction = defineProviderAction(service, {
 const getStockBarsAction = defineProviderAction(service, {
   name: "get_stock_bars",
   description: "Get historical OHLC stock bars from Alpaca Market Data API.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: s.object(
     "Input for getting Alpaca historical stock bars.",
     {
@@ -432,6 +435,7 @@ const getStockBarsAction = defineProviderAction(service, {
 const getCryptoBarsAction = defineProviderAction(service, {
   name: "get_crypto_bars",
   description: "Get historical OHLC crypto bars from Alpaca Market Data API.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: s.object(
     "Input for getting Alpaca historical crypto bars.",
     {
@@ -522,6 +526,7 @@ const getOptionContractAction = defineProviderAction(service, {
 const getStockSnapshotsAction = defineProviderAction(service, {
   name: "get_stock_snapshots",
   description: "Get latest stock snapshots from Alpaca Market Data API.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: s.object(
     "Input for getting Alpaca stock snapshots.",
     {
@@ -539,6 +544,7 @@ const getStockSnapshotsAction = defineProviderAction(service, {
 const getCryptoSnapshotsAction = defineProviderAction(service, {
   name: "get_crypto_snapshots",
   description: "Get latest crypto snapshots from Alpaca Market Data API.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: s.object(
     "Input for getting Alpaca crypto snapshots.",
     {
@@ -555,6 +561,7 @@ const getCryptoSnapshotsAction = defineProviderAction(service, {
 const listNewsAction = defineProviderAction(service, {
   name: "list_news",
   description: "List latest Alpaca news articles across stocks and crypto.",
+  requiredScopes: [alpacaDataScope],
   inputSchema: s.object(
     "Input for listing Alpaca news articles.",
     {

--- a/src/providers/alpaca/definition.ts
+++ b/src/providers/alpaca/definition.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { alpacaActions } from "./actions.ts";
+import { alpacaOAuthScopes } from "./scopes.ts";
 
 const service = "alpaca";
 
@@ -8,8 +9,15 @@ export const provider: ProviderDefinition = {
   service,
   displayName: "Alpaca",
   categories: ["Finance", "Data"],
-  authTypes: ["api_key"],
+  authTypes: ["oauth2", "api_key"],
   auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://app.alpaca.markets/oauth/authorize",
+      tokenUrl: "https://api.alpaca.markets/oauth/token",
+      scopes: alpacaOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+    },
     {
       type: "api_key",
       label: "API Secret Key",

--- a/src/providers/alpaca/executors.test.ts
+++ b/src/providers/alpaca/executors.test.ts
@@ -63,6 +63,32 @@ describe("Alpaca credentials", () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
+  it("retries OAuth environment discovery before execution when connection metadata is missing", async () => {
+    const requestedUrls: string[] = [];
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      requestedUrls.push(url);
+      if (url === "https://api.alpaca.markets/v2/account") {
+        return Response.json({ message: "not authorized" }, { status: 401 });
+      }
+      return Response.json({ id: "paper-account", account_number: "PA-PAPER" });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const context: ExecutionContext = { getCredential: async () => oauthCredential() };
+
+    const result = await executors["alpaca.get_account"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: { account: { id: "paper-account", account_number: "PA-PAPER" } },
+    });
+    expect(requestedUrls).toEqual([
+      "https://api.alpaca.markets/v2/account",
+      "https://paper-api.alpaca.markets/v2/account",
+      "https://paper-api.alpaca.markets/v2/account",
+    ]);
+  });
+
   it("uses OAuth bearer credentials for paper Trading API proxy requests", async () => {
     const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(input.toString()).toBe("https://paper-api.alpaca.markets/v2/account");

--- a/src/providers/alpaca/executors.test.ts
+++ b/src/providers/alpaca/executors.test.ts
@@ -105,6 +105,27 @@ describe("Alpaca credentials", () => {
     expect(result).toMatchObject({ ok: true, response: { status: 200, data: { id: "paper-account" } } });
   });
 
+  it.each([
+    { endpoint: "/v2/options/contracts", data: { option_contracts: [] } },
+    { endpoint: "/v2/options/contracts/AAPL250117C00200000", data: { symbol: "AAPL250117C00200000" } },
+  ])("routes $endpoint proxy requests to the paper Trading API", async ({ endpoint, data }) => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe(`https://paper-api.alpaca.markets${endpoint}`);
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer alpaca-oauth-token");
+      return Response.json(data);
+    });
+    vi.stubGlobal("fetch", fetch);
+    const context: ExecutionContext = { getCredential: async () => oauthCredential({ environment: "paper" }) };
+
+    const result = await proxy!({ endpoint, method: "GET" }, context);
+
+    expect(result).toMatchObject({
+      ok: true,
+      response: { status: 200, data },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
   it("keeps API key validation on Alpaca's key-pair headers", async () => {
     await credentialValidators.apiKey!(
       { apiKey: "secret", values: { apiKeyId: "key-id", environment: "paper" } },

--- a/src/providers/alpaca/executors.test.ts
+++ b/src/providers/alpaca/executors.test.ts
@@ -1,0 +1,108 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { credentialValidators, executors, proxy } from "./executors.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Alpaca credentials", () => {
+  it("validates OAuth credentials against a live account and records scopes", async () => {
+    const result = await credentialValidators.oauth2!(oauthCredential(), {
+      fetcher: async (url, init) => {
+        expect(url.toString()).toBe("https://api.alpaca.markets/v2/account");
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBe("Bearer alpaca-oauth-token");
+        expect(headers.get("apca-api-key-id")).toBeNull();
+        return Response.json({ id: "account-1", account_number: "PA123" });
+      },
+    });
+
+    expect(result).toMatchObject({
+      profile: { accountId: "account-1", displayName: "PA123" },
+      grantedScopes: ["data"],
+      metadata: { environment: "live", apiBaseUrl: "https://api.alpaca.markets" },
+    });
+  });
+
+  it("falls back to a paper account when the OAuth token cannot access live trading", async () => {
+    const requestedUrls: string[] = [];
+    const result = await credentialValidators.oauth2!(oauthCredential(), {
+      fetcher: async (url) => {
+        requestedUrls.push(url.toString());
+        if (url.toString().startsWith("https://api.alpaca.markets/")) {
+          return Response.json({ message: "not authorized" }, { status: 401 });
+        }
+        return Response.json({ id: "paper-account", account_number: "PA-PAPER" });
+      },
+    });
+
+    expect(requestedUrls).toEqual([
+      "https://api.alpaca.markets/v2/account",
+      "https://paper-api.alpaca.markets/v2/account",
+    ]);
+    expect(result).toMatchObject({
+      profile: { accountId: "paper-account", displayName: "PA-PAPER" },
+      metadata: { environment: "paper", apiBaseUrl: "https://paper-api.alpaca.markets" },
+    });
+  });
+
+  it("executes market-data actions with OAuth bearer credentials", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://data.alpaca.markets/v2/stocks/bars?symbols=AAPL&timeframe=1Day");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer alpaca-oauth-token");
+      return Response.json({ bars: { AAPL: [] } });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const context: ExecutionContext = { getCredential: async () => oauthCredential({ environment: "paper" }) };
+
+    const result = await executors["alpaca.get_stock_bars"]!({ symbols: ["AAPL"], timeframe: "1Day" }, context);
+
+    expect(result).toMatchObject({ ok: true, output: { bars: { AAPL: [] } } });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses OAuth bearer credentials for paper Trading API proxy requests", async () => {
+    const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input.toString()).toBe("https://paper-api.alpaca.markets/v2/account");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer alpaca-oauth-token");
+      expect(headers.get("apca-api-secret-key")).toBeNull();
+      return Response.json({ id: "paper-account" });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const context: ExecutionContext = { getCredential: async () => oauthCredential({ environment: "paper" }) };
+
+    const result = await proxy!({ endpoint: "/v2/account", method: "GET" }, context);
+
+    expect(result).toMatchObject({ ok: true, response: { status: 200, data: { id: "paper-account" } } });
+  });
+
+  it("keeps API key validation on Alpaca's key-pair headers", async () => {
+    await credentialValidators.apiKey!(
+      { apiKey: "secret", values: { apiKeyId: "key-id", environment: "paper" } },
+      {
+        fetcher: async (_url, init) => {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("apca-api-key-id")).toBe("key-id");
+          expect(headers.get("apca-api-secret-key")).toBe("secret");
+          expect(headers.get("authorization")).toBeNull();
+          return Response.json({ id: "paper-account" });
+        },
+      },
+    );
+  });
+});
+
+function oauthCredential(
+  metadata: Record<string, unknown> = { scope: "data" },
+): Extract<ResolvedCredential, { authType: "oauth2" }> {
+  return {
+    authType: "oauth2",
+    accessToken: "alpaca-oauth-token",
+    tokenType: "Bearer",
+    profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+    metadata,
+  };
+}

--- a/src/providers/alpaca/executors.ts
+++ b/src/providers/alpaca/executors.ts
@@ -74,6 +74,11 @@ export const proxy: ProviderProxyExecutor = async (input, context): Promise<Prox
 };
 
 function resolveAlpacaProxyBaseUrl(endpoint: string, environment: "paper" | "live"): string {
+  const tradingBaseUrl = environment === "live" ? liveTradingBaseUrl : paperTradingBaseUrl;
+  if (endpoint === "/v2/options/contracts" || endpoint.startsWith("/v2/options/contracts/")) {
+    return tradingBaseUrl;
+  }
+
   if (
     endpoint.startsWith("/v1/") ||
     endpoint.startsWith("/v1beta1/") ||
@@ -83,7 +88,7 @@ function resolveAlpacaProxyBaseUrl(endpoint: string, environment: "paper" | "liv
   ) {
     return dataBaseUrl;
   }
-  return environment === "live" ? liveTradingBaseUrl : paperTradingBaseUrl;
+  return tradingBaseUrl;
 }
 
 export const credentialValidators: CredentialValidators = {

--- a/src/providers/alpaca/executors.ts
+++ b/src/providers/alpaca/executors.ts
@@ -5,6 +5,7 @@ import type {
   ProviderProxyExecutor,
   ProxyExecutionResult,
 } from "../../core/types.ts";
+import type { ActionContext } from "./runtime.ts";
 
 import {
   createProviderFetch,
@@ -12,13 +13,18 @@ import {
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
-  providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
-  requireApiKeyCredential,
   toProviderProxyError,
 } from "../provider-runtime.ts";
-import { alpacaActionHandlers, readAlpacaCredential, validateAlpacaCredential } from "./runtime.ts";
+import {
+  alpacaActionHandlers,
+  alpacaCredentialHeaders,
+  readAlpacaCredential,
+  readAlpacaOAuthCredential,
+  validateAlpacaCredential,
+  validateAlpacaOAuthCredential,
+} from "./runtime.ts";
 
 const service = "alpaca";
 const paperTradingBaseUrl = "https://paper-api.alpaca.markets";
@@ -31,37 +37,22 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   handlers: alpacaActionHandlers,
   skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
-    const credential = await requireApiKeyCredential(context, service);
-    return {
-      credential: readAlpacaCredential({
-        apiKey: credential.apiKey,
-        apiKeyId: credential.values.apiKeyId,
-        environment: credential.values.environment,
-      }),
-      fetcher,
-      signal: context.signal,
-    };
+    return resolveAlpacaActionContext(context, fetcher);
   },
 });
 
 export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
   try {
-    const credential = await requireApiKeyCredential(context, service);
-    const alpacaCredential = readAlpacaCredential({
-      apiKey: credential.apiKey,
-      apiKeyId: credential.values.apiKeyId,
-      environment: credential.values.environment,
-    });
+    const providerContext = await resolveAlpacaActionContext(context, alpacaFetch);
     const url = createProviderProxyUrl(
-      resolveAlpacaProxyBaseUrl(input.endpoint, alpacaCredential.environment),
+      resolveAlpacaProxyBaseUrl(input.endpoint, providerContext.credential.environment),
       input.endpoint,
       input.query,
     );
     const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("accept", "application/json");
-    headers.set("apca-api-key-id", alpacaCredential.apiKeyId);
-    headers.set("apca-api-secret-key", alpacaCredential.apiSecretKey);
-    headers.set("user-agent", providerUserAgent);
+    for (const [name, value] of Object.entries(alpacaCredentialHeaders(providerContext.credential))) {
+      headers.set(name, value);
+    }
 
     const response = await alpacaFetch(url, {
       method: input.method,
@@ -105,4 +96,30 @@ export const credentialValidators: CredentialValidators = {
       signal,
     );
   },
+  async oauth2(input, { fetcher, signal }) {
+    return validateAlpacaOAuthCredential(input, fetcher, signal);
+  },
 };
+
+async function resolveAlpacaActionContext(context: ExecutionContext, fetcher: typeof fetch): Promise<ActionContext> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType === "api_key") {
+    return {
+      credential: readAlpacaCredential({
+        apiKey: credential.apiKey,
+        apiKeyId: credential.values.apiKeyId,
+        environment: credential.values.environment,
+      }),
+      fetcher,
+      signal: context.signal,
+    };
+  }
+  if (credential?.authType === "oauth2") {
+    return {
+      credential: readAlpacaOAuthCredential(credential, credential.metadata.environment),
+      fetcher,
+      signal: context.signal,
+    };
+  }
+  throw new ProviderRequestError(401, "Configure Alpaca credentials first.");
+}

--- a/src/providers/alpaca/executors.ts
+++ b/src/providers/alpaca/executors.ts
@@ -4,9 +4,11 @@ import type {
   ProviderExecutors,
   ProviderProxyExecutor,
   ProxyExecutionResult,
+  ResolvedCredential,
 } from "../../core/types.ts";
 import type { ActionContext } from "./runtime.ts";
 
+import { optionalString } from "../../core/cast.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -115,11 +117,30 @@ async function resolveAlpacaActionContext(context: ExecutionContext, fetcher: ty
     };
   }
   if (credential?.authType === "oauth2") {
+    const environment = await resolveAlpacaOAuthEnvironment(credential, fetcher, context.signal);
     return {
-      credential: readAlpacaOAuthCredential(credential, credential.metadata.environment),
+      credential: readAlpacaOAuthCredential(credential, environment),
       fetcher,
       signal: context.signal,
     };
   }
   throw new ProviderRequestError(401, "Configure Alpaca credentials first.");
+}
+
+async function resolveAlpacaOAuthEnvironment(
+  credential: Extract<ResolvedCredential, { authType: "oauth2" }>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<string> {
+  const storedEnvironment = optionalString(credential.metadata.environment);
+  if (storedEnvironment) {
+    return storedEnvironment;
+  }
+
+  const validation = await validateAlpacaOAuthCredential(credential, fetcher, signal);
+  const discoveredEnvironment = optionalString(validation.metadata?.environment);
+  if (!discoveredEnvironment) {
+    throw new ProviderRequestError(502, "Alpaca OAuth environment discovery returned no environment");
+  }
+  return discoveredEnvironment;
 }

--- a/src/providers/alpaca/runtime.ts
+++ b/src/providers/alpaca/runtime.ts
@@ -494,7 +494,7 @@ export function readAlpacaCredential(input: {
     authType: "api_key",
     apiSecretKey: requiredInputString(input.apiKey, "apiKey"),
     apiKeyId: requiredInputString(input.apiKeyId, "apiKeyId"),
-    environment: readEnvironment(input.environment),
+    environment: readEnvironment(input.environment, "paper"),
   };
 }
 
@@ -506,7 +506,7 @@ export function readAlpacaOAuthCredential(
     authType: "oauth2",
     accessToken: input.accessToken,
     tokenType: input.tokenType,
-    environment: readEnvironment(environment, "live"),
+    environment: readEnvironment(environment),
   };
 }
 
@@ -727,7 +727,7 @@ function requiredInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
 }
 
-function readEnvironment(value: unknown, fallback: Environment = "paper"): Environment {
+function readEnvironment(value: unknown, fallback?: Environment): Environment {
   const normalized = optionalString(value) ?? fallback;
   if (normalized === "paper" || normalized === "live") {
     return normalized;

--- a/src/providers/alpaca/runtime.ts
+++ b/src/providers/alpaca/runtime.ts
@@ -570,7 +570,7 @@ function buildAlpacaUrl(
 }
 
 /** Build authentication headers for either an Alpaca OAuth token or API key pair. */
-export function alpacaCredentialHeaders(credential: Credential): HeadersInit {
+export function alpacaCredentialHeaders(credential: Credential): Record<string, string> {
   if (credential.authType === "oauth2") {
     return {
       accept: "application/json",

--- a/src/providers/alpaca/runtime.ts
+++ b/src/providers/alpaca/runtime.ts
@@ -1,5 +1,8 @@
+import type { CredentialValidationResult, ResolvedCredential } from "../../core/types.ts";
+
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { readAlpacaGrantedScopes } from "./scopes.ts";
 
 const paperTradingBaseUrl = "https://paper-api.alpaca.markets";
 const liveTradingBaseUrl = "https://api.alpaca.markets";
@@ -10,11 +13,21 @@ type Environment = "paper" | "live";
 type ApiFamily = "trading" | "data";
 type Phase = "validate" | "execute";
 
-export interface Credential {
+export interface ApiKeyCredential {
+  authType: "api_key";
   apiKeyId: string;
   apiSecretKey: string;
   environment: Environment;
 }
+
+export interface OAuthCredential {
+  authType: "oauth2";
+  accessToken: string;
+  tokenType: string;
+  environment: Environment;
+}
+
+export type Credential = ApiKeyCredential | OAuthCredential;
 
 export interface ActionContext {
   credential: Credential;
@@ -391,12 +404,56 @@ export async function validateAlpacaCredential(
   input: { apiKey: string; apiKeyId: unknown; environment: unknown },
   fetcher: typeof fetch,
   signal?: AbortSignal,
-): Promise<{
-  profile: { accountId: string; displayName: string };
-  grantedScopes: string[];
-  metadata: Record<string, unknown>;
-}> {
+): Promise<CredentialValidationResult> {
   const credential = readAlpacaCredential(input);
+  return validateResolvedAlpacaCredential(credential, [], credential.apiKeyId, "Alpaca API Key", fetcher, signal);
+}
+
+export async function validateAlpacaOAuthCredential(
+  input: Extract<ResolvedCredential, { authType: "oauth2" }>,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const grantedScopes = readAlpacaGrantedScopes(input.metadata.scope);
+  let authorizationError: ProviderRequestError | undefined;
+
+  for (const environment of ["live", "paper"] as const) {
+    const credential = readAlpacaOAuthCredential(input, environment);
+    try {
+      return await validateResolvedAlpacaCredential(
+        credential,
+        grantedScopes,
+        `alpaca:${environment}`,
+        `Alpaca ${environment}`,
+        fetcher,
+        signal,
+        "execute",
+      );
+    } catch (error) {
+      if (error instanceof ProviderRequestError && (error.status === 401 || error.status === 403)) {
+        authorizationError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new ProviderRequestError(
+    400,
+    authorizationError?.message ?? "Alpaca OAuth token cannot access a live or paper account",
+    authorizationError?.details,
+  );
+}
+
+async function validateResolvedAlpacaCredential(
+  credential: Credential,
+  grantedScopes: string[],
+  fallbackAccountId: string,
+  fallbackDisplayName: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+  phase: Phase = "validate",
+): Promise<CredentialValidationResult> {
   const payload = await requestAlpacaJson({
     family: "trading",
     path: "/v2/account",
@@ -406,7 +463,7 @@ export async function validateAlpacaCredential(
       fetcher,
       signal,
     },
-    phase: "validate",
+    phase,
   });
   const account = normalizeRecord(payload);
   const accountId = optionalString(account.id);
@@ -414,10 +471,10 @@ export async function validateAlpacaCredential(
 
   return {
     profile: {
-      accountId: accountId ?? accountNumber ?? credential.apiKeyId,
-      displayName: accountNumber ?? accountId ?? "Alpaca API Key",
+      accountId: accountId ?? accountNumber ?? fallbackAccountId,
+      displayName: accountNumber ?? accountId ?? fallbackDisplayName,
     },
-    grantedScopes: [],
+    grantedScopes,
     metadata: compactObject({
       accountNumber,
       apiBaseUrl: tradingBaseUrl(credential.environment),
@@ -428,11 +485,28 @@ export async function validateAlpacaCredential(
   };
 }
 
-export function readAlpacaCredential(input: { apiKey: unknown; apiKeyId: unknown; environment: unknown }): Credential {
+export function readAlpacaCredential(input: {
+  apiKey: unknown;
+  apiKeyId: unknown;
+  environment: unknown;
+}): ApiKeyCredential {
   return {
+    authType: "api_key",
     apiSecretKey: requiredInputString(input.apiKey, "apiKey"),
     apiKeyId: requiredInputString(input.apiKeyId, "apiKeyId"),
     environment: readEnvironment(input.environment),
+  };
+}
+
+export function readAlpacaOAuthCredential(
+  input: Extract<ResolvedCredential, { authType: "oauth2" }>,
+  environment: unknown,
+): OAuthCredential {
+  return {
+    authType: "oauth2",
+    accessToken: input.accessToken,
+    tokenType: input.tokenType,
+    environment: readEnvironment(environment, "live"),
   };
 }
 
@@ -451,7 +525,7 @@ async function requestAlpacaJson(input: {
       buildAlpacaUrl(input.family, input.path, input.query, input.context.credential.environment),
       {
         method: "GET",
-        headers: buildAlpacaHeaders(input.context.credential),
+        headers: alpacaCredentialHeaders(input.context.credential),
         signal,
       },
     );
@@ -495,7 +569,16 @@ function buildAlpacaUrl(
   return url;
 }
 
-function buildAlpacaHeaders(credential: Credential): HeadersInit {
+/** Build authentication headers for either an Alpaca OAuth token or API key pair. */
+export function alpacaCredentialHeaders(credential: Credential): HeadersInit {
+  if (credential.authType === "oauth2") {
+    return {
+      accept: "application/json",
+      authorization: `${credential.tokenType} ${credential.accessToken}`,
+      "user-agent": providerUserAgent,
+    };
+  }
+
   return {
     accept: "application/json",
     "APCA-API-KEY-ID": credential.apiKeyId,
@@ -644,8 +727,8 @@ function requiredInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
 }
 
-function readEnvironment(value: unknown): Environment {
-  const normalized = optionalString(value) ?? "paper";
+function readEnvironment(value: unknown, fallback: Environment = "paper"): Environment {
+  const normalized = optionalString(value) ?? fallback;
   if (normalized === "paper" || normalized === "live") {
     return normalized;
   }

--- a/src/providers/alpaca/scopes.ts
+++ b/src/providers/alpaca/scopes.ts
@@ -1,0 +1,12 @@
+import { optionalString } from "../../core/cast.ts";
+
+export const alpacaDataScope = "data";
+
+/** OAuth scopes needed by the currently exposed Alpaca market-data actions. */
+export const alpacaOAuthScopes: string[] = [alpacaDataScope];
+
+/** Read Alpaca's space-delimited token scope, falling back to the requested scope. */
+export function readAlpacaGrantedScopes(value: unknown): string[] {
+  const scope = optionalString(value);
+  return scope ? [...new Set(scope.split(/\s+/u).filter(Boolean))] : [...alpacaOAuthScopes];
+}


### PR DESCRIPTION
## What changed

- add Alpaca OAuth 2.0 authorization for third-party Trading API access
- request the `data` scope used by the existing market-data actions while keeping Trading API reads on Alpaca's default read-only access
- support OAuth bearer tokens across actions and proxy requests while preserving API key-pair authentication
- discover whether an OAuth token targets live or paper trading and store that environment with the connection
- add focused tests for live and paper OAuth validation, market-data execution, proxy authentication, and API key compatibility

## Why

The Alpaca provider previously required users to paste an API key pair. Alpaca Connect supports delegated OAuth access to end-user trading accounts, so self-hosted users should be able to connect their own Alpaca OAuth application.

## Validation

- `npm exec vitest run src/providers/alpaca/executors.test.ts`
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (97 files, 910 tests)