### PR TITLE
feat(supabase): add transit storage download

### DIFF
--- a/src/providers/supabase/actions.ts
+++ b/src/providers/supabase/actions.ts
@@ -2,18 +2,9 @@ import type { ActionDefinition } from "../../core/types.ts";
 
 import { s } from "../../core/json-schema.ts";
 import { defineProviderAction } from "../../core/provider-definition.ts";
+import { supabaseScopes } from "./scopes.ts";
 
 const service = "supabase";
-
-export const supabaseProviderScopes: string[] = [
-  "organizations:read",
-  "projects:read",
-  "secrets:read",
-  "secrets:write",
-  "database:read",
-  "storage:read",
-  "edge_functions:read",
-];
 
 const projectStatuses = [
   "ACTIVE_HEALTHY",
@@ -241,7 +232,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_organizations",
     description: "List the organizations available to the authenticated Supabase account.",
-    requiredScopes: ["organizations:read"],
+    requiredScopes: [supabaseScopes.organizationsRead],
     inputSchema: s.actionInput({}, [], "No input parameters are required for this action."),
     outputSchema: s.actionOutput({
       organizations: s.array(organizationSummary, { description: "The list of organizations." }),
@@ -250,7 +241,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_organization",
     description: "Get details for a Supabase organization by slug.",
-    requiredScopes: ["organizations:read"],
+    requiredScopes: [supabaseScopes.organizationsRead],
     inputSchema: s.actionInput(
       { organizationSlug },
       ["organizationSlug"],
@@ -261,7 +252,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_organization_members",
     description: "List members of a Supabase organization.",
-    requiredScopes: ["organizations:read"],
+    requiredScopes: [supabaseScopes.organizationsRead],
     inputSchema: s.actionInput(
       { organizationSlug },
       ["organizationSlug"],
@@ -274,7 +265,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_organization_projects",
     description: "List projects in a Supabase organization with optional search and pagination.",
-    requiredScopes: ["projects:read"],
+    requiredScopes: [supabaseScopes.projectsRead],
     inputSchema: s.actionInput(
       {
         organizationSlug,
@@ -299,21 +290,21 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_projects",
     description: "List Supabase projects visible to the authenticated account.",
-    requiredScopes: ["projects:read"],
+    requiredScopes: [supabaseScopes.projectsRead],
     inputSchema: s.actionInput({}, [], "No input parameters are required for this action."),
     outputSchema: s.actionOutput({ projects: s.array(projectSummary, { description: "The list of projects." }) }),
   }),
   defineProviderAction(service, {
     name: "get_project",
     description: "Get detailed metadata for a Supabase project by project ref.",
-    requiredScopes: ["projects:read"],
+    requiredScopes: [supabaseScopes.projectsRead],
     inputSchema: projectRefInput,
     outputSchema: s.actionOutput({ project: projectDetail }),
   }),
   defineProviderAction(service, {
     name: "list_available_regions",
     description: "List Supabase regions available for creating projects in an organization.",
-    requiredScopes: ["organizations:read"],
+    requiredScopes: [supabaseScopes.organizationsRead],
     inputSchema: s.actionInput(
       {
         organizationSlug,
@@ -328,7 +319,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_project_health",
     description: "Check health for selected services in a Supabase project.",
-    requiredScopes: ["projects:read"],
+    requiredScopes: [supabaseScopes.projectsRead],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -349,7 +340,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_project_api_keys",
     description: "List API keys for a Supabase project.",
-    requiredScopes: ["secrets:read"],
+    requiredScopes: [supabaseScopes.secretsRead],
     inputSchema: s.actionInput(
       { projectRef, reveal: s.boolean({ description: "Whether to reveal the full API key values." }) },
       ["projectRef"],
@@ -360,7 +351,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_project_api_key",
     description: "Get one API key record from a Supabase project.",
-    requiredScopes: ["secrets:read"],
+    requiredScopes: [supabaseScopes.secretsRead],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -375,7 +366,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "create_project_api_key",
     description: "Create a publishable or secret API key for a Supabase project.",
-    requiredScopes: ["secrets:write"],
+    requiredScopes: [supabaseScopes.secretsWrite],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -393,7 +384,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "update_project_api_key",
     description: "Update the name, description, or JWT template for a Supabase project API key.",
-    requiredScopes: ["secrets:write"],
+    requiredScopes: [supabaseScopes.secretsWrite],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -411,7 +402,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "delete_project_api_key",
     description: "Delete a Supabase project API key.",
-    requiredScopes: ["secrets:write"],
+    requiredScopes: [supabaseScopes.secretsWrite],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -428,7 +419,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_project_secrets",
     description: "List secrets configured for a Supabase project.",
-    requiredScopes: ["secrets:read"],
+    requiredScopes: [supabaseScopes.secretsRead],
     inputSchema: projectRefInput,
     outputSchema: s.actionOutput({
       secrets: s.array(secretRecord, { description: "The project secrets returned by Supabase." }),
@@ -437,7 +428,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "upsert_project_secrets",
     description: "Bulk create or update secrets for a Supabase project.",
-    requiredScopes: ["secrets:write"],
+    requiredScopes: [supabaseScopes.secretsWrite],
     inputSchema: s.actionInput(
       { projectRef, secrets: s.array(secretInput, { minItems: 1, description: "The secrets to create or update." }) },
       ["projectRef", "secrets"],
@@ -450,7 +441,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "delete_project_secrets",
     description: "Bulk delete secrets from a Supabase project.",
-    requiredScopes: ["secrets:write"],
+    requiredScopes: [supabaseScopes.secretsWrite],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -469,7 +460,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "generate_typescript_types",
     description: "Generate TypeScript database types for a Supabase project.",
-    requiredScopes: ["database:read"],
+    requiredScopes: [supabaseScopes.databaseRead],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -485,7 +476,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "run_read_only_query",
     description: "Run a SQL query through Supabase as the read-only database user.",
-    requiredScopes: ["database:read"],
+    requiredScopes: [supabaseScopes.databaseRead],
     inputSchema: s.actionInput(
       {
         projectRef,
@@ -504,7 +495,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_storage_buckets",
     description: "List Storage buckets for a Supabase project.",
-    requiredScopes: ["storage:read"],
+    requiredScopes: [supabaseScopes.storageRead],
     inputSchema: projectRefInput,
     outputSchema: s.actionOutput({
       buckets: s.array(jsonRecord, { description: "The Storage buckets returned by Supabase." }),
@@ -513,7 +504,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "download_storage_object",
     description: "Download an object from Supabase Storage into local transit file storage.",
-    requiredScopes: ["storage:read", "secrets:read"],
+    requiredScopes: [supabaseScopes.storageRead, supabaseScopes.secretsRead],
     inputSchema: s.actionInput(
       {
         projectRef: s.string({
@@ -537,7 +528,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "list_edge_functions",
     description: "List Edge Functions in a Supabase project.",
-    requiredScopes: ["edge_functions:read"],
+    requiredScopes: [supabaseScopes.edgeFunctionsRead],
     inputSchema: projectRefInput,
     outputSchema: s.actionOutput({
       functions: s.array(jsonRecord, { description: "The Edge Functions returned by Supabase." }),
@@ -546,7 +537,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "get_edge_function",
     description: "Get metadata for one Supabase Edge Function by slug.",
-    requiredScopes: ["edge_functions:read"],
+    requiredScopes: [supabaseScopes.edgeFunctionsRead],
     inputSchema: s.actionInput(
       {
         projectRef,

--- a/src/providers/supabase/actions.ts
+++ b/src/providers/supabase/actions.ts
@@ -218,6 +218,19 @@ const healthRecord = s.object(
     description: "A Supabase service health result.",
   },
 );
+const downloadedStorageObject = s.requiredObject("A downloaded Supabase Storage object in local transit storage.", {
+  fileId: s.nonEmptyString("The bucket-qualified Supabase Storage object path."),
+  name: s.nonEmptyString("The filename used for the local transit file."),
+  mimeType: s.nonEmptyString("The downloaded object MIME type."),
+  sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),
+  file: s.requiredObject("The downloaded object in local transit file storage.", {
+    fileId: s.nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored object."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: s.nonEmptyString("The stored transit file name."),
+    mimeType: s.nonEmptyString("The stored transit file MIME type."),
+  }),
+});
 const projectRefInput = s.actionInput(
   { projectRef },
   ["projectRef"],
@@ -496,6 +509,30 @@ export const supabaseActions: ActionDefinition[] = [
     outputSchema: s.actionOutput({
       buckets: s.array(jsonRecord, { description: "The Storage buckets returned by Supabase." }),
     }),
+  }),
+  defineProviderAction(service, {
+    name: "download_storage_object",
+    description: "Download an object from Supabase Storage into local transit file storage.",
+    requiredScopes: ["storage:read", "secrets:read"],
+    inputSchema: s.actionInput(
+      {
+        projectRef: s.string({
+          minLength: 1,
+          maxLength: 64,
+          pattern: "^[a-z0-9]+$",
+          description: "The lowercase Supabase project reference used by the project API hostname.",
+        }),
+        bucketId: s.nonEmptyString("The Storage bucket identifier."),
+        objectPath: s.nonEmptyString("The complete object path inside the bucket, without a leading slash."),
+        apiKeyId: s.nonEmptyString(
+          "An optional secret or legacy service_role API key ID. When omitted, the first revealed elevated key is used.",
+        ),
+        fileName: s.nonEmptyString("An optional filename override for the local transit file."),
+      },
+      ["projectRef", "bucketId", "objectPath"],
+      "Input parameters for downloading one Supabase Storage object.",
+    ),
+    outputSchema: downloadedStorageObject,
   }),
   defineProviderAction(service, {
     name: "list_edge_functions",

--- a/src/providers/supabase/definition.ts
+++ b/src/providers/supabase/definition.ts
@@ -1,6 +1,7 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
-import { supabaseActions, supabaseProviderScopes } from "./actions.ts";
+import { supabaseActions } from "./actions.ts";
+import { supabaseProviderScopes } from "./scopes.ts";
 
 const service = "supabase";
 

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -1,0 +1,230 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAction } from "../../core/execution.ts";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { provider } from "./definition.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+  apiKey: string | null;
+}
+
+const projectRef = "abcdefghijklmnopqrst";
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "supabase-management-token",
+  tokenType: "Bearer",
+  profile: { accountId: "supabase:test", displayName: "Supabase test", grantedScopes: [] },
+  metadata: {},
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("Supabase download_storage_object", () => {
+  it("uses a revealed secret key and stores the exact object bytes", async () => {
+    const content = new Uint8Array([83, 117, 112, 0, 255]);
+    const requests = stubResponses([
+      Response.json([
+        apiKeyRecord({
+          id: "publishable-1",
+          name: "default",
+          type: "publishable",
+          api_key: "sb_publishable_test",
+        }),
+        apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" }),
+      ]),
+      new Response(content, { headers: { "content-type": "application/pdf" } }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { projectRef, bucketId: "documents", objectPath: "reports/annual report #1.pdf" },
+      store,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "documents/reports/annual report #1.pdf",
+        name: "annual report #1.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "annual report #1.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url.pathname).toBe(`/v1/projects/${projectRef}/api-keys`);
+    expect(requests[0]?.url.searchParams.get("reveal")).toBe("true");
+    expect(requests[0]?.authorization).toBe("Bearer supabase-management-token");
+    expect(requests[1]?.url.hostname).toBe(`${projectRef}.supabase.co`);
+    expect(requests[1]?.url.pathname).toBe(
+      "/storage/v1/object/authenticated/documents/reports/annual%20report%20%231.pdf",
+    );
+    expect(requests[1]?.apiKey).toBe("sb_secret_test");
+    expect(requests[1]?.authorization).toBeNull();
+    expect(create).toHaveBeenCalledOnce();
+    expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
+  });
+
+  it("uses Authorization only for an explicitly selected legacy service_role key", async () => {
+    const requests = stubResponses([
+      Response.json(
+        apiKeyRecord({ id: "service-role-1", name: "service_role", type: "legacy", api_key: "legacy-jwt" }),
+      ),
+      new Response("ok", { headers: { "content-type": "text/plain" } }),
+    ]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { projectRef, bucketId: "documents", objectPath: "notes.txt", apiKeyId: "service-role-1" },
+      store,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(requests[0]?.url.pathname).toBe(`/v1/projects/${projectRef}/api-keys/service-role-1`);
+    expect(requests[1]?.apiKey).toBe("legacy-jwt");
+    expect(requests[1]?.authorization).toBe("Bearer legacy-jwt");
+  });
+
+  it("honors the transit size limit without storing a partial object", async () => {
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response(new Uint8Array([1, 2, 3])),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload({ projectRef, bucketId: "documents", objectPath: "large.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Supabase Storage download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error before egress when transit storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload({ projectRef, bucketId: "documents", objectPath: "report.pdf" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "supabase download_storage_object requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a project reference that could change the Storage host", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { projectRef: "evil.example.com", bucketId: "documents", objectPath: "report.pdf" },
+      store,
+    );
+
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function apiKeyRecord(input: {
+  id: string;
+  name: string;
+  type: "legacy" | "publishable" | "secret";
+  api_key: string;
+}): Record<string, unknown> {
+  return {
+    ...input,
+    prefix: input.api_key.slice(0, 8),
+    hash: `hash-${input.id}`,
+  };
+}
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+      apiKey: request.headers.get("apikey"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Supabase request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("supabase");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executeAction(
+    provider.actions.find((action) => action.name === "download_storage_object")!,
+    executors["supabase.download_storage_object"],
+    input,
+    context,
+  );
+}

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -102,6 +102,48 @@ describe("Supabase download_storage_object", () => {
     expect(requests[1]?.authorization).toBe("Bearer legacy-jwt");
   });
 
+  it("preserves boundary whitespace in the object path", async () => {
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("ok", { headers: { "content-type": "text/plain" } }),
+    ]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload(
+      { projectRef, bucketId: "documents", objectPath: " reports/annual report.pdf " },
+      store,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: "documents/ reports/annual report.pdf ",
+        name: "annual report.pdf ",
+        file: { name: "annual report.pdf " },
+      },
+    });
+    expect(requests[1]?.url.pathname).toBe(
+      "/storage/v1/object/authenticated/documents/%20reports/annual%20report.pdf%20",
+    );
+  });
+
+  it("rejects dot segments instead of normalizing the object path", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ projectRef, bucketId: "documents", objectPath: "a/../secret" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectPath must not contain . or .. path segments",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([
       Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -15,8 +15,11 @@ import {
 } from "../../core/cast.ts";
 import { jsonObject, readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { supabaseProviderScopes } from "./scopes.ts";
 
 const supabaseApiBaseUrl = "https://api.supabase.com/v1";
+const supabaseProjectHostSuffix = ".supabase.co";
+const supabaseStorageAuthenticatedObjectPath = "/storage/v1/object/authenticated";
 const projectStatuses = new Set([
   "ACTIVE_HEALTHY",
   "ACTIVE_UNHEALTHY",
@@ -35,16 +38,6 @@ const projectStatuses = new Set([
   "RESIZING",
 ]);
 const apiKeyTypes = new Set(["legacy", "publishable", "secret", "unknown"]);
-
-const grantedScopes = [
-  "organizations:read",
-  "projects:read",
-  "secrets:read",
-  "secrets:write",
-  "database:read",
-  "storage:read",
-  "edge_functions:read",
-];
 
 type SupabaseActionInput = Record<string, unknown>;
 type SupabaseActionHandler = (input: SupabaseActionInput, context: BearerProviderContext) => Promise<unknown>;
@@ -159,7 +152,7 @@ export async function validateSupabaseCredential(
     profile: {
       accountId: subject ?? buildSupabaseAccountFingerprint(organizations, accessToken),
       displayName: buildSupabaseAccountLabel(organizations),
-      grantedScopes,
+      grantedScopes: supabaseProviderScopes,
     },
     metadata: {
       validationEndpoint: "/organizations",
@@ -525,7 +518,7 @@ async function supabaseDownloadStorageObject(
 
   const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
   const url = new URL(
-    `https://${projectRef}.supabase.co/storage/v1/object/authenticated/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
+    `https://${projectRef}${supabaseProjectHostSuffix}${supabaseStorageAuthenticatedObjectPath}/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
   );
   const headers: Record<string, string> = {
     accept: "*/*",

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -10,6 +10,7 @@ import {
   optionalRecord,
   optionalString,
   requiredRecord,
+  requiredRawString,
   requiredString,
   stringArray,
 } from "../../core/cast.ts";
@@ -511,9 +512,15 @@ async function supabaseDownloadStorageObject(
 
   const projectRef = readStorageProjectRef(input);
   const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
-  const objectPath = requiredString(input.objectPath, "objectPath", providerInputError);
+  const objectPath = requiredRawString(input.objectPath, "objectPath", providerInputError);
+  if (objectPath.length === 0) {
+    throw providerInputError("objectPath must not be empty");
+  }
   if (objectPath.startsWith("/")) {
     throw providerInputError("objectPath must not start with a slash");
+  }
+  if (objectPath.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw providerInputError("objectPath must not contain . or .. path segments");
   }
 
   const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -13,7 +13,7 @@ import {
   requiredString,
   stringArray,
 } from "../../core/cast.ts";
-import { jsonObject } from "../../core/request.ts";
+import { jsonObject, readBoundedResponseBytes } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const supabaseApiBaseUrl = "https://api.supabase.com/v1";
@@ -120,6 +120,9 @@ export const supabaseActionHandlers: Record<string, SupabaseActionHandler> = {
   },
   list_storage_buckets(input, context) {
     return supabaseListStorageBuckets(input, context);
+  },
+  download_storage_object(input, context) {
+    return supabaseDownloadStorageObject(input, context);
   },
   list_edge_functions(input, context) {
     return supabaseListEdgeFunctions(input, context);
@@ -503,6 +506,128 @@ async function supabaseListStorageBuckets(
       "storage buckets",
     ),
   };
+}
+
+async function supabaseDownloadStorageObject(
+  input: SupabaseActionInput,
+  context: BearerProviderContext,
+): Promise<unknown> {
+  if (!context.transitFiles) {
+    throw providerInputError("supabase download_storage_object requires local transit file storage");
+  }
+
+  const projectRef = readStorageProjectRef(input);
+  const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
+  const objectPath = requiredString(input.objectPath, "objectPath", providerInputError);
+  if (objectPath.startsWith("/")) {
+    throw providerInputError("objectPath must not start with a slash");
+  }
+
+  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
+  const url = new URL(
+    `https://${projectRef}.supabase.co/storage/v1/object/authenticated/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
+  );
+  const headers: Record<string, string> = {
+    accept: "*/*",
+    apikey: storageKey.value,
+    "user-agent": providerUserAgent,
+  };
+  if (storageKey.authorizationBearer) {
+    headers.authorization = `Bearer ${storageKey.value}`;
+  }
+
+  const response = await context.fetcher(url, { headers, signal: context.signal });
+  if (!response.ok) {
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: 64 * 1024,
+      fieldName: "Supabase Storage error response",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    throw createSupabaseError(response, parseSupabaseStorageError(bytes), "execute");
+  }
+
+  const name = optionalString(input.fileName) ?? defaultStorageObjectName(objectPath);
+  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Supabase Storage download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+
+  return {
+    fileId: `${bucketId}/${objectPath}`,
+    name,
+    mimeType,
+    sizeBytes: file.sizeBytes,
+    file,
+  };
+}
+
+interface SupabaseStorageKey {
+  value: string;
+  authorizationBearer: boolean;
+}
+
+async function resolveSupabaseStorageKey(
+  input: SupabaseActionInput,
+  projectRef: string,
+  context: BearerProviderContext,
+): Promise<SupabaseStorageKey> {
+  const apiKeyId = optionalString(input.apiKeyId);
+  const payload = await requestSupabaseJson({
+    path: apiKeyId
+      ? `/projects/${encodeURIComponent(projectRef)}/api-keys/${encodeURIComponent(apiKeyId)}`
+      : `/projects/${encodeURIComponent(projectRef)}/api-keys`,
+    context,
+    query: { reveal: true },
+  });
+  const records = apiKeyId ? [normalizeApiKeyRecord(payload)] : normalizeApiKeyListPayload(payload);
+  for (const record of records) {
+    const value = optionalString(record.apiKey);
+    const type = optionalString(record.type);
+    const name = optionalString(record.name);
+    if (value && (type === "secret" || value.startsWith("sb_secret_"))) {
+      return { value, authorizationBearer: false };
+    }
+    if (value && type === "legacy" && name === "service_role") {
+      return { value, authorizationBearer: true };
+    }
+  }
+
+  throw providerInputError(
+    apiKeyId
+      ? "The selected Supabase API key is not an elevated secret or legacy service_role key."
+      : "Supabase Storage download requires a revealed secret or legacy service_role project API key.",
+  );
+}
+
+function readStorageProjectRef(input: SupabaseActionInput): string {
+  const projectRef = readProjectRef(input);
+  if (!/^[a-z0-9]+$/.test(projectRef)) {
+    throw providerInputError("projectRef must contain only lowercase letters and numbers");
+  }
+  return projectRef;
+}
+
+function encodeStorageObjectPath(objectPath: string): string {
+  return objectPath.split("/").map(encodeURIComponent).join("/");
+}
+
+function defaultStorageObjectName(objectPath: string): string {
+  return objectPath.split("/").findLast((segment) => segment.length > 0) ?? "supabase-object";
+}
+
+function parseSupabaseStorageError(bytes: Uint8Array): unknown {
+  const body = new TextDecoder().decode(bytes).trim();
+  if (!body) {
+    return null;
+  }
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return { message: body };
+  }
 }
 
 async function supabaseListEdgeFunctions(input: SupabaseActionInput, context: BearerProviderContext): Promise<unknown> {

--- a/src/providers/supabase/scopes.ts
+++ b/src/providers/supabase/scopes.ts
@@ -1,0 +1,11 @@
+export const supabaseScopes = {
+  organizationsRead: "organizations:read",
+  projectsRead: "projects:read",
+  secretsRead: "secrets:read",
+  secretsWrite: "secrets:write",
+  databaseRead: "database:read",
+  storageRead: "storage:read",
+  edgeFunctionsRead: "edge_functions:read",
+} as const;
+
+export const supabaseProviderScopes: string[] = Object.values(supabaseScopes);


### PR DESCRIPTION
## Summary
- add `supabase.download_storage_object` for private Storage objects
- use the OAuth/PAT connection only for Management API access, then reveal an elevated project key through the documented `secrets:read` endpoint
- support current secret keys through `apikey` and legacy `service_role` JWTs through `apikey` plus `Authorization`
- validate the project-derived hostname, preserve object path segments, and store bounded response bytes in local transit storage
- cover secret and legacy key auth, byte integrity, size limits, missing transit storage, and host injection

## Verification
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test`
- `git diff --check`