### PR TITLE
feat: mqtt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "mdast-util-to-markdown": "^2.1.2",
         "micromark-extension-gfm": "^3.0.0",
         "minisearch": "^7.2.0",
+        "mqtt": "^5.15.2",
         "nodemailer": "^9.0.3",
         "pino": "^10.3.1",
         "rss-parser": "^3.13.0",
@@ -62,6 +63,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cfworker/json-schema": {
@@ -3865,7 +3875,6 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3901,6 +3910,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmmirror.com/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3912,6 +3930,15 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -4498,6 +4525,18 @@
         "libqp": "2.1.1"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/address": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
@@ -4622,6 +4661,83 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmmirror.com/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -4633,6 +4749,48 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
       "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==",
+      "license": "MIT"
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmmirror.com/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/builtin-status-codes": {
@@ -4749,6 +4907,41 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -5360,11 +5553,29 @@
       "integrity": "sha512-uPcWKbj/BJU3Tbw9XqhHqET4/LBOhvv3/SJWr7NksxA6TC5YqBpaZgawE9R+WpYFCBFSAE4Vun+xQS6w4ABdlA==",
       "license": "MIT"
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -5422,6 +5633,19 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmmirror.com/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fast-xml-builder": {
       "version": "1.3.0",
@@ -5677,7 +5901,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/hono": {
@@ -5763,6 +5986,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/imapflow": {
       "version": "1.4.6",
@@ -5915,6 +6158,16 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/jstoxml": {
       "version": "2.2.9",
