### PR TITLE
feat(googledrive): support files.get media downloads

### DIFF
--- a/src/providers/googledrive/actions.ts
+++ b/src/providers/googledrive/actions.ts
@@ -1419,36 +1419,6 @@ const actionSources: GoogledriveActionSource[] = [
     },
   },
   {
-    name: "files.download",
-    description:
-      "Download an ordinary Google Drive blob file and store the complete content in local transit file storage.",
-    requiredScopes: [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope],
-    inputSchema: s.object(
-      "Input parameters for downloading a Google Drive blob file.",
-      {
-        fileId: s.nonEmptyString("The ID of the Google Drive file to download."),
-        includeSharedDrives: s.boolean("Whether the request supports files in shared drives."),
-        acknowledgeAbuse: s.boolean(
-          "Whether the caller acknowledges the risk of downloading a file marked as abusive or malicious.",
-        ),
-      },
-      { optional: ["includeSharedDrives", "acknowledgeAbuse"] },
-    ),
-    outputSchema: s.object("The downloaded Google Drive file stored in local transit storage.", {
-      fileId: s.nonEmptyString("The Google Drive file ID returned by the metadata request."),
-      name: s.nonEmptyString("The original Google Drive file name."),
-      mimeType: s.nonEmptyString("The Google Drive file MIME type."),
-      sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
-      file: s.object("The downloaded content in local transit file storage.", {
-        fileId: s.nonEmptyString("The local transit file identifier."),
-        downloadUrl: s.url("The local transit URL for downloading the stored file."),
-        sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
-        name: s.nonEmptyString("The stored transit file name."),
-        mimeType: s.nonEmptyString("The stored transit file MIME type."),
-      }),
-    }),
-  },
-  {
     name: "files.export",
     description:
       "Export a Google Workspace file to the requested MIME type and return a transit URL for the exported content.",
@@ -1539,175 +1509,186 @@ const actionSources: GoogledriveActionSource[] = [
   },
   {
     name: "files.get",
-    description: "Get metadata for a Drive file by ID.",
+    description: "Get metadata for a Drive file by ID, or download stored file content with alt=media.",
     requiredScopes: [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope],
-    inputSchema: {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "object",
-      properties: {
-        fileId: {
-          type: "string",
-          minLength: 1,
-          description: "The ID of the file.",
-        },
-        includeSharedDrives: {
-          type: "boolean",
-          description: "When true, includes files from shared drives.",
-        },
-      },
-      additionalProperties: false,
-    },
-    outputSchema: {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-          description: "The unique identifier of the file.",
-        },
-        name: {
-          type: "string",
-          description: "The name of the file.",
-        },
-        mimeType: {
-          type: "string",
-          description: "The MIME type of the file.",
-        },
-        webViewLink: {
-          anyOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "null",
-            },
-          ],
-          description: "A link for opening the file in a relevant Google editor or viewer in a browser.",
-        },
-        createdTime: {
-          anyOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "null",
-            },
-          ],
-          description: "The time at which the file was created (RFC 3339 date-time).",
-        },
-        modifiedTime: {
-          anyOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "null",
-            },
-          ],
-          description: "The last time the file was modified by anyone (RFC 3339 date-time).",
-        },
-        sizeBytes: {
-          anyOf: [
-            {
-              type: "integer",
-              minimum: -9007199254740991,
-              maximum: 9007199254740991,
-            },
-            {
-              type: "null",
-            },
-          ],
-          description: "The size of the file's content in bytes.",
-        },
-        driveId: {
-          anyOf: [
-            {
-              type: "string",
-            },
-            {
-              type: "null",
-            },
-          ],
-          description: "The ID of the shared drive the file belongs to.",
-        },
-        parents: {
-          type: "array",
-          items: {
+    inputSchema: s.object("Input parameters for getting Drive file metadata or content.", {
+      fileId: s.nonEmptyString("The ID of the Google Drive file to retrieve."),
+      includeSharedDrives: s.optional(s.boolean("Whether the request supports files in shared drives.")),
+      alt: s.optional(
+        s.literal("media", {
+          description: "Return stored file content instead of metadata.",
+        }),
+      ),
+      acknowledgeAbuse: s.optional(
+        s.boolean("Whether the caller acknowledges the risk of downloading known malware or other abusive files."),
+      ),
+    }),
+    outputSchema: s.anyOf("Drive file metadata or downloaded file content.", [
+      {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        properties: {
+          id: {
             type: "string",
+            description: "The unique identifier of the file.",
           },
-          description: "The IDs of the parent folders containing the file.",
-        },
-        owners: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              displayName: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "null",
-                  },
-                ],
-                description: "The display name of the owner.",
+          name: {
+            type: "string",
+            description: "The name of the file.",
+          },
+          mimeType: {
+            type: "string",
+            description: "The MIME type of the file.",
+          },
+          webViewLink: {
+            anyOf: [
+              {
+                type: "string",
               },
-              emailAddress: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "null",
-                  },
-                ],
-                description: "The email address of the owner.",
+              {
+                type: "null",
               },
-              permissionId: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "null",
-                  },
-                ],
-                description: "The permission ID of the owner.",
+            ],
+            description: "A link for opening the file in a relevant Google editor or viewer in a browser.",
+          },
+          createdTime: {
+            anyOf: [
+              {
+                type: "string",
               },
-              photoLink: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "null",
-                  },
-                ],
-                description: "A link to the owner's profile photo.",
+              {
+                type: "null",
               },
