### PR TITLE
fix(zoom): use user-managed OAuth scopes

### DIFF
--- a/src/providers/zoom/scopes.ts
+++ b/src/providers/zoom/scopes.ts
@@ -1,7 +1,7 @@
-export const zoomUserReadScope = "user:read:user:admin";
-export const zoomMeetingListScope = "meeting:read:list_meetings:admin";
-export const zoomMeetingWriteScope = "meeting:write:meeting:admin";
-export const zoomMeetingUpdateScope = "meeting:update:meeting:admin";
+export const zoomUserReadScope = "user:read:user";
+export const zoomMeetingListScope = "meeting:read:list_meetings";
+export const zoomMeetingWriteScope = "meeting:write:meeting";
+export const zoomMeetingUpdateScope = "meeting:update:meeting";
 
 export const zoomProviderScopes: string[] = [
   zoomUserReadScope,


### PR DESCRIPTION
## Summary
- replace Zoom account-admin scopes with the corresponding user-managed scopes
- keep the existing four user and meeting capabilities unchanged

## Why
The provider is configured with a user-managed Zoom OAuth app. Zoom rejects the admin scope variants for that app type, preventing authorization from starting.

## Validation
- npm run generate:catalog
- npm run fix-check
- npm test: 98 files and 938 tests passed
- verified the Zoom user-managed app configuration with the replacement scopes