### PR TITLE
feat(dropbox): return transit files for downloads

### DIFF
--- a/src/providers/dropbox/actions.ts
+++ b/src/providers/dropbox/actions.ts
@@ -235,7 +235,7 @@ const metadataResultSchema = s.object(
 const downloadFileInputSchema = s.object(
   {
     path: textSchema("The Dropbox file path, file ID, or revision ID to download."),
-    fileName: textSchema("Optional file name to use for the uploaded transit file."),
+    fileName: nonEmptyString("Optional file name to use for the local transit file."),
   },
   {
     description: "Input payload for downloading a Dropbox file into transit storage.",
@@ -243,19 +243,19 @@ const downloadFileInputSchema = s.object(
   },
 );
 
-const downloadFileOutputSchema = s.object(
-  {
-    fileId: textSchema("The unique identifier of the downloaded Dropbox file."),
-    name: textSchema("The name of the downloaded Dropbox file."),
-    mimeType: textSchema("The MIME type used for the transit upload."),
-    sizeBytes: nullableInteger("The size of the downloaded file content in bytes."),
-    contentBase64: textSchema("The downloaded file content encoded as base64."),
-  },
-  {
-    description: "A Dropbox file downloaded into transit storage.",
-    required: ["fileId", "name", "mimeType", "sizeBytes", "contentBase64"],
-  },
-);
+const downloadFileOutputSchema = s.requiredObject("A Dropbox file downloaded into local transit storage.", {
+  fileId: nonEmptyString("The unique identifier of the downloaded Dropbox file."),
+  name: nonEmptyString("The name of the downloaded Dropbox file."),
+  mimeType: nonEmptyString("The MIME type of the downloaded file."),
+  sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
+  file: s.requiredObject("The downloaded file in local transit storage.", {
+    fileId: nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored file."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: nonEmptyString("The stored transit file name."),
+    mimeType: nonEmptyString("The stored transit file MIME type."),
+  }),
+});
 
 const uploadFileInputSchema = s.object(
   {
@@ -596,7 +596,7 @@ const getSharedLinkFileInputSchema = s.object(
   {
     url: nonEmptyString("The Dropbox shared link URL."),
     path: textSchema("Optional path inside the shared link when the link points to a folder."),
-    fileName: textSchema("Optional file name to use for the uploaded transit file."),
+    fileName: nonEmptyString("Optional file name to use for the local transit file."),
   },
   {
     description: "Input payload for downloading a Dropbox shared-link file into transit storage.",
@@ -737,7 +737,7 @@ export const dropboxActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "download_file",
-    description: "Download one Dropbox file and return its content encoded as base64.",
+    description: "Download one Dropbox file into local transit file storage.",
     requiredScopes: [dropboxProviderScopes.filesContentRead],
     providerPermissions: [dropboxProviderScopes.filesContentRead],
     inputSchema: downloadFileInputSchema,
@@ -865,7 +865,7 @@ export const dropboxActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "get_shared_link_file",
-    description: "Download a Dropbox shared-link file and return its content encoded as base64.",
+    description: "Download a Dropbox shared-link file into local transit file storage.",
     requiredScopes: [dropboxProviderScopes.sharingRead],
     providerPermissions: [dropboxProviderScopes.sharingRead],
     inputSchema: getSharedLinkFileInputSchema,

--- a/src/providers/dropbox/executors.test.ts
+++ b/src/providers/dropbox/executors.test.ts
@@ -1,0 +1,240 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { executeAction } from "../../core/execution.ts";
+import { provider } from "./definition.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+  apiArg: Record<string, unknown>;
+}
+
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "dropbox-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "dropbox:test", displayName: "Dropbox test", grantedScopes: [] },
+  metadata: {},
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Dropbox transit downloads", () => {
+  it("downloads a file byte-for-byte into transit storage", async () => {
+    const content = new Uint8Array([68, 114, 111, 112, 0, 255]);
+    const requests = stubResponses([
+      dropboxDownloadResponse(content, {
+        ".tag": "file",
+        id: "id:document-1",
+        name: "document.pdf",
+        size: content.length,
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDropboxAction("download_file", { path: "/document.pdf" }, store);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "id:document-1",
+        name: "document.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "document.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    });
+    expect(requests[0]?.url.pathname).toBe("/2/files/download");
+    expect(requests[0]?.authorization).toBe("Bearer dropbox-access-token");
+    expect(requests[0]?.apiArg).toEqual({ path: "/document.pdf" });
+    expect(create).toHaveBeenCalledOnce();
+    expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
+  });
+
+  it("downloads a shared-link file with a transit filename override", async () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const requests = stubResponses([
+      dropboxDownloadResponse(content, {
+        ".tag": "file",
+        id: "id:shared-1",
+        name: "source.bin",
+        size: content.length,
+      }),
+    ]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDropboxAction(
+      "get_shared_link_file",
+      {
+        url: "https://www.dropbox.com/scl/fi/example/source.bin",
+        path: "/nested/source.bin",
+        fileName: "renamed.bin",
+      },
+      store,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: "id:shared-1",
+        name: "renamed.bin",
+        sizeBytes: content.length,
+        file: { name: "renamed.bin", sizeBytes: content.length },
+      },
+    });
+    expect(requests[0]?.url.pathname).toBe("/2/sharing/get_shared_link_file");
+    expect(requests[0]?.apiArg).toEqual({
+      url: "https://www.dropbox.com/scl/fi/example/source.bin",
+      path: "/nested/source.bin",
+    });
+  });
+
+  it("rejects a reported file size above the transit limit before storing", async () => {
+    const requests = stubResponses([
+      dropboxDownloadResponse(new Uint8Array([1]), {
+        ".tag": "file",
+        id: "id:large-1",
+        name: "large.bin",
+        size: 3,
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDropboxAction("download_file", { path: "/large.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Dropbox download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("enforces the transit limit when the response exceeds reported metadata", async () => {
+    stubResponses([
+      dropboxDownloadResponse(new Uint8Array([1, 2, 3]), {
+        ".tag": "file",
+        id: "id:growing-1",
+        name: "growing.bin",
+        size: 1,
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDropboxAction("download_file", { path: "/growing.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: "Dropbox download exceeds 2 bytes", details: { status: 413 } },
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["download_file", { path: "/document.pdf" }],
+    ["get_shared_link_file", { url: "https://www.dropbox.com/s/example/document.pdf" }],
+  ] as const)("returns a clear error when %s has no transit storage", async (actionName, input) => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDropboxAction(actionName, input);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: `dropbox ${actionName} requires local transit file storage`,
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function dropboxDownloadResponse(content: Uint8Array, metadata: Record<string, unknown>): Response {
+  return new Response(Uint8Array.from(content), {
+    headers: {
+      "content-type": "application/pdf",
+      "dropbox-api-result": JSON.stringify(metadata),
+    },
+  });
+}
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+      apiArg: JSON.parse(request.headers.get("dropbox-api-arg") ?? "{}") as Record<string, unknown>,
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Dropbox request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDropboxAction(
+  actionName: "download_file" | "get_shared_link_file",
+  input: Record<string, unknown>,
+  transitFiles?: TransitFileStore,
+) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("dropbox");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executeAction(
+    provider.actions.find((action) => action.name === actionName)!,
+    executors[`dropbox.${actionName}`],
+    input,
+    context,
+  );
+}

--- a/src/providers/dropbox/executors.test.ts
+++ b/src/providers/dropbox/executors.test.ts
@@ -87,7 +87,7 @@ describe("Dropbox transit downloads", () => {
       ok: true,
       output: {
         fileId: "id:shared-1",
-        name: "renamed.bin",
+        name: "source.bin",
         sizeBytes: content.length,
         file: { name: "renamed.bin", sizeBytes: content.length },
       },

--- a/src/providers/dropbox/executors.ts
+++ b/src/providers/dropbox/executors.ts
@@ -1,4 +1,9 @@
-import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+import type {
+  CredentialValidators,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+  TransitFileWriter,
+} from "../../core/types.ts";
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
@@ -8,6 +13,7 @@ import {
   optionalString as asOptionalString,
   requiredRecord,
 } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -263,7 +269,10 @@ async function getMetadata(input: Record<string, unknown>, accessToken: string, 
 }
 
 async function downloadFile(input: Record<string, unknown>, context: ActionContext) {
-  const { accessToken, fetcher } = context;
+  const { accessToken, fetcher, transitFiles } = context;
+  if (!transitFiles) {
+    throw new ProviderRequestError(400, "dropbox download_file requires local transit file storage");
+  }
   const response = await fetcher(`${dropboxContentBaseUrl}/files/download`, {
     method: "POST",
     headers: {
@@ -272,33 +281,14 @@ async function downloadFile(input: Record<string, unknown>, context: ActionConte
         path: requireString(input.path, "dropbox download path"),
       }),
     },
+    signal: context.signal,
   });
 
   if (!response.ok) {
     throw await normalizeDropboxHttpError(response, "dropbox download failed");
   }
 
-  const metadata = parseDropboxApiResultHeader(response);
-  const normalizedMetadata = mapDropboxMetadata(metadata);
-  if (normalizedMetadata.tag !== "file") {
-    throw new ProviderRequestError(400, "dropbox download_file requires a file path");
-  }
-
-  const name = optionalString(input.fileName) ?? normalizedMetadata.name;
-  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
-  const fileId = normalizedMetadata.id;
-  if (!fileId) {
-    throw new ProviderRequestError(502, "dropbox download metadata is missing file id");
-  }
-  const bytes = Buffer.from(await response.arrayBuffer());
-
-  return {
-    fileId,
-    name,
-    mimeType,
-    sizeBytes: normalizedMetadata.sizeBytes,
-    contentBase64: bytes.toString("base64"),
-  };
+  return storeDropboxDownload(input, response, transitFiles, "download_file");
 }
 
 async function uploadFile(input: Record<string, unknown>, accessToken: string, fetcher: typeof fetch) {
@@ -593,7 +583,10 @@ async function getSharedLinkMetadata(input: Record<string, unknown>, accessToken
 }
 
 async function getSharedLinkFile(input: Record<string, unknown>, context: ActionContext) {
-  const { accessToken, fetcher } = context;
+  const { accessToken, fetcher, transitFiles } = context;
+  if (!transitFiles) {
+    throw new ProviderRequestError(400, "dropbox get_shared_link_file requires local transit file storage");
+  }
 
   const arg = compactObject({
     url: requireString(input.url, "dropbox shared link url"),
@@ -605,32 +598,53 @@ async function getSharedLinkFile(input: Record<string, unknown>, context: Action
       ...dropboxAuthHeaders(accessToken),
       "Dropbox-API-Arg": JSON.stringify(arg),
     },
+    signal: context.signal,
   });
 
   if (!response.ok) {
     throw await normalizeDropboxHttpError(response, "dropbox shared link file download failed");
   }
 
-  const metadata = parseDropboxApiResultHeader(response);
-  const normalizedMetadata = mapDropboxMetadata(metadata);
+  return storeDropboxDownload(input, response, transitFiles, "get_shared_link_file");
+}
+
+async function storeDropboxDownload(
+  input: Record<string, unknown>,
+  response: Response,
+  transitFiles: TransitFileWriter,
+  actionName: "download_file" | "get_shared_link_file",
+): Promise<unknown> {
+  const normalizedMetadata = mapDropboxMetadata(parseDropboxApiResultHeader(response));
   if (normalizedMetadata.tag !== "file") {
-    throw new ProviderRequestError(400, "dropbox get_shared_link_file requires a file");
+    throw new ProviderRequestError(400, `dropbox ${actionName} requires a file`);
   }
 
-  const name = optionalString(input.fileName) ?? normalizedMetadata.name;
-  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
   const fileId = normalizedMetadata.id;
   if (!fileId) {
-    throw new ProviderRequestError(502, "dropbox shared-link metadata is missing file id");
+    throw new ProviderRequestError(502, "dropbox download metadata is missing file id");
   }
-  const bytes = Buffer.from(await response.arrayBuffer());
+  const name = optionalString(input.fileName) ?? normalizedMetadata.name;
+  if (!name) {
+    throw new ProviderRequestError(502, "dropbox download metadata is missing file name");
+  }
+  if (normalizedMetadata.sizeBytes !== null && normalizedMetadata.sizeBytes > transitFiles.maxBytes) {
+    throw new ProviderRequestError(413, `Dropbox download exceeds ${transitFiles.maxBytes} bytes`);
+  }
+
+  const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: transitFiles.maxBytes,
+    fieldName: "Dropbox download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return {
     fileId,
     name,
     mimeType,
-    sizeBytes: normalizedMetadata.sizeBytes,
-    contentBase64: bytes.toString("base64"),
+    sizeBytes: file.sizeBytes,
+    file,
   };
 }
 

--- a/src/providers/dropbox/executors.ts
+++ b/src/providers/dropbox/executors.ts
@@ -623,10 +623,11 @@ async function storeDropboxDownload(
   if (!fileId) {
     throw new ProviderRequestError(502, "dropbox download metadata is missing file id");
   }
-  const name = optionalString(input.fileName) ?? normalizedMetadata.name;
-  if (!name) {
+  const remoteName = normalizedMetadata.name;
+  if (!remoteName) {
     throw new ProviderRequestError(502, "dropbox download metadata is missing file name");
   }
+  const transitName = optionalString(input.fileName) ?? remoteName;
   if (normalizedMetadata.sizeBytes !== null && normalizedMetadata.sizeBytes > transitFiles.maxBytes) {
     throw new ProviderRequestError(413, `Dropbox download exceeds ${transitFiles.maxBytes} bytes`);
   }
@@ -637,11 +638,11 @@ async function storeDropboxDownload(
     fieldName: "Dropbox download",
     createError: (message) => new ProviderRequestError(413, message),
   });
-  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], transitName, { type: mimeType }));
 
   return {
     fileId,
-    name,
+    name: remoteName,
     mimeType,
     sizeBytes: file.sizeBytes,
     file,


### PR DESCRIPTION
## Summary
- replace Base64 output from `download_file` and `get_shared_link_file` with the standard local transit file result
- enforce Dropbox-reported and streamed byte limits before creating a transit file
- preserve remote file metadata, support filename overrides, and forward execution cancellation
- cover direct and shared-link downloads, exact bytes, both size-limit paths, and missing transit storage

## Breaking change
- download outputs no longer include `contentBase64`; callers receive `fileId`, `name`, `mimeType`, `sizeBytes`, and nested `file` transit metadata

## Verification
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test`
- `git diff --check`