+            ],
+            description: "The time at which the file was created (RFC 3339 date-time).",
+          },
+          modifiedTime: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "null",
+              },
+            ],
+            description: "The last time the file was modified by anyone (RFC 3339 date-time).",
+          },
+          sizeBytes: {
+            anyOf: [
+              {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
+              },
+              {
+                type: "null",
+              },
+            ],
+            description: "The size of the file's content in bytes.",
+          },
+          driveId: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "null",
+              },
+            ],
+            description: "The ID of the shared drive the file belongs to.",
+          },
+          parents: {
+            type: "array",
+            items: {
+              type: "string",
             },
-            required: ["displayName", "emailAddress", "permissionId", "photoLink"],
-            additionalProperties: false,
+            description: "The IDs of the parent folders containing the file.",
           },
-          description: "The owners of the file.",
+          owners: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                displayName: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                  description: "The display name of the owner.",
+                },
+                emailAddress: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                  description: "The email address of the owner.",
+                },
+                permissionId: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                  description: "The permission ID of the owner.",
+                },
+                photoLink: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                  description: "A link to the owner's profile photo.",
+                },
+              },
+              required: ["displayName", "emailAddress", "permissionId", "photoLink"],
+              additionalProperties: false,
+            },
+            description: "The owners of the file.",
+          },
+          shared: {
+            type: "boolean",
+            description: "Whether the file has been shared.",
+          },
+          starred: {
+            type: "boolean",
+            description: "Whether the user has starred the file.",
+          },
+          trashed: {
+            type: "boolean",
+            description: "Whether the file has been trashed.",
+          },
         },
-        shared: {
-          type: "boolean",
-          description: "Whether the file has been shared.",
-        },
-        starred: {
-          type: "boolean",
-          description: "Whether the user has starred the file.",
-        },
-        trashed: {
-          type: "boolean",
-          description: "Whether the file has been trashed.",
-        },
+        required: ["id", "name", "mimeType", "webViewLink", "createdTime", "modifiedTime", "sizeBytes", "driveId"],
+        additionalProperties: false,
       },
