### PR TITLE
feat(baidu-netdisk): add transit file download

### DIFF
--- a/src/providers/baidu_netdisk/actions.ts
+++ b/src/providers/baidu_netdisk/actions.ts
@@ -95,6 +95,20 @@ const managementOutputSchema = s.object("The result of one file operation.", {
   path: nullableString("The resulting absolute path, or null when Baidu omits it."),
 });
 
+const downloadedFileSchema = s.requiredObject("A downloaded Baidu Netdisk file stored in local transit storage.", {
+  fileId: s.nonEmptyString("The Baidu Netdisk fs_id decimal string."),
+  name: s.nonEmptyString("The original Baidu Netdisk file name."),
+  mimeType: s.nonEmptyString("The downloaded file MIME type."),
+  sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
+  file: s.requiredObject("The downloaded content in local transit file storage.", {
+    fileId: s.nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored file."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: s.nonEmptyString("The stored transit file name."),
+    mimeType: s.nonEmptyString("The stored transit file MIME type."),
+  }),
+});
+
 const relocateInputSchema = (operation: string) =>
   s.object(
     `Input for ${operation}ing one Baidu Netdisk file or folder.`,
@@ -203,6 +217,20 @@ export const baiduNetdiskActions: ProviderActionDefinition[] = [
       items: s.array("The normalized semantic matches.", semanticFileSchema),
       truncated: s.boolean("Whether Baidu reports that more matches may be available."),
     }),