@@ -6248,6 +6501,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "1.22.0",
@@ -7116,6 +7375,94 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mqtt": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmmirror.com/mqtt/-/mqtt-5.15.2.tgz",
+      "integrity": "sha512-VWZU2CSUY3U3oN0PSBRDE5SNsFi4zqqNeQ/uv3pZWqY3CrBXD/dhd0ZLjlsk5YnebGlrapi4lRVNJPUNQ5aZ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmmirror.com/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mqtt/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/mrmime/-/mrmime-2.0.1.tgz",
@@ -7184,6 +7531,16 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmmirror.com/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/object-assign": {
@@ -7578,6 +7935,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmmirror.com/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7886,6 +8252,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/rolldown": {
@@ -8543,6 +8915,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
@@ -8636,7 +9014,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -9092,6 +9469,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/worker-factory": {
+      "version": "7.0.50",
+      "resolved": "https://registry.npmmirror.com/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.34",
+      "resolved": "https://registry.npmmirror.com/worker-timers/-/worker-timers-8.0.34.tgz",
+      "integrity": "sha512-WXL+Dqsm0G6dnC66rQsvM3tPT2adhbqSirWUCZGglkALOr8ocS0KlpU0iuKbjflJOlu3ydZikMEVrYnHOM9suw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.18",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.18",
+      "resolved": "https://registry.npmmirror.com/worker-timers-broker/-/worker-timers-broker-8.0.18.tgz",
+      "integrity": "sha512-FrjzDVX1wKfZN0gRbCFqv8VHuTncG4sbI/WGEg4tSSQeIsnwqg4YBYWMAHYLJtUDEYYmiK65UKFrVMVk2irDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmmirror.com/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
+      }
+    },
     "node_modules/workerd": {
       "version": "1.20260722.1",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
@@ -9166,7 +9590,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mdast-util-to-markdown": "^2.1.2",
     "micromark-extension-gfm": "^3.0.0",
     "minisearch": "^7.2.0",
+    "mqtt": "^5.15.2",
     "nodemailer": "^9.0.3",
     "pino": "^10.3.1",
     "rss-parser": "^3.13.0",

--- a/src/core/guarded-websocket.test.ts
+++ b/src/core/guarded-websocket.test.ts
@@ -10,11 +10,13 @@ class FakeSocket {
   static opened: FakeSocket[] = [];
 
   readonly url: string;
+  readonly protocols?: string | string[];
   closed = false;
   private readonly listeners = new Map<string, Listener[]>();
 
-  constructor(url: string) {
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
+    this.protocols = protocols;
     FakeSocket.opened.push(this);
   }
 
@@ -42,8 +44,8 @@ class FakeSocket {
 
 /** Constructor that reports the socket back so the test can drive its events. */
 function fakeConstructor(onCreate?: (socket: FakeSocket) => void): WebSocketConstructor {
-  return function FakeWebSocket(url: string) {
-    const socket = new FakeSocket(url);
+  return function FakeWebSocket(url: string, protocols?: string | string[]) {
+    const socket = new FakeSocket(url, protocols);
     // Open on the next tick so the caller has attached its handshake listeners.
     globalThis.setTimeout(() => onCreate?.(socket), 0);
     return socket;
@@ -201,6 +203,15 @@ describe("openGuardedWebSocket scheme mapping", () => {
       webSocketConstructor: openingConstructor(),
     });
     expect(FakeSocket.opened[0]?.url).toBe("wss://ha.example.com/api/websocket");
+  });
+
+  it("forwards WebSocket subprotocols to the guarded constructor", async () => {
+    FakeSocket.opened = [];
+    await openGuardedWebSocket("wss://broker.example.com/mqtt", {
+      webSocketConstructor: openingConstructor(),
+      protocols: ["mqtt"],
+    });
+    expect(FakeSocket.opened[0]?.protocols).toEqual(["mqtt"]);
   });
 });
 

--- a/src/core/guarded-websocket.ts
+++ b/src/core/guarded-websocket.ts
@@ -28,7 +28,7 @@ export interface WebSocketLike {
 }
 
 /** Constructor shape used to open a client WebSocket. */
-export type WebSocketConstructor = new (url: string) => WebSocketLike;
+export type WebSocketConstructor = new (url: string, protocols?: string | string[]) => WebSocketLike;
 
 /**
  * Why {@link openGuardedWebSocket} failed after the URL passed the egress guard.
@@ -69,6 +69,8 @@ export interface GuardedWebSocketOptions {
   fieldName?: string;
   /** Constructor override, for tests. Defaults to `globalThis.WebSocket`. */
   webSocketConstructor?: WebSocketConstructor;
+  /** WebSocket subprotocols offered during the opening handshake. */
+  protocols?: string | string[];
 }
 
 const defaultConnectTimeoutMs = 15_000;
@@ -133,7 +135,7 @@ function openSocket(
   return new Promise<WebSocketLike>((resolve, reject) => {
     let socket: WebSocketLike;
     try {
-      socket = new constructor(target);
+      socket = new constructor(target, options.protocols);
     } catch (error) {
       reject(createFailure("connect", `WebSocket connection failed: ${describeError(error)}`));
       return;

--- a/src/providers/mqtt/actions.ts
+++ b/src/providers/mqtt/actions.ts
@@ -25,7 +25,7 @@ export const mqttActions: ActionDefinition[] = [
     outputSchema: s.object("The completed MQTT publish operation.", {
       topic: s.string("Topic the message was published to."),
       qos: qosSchema,
-      retain: s.boolean("Whether the published message was retained by the broker."),
+      retain: s.boolean("Whether the MQTT PUBLISH retain flag was requested."),
       protocolVersion: protocolVersionSchema,
       deliveryAcknowledged: s.boolean(
         "Whether the MQTT publish acknowledgement flow completed. This does not mean a consumer processed the message.",

--- a/src/providers/mqtt/actions.ts
+++ b/src/providers/mqtt/actions.ts
@@ -1,0 +1,66 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "mqtt";
+const qosSchema = s.integer("MQTT quality of service level.", { minimum: 0, maximum: 2 });
+const protocolVersionSchema = s.stringEnum("MQTT protocol version used for the connection.", ["3.1.1", "5.0"]);
+
+export const mqttActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "publish_message",
+    description: "Publish one UTF-8 or base64-encoded message through a short-lived MQTT-over-WebSocket connection.",
+    inputSchema: s.object(
+      "The message to publish to the connected MQTT broker.",
+      {
+        topic: s.nonEmptyString("Exact MQTT topic to publish to. Topic wildcards are not allowed."),
+        payload: s.string("Message payload encoded according to payloadEncoding."),
+        payloadEncoding: s.stringEnum("How to decode payload before publishing it.", ["utf8", "base64"]),
+        qos: qosSchema,
+        retain: s.boolean("Whether the broker should retain this message for future subscribers."),
+      },
+      { optional: ["payloadEncoding", "qos", "retain"] },
+    ),
+    outputSchema: s.object("The completed MQTT publish operation.", {
+      topic: s.string("Topic the message was published to."),
+      qos: qosSchema,
+      retain: s.boolean("Whether the published message was retained by the broker."),
+      protocolVersion: protocolVersionSchema,
+      deliveryAcknowledged: s.boolean(
+        "Whether the MQTT publish acknowledgement flow completed. This does not mean a consumer processed the message.",
+      ),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "receive_messages",
+    description:
+      "Wait briefly for new messages on an MQTT topic filter. This is not a persistent subscription and can miss messages between action calls.",
+    inputSchema: s.object(
+      "The bounded MQTT subscription to open for this action call.",
+      {
+        topicFilter: s.nonEmptyString("MQTT topic filter to subscribe to, including + or # wildcards when needed."),
+        qos: qosSchema,
+        timeoutSeconds: s.integer("Maximum time to wait for messages before returning.", { minimum: 1, maximum: 30 }),
+        maxMessages: s.integer("Maximum number of messages to collect before returning.", { minimum: 1, maximum: 100 }),
+        payloadEncoding: s.stringEnum("How received message payloads should be returned.", ["utf8", "base64"]),
+      },
+      { optional: ["qos", "timeoutSeconds", "maxMessages", "payloadEncoding"] },
+    ),
+    outputSchema: s.object("Messages observed during the bounded subscription window.", {
+      messages: s.array(
+        "Messages received after the subscription became active.",
+        s.object("One MQTT message received from the broker.", {
+          topic: s.string("Exact MQTT topic the message was published to."),
+          payload: s.string("Message payload encoded according to payloadEncoding."),
+          qos: qosSchema,
+          retain: s.boolean("Whether the broker marked this as a retained message."),
+          duplicate: s.boolean("Whether the MQTT DUP flag was set."),
+        }),
+        { maxItems: 100 },
+      ),
+      timedOut: s.boolean("Whether the collection window ended because timeoutSeconds elapsed."),
+      protocolVersion: protocolVersionSchema,
+    }),
+  }),
+];

--- a/src/providers/mqtt/definition.ts
+++ b/src/providers/mqtt/definition.ts
@@ -18,7 +18,7 @@ export const provider: ProviderDefinition = {
           label: "WebSocket URL",
           inputType: "text",
           required: true,
-          secret: false,
+          secret: true,
           placeholder: "wss://broker.example.com/mqtt",
           description:
             "The complete ws:// or wss:// URL of the broker's MQTT-over-WebSocket listener, including its path. Private targets require a self-hosted runtime with OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK enabled.",

--- a/src/providers/mqtt/definition.ts
+++ b/src/providers/mqtt/definition.ts
@@ -1,0 +1,59 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { mqttActions } from "./actions.ts";
+
+export const provider: ProviderDefinition = {
+  service: "mqtt",
+  displayName: "MQTT",
+  description:
+    "Publish messages or briefly wait for new messages on any MQTT broker that exposes a WebSocket listener.",
+  categories: ["Developer Tools", "Infrastructure"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "websocketUrl",
+          label: "WebSocket URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "wss://broker.example.com/mqtt",
+          description:
+            "The complete ws:// or wss:// URL of the broker's MQTT-over-WebSocket listener, including its path. Private targets require a self-hosted runtime with OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK enabled.",
+        },
+        {
+          key: "username",
+          label: "Username",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "mqtt-user",
+          description: "Optional MQTT CONNECT username configured by the broker operator.",
+        },
+        {
+          key: "password",
+          label: "Password",
+          inputType: "password",
+          required: false,
+          secret: true,
+          placeholder: "mqtt-password",
+          description:
+            "Optional MQTT CONNECT password configured by the broker operator. A username is required when set.",
+        },
+        {
+          key: "protocolVersion",
+          label: "Protocol Version",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "3.1.1",
+          description: "MQTT protocol version. Use 3.1.1 by default, or enter 5.0 when the broker supports MQTT 5.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://mqtt.org",
+  actions: mqttActions,
+};

--- a/src/providers/mqtt/executors.ts
+++ b/src/providers/mqtt/executors.ts
@@ -1,0 +1,26 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+} from "../../core/types.ts";
+
+import { defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { createMqttContext, mqttActionHandlers, validateMqttCredential } from "./runtime.ts";
+
+const service = "mqtt";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: mqttActionHandlers,
+  async createContext(context: ExecutionContext) {
+    const credential = await requireCustomCredential(context, service);
+    return createMqttContext(credential.values, context.signal);
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { signal }): Promise<CredentialValidationResult> {
+    return validateMqttCredential(input.values, signal);
+  },
+};

--- a/src/providers/mqtt/mqtt-action-coverage.md
+++ b/src/providers/mqtt/mqtt-action-coverage.md
@@ -1,0 +1,25 @@
+# MQTT Action Coverage
+
+## Scope
+
+The first MQTT provider release supports brokers that expose MQTT over `ws://` or `wss://`. Every action uses a new clean connection and closes it before returning.
+
+Implemented actions:
+
+- `publish_message`: publish one UTF-8 or base64 payload with QoS 0, 1, or 2 and optional retain.
+- `receive_messages`: subscribe for at most 30 seconds and return up to 100 messages received during that window.
+
+## Deliberate Limits
+
+- `receive_messages` is not a durable consumer. Non-retained messages published between action calls are missed.
+- MQTT 3.1.1 is the default. MQTT 5.0 is explicit; the provider does not reconnect with another protocol version after a failed handshake.
+- Raw `mqtt://` and `mqtts://` transport, persistent sessions, background subscriptions, workflow triggers, offline inboxes, mTLS, custom certificate authorities, and cloud-vendor signing are deferred.
+- Private-network brokers require a self-hosted runtime with `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` enabled. Cloudflare Workers cannot route to LAN brokers.
+
+## Transport Safety
+
+The provider opens the connection through `openGuardedWebSocket`, including URL and DNS validation, and then hands the already-open socket to MQTT.js. MQTT.js does not open an independent connection. The shared guard now accepts WebSocket subprotocols so the handshake can offer `mqtt` without bypassing egress policy.
+
+## Proxy Decision
+
+Generic HTTP proxy support does not apply because MQTT is a stateful binary protocol over WebSocket rather than a stable HTTP API origin.

--- a/src/providers/mqtt/runtime.test.ts
+++ b/src/providers/mqtt/runtime.test.ts
@@ -1,0 +1,146 @@
+import type { GuardedWebSocketOptions, WebSocketLike } from "../../core/guarded-websocket.ts";
+import type { IClientOptions, MqttClient } from "mqtt";
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createMqttActionHandlers, createMqttContext, openMqttClient } from "./runtime.ts";
+
+class FakeMqttClient extends EventEmitter {
+  public published?: { topic: string; payload: Buffer; options: unknown };
+  public onSubscribe?: () => void;
+
+  public publishAsync(topic: string, payload: Buffer, options: unknown): Promise<undefined> {
+    this.published = { topic, payload, options };
+    return Promise.resolve(undefined);
+  }
+
+  public subscribeAsync(): Promise<[]> {
+    queueMicrotask(() => this.onSubscribe?.());
+    return Promise.resolve([]);
+  }
+
+  public unsubscribeAsync(): Promise<undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public endAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeWebSocket implements WebSocketLike {
+  public send(): void {}
+  public close(): void {}
+  public addEventListener(): void {}
+}
+
+describe("MQTT credential context", () => {
+  it("defaults to MQTT 3.1.1 and normalizes the WebSocket URL", () => {
+    expect(createMqttContext({ websocketUrl: "wss://broker.example.com/mqtt" })).toMatchObject({
+      websocketUrl: "wss://broker.example.com/mqtt",
+      protocolVersion: "3.1.1",
+    });
+  });
+
+  it("rejects a password without a username", () => {
+    expect(() => createMqttContext({ websocketUrl: "wss://broker.example.com/mqtt", password: "secret" })).toThrow(
+      /username is required/,
+    );
+  });
+
+  it("rejects non-WebSocket transports", () => {
+    expect(() => createMqttContext({ websocketUrl: "mqtts://broker.example.com:8883" })).toThrow(/must use ws or wss/);
+  });
+});
+
+describe("MQTT guarded WebSocket handoff", () => {
+  it("opens one guarded mqtt socket and gives it to the MQTT.js native transport", async () => {
+    const socket = new FakeWebSocket();
+    let guardedOptions: GuardedWebSocketOptions | undefined;
+    let mqttOptions: IClientOptions | undefined;
+    const client = new FakeMqttClient();
+    const openWebSocket = vi.fn(async (_url: string, options: GuardedWebSocketOptions) => {
+      guardedOptions = options;
+      return socket;
+    });
+    const connect = vi.fn((_url: string, options: IClientOptions) => {
+      mqttOptions = options;
+      expect(options.createWebsocket?.(_url, ["mqtt"], options)).toBe(socket);
+      queueMicrotask(() => client.emit("connect"));
+      return client as unknown as MqttClient;
+    });
+
+    await expect(
+      openMqttClient({ websocketUrl: "wss://broker.example.com/mqtt", protocolVersion: "5.0" }, undefined, {
+        connect,
+        openWebSocket,
+      }),
+    ).resolves.toBe(client);
+
+    expect(openWebSocket).toHaveBeenCalledWith(
+      "wss://broker.example.com/mqtt",
+      expect.objectContaining({ fieldName: "websocketUrl", protocols: ["mqtt"] }),
+    );
+    expect(guardedOptions?.allowPrivateNetwork).toBeTypeOf("function");
+    expect(mqttOptions).toMatchObject({ forceNativeWebSocket: true, protocolVersion: 5, reconnectPeriod: 0 });
+  });
+});
+
+describe("MQTT publish action", () => {
+  it("decodes base64 and reports the MQTT acknowledgement boundary", async () => {
+    const client = new FakeMqttClient();
+    const handlers = createMqttActionHandlers({
+      openClient: async () => client as unknown as MqttClient,
+    });
+
+    await expect(
+      handlers.publish_message?.(
+        { topic: "devices/one/command", payload: "AP+A", payloadEncoding: "base64", qos: 1, retain: true },
+        { websocketUrl: "wss://broker.example.com/mqtt", protocolVersion: "3.1.1" },
+      ),
+    ).resolves.toEqual({
+      topic: "devices/one/command",
+      qos: 1,
+      retain: true,
+      protocolVersion: "3.1.1",
+      deliveryAcknowledged: true,
+    });
+    expect(client.published).toMatchObject({
+      topic: "devices/one/command",
+      payload: Buffer.from([0, 255, 128]),
+      options: { qos: 1, retain: true },
+    });
+  });
+});
+
+describe("MQTT receive action", () => {
+  it("stops at maxMessages even when more messages arrive in the same turn", async () => {
+    const client = new FakeMqttClient();
+    client.onSubscribe = () => {
+      client.emit("message", "devices/one/status", Buffer.from("first"), { qos: 1, retain: false, dup: false });
+      client.emit("message", "devices/two/status", Buffer.from("second"), { qos: 1, retain: false, dup: false });
+    };
+    const handlers = createMqttActionHandlers({
+      openClient: async () => client as unknown as MqttClient,
+    });
+
+    await expect(
+      handlers.receive_messages?.(
+        { topicFilter: "devices/+/status", maxMessages: 1, timeoutSeconds: 1 },
+        { websocketUrl: "wss://broker.example.com/mqtt", protocolVersion: "3.1.1" },
+      ),
+    ).resolves.toEqual({
+      messages: [
+        {
+          topic: "devices/one/status",
+          payload: "first",
+          qos: 1,
+          retain: false,
+          duplicate: false,
+        },
+      ],
+      timedOut: false,
+      protocolVersion: "3.1.1",
+    });
+  });
+});

--- a/src/providers/mqtt/runtime.test.ts
+++ b/src/providers/mqtt/runtime.test.ts
@@ -3,20 +3,21 @@ import type { IClientOptions, MqttClient } from "mqtt";
 
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { createMqttActionHandlers, createMqttContext, openMqttClient } from "./runtime.ts";
+import { createMqttActionHandlers, createMqttContext, openMqttClient, validateMqttCredential } from "./runtime.ts";
 
 class FakeMqttClient extends EventEmitter {
   public published?: { topic: string; payload: Buffer; options: unknown };
   public onSubscribe?: () => void;
+  public subscriptionGrants: Array<{ qos: 0 | 1 | 2 | 128; topic: string }> = [];
 
   public publishAsync(topic: string, payload: Buffer, options: unknown): Promise<undefined> {
     this.published = { topic, payload, options };
     return Promise.resolve(undefined);
   }
 
-  public subscribeAsync(): Promise<[]> {
+  public subscribeAsync(): Promise<Array<{ qos: 0 | 1 | 2 | 128; topic: string }>> {
     queueMicrotask(() => this.onSubscribe?.());
-    return Promise.resolve([]);
+    return Promise.resolve(this.subscriptionGrants);
   }
 
   public unsubscribeAsync(): Promise<undefined> {
@@ -50,6 +51,22 @@ describe("MQTT credential context", () => {
 
   it("rejects non-WebSocket transports", () => {
     expect(() => createMqttContext({ websocketUrl: "mqtts://broker.example.com:8883" })).toThrow(/must use ws or wss/);
+  });
+
+  it("omits signed query parameters from validation metadata", async () => {
+    const client = new FakeMqttClient();
+    await expect(
+      validateMqttCredential(
+        { websocketUrl: "wss://broker.example.com/mqtt?X-Amz-Signature=secret" },
+        undefined,
+        async () => client as unknown as MqttClient,
+      ),
+    ).resolves.toMatchObject({
+      metadata: {
+        websocketEndpoint: "wss://broker.example.com/mqtt",
+        protocolVersion: "3.1.1",
+      },
+    });
   });
 });
 
@@ -142,5 +159,37 @@ describe("MQTT receive action", () => {
       timedOut: false,
       protocolVersion: "3.1.1",
     });
+  });
+
+  it("rejects a broker-denied subscription", async () => {
+    const client = new FakeMqttClient();
+    client.subscriptionGrants = [{ topic: "private/#", qos: 128 }];
+    const handlers = createMqttActionHandlers({
+      openClient: async () => client as unknown as MqttClient,
+    });
+
+    await expect(
+      handlers.receive_messages?.(
+        { topicFilter: "private/#", timeoutSeconds: 1 },
+        { websocketUrl: "wss://broker.example.com/mqtt", protocolVersion: "3.1.1" },
+      ),
+    ).rejects.toThrow(/rejected subscription/);
+  });
+
+  it.each(["error", "close"])("fails when the client emits %s after subscribing", async (event) => {
+    const client = new FakeMqttClient();
+    client.subscriptionGrants = [{ topic: "devices/#", qos: 0 }];
+    const handlers = createMqttActionHandlers({
+      openClient: async () => client as unknown as MqttClient,
+    });
+    const result = handlers.receive_messages?.(
+      { topicFilter: "devices/#", timeoutSeconds: 1 },
+      { websocketUrl: "wss://broker.example.com/mqtt", protocolVersion: "3.1.1" },
+    );
+    await vi.waitFor(() => expect(client.listenerCount(event)).toBeGreaterThan(0));
+
+    client.emit(event, event === "error" ? new Error("socket failed") : undefined);
+
+    await expect(result).rejects.toThrow(event === "error" ? /socket failed/ : /closed while receiving/);
   });
 });

--- a/src/providers/mqtt/runtime.ts
+++ b/src/providers/mqtt/runtime.ts
@@ -131,9 +131,10 @@ export function createMqttContext(values: Record<string, string>, signal?: Abort
 export async function validateMqttCredential(
   values: Record<string, string>,
   signal?: AbortSignal,
+  openClient: MqttActionDependencies["openClient"] = openMqttClient,
 ): Promise<CredentialValidationResult> {
   const context = createMqttContext(values, signal);
-  const client = await openMqttClient(context, context.signal);
+  const client = await openClient(context, context.signal);
   await closeMqttClient(client);
   const url = new URL(context.websocketUrl);
   return {
@@ -143,7 +144,7 @@ export async function validateMqttCredential(
     },
     grantedScopes: [],
     metadata: {
-      websocketUrl: context.websocketUrl,
+      websocketEndpoint: `${url.origin}${url.pathname}`,
       protocolVersion: context.protocolVersion,
     },
   };
@@ -235,14 +236,21 @@ async function receiveMessages(client: MqttClient, options: ReceiveMessagesOptio
     }
   };
   const onAbort = (): void => failOnce(new ProviderRequestError(499, "MQTT receive was aborted"));
+  const onError = (error: Error): void => failOnce(toMqttError(error, "MQTT receive failed"));
+  const onClose = (): void => failOnce(new ProviderRequestError(502, "MQTT connection closed while receiving"));
   client.on("message", onMessage);
   try {
     const subscribeOptions: IClientSubscribeOptions = { qos: options.qos };
-    await withAbort(
+    const grants = await withAbort(
       client.subscribeAsync(options.topicFilter, subscribeOptions),
       options.signal,
       "MQTT subscription was aborted",
     );
+    if (grants.some((grant) => grant.qos === 128)) {
+      throw new ProviderRequestError(403, `MQTT broker rejected subscription to ${options.topicFilter}`);
+    }
+    client.on("error", onError);
+    client.on("close", onClose);
     options.signal?.addEventListener("abort", onAbort, { once: true });
     const timer = globalThis.setTimeout(() => complete({ messages, timedOut: true }), options.timeoutMs);
     try {
@@ -256,6 +264,8 @@ async function receiveMessages(client: MqttClient, options: ReceiveMessagesOptio
   } finally {
     options.signal?.removeEventListener("abort", onAbort);
     client.removeListener("message", onMessage);
+    client.removeListener("error", onError);
+    client.removeListener("close", onClose);
     await client.unsubscribeAsync(options.topicFilter).catch(() => undefined);
   }
 }

--- a/src/providers/mqtt/runtime.ts
+++ b/src/providers/mqtt/runtime.ts
@@ -1,0 +1,390 @@
+import type { GuardedWebSocketOptions, WebSocketLike } from "../../core/guarded-websocket.ts";
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { IClientOptions, IClientPublishOptions, IClientSubscribeOptions, IPublishPacket, MqttClient } from "mqtt";
+
+import mqtt from "mqtt";
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import { optionalInteger, optionalString } from "../../core/cast.ts";
+import { openGuardedWebSocket } from "../../core/guarded-websocket.ts";
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+type MqttProtocolVersion = "3.1.1" | "5.0";
+type PayloadEncoding = "utf8" | "base64";
+type QualityOfService = 0 | 1 | 2;
+type MqttActionHandler = (input: Record<string, unknown>, context: MqttActionContext) => Promise<unknown>;
+
+interface MqttCredential {
+  websocketUrl: string;
+  username?: string;
+  password?: string;
+  protocolVersion: MqttProtocolVersion;
+}
+
+interface ReceivedMessage {
+  topic: string;
+  payload: string;
+  qos: QualityOfService;
+  retain: boolean;
+  duplicate: boolean;
+}
+
+interface ReceiveResult {
+  messages: ReceivedMessage[];
+  timedOut: boolean;
+}
+
+export interface MqttConnectionDependencies {
+  connect: (url: string, options: IClientOptions) => MqttClient;
+  openWebSocket: (url: string, options: GuardedWebSocketOptions) => Promise<WebSocketLike>;
+}
+
+export interface MqttActionContext extends MqttCredential {
+  signal?: AbortSignal;
+}
+
+export interface MqttActionDependencies {
+  openClient: (credential: MqttCredential, signal?: AbortSignal) => Promise<MqttClient>;
+}
+
+const defaultDependencies: MqttConnectionDependencies = {
+  connect: (url, options) => mqtt.connect(url, options),
+  openWebSocket: (url, options) => openGuardedWebSocket(url, options),
+};
+
+export const mqttActionHandlers: Record<string, MqttActionHandler> = createMqttActionHandlers();
+
+export function createMqttActionHandlers(
+  dependencies: MqttActionDependencies = { openClient: openMqttClient },
+): Record<string, MqttActionHandler> {
+  return {
+    async publish_message(input, context) {
+      const topic = requireString(input.topic, "topic");
+      if (topic.includes("+") || topic.includes("#")) {
+        throw new ProviderRequestError(400, "topic must not contain MQTT wildcards");
+      }
+      const payloadEncoding = readPayloadEncoding(input.payloadEncoding);
+      const payload = decodePayload(requirePresentString(input.payload, "payload"), payloadEncoding);
+      const qos = readQos(input.qos);
+      const retain = input.retain === true;
+      const client = await dependencies.openClient(context, context.signal);
+      try {
+        const publishOptions: IClientPublishOptions = { qos, retain };
+        await withAbort(
+          client.publishAsync(topic, payload, publishOptions),
+          context.signal,
+          "MQTT publish was aborted",
+        );
+        return {
+          topic,
+          qos,
+          retain,
+          protocolVersion: context.protocolVersion,
+          deliveryAcknowledged: qos !== 0,
+        };
+      } finally {
+        await closeMqttClient(client);
+      }
+    },
+
+    async receive_messages(input, context) {
+      const topicFilter = requireString(input.topicFilter, "topicFilter");
+      const qos = readQos(input.qos);
+      const timeoutSeconds = readBoundedInteger(input.timeoutSeconds, "timeoutSeconds", 10, 1, 30);
+      const maxMessages = readBoundedInteger(input.maxMessages, "maxMessages", 1, 1, 100);
+      const payloadEncoding = readPayloadEncoding(input.payloadEncoding);
+      const client = await dependencies.openClient(context, context.signal);
+      try {
+        const result = await receiveMessages(client, {
+          topicFilter,
+          qos,
+          timeoutMs: timeoutSeconds * 1_000,
+          maxMessages,
+          payloadEncoding,
+          signal: context.signal,
+        });
+        return { ...result, protocolVersion: context.protocolVersion };
+      } finally {
+        await closeMqttClient(client);
+      }
+    },
+  };
+}
+
+export function createMqttContext(values: Record<string, string>, signal?: AbortSignal): MqttActionContext {
+  const websocketUrl = normalizeWebSocketUrl(values.websocketUrl);
+  const username = optionalString(values.username);
+  const password = optionalString(values.password);
+  if (password && !username) {
+    throw new ProviderRequestError(400, "username is required when password is configured");
+  }
+  return {
+    websocketUrl,
+    username,
+    password,
+    protocolVersion: readProtocolVersion(values.protocolVersion),
+    signal,
+  };
+}
+
+export async function validateMqttCredential(
+  values: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createMqttContext(values, signal);
+  const client = await openMqttClient(context, context.signal);
+  await closeMqttClient(client);
+  const url = new URL(context.websocketUrl);
+  return {
+    profile: {
+      accountId: `mqtt:${url.host}${url.pathname}`,
+      displayName: url.host,
+    },
+    grantedScopes: [],
+    metadata: {
+      websocketUrl: context.websocketUrl,
+      protocolVersion: context.protocolVersion,
+    },
+  };
+}
+
+export async function openMqttClient(
+  credential: MqttCredential,
+  signal?: AbortSignal,
+  dependencies: MqttConnectionDependencies = defaultDependencies,
+): Promise<MqttClient> {
+  const websocket = await dependencies.openWebSocket(credential.websocketUrl, {
+    allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    fieldName: "websocketUrl",
+    protocols: ["mqtt"],
+    signal,
+  });
+  let handedOff = false;
+  const options: IClientOptions = {
+    clean: true,
+    clientId: `oomol-connect-${randomUUID()}`,
+    connectTimeout: 15_000,
+    forceNativeWebSocket: true,
+    protocolVersion: credential.protocolVersion === "5.0" ? 5 : 4,
+    reconnectPeriod: 0,
+    username: credential.username,
+    password: credential.password,
+    createWebsocket(_url, protocols) {
+      if (handedOff) {
+        throw new ProviderRequestError(502, "MQTT.js requested more than one WebSocket connection");
+      }
+      handedOff = true;
+      if (protocols.length !== 1 || protocols[0] !== "mqtt") {
+        throw new ProviderRequestError(502, "MQTT.js requested an unexpected WebSocket subprotocol");
+      }
+      return websocket;
+    },
+  };
+
+  let client: MqttClient;
+  try {
+    client = dependencies.connect(credential.websocketUrl, options);
+    await waitForMqttConnection(client, signal);
+    return client;
+  } catch (error) {
+    closeWebSocket(websocket);
+    throw toMqttError(error, "MQTT connection failed");
+  }
+}
+
+interface ReceiveMessagesOptions {
+  topicFilter: string;
+  qos: QualityOfService;
+  timeoutMs: number;
+  maxMessages: number;
+  payloadEncoding: PayloadEncoding;
+  signal?: AbortSignal;
+}
+
+async function receiveMessages(client: MqttClient, options: ReceiveMessagesOptions): Promise<ReceiveResult> {
+  const messages: ReceivedMessage[] = [];
+  let settled = false;
+  let finish: (result: ReceiveResult) => void = () => {};
+  let fail: (error: Error) => void = () => {};
+  const result = new Promise<ReceiveResult>((resolve, reject) => {
+    finish = resolve;
+    fail = reject;
+  });
+  const complete = (value: ReceiveResult): void => {
+    if (settled) return;
+    settled = true;
+    finish(value);
+  };
+  const failOnce = (error: Error): void => {
+    if (settled) return;
+    settled = true;
+    fail(error);
+  };
+  const onMessage = (topic: string, payload: Buffer, packet: IPublishPacket): void => {
+    if (settled) return;
+    messages.push({
+      topic,
+      payload: encodePayload(payload, options.payloadEncoding),
+      qos: readPacketQos(packet.qos),
+      retain: packet.retain === true,
+      duplicate: packet.dup === true,
+    });
+    if (messages.length >= options.maxMessages) {
+      complete({ messages, timedOut: false });
+    }
+  };
+  const onAbort = (): void => failOnce(new ProviderRequestError(499, "MQTT receive was aborted"));
+  client.on("message", onMessage);
+  try {
+    const subscribeOptions: IClientSubscribeOptions = { qos: options.qos };
+    await withAbort(
+      client.subscribeAsync(options.topicFilter, subscribeOptions),
+      options.signal,
+      "MQTT subscription was aborted",
+    );
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    const timer = globalThis.setTimeout(() => complete({ messages, timedOut: true }), options.timeoutMs);
+    try {
+      if (options.signal?.aborted) onAbort();
+      return await result;
+    } finally {
+      globalThis.clearTimeout(timer);
+    }
+  } catch (error) {
+    throw toMqttError(error, "MQTT subscription failed");
+  } finally {
+    options.signal?.removeEventListener("abort", onAbort);
+    client.removeListener("message", onMessage);
+    await client.unsubscribeAsync(options.topicFilter).catch(() => undefined);
+  }
+}
+
+function waitForMqttConnection(client: MqttClient, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onConnect = (): void => finish(resolve);
+    const onError = (error: Error): void => finish(() => reject(error));
+    const onClose = (): void => finish(() => reject(new Error("MQTT connection closed before CONNACK")));
+    const onAbort = (): void => finish(() => reject(new ProviderRequestError(499, "MQTT connection was aborted")));
+    const finish = (complete: () => void): void => {
+      client.removeListener("connect", onConnect);
+      client.removeListener("error", onError);
+      client.removeListener("close", onClose);
+      signal?.removeEventListener("abort", onAbort);
+      complete();
+    };
+    client.once("connect", onConnect);
+    client.once("error", onError);
+    client.once("close", onClose);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined, message: string): Promise<T> {
+  if (!signal) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => reject(new ProviderRequestError(499, message));
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
+async function closeMqttClient(client: MqttClient): Promise<void> {
+  try {
+    await client.endAsync();
+  } catch {
+    await client.endAsync(true).catch(() => undefined);
+  }
+}
+
+function closeWebSocket(socket: WebSocketLike): void {
+  try {
+    socket.close();
+  } catch {
+    // The connection error remains more useful than a secondary close failure.
+  }
+}
+
+function normalizeWebSocketUrl(value: unknown): string {
+  const rawValue = requireString(value, "websocketUrl");
+  let url: URL;
+  try {
+    url = new URL(rawValue);
+  } catch {
+    throw new ProviderRequestError(400, "websocketUrl must be a valid URL");
+  }
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new ProviderRequestError(400, "websocketUrl must use ws or wss");
+  }
+  if (url.username || url.password || url.hash) {
+    throw new ProviderRequestError(400, "websocketUrl must not contain credentials or a fragment");
+  }
+  return url.toString();
+}
+
+function readProtocolVersion(value: unknown): MqttProtocolVersion {
+  const version = optionalString(value) ?? "3.1.1";
+  if (version === "3.1.1" || version === "5.0") return version;
+  throw new ProviderRequestError(400, "protocolVersion must be 3.1.1 or 5.0");
+}
+
+function readPayloadEncoding(value: unknown): PayloadEncoding {
+  const encoding = optionalString(value) ?? "utf8";
+  if (encoding === "utf8" || encoding === "base64") return encoding;
+  throw new ProviderRequestError(400, "payloadEncoding must be utf8 or base64");
+}
+
+function readQos(value: unknown): QualityOfService {
+  const qos = optionalInteger(value) ?? 0;
+  if (qos === 0 || qos === 1 || qos === 2) return qos;
+  throw new ProviderRequestError(400, "qos must be 0, 1, or 2");
+}
+
+function readPacketQos(value: unknown): QualityOfService {
+  return value === 1 || value === 2 ? value : 0;
+}
+
+function readBoundedInteger(
+  value: unknown,
+  field: string,
+  defaultValue: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const parsed = optionalInteger(value) ?? defaultValue;
+  if (minimum <= parsed && parsed <= maximum) return parsed;
+  throw new ProviderRequestError(400, `${field} must be between ${minimum} and ${maximum}`);
+}
+
+function decodePayload(payload: string, encoding: PayloadEncoding): Buffer {
+  if (encoding === "utf8") return Buffer.from(payload, "utf8");
+  const decoded = Buffer.from(payload, "base64");
+  const normalizedInput = payload.replaceAll("=", "");
+  const normalizedOutput = decoded.toString("base64").replaceAll("=", "");
+  if (normalizedInput !== normalizedOutput) {
+    throw new ProviderRequestError(400, "payload must be valid base64 when payloadEncoding is base64");
+  }
+  return decoded;
+}
+
+function encodePayload(payload: Buffer, encoding: PayloadEncoding): string {
+  return payload.toString(encoding === "base64" ? "base64" : "utf8");
+}
+
+function requireString(value: unknown, field: string): string {
+  const parsed = optionalString(value);
+  if (parsed) return parsed;
+  throw new ProviderRequestError(400, `${field} is required`);
+}
+
+function requirePresentString(value: unknown, field: string): string {
+  if (typeof value === "string") return value;
+  throw new ProviderRequestError(400, `${field} is required`);
+}
+
+function toMqttError(error: unknown, fallback: string): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  return new ProviderRequestError(502, error instanceof Error ? error.message : fallback, error);
+}


### PR DESCRIPTION
## Summary

- add a generic MQTT-over-WebSocket provider with short-lived publish and bounded receive actions
- route MQTT.js through the shared guarded WebSocket transport, including the `mqtt` subprotocol
- support MQTT 3.1.1 by default and explicit MQTT 5.0 connections
- document persistent-session, private-network, and transport limits

## Validation

- `npm run fix-check`
- `npm exec vitest run src/core/guarded-websocket.test.ts src/providers/mqtt/runtime.test.ts`
- `npm run generate:catalog`
- `npm run build:web`
- `wrangler deploy --dry-run` against the Cloudflare Worker entry
- Node and workerd runtime probes with QoS 1 and binary payloads

Closes #344