### PR TITLE
feat(providers): add OrcaRouter

### DIFF
--- a/src/providers/orcarouter/actions.ts
+++ b/src/providers/orcarouter/actions.ts
@@ -1,0 +1,161 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "orcarouter";
+
+const rawObjectSchema = s.looseObject("A JSON object returned by OrcaRouter.");
+const rawObjectArraySchema = s.array("A list of JSON objects returned by OrcaRouter.", rawObjectSchema);
+const noInputSchema = s.object("This action requires no additional input parameters.", {});
+
+const chatCompletionInputSchema = s.object(
+  "Input parameters when creating an OrcaRouter chat completion.",
+  {
+    model: s.nonEmptyString(
+      "The namespaced model ID to use, such as `orcarouter/auto` or `openai/gpt-4o-mini`. OrcaRouter routes the request to the matching upstream.",
+    ),
+    messages: s.array("An ordered list of conversation messages.", rawObjectSchema, { minItems: 1 }),
+    n: s.positiveInteger("The number of choices to generate."),
+    stop: s.anyOf("Stop sequences for generation.", [
+      s.nonEmptyString("A single stop sequence."),
+      s.array("Multiple stop sequences.", s.nonEmptyString("A stop sequence."), { minItems: 1 }),
+    ]),
+    user: s.string("The end user's unique identifier."),
+    top_p: s.number("Nucleus sampling parameter.", { minimum: 0, maximum: 1 }),
+    stream: s.boolean("Whether to request a streaming response. Connector actions only support false or omitted."),
+    functions: rawObjectArraySchema,
+    function_call: s.anyOf("Legacy function calling strategy converted to tool_choice at execution time.", [
+      s.stringEnum(["none", "auto"]),
+      rawObjectSchema,
+    ]),
+    logit_bias: s.record("Token bias map.", s.number("The bias value for this token.")),
+    max_tokens: s.positiveInteger("The maximum number of output tokens."),
+    max_completion_tokens: s.positiveInteger("New max output token field, taking precedence over max_tokens."),
+    temperature: s.number("Sampling temperature.", { minimum: 0, maximum: 2 }),
+    presence_penalty: s.number("Presence penalty.", { minimum: -2, maximum: 2 }),
+    frequency_penalty: s.number("Frequency penalty.", { minimum: -2, maximum: 2 }),
+    logprobs: s.boolean("Whether to return token-level probabilities."),
+    top_logprobs: s.integer("The number of top logprobs to return.", { minimum: 0, maximum: 20 }),
+    tools: rawObjectArraySchema,
+    tool_choice: s.anyOf("Tool selection strategy.", [s.stringEnum(["none", "auto", "required"]), rawObjectSchema]),
+    response_format: rawObjectSchema,
+    metadata: rawObjectSchema,
+    parallel_tool_calls: s.boolean("Whether to allow parallel tool calls."),
+  },
+  {
+    required: ["model", "messages"],
+    optional: [
+      "n",
+      "stop",
+      "user",
+      "top_p",
+      "stream",
+      "functions",
+      "function_call",
+      "logit_bias",
+      "max_tokens",
+      "max_completion_tokens",
+      "temperature",
+      "presence_penalty",
+      "frequency_penalty",
+      "logprobs",
+      "top_logprobs",
+      "tools",
+      "tool_choice",
+      "response_format",
+      "metadata",
+      "parallel_tool_calls",
+    ],
+    additionalProperties: true,
+  },
+);
+
+const messageInputSchema = s.object(
+  "Input parameters when creating an OrcaRouter Anthropic-format message.",
+  {
+    model: s.nonEmptyString(
+      "The namespaced model ID to use, such as `orcarouter/auto` or `anthropic/claude-haiku-4.5`. OrcaRouter routes the request to the matching upstream.",
+    ),
+    max_tokens: s.positiveInteger("The maximum number of output tokens."),
+    messages: s.array("An ordered list of Anthropic-format messages.", rawObjectSchema, { minItems: 1 }),
+    user: s.string("The end user's unique identifier."),
+    tools: rawObjectArraySchema,
+    top_k: s.nonNegativeInteger("Top-k sampling parameter."),
+    top_p: s.number("Nucleus sampling parameter.", { minimum: 0, maximum: 1 }),
+    stream: s.boolean("Whether to request a streaming response. Connector actions only support false or omitted."),
+    system: s.anyOf("System prompt content.", [
+      s.string("System prompt text."),
+      s.array("Structured system prompt content blocks.", rawObjectSchema, { minItems: 1 }),
+    ]),
+    metadata: rawObjectSchema,
+    stop_sequences: s.stringArray("Stop sequences for generation."),
+    temperature: s.number("Sampling temperature.", { minimum: 0, maximum: 2 }),
+    tool_choice: s.anyOf("Tool selection strategy.", [s.stringEnum(["auto", "any", "none"]), rawObjectSchema]),
+  },
+  {
+    required: ["model", "max_tokens", "messages"],
+    optional: [
+      "user",
+      "tools",
+      "top_k",
+      "top_p",
+      "stream",
+      "system",
+      "metadata",
+      "stop_sequences",
+      "temperature",
+      "tool_choice",
+    ],
+    additionalProperties: true,
+  },
+);
+
+const embeddingInputSchema = s.object(
+  "Input parameters when creating an OrcaRouter embedding.",
+  {
+    model: s.nonEmptyString("The namespaced embedding model ID to use, such as `openai/text-embedding-3-small`."),
+    input: s.anyOf("Text to embed.", [
+      s.nonEmptyString("A single text string to embed."),
+      s.array("A list of text strings to embed.", s.nonEmptyString("A text string to embed."), { minItems: 1 }),
+    ]),
+    encoding_format: s.stringEnum("The format to return the embeddings in.", ["float", "base64"]),
+  },
+  {
+    required: ["model", "input"],
+    optional: ["encoding_format"],
+  },
+);
+
+const modelListOutputSchema = s.object("Standard OrcaRouter response that returns a list of models.", {
+  data: rawObjectArraySchema,
+});
+
+export const orcarouterActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "create_chat_completion",
+    description: "Create an OrcaRouter chat completion through the OpenAI-compatible `/chat/completions` endpoint.",
+    inputSchema: chatCompletionInputSchema,
+    outputSchema: rawObjectSchema,
+  }),
+  defineProviderAction(service, {
+    name: "create_message",
+    description: "Create an OrcaRouter Anthropic-format message through the `/messages` endpoint.",
+    inputSchema: messageInputSchema,
+    outputSchema: rawObjectSchema,
+  }),
+  defineProviderAction(service, {
+    name: "list_models",
+    description: "List the models available through OrcaRouter.",
+    inputSchema: noInputSchema,
+    outputSchema: modelListOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "create_embeddings",
+    description: "Create embeddings through the OpenAI-compatible `/embeddings` endpoint.",
+    inputSchema: embeddingInputSchema,
+    outputSchema: s.object("Standard OrcaRouter response that returns a list of embeddings.", {
+      data: rawObjectArraySchema,
+    }),
+  }),
+];