+  }),
+  defineProviderAction("baidu_netdisk", {
+    name: "download_file",
+    description: "Download one Baidu Netdisk file by fs_id into local transit file storage.",
+    requiredScopes: [baiduNetdiskConnectorScopes.rootFilesRead],
+    providerPermissions: [baiduNetdiskProviderScopes.netdisk],
+    inputSchema: s.requiredObject("Input for downloading one Baidu Netdisk file.", {
+      fsId: s.string({
+        minLength: 1,
+        pattern: "^[0-9]+$",
+        description: "The lossless Baidu Netdisk fs_id decimal string.",
+      }),
+    }),
+    outputSchema: downloadedFileSchema,
   }),
   defineProviderAction("baidu_netdisk", {
     name: "upload_file_from_url",

--- a/src/providers/baidu_netdisk/executors.test.ts
+++ b/src/providers/baidu_netdisk/executors.test.ts
@@ -1,0 +1,257 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  userAgent: string | null;
+}
+
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "baidu-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "baidu:test", displayName: "Baidu test", grantedScopes: [] },
+  metadata: {},
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("Baidu Netdisk download_file", () => {
+  it("downloads the requested fs_id byte-for-byte into transit storage", async () => {
+    const content = new Uint8Array([0, 1, 2, 254, 255]);
+    const requests = stubResponses([
+      new Response(
+        '{"errno":0,"list":[{"fs_id":9007199254740993,"filename":"archive.bin","size":5,"isdir":0,"dlink":"https://d.pcs.baidu.com/file/test?fid=1"}]}',
+        { headers: { "content-type": "application/json" } },
+      ),
+      new Response(content, { headers: { "content-type": "application/octet-stream" } }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload("9007199254740993", store);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "9007199254740993",
+        name: "archive.bin",
+        mimeType: "application/octet-stream",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "archive.bin",
+          mimeType: "application/octet-stream",
+        },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url.pathname).toBe("/rest/2.0/xpan/multimedia");
+    expect(requests[0]?.url.searchParams.get("method")).toBe("filemetas");
+    expect(requests[0]?.url.searchParams.get("dlink")).toBe("1");
+    expect(requests[0]?.url.searchParams.get("fsids")).toBe("[9007199254740993]");
+    expect(requests[0]?.url.searchParams.get("access_token")).toBe("baidu-access-token");
+    expect(requests[1]?.url.hostname).toBe("d.pcs.baidu.com");
+    expect(requests[1]?.url.searchParams.get("access_token")).toBe("baidu-access-token");
+    expect(requests[1]?.userAgent).toBe("pan.baidu.com");
+    expect(create).toHaveBeenCalledOnce();
+    const storedFile = create.mock.calls[0]![0];
+    expect(new Uint8Array(await storedFile.arrayBuffer())).toEqual(content);
+  });
+
+  it("rejects a file whose reported size exceeds the transit limit before downloading", async () => {
+    const requests = stubResponses([
+      Response.json({
+        errno: 0,
+        list: [
+          {
+            fs_id: 123,
+            filename: "large.bin",
+            size: 3,
+            isdir: 0,
+            dlink: "https://d.pcs.baidu.com/file/large",
+          },
+        ],
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload("123", store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Baidu Netdisk file exceeds local transit limit of 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("fails without truncating when the response exceeds the transit limit", async () => {
+    const requests = stubResponses([
+      Response.json({
+        errno: 0,
+        list: [
+          {
+            fs_id: 123,
+            filename: "growing.bin",
+            size: 1,
+            isdir: 0,
+            dlink: "https://d.pcs.baidu.com/file/growing",
+          },
+        ],
+      }),
+      new Response(new Uint8Array([1, 2, 3])),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload("123", store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Baidu Netdisk download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("rejects folders and untrusted download URLs", async () => {
+    const folderRequests = stubResponses([
+      Response.json({
+        errno: 0,
+        list: [
+          {
+            fs_id: 123,
+            filename: "folder",
+            size: 0,
+            isdir: 1,
+            dlink: "https://d.pcs.baidu.com/file/folder",
+          },
+        ],
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const folderResult = await executeDownload("123", store);
+
+    expect(folderResult).toMatchObject({
+      ok: false,
+      error: { message: "baidu_netdisk download_file requires a file fsId" },
+    });
+    expect(folderRequests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+
+    const untrustedRequests = stubResponses([
+      Response.json({
+        errno: 0,
+        list: [
+          {
+            fs_id: 123,
+            filename: "secret.bin",
+            size: 1,
+            isdir: 0,
+            dlink: "https://attacker.example/file/secret",
+          },
+        ],
+      }),
+    ]);
+
+    const untrustedResult = await executeDownload("123", store);
+
+    expect(untrustedResult).toMatchObject({
+      ok: false,
+      error: { message: "baidu_netdisk returned an untrusted download URL" },
+    });
+    expect(untrustedRequests).toHaveLength(1);
+  });
+
+  it("returns a clear error when transit file storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload("123");
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "baidu_netdisk download_file requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      userAgent: request.headers.get("user-agent"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Baidu Netdisk request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(fsId: string, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("baidu_netdisk");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executors["baidu_netdisk.download_file"]!({ fsId }, context);
+}

--- a/src/providers/baidu_netdisk/executors.ts
+++ b/src/providers/baidu_netdisk/executors.ts
@@ -1,13 +1,14 @@
-import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidators, ProviderExecutors, TransitFileWriter } from "../../core/types.ts";
 
 import { optionalString, requiredString } from "../../core/cast.ts";
 import { defineProviderExecutors, requireOAuthCredential } from "../provider-runtime.ts";
 import { executeBaiduNetdiskMcpAction, verifyBaiduNetdiskMcpConnection } from "./runtime-mcp.ts";
-import { fetchBaiduNetdiskAccount, getBaiduNetdiskQuota } from "./runtime.ts";
+import { downloadBaiduNetdiskFile, fetchBaiduNetdiskAccount, getBaiduNetdiskQuota } from "./runtime.ts";
 
 interface BaiduNetdiskContext {
   accessToken: string;
   fetcher: typeof fetch;
+  transitFiles?: TransitFileWriter;
   signal?: AbortSignal;
 }
 
@@ -23,6 +24,9 @@ const handlers: Record<string, (input: Record<string, unknown>, context: BaiduNe
   },
   get_quota(_input, context) {
     return getBaiduNetdiskQuota(context);
+  },
+  download_file(input, context) {
+    return downloadBaiduNetdiskFile(input, context);
   },
 };
 
@@ -45,7 +49,12 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   handlers,
   async createContext(context, fetcher) {
     const credential = await requireOAuthCredential(context, "baidu_netdisk");
-    return { accessToken: credential.accessToken, fetcher, signal: context.signal };
+    return {
+      accessToken: credential.accessToken,
+      fetcher,
+      transitFiles: context.transitFiles,
+      signal: context.signal,
+    };
   },
   skipDnsValidation: true,
 });

--- a/src/providers/baidu_netdisk/runtime.ts
+++ b/src/providers/baidu_netdisk/runtime.ts
@@ -1,5 +1,8 @@
-import { compactObject, optionalInteger, optionalString } from "../../core/cast.ts";
-import { ProviderRequestError } from "../provider-runtime.ts";
+import type { TransitFileWriter } from "../../core/types.ts";
+
+import { compactObject, optionalInteger, optionalString, requiredRawString, requiredString } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import { providerFetch, ProviderRequestError, readProviderTextBody } from "../provider-runtime.ts";
 
 const baiduPanBaseUrl = "https://pan.baidu.com";
 const losslessIntegerKeys = new Set(["fs_id", "fsid", "pid", "uk", "request_id", "cursor"]);
@@ -10,6 +13,10 @@ interface BaiduNetdiskRequestContext {
   accessToken: string;
   fetcher: typeof fetch;
   signal?: AbortSignal;
+}
+
+interface BaiduNetdiskDownloadContext extends BaiduNetdiskRequestContext {
+  transitFiles?: TransitFileWriter;
 }
 
 export interface BaiduNetdiskAccount {
@@ -72,6 +79,122 @@ export async function getBaiduNetdiskQuota(context: BaiduNetdiskRequestContext):
     freeQuotaBytes: requireInteger(payload.free, "free"),
     expiresWithinSevenDays: payload.expire === true,
   };
+}
+
+export async function downloadBaiduNetdiskFile(
+  input: Record<string, unknown>,
+  context: BaiduNetdiskDownloadContext,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "baidu_netdisk download_file requires local transit file storage");
+  }
+
+  const requestedFsId = requiredString(input.fsId, "fsId", (message) => new ProviderRequestError(400, message));
+  if (!/^\d+$/u.test(requestedFsId)) {
+    throw new ProviderRequestError(400, "fsId must be a decimal string");
+  }
+
+  const metadataUrl = new URL("/rest/2.0/xpan/multimedia", baiduPanBaseUrl);
+  metadataUrl.searchParams.set("method", "filemetas");
+  metadataUrl.searchParams.set("dlink", "1");
+  metadataUrl.searchParams.set("fsids", `[${requestedFsId}]`);
+  const metadataPayload = await requestBaiduNetdiskApi(metadataUrl, context.accessToken, context.fetcher, "read", {
+    signal: context.signal,
+  });
+  const metadata = readDownloadMetadata(metadataPayload, requestedFsId);
+  if (metadata.sizeBytes > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(
+      413,
+      `Baidu Netdisk file exceeds local transit limit of ${context.transitFiles.maxBytes} bytes`,
+    );
+  }
+
+  const downloadUrl = readBaiduDownloadUrl(metadata.downloadUrl);
+  downloadUrl.searchParams.set("access_token", context.accessToken);
+  const response = await providerFetch(downloadUrl, {
+    headers: {
+      accept: "*/*",
+      "user-agent": "pan.baidu.com",
+    },
+    signal: context.signal,
+  });
+  if (!response.ok) {
+    const message = await readProviderTextBody(response, "Baidu Netdisk download error", 1024 * 1024).catch(() => "");
+    throw new ProviderRequestError(
+      response.status >= 500 ? 502 : response.status,
+      message || `baidu_netdisk download failed with HTTP ${response.status}`,
+    );
+  }
+
+  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Baidu Netdisk download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], metadata.name, { type: mimeType }));
+
+  return {
+    fileId: metadata.fileId,
+    name: metadata.name,
+    mimeType,
+    sizeBytes: file.sizeBytes,
+    file,
+  };
+}
+
+interface BaiduDownloadMetadata {
+  fileId: string;
+  name: string;
+  sizeBytes: number;
+  downloadUrl: string;
+}
+
+function readDownloadMetadata(payload: Record<string, unknown>, requestedFsId: string): BaiduDownloadMetadata {
+  if (!Array.isArray(payload.list) || payload.list.length !== 1) {
+    throw new ProviderRequestError(502, "baidu_netdisk download metadata is missing the requested file");
+  }
+  const item = payload.list[0];
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    throw new ProviderRequestError(502, "baidu_netdisk download metadata is malformed");
+  }
+  const metadata = item as Record<string, unknown>;
+  if (metadata.isdir === 1) {
+    throw new ProviderRequestError(400, "baidu_netdisk download_file requires a file fsId");
+  }
+  const fileId = requireLosslessId(metadata.fs_id, "list[0].fs_id");
+  if (fileId !== requestedFsId) {
+    throw new ProviderRequestError(502, "baidu_netdisk returned metadata for a different file");
+  }
+  const name = requiredRawString(metadata.filename, "filename", (message) => new ProviderRequestError(502, message));
+  if (name.length === 0) {
+    throw new ProviderRequestError(502, "baidu_netdisk download metadata filename must not be empty");
+  }
+  const sizeBytes = requireInteger(metadata.size, "list[0].size");
+  const downloadUrl = requiredString(metadata.dlink, "dlink", (message) => new ProviderRequestError(502, message));
+  return { fileId, name, sizeBytes, downloadUrl };
+}
+
+function readBaiduDownloadUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ProviderRequestError(502, "baidu_netdisk returned an invalid download URL");
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (
+    url.protocol !== "https:" ||
+    !(
+      hostname === "baidu.com" ||
+      hostname.endsWith(".baidu.com") ||
+      hostname === "baidupcs.com" ||
+      hostname.endsWith(".baidupcs.com")
+    )
+  ) {
+    throw new ProviderRequestError(502, "baidu_netdisk returned an untrusted download URL");
+  }
+  return url;
 }
 
 export function normalizeBaiduNetdiskError(


### PR DESCRIPTION
## Summary

- add `baidu_netdisk.download_file` for lossless `fs_id` values
- follow the official metadata plus dlink download flow and preserve provider filename and file ID
- store exact response bytes in local transit storage with metadata and streaming size-limit enforcement
- keep provider-returned dlink requests on the public SSRF-guarded fetch and reject untrusted download hosts before attaching the OAuth token
- cover byte integrity, lossless IDs, request parameters, size limits, folders, untrusted links, and missing transit storage

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npx vitest run src/providers/baidu_netdisk/executors.test.ts`
- `npm test` (105 files, 986 tests)