### PR TITLE
feat(canva-cn): add OAuth provider

### DIFF
--- a/src/providers/canva/actions.ts
+++ b/src/providers/canva/actions.ts
@@ -3,8 +3,6 @@ import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
 
-const service = "canva" as const;
-
 export const canvaProviderScopes = {
   designMetaRead: "design:meta:read",
   designContentRead: "design:content:read",
@@ -15,6 +13,17 @@ export const canvaProviderScopes = {
   folderWrite: "folder:write",
   profileRead: "profile:read",
 } as const;
+
+export const canvaOAuthScopes: string[] = [
+  canvaProviderScopes.designMetaRead,
+  canvaProviderScopes.designContentRead,
+  canvaProviderScopes.designContentWrite,
+  canvaProviderScopes.assetRead,
+  canvaProviderScopes.assetWrite,
+  canvaProviderScopes.folderRead,
+  canvaProviderScopes.folderWrite,
+  canvaProviderScopes.profileRead,
+];
 
 const emptyInputSchema = s.object("No input is required for this action.", {});
 
@@ -233,239 +242,244 @@ const folderItemSchema = s.object("A normalized Canva folder item.", {
   updatedAt: s.nullable(s.dateTime("The item update timestamp when returned.")),
 });
 
-export const canvaActions: ActionDefinition[] = [
-  defineProviderAction(service, {
-    name: "get_current_user",
-    description: "Get the Canva user and profile associated with the current OAuth token.",
-    requiredScopes: [canvaProviderScopes.profileRead],
-    providerPermissions: [canvaProviderScopes.profileRead],
-    inputSchema: emptyInputSchema,
-    outputSchema: s.object("The normalized Canva current user profile.", {
-      userId: s.string("The Canva user ID."),
-      teamId: s.nullable(s.string("The Canva team ID when returned.")),
-      displayName: s.nullable(s.string("The Canva display name when returned.")),
+/** Build the shared Canva action catalog for one regional service. */
+export function createCanvaActions(service: string): ActionDefinition[] {
+  return [
+    defineProviderAction(service, {
+      name: "get_current_user",
+      description: "Get the Canva user and profile associated with the current OAuth token.",
+      requiredScopes: [canvaProviderScopes.profileRead],
+      providerPermissions: [canvaProviderScopes.profileRead],
+      inputSchema: emptyInputSchema,
+      outputSchema: s.object("The normalized Canva current user profile.", {
+        userId: s.string("The Canva user ID."),
+        teamId: s.nullable(s.string("The Canva team ID when returned.")),
+        displayName: s.nullable(s.string("The Canva display name when returned.")),
+      }),
     }),
-  }),
-  defineProviderAction(service, {
-    name: "list_designs",
-    description:
-      "List metadata for the current Canva user's designs, with optional search, ownership, sorting, and pagination filters.",
-    requiredScopes: [canvaProviderScopes.designMetaRead],
-    providerPermissions: [canvaProviderScopes.designMetaRead],
-    inputSchema: s.object(
-      "Input parameters for listing Canva design metadata.",
-      {
-        query: s.string("A search term for filtering designs.", { minLength: 1, maxLength: 255 }),
-        continuation: s.string("The continuation token returned by a previous list_designs call.", {
-          minLength: 1,
-        }),
-        ownership: s.stringEnum("Filter designs by the current user's ownership.", ["any", "owned", "shared"]),
-        sortBy: s.stringEnum("The Canva sort order for the design list.", [
-          "relevance",
-          "modified_descending",
-          "modified_ascending",
-          "title_ascending",
-          "title_descending",
-        ]),
-        limit: s.integer("The maximum number of designs to return.", {
-          minimum: 1,
-          maximum: 100,
-        }),
-      },
-      { optional: ["query", "continuation", "ownership", "sortBy", "limit"] },
-    ),
-    outputSchema: s.object("A Canva design listing page.", {
-      designs: s.array("The normalized Canva designs returned in this page.", canvaDesignSchema),
-      continuation: s.nullable(s.string("The continuation token to request the next page when available.")),
+    defineProviderAction(service, {
+      name: "list_designs",
+      description:
+        "List metadata for the current Canva user's designs, with optional search, ownership, sorting, and pagination filters.",
+      requiredScopes: [canvaProviderScopes.designMetaRead],
+      providerPermissions: [canvaProviderScopes.designMetaRead],
+      inputSchema: s.object(
+        "Input parameters for listing Canva design metadata.",
+        {
+          query: s.string("A search term for filtering designs.", { minLength: 1, maxLength: 255 }),
+          continuation: s.string("The continuation token returned by a previous list_designs call.", {
+            minLength: 1,
+          }),
+          ownership: s.stringEnum("Filter designs by the current user's ownership.", ["any", "owned", "shared"]),
+          sortBy: s.stringEnum("The Canva sort order for the design list.", [
+            "relevance",
+            "modified_descending",
+            "modified_ascending",
+            "title_ascending",
+            "title_descending",
+          ]),
+          limit: s.integer("The maximum number of designs to return.", {
+            minimum: 1,
+            maximum: 100,
+          }),
+        },
+        { optional: ["query", "continuation", "ownership", "sortBy", "limit"] },
+      ),
+      outputSchema: s.object("A Canva design listing page.", {
+        designs: s.array("The normalized Canva designs returned in this page.", canvaDesignSchema),
+        continuation: s.nullable(s.string("The continuation token to request the next page when available.")),
+      }),
     }),
-  }),
-  defineProviderAction(service, {
-    name: "get_design",
-    description: "Get metadata for a Canva design, including owner, URLs, and thumbnail details.",
-    requiredScopes: [canvaProviderScopes.designMetaRead],
-    providerPermissions: [canvaProviderScopes.designMetaRead],
-    inputSchema: s.object("Input parameters for retrieving one Canva design.", {
-      designId: s.string("The Canva design ID.", { minLength: 1 }),
+    defineProviderAction(service, {
+      name: "get_design",
+      description: "Get metadata for a Canva design, including owner, URLs, and thumbnail details.",
+      requiredScopes: [canvaProviderScopes.designMetaRead],
+      providerPermissions: [canvaProviderScopes.designMetaRead],
+      inputSchema: s.object("Input parameters for retrieving one Canva design.", {
+        designId: s.string("The Canva design ID.", { minLength: 1 }),
+      }),
+      outputSchema: s.object("The normalized Canva design metadata response.", {
+        design: canvaDesignSchema,
+      }),
     }),
-    outputSchema: s.object("The normalized Canva design metadata response.", {
-      design: canvaDesignSchema,
+    defineProviderAction(service, {
+      name: "create_design",
+      description:
+        "Create a new Canva design from a preset type, custom dimensions, an optional image asset, an existing design, or a brand template.",
+      requiredScopes: [canvaProviderScopes.designContentWrite],
+      providerPermissions: [canvaProviderScopes.designContentWrite],
+      inputSchema: createDesignInputSchema,
+      outputSchema: s.object("The Canva design creation response.", {
+        design: canvaDesignSchema,
+      }),
     }),
-  }),
-  defineProviderAction(service, {
-    name: "create_design",
-    description:
-      "Create a new Canva design from a preset type, custom dimensions, an optional image asset, an existing design, or a brand template.",
-    requiredScopes: [canvaProviderScopes.designContentWrite],
-    providerPermissions: [canvaProviderScopes.designContentWrite],
-    inputSchema: createDesignInputSchema,
-    outputSchema: s.object("The Canva design creation response.", {
-      design: canvaDesignSchema,
+    defineProviderAction(service, {
+      name: "list_folder_items",
+      description:
+        "List Canva folder contents, including folders, designs, and image assets, with pagination and filtering options.",
+      requiredScopes: [canvaProviderScopes.folderRead],
+      providerPermissions: [canvaProviderScopes.folderRead],
+      inputSchema: s.object(
+        "Input parameters for listing Canva folder items.",
+        {
+          folderId: s.string("The Canva folder ID to list.", { minLength: 1, maxLength: 50 }),
+          continuation: s.string("The continuation token returned by a previous list_folder_items call.", {
+            minLength: 1,
+          }),
+          limit: s.integer("The maximum number of folder items to return.", {
+            minimum: 1,
+            maximum: 100,
+          }),
+          itemTypes: s.array(
+            "The Canva folder item types to include.",
+            s.stringEnum("One Canva folder item type.", ["design", "folder", "image"]),
+            { minItems: 1 },
+          ),
+          sortBy: s.stringEnum("The Canva sort order for folder items.", [
+            "created_ascending",
+            "created_descending",
+            "modified_ascending",
+            "modified_descending",
+            "title_ascending",
+            "title_descending",
+          ]),
+          pinStatus: s.stringEnum("Filter folder items by pinned status.", ["any", "pinned"]),
+        },
+        { optional: ["continuation", "limit", "itemTypes", "sortBy", "pinStatus"] },
+      ),
+      outputSchema: s.object("A Canva folder item listing page.", {
+        items: s.array("The normalized Canva folder items returned in this page.", folderItemSchema),
+        continuation: s.nullable(s.string("The continuation token to request the next page when available.")),
+      }),
     }),
-  }),
-  defineProviderAction(service, {
-    name: "list_folder_items",
-    description:
-      "List Canva folder contents, including folders, designs, and image assets, with pagination and filtering options.",
-    requiredScopes: [canvaProviderScopes.folderRead],
-    providerPermissions: [canvaProviderScopes.folderRead],
-    inputSchema: s.object(
-      "Input parameters for listing Canva folder items.",
-      {
-        folderId: s.string("The Canva folder ID to list.", { minLength: 1, maxLength: 50 }),
-        continuation: s.string("The continuation token returned by a previous list_folder_items call.", {
-          minLength: 1,
-        }),
-        limit: s.integer("The maximum number of folder items to return.", {
-          minimum: 1,
-          maximum: 100,
-        }),
-        itemTypes: s.array(
-          "The Canva folder item types to include.",
-          s.stringEnum("One Canva folder item type.", ["design", "folder", "image"]),
-          { minItems: 1 },
+    defineProviderAction(service, {
+      name: "create_folder",
+      description: "Create a Canva folder at the top level, in uploads, or inside another folder.",
+      requiredScopes: [canvaProviderScopes.folderWrite],
+      providerPermissions: [canvaProviderScopes.folderWrite],
+      inputSchema: s.object("Input parameters for creating a Canva folder.", {
+        name: s.string("The Canva folder name.", { minLength: 1, maxLength: 255 }),
+        parentFolderId: s.string(
+          "The parent folder ID, root for the top-level projects area, or uploads for the user's Uploads folder.",
+          { minLength: 1, maxLength: 50 },
         ),
-        sortBy: s.stringEnum("The Canva sort order for folder items.", [
-          "created_ascending",
-          "created_descending",
-          "modified_ascending",
-          "modified_descending",
-          "title_ascending",
-          "title_descending",
-        ]),
-        pinStatus: s.stringEnum("Filter folder items by pinned status.", ["any", "pinned"]),
+      }),
+      outputSchema: s.object("The Canva folder creation response.", {
+        folder: canvaFolderSchema,
+      }),
+    }),
+    defineProviderAction(service, {
+      name: "move_folder_item",
+      description: "Move a Canva folder item to another Canva folder.",
+      requiredScopes: [canvaProviderScopes.folderWrite],
+      providerPermissions: [canvaProviderScopes.folderWrite],
+      inputSchema: s.object("Input parameters for moving a Canva folder item.", {
+        itemId: s.string("The Canva item ID to move.", { minLength: 1, maxLength: 50 }),
+        toFolderId: s.string("The destination Canva folder ID, or root for the top-level projects area.", {
+          minLength: 1,
+          maxLength: 50,
+        }),
+      }),
+      outputSchema: s.object("A Canva folder item move acknowledgement.", {
+        moved: s.boolean("Whether Canva accepted the move request."),
+        itemId: s.string("The Canva item ID that was moved."),
+        toFolderId: s.string("The destination Canva folder ID."),
+      }),
+    }),
+    defineProviderAction(service, {
+      name: "get_asset",
+      description: "Get metadata for a Canva asset, including owner, thumbnail, and type-specific metadata.",
+      requiredScopes: [canvaProviderScopes.assetRead],
+      providerPermissions: [canvaProviderScopes.assetRead],
+      inputSchema: s.object("Input parameters for retrieving one Canva asset.", {
+        assetId: s.string("The Canva asset ID.", { minLength: 1, maxLength: 50 }),
+      }),
+      outputSchema: s.object("The normalized Canva asset metadata response.", {
+        asset: assetSchema,
+      }),
+    }),
+    defineProviderAction(service, {
+      name: "get_design_export_formats",
+      description: "List the file formats currently available for exporting a Canva design.",
+      requiredScopes: [canvaProviderScopes.designContentRead],
+      providerPermissions: [canvaProviderScopes.designContentRead],
+      inputSchema: s.object("Input parameters for listing Canva design export formats.", {
+        designId: s.string("The Canva design ID.", { minLength: 1 }),
+      }),
+      outputSchema: s.object("The Canva design export format response.", {
+        formats: s.array(
+          "The raw Canva export format objects supported by this design.",
+          s.looseObject("A Canva export format object."),
+        ),
+      }),
+    }),
+    defineProviderAction(service, {
+      name: "create_design_export_job",
+      description: "Start an asynchronous Canva export job for a design and return the job handle for polling.",
+      requiredScopes: [canvaProviderScopes.designContentRead],
+      providerPermissions: [canvaProviderScopes.designContentRead],
+      asyncLifecycle: {
+        startActionId: `${service}.create_design_export_job`,
+        statusActionId: `${service}.get_design_export_job`,
       },
-      { optional: ["continuation", "limit", "itemTypes", "sortBy", "pinStatus"] },
-    ),
-    outputSchema: s.object("A Canva folder item listing page.", {
-      items: s.array("The normalized Canva folder items returned in this page.", folderItemSchema),
-      continuation: s.nullable(s.string("The continuation token to request the next page when available.")),
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "create_folder",
-    description: "Create a Canva folder at the top level, in uploads, or inside another folder.",
-    requiredScopes: [canvaProviderScopes.folderWrite],
-    providerPermissions: [canvaProviderScopes.folderWrite],
-    inputSchema: s.object("Input parameters for creating a Canva folder.", {
-      name: s.string("The Canva folder name.", { minLength: 1, maxLength: 255 }),
-      parentFolderId: s.string(
-        "The parent folder ID, root for the top-level projects area, or uploads for the user's Uploads folder.",
-        { minLength: 1, maxLength: 50 },
-      ),
-    }),
-    outputSchema: s.object("The Canva folder creation response.", {
-      folder: canvaFolderSchema,
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "move_folder_item",
-    description: "Move a Canva folder item to another Canva folder.",
-    requiredScopes: [canvaProviderScopes.folderWrite],
-    providerPermissions: [canvaProviderScopes.folderWrite],
-    inputSchema: s.object("Input parameters for moving a Canva folder item.", {
-      itemId: s.string("The Canva item ID to move.", { minLength: 1, maxLength: 50 }),
-      toFolderId: s.string("The destination Canva folder ID, or root for the top-level projects area.", {
-        minLength: 1,
-        maxLength: 50,
+      inputSchema: s.object("Input parameters for creating a Canva design export job.", {
+        designId: s.string("The Canva design ID to export.", { minLength: 1 }),
+        format: exportFormatSchema,
+      }),
+      outputSchema: s.object("The Canva design export job creation response.", {
+        job: exportJobSchema,
       }),
     }),
-    outputSchema: s.object("A Canva folder item move acknowledgement.", {
-      moved: s.boolean("Whether Canva accepted the move request."),
-      itemId: s.string("The Canva item ID that was moved."),
-      toFolderId: s.string("The destination Canva folder ID."),
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "get_asset",
-    description: "Get metadata for a Canva asset, including owner, thumbnail, and type-specific metadata.",
-    requiredScopes: [canvaProviderScopes.assetRead],
-    providerPermissions: [canvaProviderScopes.assetRead],
-    inputSchema: s.object("Input parameters for retrieving one Canva asset.", {
-      assetId: s.string("The Canva asset ID.", { minLength: 1, maxLength: 50 }),
-    }),
-    outputSchema: s.object("The normalized Canva asset metadata response.", {
-      asset: assetSchema,
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "get_design_export_formats",
-    description: "List the file formats currently available for exporting a Canva design.",
-    requiredScopes: [canvaProviderScopes.designContentRead],
-    providerPermissions: [canvaProviderScopes.designContentRead],
-    inputSchema: s.object("Input parameters for listing Canva design export formats.", {
-      designId: s.string("The Canva design ID.", { minLength: 1 }),
-    }),
-    outputSchema: s.object("The Canva design export format response.", {
-      formats: s.array(
-        "The raw Canva export format objects supported by this design.",
-        s.looseObject("A Canva export format object."),
-      ),
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "create_design_export_job",
-    description: "Start an asynchronous Canva export job for a design and return the job handle for polling.",
-    requiredScopes: [canvaProviderScopes.designContentRead],
-    providerPermissions: [canvaProviderScopes.designContentRead],
-    asyncLifecycle: {
-      startActionId: "canva.create_design_export_job",
-      statusActionId: "canva.get_design_export_job",
-    },
-    inputSchema: s.object("Input parameters for creating a Canva design export job.", {
-      designId: s.string("The Canva design ID to export.", { minLength: 1 }),
-      format: exportFormatSchema,
-    }),
-    outputSchema: s.object("The Canva design export job creation response.", {
-      job: exportJobSchema,
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "get_design_export_job",
-    description:
-      "Get the current status and result URLs for a Canva design export job created by create_design_export_job.",
-    requiredScopes: [canvaProviderScopes.designContentRead],
-    providerPermissions: [canvaProviderScopes.designContentRead],
-    inputSchema: s.object("Input parameters for retrieving a Canva design export job.", {
-      exportId: s.string("The Canva export job ID.", { minLength: 1 }),
-    }),
-    outputSchema: s.object("The Canva design export job response.", {
-      job: exportJobSchema,
-    }),
-  }),
-  defineProviderAction(service, {
-    name: "create_url_asset_upload_job",
-    description:
-      "Start an asynchronous Canva asset upload job from a publicly accessible URL and return the job handle for polling.",
-    requiredScopes: [canvaProviderScopes.assetWrite],
-    providerPermissions: [canvaProviderScopes.assetWrite],
-    asyncLifecycle: {
-      startActionId: "canva.create_url_asset_upload_job",
-      statusActionId: "canva.get_url_asset_upload_job",
-    },
-    inputSchema: s.object("Input parameters for uploading a Canva asset from a URL.", {
-      name: s.string("The asset name shown in Canva.", { minLength: 1, maxLength: 255 }),
-      url: s.string("The publicly accessible URL of the file to upload to Canva.", {
-        format: "uri",
-        maxLength: 2048,
+    defineProviderAction(service, {
+      name: "get_design_export_job",
+      description:
+        "Get the current status and result URLs for a Canva design export job created by create_design_export_job.",
+      requiredScopes: [canvaProviderScopes.designContentRead],
+      providerPermissions: [canvaProviderScopes.designContentRead],
+      inputSchema: s.object("Input parameters for retrieving a Canva design export job.", {
+        exportId: s.string("The Canva export job ID.", { minLength: 1 }),
+      }),
+      outputSchema: s.object("The Canva design export job response.", {
+        job: exportJobSchema,
       }),
     }),
-    outputSchema: s.object("The Canva URL asset upload job creation response.", {
-      job: assetUploadJobSchema,
+    defineProviderAction(service, {
+      name: "create_url_asset_upload_job",
+      description:
+        "Start an asynchronous Canva asset upload job from a publicly accessible URL and return the job handle for polling.",
+      requiredScopes: [canvaProviderScopes.assetWrite],
+      providerPermissions: [canvaProviderScopes.assetWrite],
+      asyncLifecycle: {
+        startActionId: `${service}.create_url_asset_upload_job`,
+        statusActionId: `${service}.get_url_asset_upload_job`,
+      },
+      inputSchema: s.object("Input parameters for uploading a Canva asset from a URL.", {
+        name: s.string("The asset name shown in Canva.", { minLength: 1, maxLength: 255 }),
+        url: s.string("The publicly accessible URL of the file to upload to Canva.", {
+          format: "uri",
+          maxLength: 2048,
+        }),
+      }),
+      outputSchema: s.object("The Canva URL asset upload job creation response.", {
+        job: assetUploadJobSchema,
+      }),
     }),
-  }),
-  defineProviderAction(service, {
-    name: "get_url_asset_upload_job",
-    description: "Get the current status and uploaded asset metadata for a Canva URL asset upload job.",
-    requiredScopes: [canvaProviderScopes.assetRead],
-    providerPermissions: [canvaProviderScopes.assetRead],
-    inputSchema: s.object("Input parameters for retrieving a Canva URL asset upload job.", {
-      jobId: s.string("The Canva asset upload job ID.", { minLength: 1 }),
+    defineProviderAction(service, {
+      name: "get_url_asset_upload_job",
+      description: "Get the current status and uploaded asset metadata for a Canva URL asset upload job.",
+      requiredScopes: [canvaProviderScopes.assetRead],
+      providerPermissions: [canvaProviderScopes.assetRead],
+      inputSchema: s.object("Input parameters for retrieving a Canva URL asset upload job.", {
+        jobId: s.string("The Canva asset upload job ID.", { minLength: 1 }),
+      }),
+      outputSchema: s.object("The Canva URL asset upload job response.", {
+        job: assetUploadJobSchema,
+      }),
     }),
-    outputSchema: s.object("The Canva URL asset upload job response.", {
-      job: assetUploadJobSchema,
-    }),
-  }),
-];
+  ];
+}
+
+export const canvaActions: ActionDefinition[] = createCanvaActions("canva");
 
 export const canvaActionByName: Map<string, ActionDefinition> = new Map(
   canvaActions.map((action) => [action.name, action] as const),

--- a/src/providers/canva/definition.ts
+++ b/src/providers/canva/definition.ts
@@ -1,6 +1,6 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
-import { canvaActions, canvaProviderScopes } from "./actions.ts";
+import { canvaActions, canvaOAuthScopes } from "./actions.ts";
 
 const service = "canva";
 
@@ -14,16 +14,7 @@ export const provider: ProviderDefinition = {
       type: "oauth2",
       authorizationUrl: "https://www.canva.com/api/oauth/authorize",
       tokenUrl: "https://api.canva.com/rest/v1/oauth/token",
-      scopes: [
-        canvaProviderScopes.designMetaRead,
-        canvaProviderScopes.designContentRead,
-        canvaProviderScopes.designContentWrite,
-        canvaProviderScopes.assetRead,
-        canvaProviderScopes.assetWrite,
-        canvaProviderScopes.folderRead,
-        canvaProviderScopes.folderWrite,
-        canvaProviderScopes.profileRead,
-      ],
+      scopes: canvaOAuthScopes,
       tokenEndpointAuthMethod: "client_secret_basic",
       pkce: {
         method: "S256",

--- a/src/providers/canva/executors.test.ts
+++ b/src/providers/canva/executors.test.ts
@@ -1,0 +1,59 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { createCanvaExecutors } from "./executors.ts";
+
+interface FetchCall {
+  url: string;
+  authorization: string | null;
+}
+
+const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "test-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "canva:test", displayName: "Canva test", grantedScopes: [] },
+  metadata: {},
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("Canva regional executors", () => {
+  it("keeps credentials and API requests isolated by regional service", async () => {
+    const calls: FetchCall[] = [];
+    const credentialServices: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      calls.push({ url: request.url, authorization: request.headers.get("authorization") });
+      if (request.url.endsWith("/profile")) {
+        return Response.json({ profile: { display_name: "Canva user" } });
+      }
+      return Response.json({ team_user: { user_id: "user-1", team_id: "team-1" } });
+    });
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "93.184.216.34", family: 4 }]);
+
+    const context: ExecutionContext = {
+      getCredential: async (service) => {
+        credentialServices.push(service);
+        return credential;
+      },
+    };
+    const international = createCanvaExecutors("canva", "https://api.canva.com/rest");
+    const china = createCanvaExecutors("canva_cn", "https://api.canva.cn/rest");
+
+    await expect(international["canva.get_current_user"]!({}, context)).resolves.toMatchObject({ ok: true });
+    await expect(china["canva_cn.get_current_user"]!({}, context)).resolves.toMatchObject({ ok: true });
+
+    expect(credentialServices).toEqual(["canva", "canva_cn"]);
+    expect(calls).toEqual([
+      { url: "https://api.canva.com/rest/v1/users/me", authorization: "Bearer test-access-token" },
+      { url: "https://api.canva.com/rest/v1/users/me/profile", authorization: "Bearer test-access-token" },
+      { url: "https://api.canva.cn/rest/v1/users/me", authorization: "Bearer test-access-token" },
+      { url: "https://api.canva.cn/rest/v1/users/me/profile", authorization: "Bearer test-access-token" },
+    ]);
+  });
+});

--- a/src/providers/canva/executors.ts
+++ b/src/providers/canva/executors.ts
@@ -9,111 +9,121 @@ const canvaApiBaseUrl = "https://api.canva.com/rest";
 
 type CanvaActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
 
-export const canvaActionHandlers: Record<string, CanvaActionHandler> = {
-  get_current_user(_input, context) {
-    return getCurrentUser(context);
-  },
-  list_designs(input, context) {
-    return listDesigns(input, context);
-  },
-  get_design(input, context) {
-    return getDesign(input, context);
-  },
-  create_design(input, context) {
-    return createDesign(input, context);
-  },
-  list_folder_items(input, context) {
-    return listFolderItems(input, context);
-  },
-  create_folder(input, context) {
-    return createFolder(input, context);
-  },
-  move_folder_item(input, context) {
-    return moveFolderItem(input, context);
-  },
-  get_asset(input, context) {
-    return getAsset(input, context);
-  },
-  get_design_export_formats(input, context) {
-    return getDesignExportFormats(input, context);
-  },
-  create_design_export_job(input, context) {
-    return createDesignExportJob(input, context);
-  },
-  get_design_export_job(input, context) {
-    return getDesignExportJob(input, context);
-  },
-  create_url_asset_upload_job(input, context) {
-    return createUrlAssetUploadJob(input, context);
-  },
-  get_url_asset_upload_job(input, context) {
-    return getUrlAssetUploadJob(input, context);
-  },
-};
+/** Build Canva executors for one regional OAuth service and API base URL. */
+export function createCanvaExecutors(service: string, apiBaseUrl: string): ProviderExecutors {
+  return defineOAuthProviderExecutors(service, createCanvaActionHandlers(apiBaseUrl));
+}
 
-export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, canvaActionHandlers);
+export const canvaActionHandlers: Record<string, CanvaActionHandler> = createCanvaActionHandlers(canvaApiBaseUrl);
 
-async function getCurrentUser(context: OAuthProviderContext) {
-  const account = await canvaJsonRequest("GET", "/v1/users/me", context);
-  const profile = await canvaJsonRequest("GET", "/v1/users/me/profile", context);
+export const executors: ProviderExecutors = createCanvaExecutors(service, canvaApiBaseUrl);
+
+function createCanvaActionHandlers(apiBaseUrl: string): Record<string, CanvaActionHandler> {
+  return {
+    get_current_user(_input, context) {
+      return getCurrentUser(context, apiBaseUrl);
+    },
+    list_designs(input, context) {
+      return listDesigns(input, context, apiBaseUrl);
+    },
+    get_design(input, context) {
+      return getDesign(input, context, apiBaseUrl);
+    },
+    create_design(input, context) {
+      return createDesign(input, context, apiBaseUrl);
+    },
+    list_folder_items(input, context) {
+      return listFolderItems(input, context, apiBaseUrl);
+    },
+    create_folder(input, context) {
+      return createFolder(input, context, apiBaseUrl);
+    },
+    move_folder_item(input, context) {
+      return moveFolderItem(input, context, apiBaseUrl);
+    },
+    get_asset(input, context) {
+      return getAsset(input, context, apiBaseUrl);
+    },
+    get_design_export_formats(input, context) {
+      return getDesignExportFormats(input, context, apiBaseUrl);
+    },
+    create_design_export_job(input, context) {
+      return createDesignExportJob(input, context, apiBaseUrl);
+    },
+    get_design_export_job(input, context) {
+      return getDesignExportJob(input, context, apiBaseUrl);
+    },
+    create_url_asset_upload_job(input, context) {
+      return createUrlAssetUploadJob(input, context, apiBaseUrl);
+    },
+    get_url_asset_upload_job(input, context) {
+      return getUrlAssetUploadJob(input, context, apiBaseUrl);
+    },
+  };
+}
+
+async function getCurrentUser(context: OAuthProviderContext, apiBaseUrl: string) {
+  const account = await canvaJsonRequest("GET", "/v1/users/me", context, apiBaseUrl);
+  const profile = await canvaJsonRequest("GET", "/v1/users/me/profile", context, apiBaseUrl);
   return normalizeCurrentUser(account, profile);
 }
 
-async function listDesigns(input: Record<string, unknown>, context: OAuthProviderContext) {
-  const url = new URL(`${canvaApiBaseUrl}/v1/designs`);
+async function listDesigns(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
+  const url = new URL(`${apiBaseUrl}/v1/designs`);
   appendQuery(url, "query", optionalString(input.query));
   appendQuery(url, "continuation", optionalString(input.continuation));
   appendQuery(url, "ownership", optionalString(input.ownership));
   appendQuery(url, "sort_by", optionalString(input.sortBy));
   appendQuery(url, "limit", optionalIntegerString(input.limit));
-  const payload = await canvaJsonRequest("GET", url.toString(), context);
+  const payload = await canvaJsonRequest("GET", url.toString(), context, apiBaseUrl);
   return {
     designs: readObjectArray(payload.items).map(mapCanvaDesign),
     continuation: optionalString(payload.continuation) ?? null,
   };
 }
 
-async function getDesign(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function getDesign(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const designId = requireCanvaString(input.designId, "canva designId");
-  const payload = await canvaJsonRequest("GET", `/v1/designs/${encodeURIComponent(designId)}`, context);
+  const payload = await canvaJsonRequest("GET", `/v1/designs/${encodeURIComponent(designId)}`, context, apiBaseUrl);
   return { design: mapCanvaDesign(requiredRecord(payload.design, "design", requestError)) };
 }
 
-async function createDesign(input: Record<string, unknown>, context: OAuthProviderContext) {
-  const payload = await canvaJsonRequest("POST", "/v1/designs", context, mapCreateDesignBody(input));
+async function createDesign(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
+  const payload = await canvaJsonRequest("POST", "/v1/designs", context, apiBaseUrl, mapCreateDesignBody(input));
   return { design: mapCanvaDesign(requiredRecord(payload.design, "design", requestError)) };
 }
 
-async function listFolderItems(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function listFolderItems(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const folderId = requireCanvaString(input.folderId, "canva folderId");
-  const url = new URL(`${canvaApiBaseUrl}/v1/folders/${encodeURIComponent(folderId)}/items`);
+  const url = new URL(`${apiBaseUrl}/v1/folders/${encodeURIComponent(folderId)}/items`);
   appendQuery(url, "continuation", optionalString(input.continuation));
   appendQuery(url, "limit", optionalIntegerString(input.limit));
   appendQuery(url, "item_types", optionalStringList(input.itemTypes));
   appendQuery(url, "sort_by", optionalString(input.sortBy));
   appendQuery(url, "pin_status", optionalString(input.pinStatus));
-  const payload = await canvaJsonRequest("GET", url.toString(), context);
+  const payload = await canvaJsonRequest("GET", url.toString(), context, apiBaseUrl);
   return {
     items: readObjectArray(payload.items).map(mapFolderItem),
     continuation: optionalString(payload.continuation) ?? null,
   };
 }
 
-async function createFolder(input: Record<string, unknown>, context: OAuthProviderContext) {
-  const payload = await canvaJsonRequest("POST", "/v1/folders", context, {
+async function createFolder(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
+  const payload = await canvaJsonRequest("POST", "/v1/folders", context, apiBaseUrl, {
     name: requireCanvaString(input.name, "canva folder name"),
     parent_folder_id: requireCanvaString(input.parentFolderId, "canva parentFolderId"),
   });
   return { folder: mapCanvaFolder(requiredRecord(payload.folder, "folder", requestError)) };
 }
 
-async function moveFolderItem(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function moveFolderItem(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const itemId = requireCanvaString(input.itemId, "canva itemId");
   const toFolderId = requireCanvaString(input.toFolderId, "canva toFolderId");
   await canvaJsonRequest(
     "POST",
     "/v1/folders/move",
     context,
+    apiBaseUrl,
     {
       item_id: itemId,
       to_folder_id: toFolderId,
@@ -123,43 +133,65 @@ async function moveFolderItem(input: Record<string, unknown>, context: OAuthProv
   return { moved: true, itemId, toFolderId };
 }
 
-async function getAsset(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function getAsset(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const assetId = requireCanvaString(input.assetId, "canva assetId");
-  const payload = await canvaJsonRequest("GET", `/v1/assets/${encodeURIComponent(assetId)}`, context);
+  const payload = await canvaJsonRequest("GET", `/v1/assets/${encodeURIComponent(assetId)}`, context, apiBaseUrl);
   return { asset: mapCanvaAsset(requiredRecord(payload.asset, "asset", requestError)) };
 }
 
-async function getDesignExportFormats(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function getDesignExportFormats(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+  apiBaseUrl: string,
+) {
   const designId = requireCanvaString(input.designId, "canva designId");
-  const payload = await canvaJsonRequest("GET", `/v1/designs/${encodeURIComponent(designId)}/export-formats`, context);
+  const payload = await canvaJsonRequest(
+    "GET",
+    `/v1/designs/${encodeURIComponent(designId)}/export-formats`,
+    context,
+    apiBaseUrl,
+  );
   return { formats: readObjectArray(payload.formats) };
 }
 
-async function createDesignExportJob(input: Record<string, unknown>, context: OAuthProviderContext) {
-  const payload = await canvaJsonRequest("POST", "/v1/exports", context, {
+async function createDesignExportJob(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+  apiBaseUrl: string,
+) {
+  const payload = await canvaJsonRequest("POST", "/v1/exports", context, apiBaseUrl, {
     design_id: requireCanvaString(input.designId, "canva designId"),
     format: mapExportFormat(requiredRecord(input.format, "format", requestError)),
   });
   return { job: mapExportJob(requiredRecord(payload.job, "job", requestError)) };
 }
 
-async function getDesignExportJob(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function getDesignExportJob(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const exportId = requireCanvaString(input.exportId, "canva exportId");
-  const payload = await canvaJsonRequest("GET", `/v1/exports/${encodeURIComponent(exportId)}`, context);
+  const payload = await canvaJsonRequest("GET", `/v1/exports/${encodeURIComponent(exportId)}`, context, apiBaseUrl);
   return { job: mapExportJob(requiredRecord(payload.job, "job", requestError)) };
 }
 
-async function createUrlAssetUploadJob(input: Record<string, unknown>, context: OAuthProviderContext) {
-  const payload = await canvaJsonRequest("POST", "/v1/url-asset-uploads", context, {
+async function createUrlAssetUploadJob(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+  apiBaseUrl: string,
+) {
+  const payload = await canvaJsonRequest("POST", "/v1/url-asset-uploads", context, apiBaseUrl, {
     name: requireCanvaString(input.name, "canva asset name"),
     url: requireCanvaString(input.url, "canva asset url"),
   });
   return { job: mapAssetUploadJob(requiredRecord(payload.job, "job", requestError)) };
 }
 
-async function getUrlAssetUploadJob(input: Record<string, unknown>, context: OAuthProviderContext) {
+async function getUrlAssetUploadJob(input: Record<string, unknown>, context: OAuthProviderContext, apiBaseUrl: string) {
   const jobId = requireCanvaString(input.jobId, "canva asset upload jobId");
-  const payload = await canvaJsonRequest("GET", `/v1/url-asset-uploads/${encodeURIComponent(jobId)}`, context);
+  const payload = await canvaJsonRequest(
+    "GET",
+    `/v1/url-asset-uploads/${encodeURIComponent(jobId)}`,
+    context,
+    apiBaseUrl,
+  );
   return { job: mapAssetUploadJob(requiredRecord(payload.job, "job", requestError)) };
 }
 
@@ -167,10 +199,11 @@ async function canvaJsonRequest(
   method: "GET" | "POST",
   pathOrUrl: string,
   context: OAuthProviderContext,
+  apiBaseUrl: string,
   body?: Record<string, unknown>,
   allowNoContent = false,
 ) {
-  const url = pathOrUrl.startsWith("https://") ? pathOrUrl : `${canvaApiBaseUrl}${pathOrUrl}`;
+  const url = pathOrUrl.startsWith("https://") ? pathOrUrl : `${apiBaseUrl}${pathOrUrl}`;
   const response = await context.fetcher(url, {
     method,
     headers: {

--- a/src/providers/canva_cn/definition.ts
+++ b/src/providers/canva_cn/definition.ts
@@ -1,0 +1,30 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { canvaOAuthScopes, createCanvaActions } from "../canva/actions.ts";
+
+const service = "canva_cn";
+
+/**
+ * Canva China uses a separate OAuth application and regional API endpoints
+ * from the international Canva platform.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Canva China",
+  categories: ["Design & Media", "Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://www.canva.cn/api/oauth/authorize",
+      tokenUrl: "https://api.canva.cn/rest/v1/oauth/token",
+      scopes: canvaOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_basic",
+      pkce: {
+        method: "S256",
+      },
+    },
+  ],
+  homepageUrl: "https://www.canva.cn",
+  actions: createCanvaActions(service),
+};

--- a/src/providers/canva_cn/executors.ts
+++ b/src/providers/canva_cn/executors.ts
@@ -1,0 +1,5 @@
+import type { ProviderExecutors } from "../../core/types.ts";
+
+import { createCanvaExecutors } from "../canva/executors.ts";
+
+export const executors: ProviderExecutors = createCanvaExecutors("canva_cn", "https://api.canva.cn/rest");


### PR DESCRIPTION
## Summary

- add `canva_cn` as an OAuth2 provider isolated from the international `canva` service
- use the Canva China authorization, token, and REST API endpoints under `canva.cn`
- share Canva action schemas and executor behavior through regional factories while keeping credentials and API requests separated by service
- preserve Canva's client-secret Basic authentication and PKCE S256 flow

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (99 files, 939 tests)
- verified the China token and current-user endpoints expose the same OAuth/API error contracts as the international endpoints