-      required: ["id", "name", "mimeType", "webViewLink", "createdTime", "modifiedTime", "sizeBytes", "driveId"],
-      additionalProperties: false,
-    },
+      s.object("The downloaded Google Drive file stored in local transit storage.", {
+        fileId: s.nonEmptyString("The Google Drive file ID returned by the metadata request."),
+        name: s.nonEmptyString("The original Google Drive file name."),
+        mimeType: s.nonEmptyString("The Google Drive file MIME type."),
+        sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
+        file: s.object("The downloaded content in local transit file storage.", {
+          fileId: s.nonEmptyString("The local transit file identifier."),
+          downloadUrl: s.url("The local transit URL for downloading the stored file."),
+          sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+          name: s.nonEmptyString("The stored transit file name."),
+          mimeType: s.nonEmptyString("The stored transit file MIME type."),
+        }),
+      }),
+    ]),
   },
   {
     name: "files.list",

--- a/src/providers/googledrive/actions.ts
+++ b/src/providers/googledrive/actions.ts
@@ -1,5 +1,6 @@
 import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
 
+import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
 import { googleDriveFullScope, googleDriveMetadataReadonlyScope, googleDriveReadonlyScope } from "./scopes.ts";
 
@@ -1416,6 +1417,36 @@ const actionSources: GoogledriveActionSource[] = [
       required: ["drives", "nextPageToken"],
       additionalProperties: false,
     },
+  },
+  {
+    name: "files.download",
+    description:
+      "Download an ordinary Google Drive blob file and store the complete content in local transit file storage.",
+    requiredScopes: [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope],
+    inputSchema: s.object(
+      "Input parameters for downloading a Google Drive blob file.",
+      {
+        fileId: s.nonEmptyString("The ID of the Google Drive file to download."),
+        includeSharedDrives: s.boolean("Whether the request supports files in shared drives."),
+        acknowledgeAbuse: s.boolean(
+          "Whether the caller acknowledges the risk of downloading a file marked as abusive or malicious.",
+        ),
+      },
+      { optional: ["includeSharedDrives", "acknowledgeAbuse"] },
+    ),
+    outputSchema: s.object("The downloaded Google Drive file stored in local transit storage.", {
+      fileId: s.nonEmptyString("The Google Drive file ID returned by the metadata request."),
+      name: s.nonEmptyString("The original Google Drive file name."),
+      mimeType: s.nonEmptyString("The Google Drive file MIME type."),
+      sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
+      file: s.object("The downloaded content in local transit file storage.", {
+        fileId: s.nonEmptyString("The local transit file identifier."),
+        downloadUrl: s.url("The local transit URL for downloading the stored file."),
+        sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+        name: s.nonEmptyString("The stored transit file name."),
+        mimeType: s.nonEmptyString("The stored transit file MIME type."),
+      }),
+    }),
   },
   {
     name: "files.export",

--- a/src/providers/googledrive/executors.test.ts
+++ b/src/providers/googledrive/executors.test.ts
@@ -1,10 +1,10 @@
 import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAction } from "../../core/execution.ts";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { provider } from "./definition.ts";
 import { executors } from "./executors.ts";
