### PR TITLE
fix oauth configuration for Calendly and Zoom

### DIFF
--- a/src/providers/calendly/definition.ts
+++ b/src/providers/calendly/definition.ts
@@ -15,10 +15,12 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://calendly.com/oauth/authorize",
-      tokenUrl: "https://calendly.com/oauth/token",
+      authorizationUrl: "https://auth.calendly.com/oauth/authorize",
+      tokenUrl: "https://auth.calendly.com/oauth/token",
+      refreshTokenUrl: "https://auth.calendly.com/oauth/token",
       scopes: calendlyProviderScopes,
-      tokenEndpointAuthMethod: "client_secret_post",
+      tokenEndpointAuthMethod: "client_secret_basic",
+      pkce: { method: "S256" },
     },
     {
       type: "api_key",

--- a/src/providers/zoom/scopes.ts
+++ b/src/providers/zoom/scopes.ts
@@ -1,7 +1,7 @@
-export const zoomUserReadScope = "user:read:user:admin";
-export const zoomMeetingListScope = "meeting:read:list_meetings:admin";
-export const zoomMeetingWriteScope = "meeting:write:meeting:admin";
-export const zoomMeetingUpdateScope = "meeting:update:meeting:admin";
+export const zoomUserReadScope = "user:read:user";
+export const zoomMeetingListScope = "meeting:read:list_meetings";
+export const zoomMeetingWriteScope = "meeting:write:meeting";
+export const zoomMeetingUpdateScope = "meeting:update:meeting";
 
 export const zoomProviderScopes: string[] = [
   zoomUserReadScope,


### PR DESCRIPTION
## Summary
- use the current Calendly authorization and token endpoints, client secret Basic auth, and PKCE
- request user-managed Zoom scopes instead of account-admin scopes

## Why
The Calendly app is configured for the current OAuth flow. Zoom is a user-managed app and rejects the admin scopes currently requested by the provider.

## Validation
- npm run fix-check
- verified the Calendly OAuth consent and callback against a production app
- verified the Zoom user-managed app configuration with the replacement scopes