### PR TITLE
fix(calendly): update OAuth configuration

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -57,6 +57,40 @@ describe("OAuth token requests", () => {
     expect(String(init?.body)).toContain("code=authorization-code");
   });
 
+  it("keeps client_secret_basic credentials out of authorization-code and refresh bodies", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ access_token: "access-token", refresh_token: "refresh-token" }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+    const basicRequest = {
+      ...authorizationCodeRequest,
+      tokenEndpointAuthMethod: "client_secret_basic" as const,
+    };
+
+    await requestAuthorizationCodeToken(basicRequest);
+    await requestRefreshToken({ ...basicRequest, refreshToken: "stored-refresh-token" });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    const authorizationCodeInit = fetcher.mock.calls[0]?.[1];
+    const refreshInit = fetcher.mock.calls[1]?.[1];
+    const expectedAuthorization = `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`;
+
+    for (const init of [authorizationCodeInit, refreshInit]) {
+      expect(init?.headers).toMatchObject({ authorization: expectedAuthorization });
+      expect(init?.body).toBeInstanceOf(URLSearchParams);
+      if (!(init?.body instanceof URLSearchParams)) {
+        throw new Error("Expected OAuth token request body to use URLSearchParams");
+      }
+      expect(init.body.has("client_secret")).toBe(false);
+    }
+
+    if (!(authorizationCodeInit?.body instanceof URLSearchParams) || !(refreshInit?.body instanceof URLSearchParams)) {
+      throw new Error("Expected both OAuth token request bodies to use URLSearchParams");
+    }
+    expect(authorizationCodeInit.body.get("grant_type")).toBe("authorization_code");
+    expect(refreshInit.body.get("grant_type")).toBe("refresh_token");
+  });
+
   it("rejects a redirecting token endpoint without following it, on Workers too", async () => {
     const calls: string[] = [];
     // Mirrors the Cloudflare Workers runtime: `redirect: "error"` is not

--- a/src/providers/calendly/definition.ts
+++ b/src/providers/calendly/definition.ts
@@ -3,6 +3,8 @@ import type { ProviderDefinition } from "../../core/types.ts";
 import { calendlyActions, calendlyProviderScopes } from "./actions.ts";
 
 const service = "calendly";
+const calendlyOAuthAuthorizationUrl = "https://auth.calendly.com/oauth/authorize";
+const calendlyOAuthTokenUrl = "https://auth.calendly.com/oauth/token";
 
 /**
  * Calendly provider backed by the Calendly API v2.
@@ -15,9 +17,9 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://auth.calendly.com/oauth/authorize",
-      tokenUrl: "https://auth.calendly.com/oauth/token",
-      refreshTokenUrl: "https://auth.calendly.com/oauth/token",
+      authorizationUrl: calendlyOAuthAuthorizationUrl,
+      tokenUrl: calendlyOAuthTokenUrl,
+      refreshTokenUrl: calendlyOAuthTokenUrl,
       scopes: calendlyProviderScopes,
       tokenEndpointAuthMethod: "client_secret_basic",
       pkce: { method: "S256" },

--- a/src/providers/calendly/definition.ts
+++ b/src/providers/calendly/definition.ts
@@ -15,10 +15,12 @@ export const provider: ProviderDefinition = {
   auth: [
     {
       type: "oauth2",
-      authorizationUrl: "https://calendly.com/oauth/authorize",
-      tokenUrl: "https://calendly.com/oauth/token",
+      authorizationUrl: "https://auth.calendly.com/oauth/authorize",
+      tokenUrl: "https://auth.calendly.com/oauth/token",
+      refreshTokenUrl: "https://auth.calendly.com/oauth/token",
       scopes: calendlyProviderScopes,
-      tokenEndpointAuthMethod: "client_secret_post",
+      tokenEndpointAuthMethod: "client_secret_basic",
+      pkce: { method: "S256" },
     },
     {
       type: "api_key",


### PR DESCRIPTION
## Summary
- use the current Calendly authorization and token endpoints
- authenticate token requests with client secret Basic auth
- enable S256 PKCE and use the same endpoint for refresh tokens
- cover authorization-code and refresh-token Basic authentication boundaries

## Why
Calendly documents its current OAuth endpoints under auth.calendly.com. Aligning the provider with that flow avoids relying on the legacy calendly.com endpoints.

## Validation
- npm run generate:catalog
- npm run fix-check
- npm test: 98 files and 939 tests passed
- verified the production Calendly app consent and callback flow