-import { googleDriveMetadataReadonlyScope, googleDriveReadonlyScope } from "./scopes.ts";
 
 interface CapturedRequest {
   url: URL;
@@ -28,15 +28,30 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("Google Drive files.download", () => {
-  it("is registered in the catalog and executor map with read-only scopes", () => {
-    const action = provider.actions.find((candidate) => candidate.name === "files.download");
+describe("Google Drive files.get", () => {
+  it("returns metadata when alt is omitted", async () => {
+    const requests = stubGoogleResponses([
+      Response.json({ id: "drive-file-1", name: "notes.txt", mimeType: "text/plain", size: "6" }),
+    ]);
 
-    expect(action).toMatchObject({
-      id: "googledrive.files.download",
-      requiredScopes: [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope],
+    const result = await executeGet({ fileId: "drive-file-1" });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        id: "drive-file-1",
+        name: "notes.txt",
+        mimeType: "text/plain",
+        webViewLink: null,
+        createdTime: null,
+        modifiedTime: null,
+        sizeBytes: 6,
+        driveId: null,
+      },
     });
-    expect(executors["googledrive.files.download"]).toBeTypeOf("function");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.pathname).toBe("/drive/v3/files/drive-file-1");
+    expect(requests[0]?.url.searchParams.get("alt")).toBeNull();
   });
 
   it("downloads a blob file with shared-drive and abuse acknowledgement parameters", async () => {
@@ -47,8 +62,8 @@ describe("Google Drive files.download", () => {
     ]);
     const { store, create } = createTransitFileStore(1024);
 
-    const result = await executeDownload(
-      { fileId: "requested-file-id", includeSharedDrives: true, acknowledgeAbuse: true },
+    const result = await executeGet(
+      { fileId: "requested-file-id", alt: "media", includeSharedDrives: true, acknowledgeAbuse: true },
       store,
     );
 
@@ -93,7 +108,7 @@ describe("Google Drive files.download", () => {
     ]);
     const { store, create } = createTransitFileStore(2);
 
-    const result = await executeDownload({ fileId: "drive-file-2" }, store);
+    const result = await executeGet({ fileId: "drive-file-2", alt: "media" }, store);
 
     expect(result).toMatchObject({
       ok: false,
@@ -107,6 +122,26 @@ describe("Google Drive files.download", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it("does not start the download when the reported size exceeds the transit limit", async () => {
+    const requests = stubGoogleResponses([
+      Response.json({ id: "drive-file-3", name: "large.bin", mimeType: "application/octet-stream", size: "3" }),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeGet({ fileId: "drive-file-3", alt: "media" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Google Drive file exceeds local transit limit of 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("rejects Google Workspace files and directs callers to files.export", async () => {
     const requests = stubGoogleResponses([
       Response.json({
@@ -117,13 +152,14 @@ describe("Google Drive files.download", () => {
     ]);
     const { store, create } = createTransitFileStore(1024);
 
-    const result = await executeDownload({ fileId: "workspace-file-1" }, store);
+    const result = await executeGet({ fileId: "workspace-file-1", alt: "media" }, store);
 
     expect(result).toMatchObject({
       ok: false,
       error: {
         code: "invalid_input",
-        message: "Google Workspace files must be downloaded with files.export.",
+        message:
+          "Google Workspace-native files cannot be downloaded with files.get alt=media. Use files.export when supported.",
       },
     });
     expect(requests).toHaveLength(1);
@@ -134,13 +170,13 @@ describe("Google Drive files.download", () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
 
-    const result = await executeDownload({ fileId: "drive-file-1" });
+    const result = await executeGet({ fileId: "drive-file-1", alt: "media" });
 
     expect(result).toMatchObject({
       ok: false,
       error: {
         code: "invalid_input",
-        message: "files.download requires local transit file storage.",
+        message: "files.get with alt=media requires local transit file storage.",
       },
     });
     expect(fetch).not.toHaveBeenCalled();
@@ -190,7 +226,7 @@ function createTransitFileStore(maxBytes: number): {
   };
 }
 
-async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+async function executeGet(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
   const context: ExecutionContext = {
     getCredential: async (service) => {
       expect(service).toBe("googledrive");
@@ -200,5 +236,10 @@ async function executeDownload(input: Record<string, unknown>, transitFiles?: Tr
   if (transitFiles) {
     context.transitFiles = transitFiles;
   }
-  return executors["googledrive.files.download"]!(input, context);
+  return executeAction(
+    provider.actions.find((action) => action.name === "files.get")!,
+    executors["googledrive.files.get"],
+    input,
+    context,
+  );
 }

--- a/src/providers/googledrive/executors.test.ts
+++ b/src/providers/googledrive/executors.test.ts
@@ -1,0 +1,204 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { provider } from "./definition.ts";
+import { executors } from "./executors.ts";
+import { googleDriveMetadataReadonlyScope, googleDriveReadonlyScope } from "./scopes.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+}
+
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "drive-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "drive:test", displayName: "Drive test", grantedScopes: [] },
+  metadata: {},
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("Google Drive files.download", () => {
+  it("is registered in the catalog and executor map with read-only scopes", () => {
+    const action = provider.actions.find((candidate) => candidate.name === "files.download");
+
+    expect(action).toMatchObject({
+      id: "googledrive.files.download",
+      requiredScopes: [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope],
+    });
+    expect(executors["googledrive.files.download"]).toBeTypeOf("function");
+  });
+
+  it("downloads a blob file with shared-drive and abuse acknowledgement parameters", async () => {
+    const content = new Uint8Array([72, 101, 108, 108, 111, 10]);
+    const requests = stubGoogleResponses([
+      Response.json({ id: "drive-file-1", name: "notes.txt", mimeType: "text/plain", size: String(content.length) }),
+      new Response(content, { headers: { "content-type": "application/octet-stream" } }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { fileId: "requested-file-id", includeSharedDrives: true, acknowledgeAbuse: true },
+      store,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "drive-file-1",
+        name: "notes.txt",
+        mimeType: "text/plain",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "notes.txt",
+          mimeType: "text/plain",
+        },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url.pathname).toBe("/drive/v3/files/requested-file-id");
+    expect(requests[0]?.url.searchParams.get("supportsAllDrives")).toBe("true");
+    expect(requests[0]?.url.searchParams.get("alt")).toBeNull();
+    expect(requests[1]?.url.pathname).toBe("/drive/v3/files/drive-file-1");
+    expect(Object.fromEntries(requests[1]!.url.searchParams)).toEqual({
+      alt: "media",
+      supportsAllDrives: "true",
+      acknowledgeAbuse: "true",
+    });
+    expect(requests.every((request) => request.authorization === "Bearer drive-access-token")).toBe(true);
+    expect(create).toHaveBeenCalledOnce();
+    const storedFile = create.mock.calls[0]![0];
+    expect(storedFile.name).toBe("notes.txt");
+    expect(storedFile.type).toBe("text/plain");
+    expect(new Uint8Array(await storedFile.arrayBuffer())).toEqual(content);
+  });
+
+  it("fails without truncating when the response exceeds the transit limit", async () => {
+    const requests = stubGoogleResponses([
+      Response.json({ id: "drive-file-2", name: "large.bin", mimeType: "application/octet-stream" }),
+      new Response(new Uint8Array([1, 2, 3])),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload({ fileId: "drive-file-2" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Google Drive download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("rejects Google Workspace files and directs callers to files.export", async () => {
+    const requests = stubGoogleResponses([
+      Response.json({
+        id: "workspace-file-1",
+        name: "Project plan",
+        mimeType: "application/vnd.google-apps.document",
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ fileId: "workspace-file-1" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Google Workspace files must be downloaded with files.export.",
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when transit file storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload({ fileId: "drive-file-1" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "files.download requires local transit file storage.",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubGoogleResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Google Drive request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("googledrive");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executors["googledrive.files.download"]!(input, context);
+}

--- a/src/providers/googledrive/executors.ts
+++ b/src/providers/googledrive/executors.ts
@@ -2,6 +2,7 @@ import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } f
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { randomUUID } from "node:crypto";
+import { requiredRawString, requiredString } from "../../core/cast.ts";
 import { readBoundedResponseBytes } from "../../core/request.ts";
 import { googleJsonRequest, googleRequest } from "../google-runtime.ts";
 import {
@@ -98,6 +99,9 @@ const googledriveActionHandlers: Record<string, ActionHandler> = {
   },
   "files.get"(input, { accessToken, fetcher }) {
     return getFileMetadata(input, accessToken, fetcher);
+  },
+  "files.download"(input, context) {
+    return downloadFile(input, context);
   },
   "files.export"(input, context) {
     return exportFile(input, context);
@@ -494,6 +498,64 @@ async function getFileMetadata(input: Record<string, unknown>, accessToken: stri
   return normalizeDriveFile(payload);
 }
 
+async function downloadFile(input: Record<string, unknown>, context: ActionContext) {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "files.download requires local transit file storage.");
+  }
+
+  const includeSharedDrives = resolveSupportsAllDrives(input);
+  const metadata = await fetchDriveFile(
+    resolveFileId(input),
+    context.accessToken,
+    context.fetcher,
+    includeSharedDrives,
+    context.signal,
+  );
+  const fileId = requiredString(metadata.id, "Google Drive file metadata id", providerMetadataError);
+  const name = requiredRawString(metadata.name, "Google Drive file metadata name", providerMetadataError);
+  if (name.length === 0) {
+    throw providerMetadataError("Google Drive file metadata name must not be empty");
+  }
+  const mimeType = requiredString(metadata.mimeType, "Google Drive file metadata MIME type", providerMetadataError);
+  if (mimeType.toLowerCase().startsWith("application/vnd.google-apps.")) {
+    throw new ProviderRequestError(400, "Google Workspace files must be downloaded with files.export.");
+  }
+
+  const reportedSizeBytes = parseSizeBytes(metadata.size);
+  if (reportedSizeBytes !== null && reportedSizeBytes > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(
+      413,
+      `Google Drive file exceeds local transit limit of ${context.transitFiles.maxBytes} bytes`,
+    );
+  }
+
+  const response = await googleRequest(`${driveApiBaseUrl}/files/${fileId}`, {
+    accessToken: context.accessToken,
+    fetcher: context.fetcher,
+    signal: context.signal,
+    query: compactObject({
+      alt: "media",
+      supportsAllDrives: String(includeSharedDrives),
+      acknowledgeAbuse: optionalBoolean(input.acknowledgeAbuse)?.toString(),
+    }),
+    timeoutMs: 300_000,
+  });
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Google Drive download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+
+  return {
+    fileId,
+    name,
+    mimeType,
+    sizeBytes: file.sizeBytes,
+    file,
+  };
+}
+
 async function exportFile(input: Record<string, unknown>, context: ActionContext) {
   if (!context.transitFiles) {
     throw new ProviderRequestError(400, "files.export requires local transit file storage.");
@@ -690,15 +752,21 @@ async function fetchDriveFile(
   accessToken: string,
   fetcher: typeof fetch,
   includeSharedDrives: boolean,
+  signal?: AbortSignal,
 ) {
   return googleJsonRequest<Record<string, unknown>>(`${driveApiBaseUrl}/files/${fileId}`, {
     accessToken,
     fetcher,
+    signal,
     query: {
       fields: driveFileFields,
       supportsAllDrives: String(includeSharedDrives),
     },
   });
+}
+
+function providerMetadataError(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
 }
 
 function extensionForExportMimeType(mimeType: string): string {

--- a/src/providers/googledrive/executors.ts
+++ b/src/providers/googledrive/executors.ts
@@ -97,11 +97,10 @@ const googledriveActionHandlers: Record<string, ActionHandler> = {
   "files.list"(input, { accessToken, fetcher }) {
     return listFiles(input, accessToken, fetcher);
   },
-  "files.get"(input, { accessToken, fetcher }) {
-    return getFileMetadata(input, accessToken, fetcher);
-  },
-  "files.download"(input, context) {
-    return downloadFile(input, context);
+  "files.get"(input, context) {
+    return input.alt === "media"
+      ? downloadFile(input, context)
+      : getFileMetadata(input, context.accessToken, context.fetcher);
   },
   "files.export"(input, context) {
     return exportFile(input, context);
@@ -500,7 +499,7 @@ async function getFileMetadata(input: Record<string, unknown>, accessToken: stri
 
 async function downloadFile(input: Record<string, unknown>, context: ActionContext) {
   if (!context.transitFiles) {
-    throw new ProviderRequestError(400, "files.download requires local transit file storage.");
+    throw new ProviderRequestError(400, "files.get with alt=media requires local transit file storage.");
   }
 
   const includeSharedDrives = resolveSupportsAllDrives(input);
@@ -518,7 +517,10 @@ async function downloadFile(input: Record<string, unknown>, context: ActionConte
   }
   const mimeType = requiredString(metadata.mimeType, "Google Drive file metadata MIME type", providerMetadataError);
   if (mimeType.toLowerCase().startsWith("application/vnd.google-apps.")) {
-    throw new ProviderRequestError(400, "Google Workspace files must be downloaded with files.export.");
+    throw new ProviderRequestError(
+      400,
+      "Google Workspace-native files cannot be downloaded with files.get alt=media. Use files.export when supported.",
+    );
   }
 
   const reportedSizeBytes = parseSizeBytes(metadata.size);


### PR DESCRIPTION
## Summary

- extend the official `googledrive.files.get` action with optional `alt: "media"` support while preserving metadata responses by default
- prefetch metadata for the canonical file ID, original name, MIME type, and reported size
- download through the guarded Google runtime with shared-drive support, abuse acknowledgement, cancellation, timeout, and transit size enforcement
- return downloaded content through the existing local transit file shape
- reject Google Workspace-native files with guidance to use `files.export` when the file type supports export
- avoid using `files.download`, which is a distinct Google Drive long-running operation API

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npx vitest run src/providers/googledrive/executors.test.ts` (6 tests)
- `npm test` (102 files, 961 tests)