--- a/src/providers/orcarouter/definition.ts
+++ b/src/providers/orcarouter/definition.ts
@@ -1,0 +1,27 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { orcarouterActions } from "./actions.ts";
+
+const service = "orcarouter";
+
+/**
+ * OrcaRouter provider backed by OrcaRouter API keys.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "OrcaRouter",
+  categories: ["AI", "Developer Tools"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "sk-orca-...",
+      description:
+        "OrcaRouter API key used with the Authorization Bearer header. Get it from https://www.orcarouter.ai/console.",
+      extraFields: [],
+    },
+  ],
+  homepageUrl: "https://www.orcarouter.ai",
+  actions: orcarouterActions,
+};

--- a/src/providers/orcarouter/executors.ts
+++ b/src/providers/orcarouter/executors.ts
@@ -6,6 +6,7 @@ import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent 
 
 const service = "orcarouter";
 const orcarouterApiBaseUrl = "https://api.orcarouter.ai/v1";
+const anthropicApiVersion = "2023-06-01";
 
 type QueryValue = string | number | boolean | undefined;
 type OrcarouterActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -15,6 +16,7 @@ interface OrcarouterRequestInput {
   path: string;
   query?: Record<string, QueryValue>;
   body?: Record<string, unknown>;
+  anthropicVersion?: string;
   mode?: "validate" | "execute";
 }
 
@@ -39,6 +41,7 @@ export const orcarouterActionHandlers: Record<string, OrcarouterActionHandler> =
         method: "POST",
         path: "/messages",
         body: compactObject(input),
+        anthropicVersion: anthropicApiVersion,
       },
       context,
     );
@@ -103,7 +106,7 @@ async function orcarouterRequest(
   try {
     response = await context.fetcher(url, {
       method: input.method ?? "GET",
-      headers: buildOrcarouterHeaders(apiKey, input.body != null),
+      headers: buildOrcarouterHeaders(apiKey, input.body != null, input.anthropicVersion),
       body: input.body == null ? undefined : JSON.stringify(input.body),
       signal: context.signal,
     });
@@ -118,7 +121,7 @@ async function orcarouterRequest(
   return response.json() as Promise<unknown>;
 }
 
-function buildOrcarouterHeaders(apiKey: string, includeJsonContentType: boolean): Headers {
+function buildOrcarouterHeaders(apiKey: string, includeJsonContentType: boolean, anthropicVersion?: string): Headers {
   const headers = new Headers({
     authorization: `Bearer ${apiKey}`,
     "user-agent": providerUserAgent,
@@ -126,6 +129,9 @@ function buildOrcarouterHeaders(apiKey: string, includeJsonContentType: boolean)
 
   if (includeJsonContentType) {
     headers.set("content-type", "application/json");
+  }
+  if (anthropicVersion) {
+    headers.set("anthropic-version", anthropicVersion);
   }
 
   return headers;

--- a/src/providers/orcarouter/executors.ts
+++ b/src/providers/orcarouter/executors.ts
@@ -1,0 +1,205 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+
+import { compactObject, optionalString } from "../../core/cast.ts";
+import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+
+const service = "orcarouter";
+const orcarouterApiBaseUrl = "https://api.orcarouter.ai/v1";
+
+type QueryValue = string | number | boolean | undefined;
+type OrcarouterActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+
+interface OrcarouterRequestInput {
+  method?: "GET" | "POST";
+  path: string;
+  query?: Record<string, QueryValue>;
+  body?: Record<string, unknown>;
+  mode?: "validate" | "execute";
+}
+
+export const orcarouterActionHandlers: Record<string, OrcarouterActionHandler> = {
+  create_chat_completion(input, context) {
+    assertStreamingDisabled(input);
+    return orcarouterRequest(
+      context.apiKey,
+      {
+        method: "POST",
+        path: "/chat/completions",
+        body: compactObject(input),
+      },
+      context,
+    );
+  },
+  create_message(input, context) {
+    assertStreamingDisabled(input);
+    return orcarouterRequest(
+      context.apiKey,
+      {
+        method: "POST",
+        path: "/messages",
+        body: compactObject(input),
+      },
+      context,
+    );
+  },
+  list_models(_input, context) {
+    return orcarouterRequest(context.apiKey, { path: "/models" }, context);
+  },
+  create_embeddings(input, context) {
+    return orcarouterRequest(
+      context.apiKey,
+      {
+        method: "POST",
+        path: "/embeddings",
+        body: compactObject(input),
+      },
+      context,
+    );
+  },
+};
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, orcarouterActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    const payload = (await orcarouterRequest(
+      input.apiKey,
+      {
+        path: "/models",
+        mode: "validate",
+      },
+      {
+        apiKey: input.apiKey,
+        fetcher,
+        signal,
+      },
+    )) as {
+      data?: Array<{ id?: unknown }>;
+    };
+
+    return {
+      profile: {
+        displayName: "OrcaRouter API Key",
+      },
+      grantedScopes: [],
+      metadata: {
+        validationEndpoint: "/models",
+        availableModels: (payload.data ?? [])
+          .map((model) => model.id)
+          .filter((model): model is string => typeof model === "string"),
+      },
+    };
+  },
+};
+
+async function orcarouterRequest(
+  apiKey: string,
+  input: OrcarouterRequestInput,
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
+): Promise<unknown> {
+  const url = buildOrcarouterUrl(input.path, input.query ?? {});
+  let response: Response;
+  try {
+    response = await context.fetcher(url, {
+      method: input.method ?? "GET",
+      headers: buildOrcarouterHeaders(apiKey, input.body != null),
+      body: input.body == null ? undefined : JSON.stringify(input.body),
+      signal: context.signal,
+    });
+  } catch (error) {
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `OrcaRouter request failed: ${error.message}` : "OrcaRouter request failed",
+    );
+  }
+
+  await assertOrcarouterResponse(response, input.mode ?? "execute");
+  return response.json() as Promise<unknown>;
+}
+
+function buildOrcarouterHeaders(apiKey: string, includeJsonContentType: boolean): Headers {
+  const headers = new Headers({
+    authorization: `Bearer ${apiKey}`,
+    "user-agent": providerUserAgent,
+  });
+
+  if (includeJsonContentType) {
+    headers.set("content-type", "application/json");
+  }
+
+  return headers;
+}
+
+function buildOrcarouterUrl(path: string, query: Record<string, QueryValue>): string {
+  const url = new URL(`${orcarouterApiBaseUrl}${path}`);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function assertStreamingDisabled(input: Record<string, unknown>): void {
+  if (input.stream === true) {
+    throw new ProviderRequestError(400, "stream=true is not supported by connector actions");
+  }
+}
+
+async function assertOrcarouterResponse(response: Response, mode: "validate" | "execute"): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const error = await readOrcarouterError(response);
+  if (response.status === 429) {
+    throw new ProviderRequestError(429, error.message, error);
+  }
+  if (mode === "validate" && (response.status === 401 || response.status === 403)) {
+    throw new ProviderRequestError(400, error.message, error);
+  }
+  if (mode === "execute" && response.status === 401) {
+    throw new ProviderRequestError(401, error.message, error);
+  }
+  if (response.status === 400 || response.status === 404 || response.status === 413 || response.status === 422) {
+    throw new ProviderRequestError(400, error.message, error);
+  }
+
+  throw new ProviderRequestError(response.status || 502, error.message, error);
+}
+
+async function readOrcarouterError(response: Response): Promise<{
+  type: string;
+  code?: string | number;
+  message: string;
+}> {
+  const rawText = (await response.text().catch(() => "")) || `OrcaRouter request failed with status ${response.status}`;
+
+  try {
+    const payload = JSON.parse(rawText) as Record<string, unknown>;
+    const nestedError = optionalRecordFrom(payload.error);
+
+    return {
+      type: optionalString(nestedError?.type) ?? optionalString(payload.type) ?? "provider_error",
+      code: readErrorCode(nestedError?.code),
+      message: optionalString(nestedError?.message) ?? optionalString(payload.message) ?? rawText,
+    };
+  } catch {
+    return {
+      type: "provider_error",
+      message: rawText,
+    };
+  }
+}
+
+function readErrorCode(value: unknown): string | number | undefined {
+  return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+function optionalRecordFrom(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
# Add OrcaRouter as a named provider

## Overview

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class provider under `src/providers/orcarouter/`, mirroring the existing OpenRouter wiring. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Files added

- `src/providers/orcarouter/definition.ts`: provider catalog source — api_key auth, base URL `https://api.orcarouter.ai/v1`, homepage.
- `src/providers/orcarouter/actions.ts`: action schemas for `create_chat_completion`, `create_message` (Anthropic-format), `list_models` and `create_embeddings`.
- `src/providers/orcarouter/executors.ts`: local executors via `defineApiKeyProviderExecutors`, plus a `/models`-backed credential validator.

The generated registry and `catalog/apps/*.json` are produced by `npm run generate:catalog` (gitignored, regenerated in CI postinstall) — no generated files are hand-edited.

## Provider actions

| Action | Endpoint | Notes |
|---|---|---|
| `create_chat_completion` | `POST /chat/completions` | OpenAI-compatible; accepts namespaced model ids such as `orcarouter/auto` or `openai/gpt-4o-mini` |
| `create_message` | `POST /messages` | Anthropic-format messages endpoint |
| `list_models` | `GET /models` | Model catalog, also used by the credential validator |
| `create_embeddings` | `POST /embeddings` | OpenAI-compatible embeddings |

## Why a separate provider

This mirrors how `openrouter` is wired in this repository, so users get a first-class catalog entry, schema-validated actions and a credential validator instead of configuring OrcaRouter as a bare OpenAI-compatible passthrough.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Add an OrcaRouter provider connection with that key.
3. Pick a model id such as `orcarouter/auto`, `openai/gpt-4o-mini` or `anthropic/claude-haiku-4.5`.

## Verification

- `npm run lint` (oxlint): clean.
- `npm run format` (oxfmt): clean.
- `npm run typecheck`: passes; registry regenerated for 1368 providers including `orcarouter`.
- `npm test` (vitest): 905 passed (96 files).
- Live against OrcaRouter through the real executor path (guarded fetch + `ORCAROUTER_API_KEY`): `list_models`, `create_chat_completion` (routed to gemini-3.1-flash-lite), `create_message` (claude-haiku-4.5), `create_embeddings` and the `/models` credential validator all returned 200.
