### PR TITLE
feat(cloudflare-r2): add transit object download

### DIFF
--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -85,6 +85,20 @@ const corsRuleSchema = s.object(
   { required: ["allowed"], optional: ["id", "exposeHeaders", "maxAgeSeconds"] },
 );
 
+const downloadedObjectSchema = s.requiredObject("A downloaded R2 object stored in local transit storage.", {
+  fileId: s.nonEmptyString("The R2 object key."),
+  name: s.nonEmptyString("The filename used for the local transit file."),
+  mimeType: s.nonEmptyString("The downloaded object MIME type."),
+  sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),
+  file: s.requiredObject("The downloaded object in local transit file storage.", {
+    fileId: s.nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored object."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: s.nonEmptyString("The stored transit file name."),
+    mimeType: s.nonEmptyString("The stored transit file MIME type."),
+  }),
+});
+
 const updateBucketInputSchema = s.object(
   "The input payload for this action.",
   {
@@ -101,6 +115,7 @@ export type CloudflareR2ActionName =
   | "list_accounts"
   | "list_buckets"
   | "get_bucket"
+  | "download_object"
   | "create_bucket"
   | "update_bucket"
   | "delete_bucket"
@@ -172,6 +187,24 @@ export const cloudflareR2Actions: ActionDefinition[] = [
       { required: ["bucketName"], optional: ["accountId", "jurisdiction"] },
     ),
     outputSchema: s.object("The output payload for this action.", { bucket: bucketSchema }),
+  }),
+  defineProviderAction(service, {
+    name: "download_object",
+    description: "Download one R2 object into local transit file storage.",
+    requiredScopes: [r2ReadScope],
+    providerPermissions: [r2ReadPermission],
+    inputSchema: s.object(
+      "The input payload for downloading one R2 object.",
+      {
+        accountId: accountIdSchema,
+        bucketName: bucketNameSchema,
+        objectKey: s.nonEmptyString("The complete R2 object key. Slashes are preserved as key delimiters."),
+        fileName: s.nonEmptyString("An optional filename override for the local transit file."),
+        jurisdiction: jurisdictionSchema,
+      },
+      { required: ["bucketName", "objectKey"], optional: ["accountId", "fileName", "jurisdiction"] },
+    ),
+    outputSchema: downloadedObjectSchema,
   }),
   defineProviderAction(service, {
     name: "create_bucket",

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -66,6 +66,26 @@ describe("Cloudflare R2 download_object", () => {
     expect(new Uint8Array(await storedFile.arrayBuffer())).toEqual(content);
   });
 
+  it("preserves boundary whitespace and strictly encodes reserved key characters", async () => {
+    const objectKey = " reports/file!'()*.txt ";
+    const requests = stubResponses([new Response("ok")]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucketName: "documents", objectKey, fileName: "report.txt" }, store);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: objectKey,
+        name: "report.txt",
+        file: { name: "report.txt" },
+      },
+    });
+    expect(requests[0]?.url.pathname).toBe(
+      "/client/v4/accounts/account-1/r2/buckets/documents/objects/%20reports/file%21%27%28%29%2A.txt%20",
+    );
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
     const { store, create } = createTransitFileStore(2);

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -1,0 +1,159 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+  jurisdiction: string | null;
+}
+
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "cloudflare-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "account-1", displayName: "Cloudflare test", grantedScopes: [] },
+  metadata: { accountId: "account-1" },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Cloudflare R2 download_object", () => {
+  it("downloads an object byte-for-byte into transit storage", async () => {
+    const content = new Uint8Array([82, 50, 0, 255]);
+    const requests = stubResponses([
+      new Response(content, {
+        headers: {
+          "content-type": "application/pdf",
+          etag: '"etag-1"',
+        },
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { bucketName: "documents", objectKey: "reports/annual report #1.pdf", jurisdiction: "eu" },
+      store,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "reports/annual report #1.pdf",
+        name: "annual report #1.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "annual report #1.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.pathname).toBe(
+      "/client/v4/accounts/account-1/r2/buckets/documents/objects/reports/annual%20report%20%231.pdf",
+    );
+    expect(requests[0]?.authorization).toBe("Bearer cloudflare-access-token");
+    expect(requests[0]?.jurisdiction).toBe("eu");
+    expect(create).toHaveBeenCalledOnce();
+    const storedFile = create.mock.calls[0]![0];
+    expect(new Uint8Array(await storedFile.arrayBuffer())).toEqual(content);
+  });
+
+  it("honors the transit size limit without storing a partial object", async () => {
+    const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload({ bucketName: "documents", objectKey: "large.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Cloudflare R2 download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when transit file storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload({ bucketName: "documents", objectKey: "report.pdf" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "cloudflare_r2 download_object requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+      jurisdiction: request.headers.get("cf-r2-jurisdiction"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Cloudflare R2 request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("cloudflare_r2");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executors["cloudflare_r2.download_object"]!(input, context);
+}

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -86,6 +86,23 @@ describe("Cloudflare R2 download_object", () => {
     );
   });
 
+  it("rejects dot segments instead of normalizing the object key", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucketName: "documents", objectKey: "a/../secret" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectKey must not contain . or .. path segments",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
     const { store, create } = createTransitFileStore(2);

--- a/src/providers/cloudflare_r2/executors.ts
+++ b/src/providers/cloudflare_r2/executors.ts
@@ -50,6 +50,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<CloudflareR2
         ),
         metadata: credential.metadata,
         fetcher,
+        transitFiles: context.transitFiles,
         signal: context.signal,
       };
     }
@@ -60,6 +61,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<CloudflareR2
         accountId: optionalString(credential.metadata.accountId),
         metadata: credential.metadata,
         fetcher,
+        transitFiles: context.transitFiles,
         signal: context.signal,
       };
     }

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -1,9 +1,9 @@
-import type { CredentialValidationResult } from "../../core/types.ts";
+import type { CredentialValidationResult, TransitFileWriter } from "../../core/types.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { CloudflareR2ActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { queryParams } from "../../core/request.ts";
+import { queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface CloudflareR2Context {
@@ -12,6 +12,7 @@ export interface CloudflareR2Context {
   accountId?: string;
   metadata: Record<string, unknown>;
   fetcher: typeof fetch;
+  transitFiles?: TransitFileWriter;
   signal?: AbortSignal;
 }
 
@@ -48,6 +49,9 @@ export const cloudflareR2ActionHandlers: Record<CloudflareR2ActionName, Provider
   },
   get_bucket(input, context) {
     return getBucket(input, context);
+  },
+  download_object(input, context) {
+    return downloadObject(input, context);
   },
   create_bucket(input, context) {
     return createBucket(input, context);
@@ -172,6 +176,53 @@ async function getBucket(input: Record<string, unknown>, context: CloudflareR2Co
   );
   return {
     bucket: normalizeR2Bucket(envelope.result),
+  };
+}
+
+async function downloadObject(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "cloudflare_r2 download_object requires local transit file storage");
+  }
+
+  const accountId = resolveAccountId(input, context);
+  const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
+  const objectKey = requiredString(input.objectKey, "objectKey", providerInputError);
+  const url = buildCloudflareR2Url(
+    `/accounts/${encodeURIComponent(accountId)}/r2/buckets/${encodeURIComponent(bucketName)}/objects/${encodeR2ObjectKey(objectKey)}`,
+  );
+  const headers: Record<string, string> = {
+    accept: "*/*",
+    authorization: `Bearer ${context.accessToken}`,
+    "user-agent": providerUserAgent,
+  };
+  const jurisdiction = optionalString(input.jurisdiction);
+  if (jurisdiction) {
+    headers["cf-r2-jurisdiction"] = jurisdiction;
+  }
+  const response = await context.fetcher(url, {
+    headers,
+    signal: context.signal,
+  });
+  if (!response.ok) {
+    const envelope = await readCloudflareR2Envelope(response);
+    throw normalizeCloudflareR2Error(response, envelope, "execute");
+  }
+
+  const name = optionalString(input.fileName) ?? defaultObjectFileName(objectKey);
+  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Cloudflare R2 download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+
+  return {
+    fileId: objectKey,
+    name,
+    mimeType,
+    sizeBytes: file.sizeBytes,
+    file,
   };
 }
 
@@ -333,6 +384,18 @@ function buildJurisdictionHeaders(input: Record<string, unknown>): Record<string
   return {
     "cf-r2-jurisdiction": optionalString(input.jurisdiction),
   };
+}
+
+function encodeR2ObjectKey(objectKey: string): string {
+  return objectKey.split("/").map(encodeURIComponent).join("/");
+}
+
+function defaultObjectFileName(objectKey: string): string {
+  return objectKey.split("/").findLast((segment) => segment.length > 0) ?? "r2-object";
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
 }
 
 async function requestEnvelope(

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -2,7 +2,14 @@ import type { CredentialValidationResult, TransitFileWriter } from "../../core/t
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { CloudflareR2ActionName } from "./actions.ts";
 
-import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import {
+  compactObject,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredRawString,
+  requiredString,
+} from "../../core/cast.ts";
 import { queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
@@ -186,7 +193,10 @@ async function downloadObject(input: Record<string, unknown>, context: Cloudflar
 
   const accountId = resolveAccountId(input, context);
   const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
-  const objectKey = requiredString(input.objectKey, "objectKey", providerInputError);
+  const objectKey = requiredRawString(input.objectKey, "objectKey", providerInputError);
+  if (objectKey.length === 0) {
+    throw providerInputError("objectKey must not be empty");
+  }
   const url = buildCloudflareR2Url(
     `/accounts/${encodeURIComponent(accountId)}/r2/buckets/${encodeURIComponent(bucketName)}/objects/${encodeR2ObjectKey(objectKey)}`,
   );
@@ -387,7 +397,13 @@ function buildJurisdictionHeaders(input: Record<string, unknown>): Record<string
 }
 
 function encodeR2ObjectKey(objectKey: string): string {
-  return objectKey.split("/").map(encodeURIComponent).join("/");
+  return objectKey.split("/").map(encodeR2ObjectKeySegment).join("/");
+}
+
+function encodeR2ObjectKeySegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/[!'()*]/g, (character) => {
+    return `%${character.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
 }
 
 function defaultObjectFileName(objectKey: string): string {

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -197,6 +197,9 @@ async function downloadObject(input: Record<string, unknown>, context: Cloudflar
   if (objectKey.length === 0) {
     throw providerInputError("objectKey must not be empty");
   }
+  if (objectKey.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw providerInputError("objectKey must not contain . or .. path segments");
+  }
   const url = buildCloudflareR2Url(
     `/accounts/${encodeURIComponent(accountId)}/r2/buckets/${encodeURIComponent(bucketName)}/objects/${encodeR2ObjectKey(objectKey)}`,
   );


### PR DESCRIPTION
## Summary
- add `cloudflare_r2.download_object` using Cloudflare R2's REST Get Object API for OAuth and API Token connections
- preserve slash-delimited object keys while encoding reserved path characters
- store bounded response bytes in local transit storage with the standard file result shape
- cover byte integrity, request encoding and authorization, size limits, and missing transit storage

## Verification
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test`
- `git diff --check`