### PR TITLE
feat(one-drive): return transit files for downloads

### DIFF
--- a/src/providers/one_drive/actions.ts
+++ b/src/providers/one_drive/actions.ts
@@ -244,7 +244,7 @@ const actions: OneDriveActionSource[] = [
         format: s.stringEnum(["pdf", "html"], {
           description: "Optional format to convert the file into before download.",
         }),
-        fileName: nonEmptyString("Optional file name to use for the downloaded file."),
+        fileName: nonEmptyString("Optional file name to use for the local transit file."),
       },
       ["itemId"],
     ),
@@ -257,7 +257,7 @@ const actions: OneDriveActionSource[] = [
       {
         driveId,
         itemPath: flexibleItemPath,
-        fileName: nonEmptyString("Optional file name to use for the downloaded file."),
+        fileName: nonEmptyString("Optional file name to use for the local transit file."),
       },
       ["itemPath"],
     ),
@@ -272,7 +272,7 @@ const actions: OneDriveActionSource[] = [
         format: s.stringEnum(["pdf", "html"], { description: "Format to convert the drive item into." }),
         itemId,
         pathAndFilename: flexibleItemPath,
-        fileName: nonEmptyString("Optional file name to use for the downloaded file."),
+        fileName: nonEmptyString("Optional file name to use for the local transit file."),
       },
       ["format"],
     ),

--- a/src/providers/one_drive/actions.ts
+++ b/src/providers/one_drive/actions.ts
@@ -115,21 +115,19 @@ const listDriveItemsOutput = s.object(
   },
   { required: ["items", "nextLink"], description: "OneDrive list response." },
 );
-const downloadedFile = s.object(
-  {
-    name: nonEmptyString("The downloaded file name."),
-    mimeType: nonEmptyString("The MIME type of the downloaded file."),
-    contentBase64: nonEmptyString("The downloaded file content encoded as base64."),
-  },
-  { required: ["name", "mimeType", "contentBase64"], description: "A downloaded OneDrive file." },
-);
-const downloadOutput = s.object(
-  {
-    content: s.nullable(downloadedFile),
-    notModified: s.boolean({ description: "Whether the OneDrive server returned HTTP 304 Not Modified." }),
-  },
-  { required: ["content", "notModified"], description: "OneDrive download response." },
-);
+const downloadOutput = s.requiredObject("A OneDrive file downloaded into local transit storage.", {
+  fileId: nonEmptyString("The unique identifier of the downloaded OneDrive item."),
+  name: nonEmptyString("The downloaded file name."),
+  mimeType: nonEmptyString("The MIME type of the downloaded file."),
+  sizeBytes: s.nonNegativeInteger("The downloaded file size in bytes."),
+  file: s.requiredObject("The downloaded file in local transit storage.", {
+    fileId: nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored file."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: nonEmptyString("The stored transit file name."),
+    mimeType: nonEmptyString("The stored transit file MIME type."),
+  }),
+});
 const fileSystemInfo = s.object(
   {
     createdDateTime: s.dateTime("Client-side creation timestamp."),
@@ -238,7 +236,7 @@ const actions: OneDriveActionSource[] = [
   ),
   read(
     "download_file",
-    "Download one file from OneDrive by item ID and return its content encoded as base64.",
+    "Download one file from OneDrive by item ID into local transit file storage.",
     input(
       {
         driveId,
@@ -247,7 +245,6 @@ const actions: OneDriveActionSource[] = [
           description: "Optional format to convert the file into before download.",
         }),
         fileName: nonEmptyString("Optional file name to use for the downloaded file."),
-        ifNoneMatch: nonEmptyString("Optional eTag or cTag used for conditional download requests."),
       },
       ["itemId"],
     ),
@@ -255,13 +252,12 @@ const actions: OneDriveActionSource[] = [
   ),
   read(
     "download_file_by_path",
-    "Download one file from OneDrive by path and return its content encoded as base64.",
+    "Download one file from OneDrive by path into local transit file storage.",
     input(
       {
         driveId,
         itemPath: flexibleItemPath,
         fileName: nonEmptyString("Optional file name to use for the downloaded file."),
-        ifNoneMatch: nonEmptyString("Optional eTag or cTag used for conditional download requests."),
       },
       ["itemPath"],
     ),
@@ -269,7 +265,7 @@ const actions: OneDriveActionSource[] = [
   ),
   read(
     "download_item_as_format",
-    "Download one drive item after converting it to a supported Microsoft Graph format.",
+    "Download one drive item into local transit storage after converting it to a supported Microsoft Graph format.",
     input(
       {
         driveId,

--- a/src/providers/one_drive/executors.test.ts
+++ b/src/providers/one_drive/executors.test.ts
@@ -118,7 +118,7 @@ describe("OneDrive transit downloads", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      output: { fileId: "item-3", name: "renamed.csv", file: { name: "renamed.csv" } },
+      output: { fileId: "item-3", name: "report.csv", file: { name: "renamed.csv" } },
     });
     expect(requests[0]?.url.pathname).toBe("/v1.0/me/drive/root:/reports/report.csv:");
     expect(requests[1]?.url.pathname).toBe("/v1.0/me/drive/root:/reports/report.csv:/content");

--- a/src/providers/one_drive/executors.test.ts
+++ b/src/providers/one_drive/executors.test.ts
@@ -1,0 +1,249 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAction } from "../../core/execution.ts";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { provider } from "./definition.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+}
+
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "onedrive-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "onedrive:test", displayName: "OneDrive test", grantedScopes: [] },
+  metadata: {},
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("OneDrive transit downloads", () => {
+  it("follows the guarded content redirect and stores exact file bytes", async () => {
+    const content = new Uint8Array([79, 110, 101, 0, 255]);
+    const requests = stubResponses([
+      Response.json({
+        id: "item-1",
+        name: "notes.txt",
+        size: content.length,
+        file: { mimeType: "text/plain" },
+      }),
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://public.dm.files.1drv.com/download/item-1" },
+      }),
+      new Response(Uint8Array.from(content), { headers: { "content-type": "text/plain; charset=utf-8" } }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeOneDriveAction("download_file", { itemId: "item-1" }, store);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "item-1",
+        name: "notes.txt",
+        mimeType: "text/plain",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "notes.txt",
+          mimeType: "text/plain",
+        },
+      },
+    });
+    expect(requests).toHaveLength(3);
+    expect(requests[0]?.url.pathname).toBe("/v1.0/me/drive/items/item-1");
+    expect(requests[0]?.url.searchParams.get("$select")).toBe("id,name,size,file,folder");
+    expect(requests[1]?.url.pathname).toBe("/v1.0/me/drive/items/item-1/content");
+    expect(requests[0]?.authorization).toBe("Bearer onedrive-access-token");
+    expect(requests[1]?.authorization).toBe("Bearer onedrive-access-token");
+    expect(requests[2]?.authorization).toBeNull();
+    expect(create).toHaveBeenCalledOnce();
+    expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
+  });
+
+  it("stores converted content with the converted extension and MIME type", async () => {
+    const content = new Uint8Array([37, 80, 68, 70]);
+    const requests = stubResponses([
+      Response.json({
+        id: "item-2",
+        name: "proposal.docx",
+        size: 10_000,
+        file: { mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+      }),
+      new Response(Uint8Array.from(content), { headers: { "content-type": "application/octet-stream" } }),
+    ]);
+    const { store } = createTransitFileStore(16);
+
+    const result = await executeOneDriveAction("download_item_as_format", { itemId: "item-2", format: "pdf" }, store);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: "item-2",
+        name: "proposal.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: { name: "proposal.pdf", mimeType: "application/pdf", sizeBytes: content.length },
+      },
+    });
+    expect(requests[1]?.url.searchParams.get("format")).toBe("pdf");
+  });
+
+  it("supports path-based downloads with the same transit result", async () => {
+    const requests = stubResponses([
+      Response.json({ id: "item-3", name: "report.csv", size: 2, file: { mimeType: "text/csv" } }),
+      new Response("ok", { headers: { "content-type": "text/csv" } }),
+    ]);
+    const { store } = createTransitFileStore(16);
+
+    const result = await executeOneDriveAction(
+      "download_file_by_path",
+      { itemPath: "/reports/report.csv", fileName: "renamed.csv" },
+      store,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: { fileId: "item-3", name: "renamed.csv", file: { name: "renamed.csv" } },
+    });
+    expect(requests[0]?.url.pathname).toBe("/v1.0/me/drive/root:/reports/report.csv:");
+    expect(requests[1]?.url.pathname).toBe("/v1.0/me/drive/root:/reports/report.csv:/content");
+  });
+
+  it("rejects a reported raw file size above the transit limit before downloading content", async () => {
+    const requests = stubResponses([
+      Response.json({ id: "item-4", name: "large.bin", size: 3, file: { mimeType: "application/octet-stream" } }),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeOneDriveAction("download_file", { itemId: "item-4" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "OneDrive download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("enforces the transit limit when the response exceeds reported metadata", async () => {
+    stubResponses([
+      Response.json({ id: "item-5", name: "growing.bin", size: 1, file: { mimeType: "application/octet-stream" } }),
+      new Response(Uint8Array.from([1, 2, 3])),
+    ]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeOneDriveAction("download_file", { itemId: "item-5" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: "OneDrive download exceeds 2 bytes", details: { status: 413 } },
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["download_file", { itemId: "item-1" }],
+    ["download_file_by_path", { itemPath: "/notes.txt" }],
+    ["download_item_as_format", { itemId: "item-1", format: "pdf" }],
+  ] as const)("returns a clear error when %s has no transit storage", async (actionName, input) => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeOneDriveAction(actionName, input);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "one_drive downloads require local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected OneDrive request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+type OneDriveDownloadAction = "download_file" | "download_file_by_path" | "download_item_as_format";
+
+async function executeOneDriveAction(
+  actionName: OneDriveDownloadAction,
+  input: Record<string, unknown>,
+  transitFiles?: TransitFileStore,
+) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("one_drive");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executeAction(
+    provider.actions.find((action) => action.name === actionName)!,
+    executors[`one_drive.${actionName}`],
+    input,
+    context,
+  );
+}

--- a/src/providers/one_drive/executors.test.ts
+++ b/src/providers/one_drive/executors.test.ts
@@ -9,6 +9,7 @@ import { executors } from "./executors.ts";
 interface CapturedRequest {
   url: URL;
   authorization: string | null;
+  signal: AbortSignal | null;
 }
 
 const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
@@ -45,8 +46,9 @@ describe("OneDrive transit downloads", () => {
       new Response(Uint8Array.from(content), { headers: { "content-type": "text/plain; charset=utf-8" } }),
     ]);
     const { store, create } = createTransitFileStore(1024);
+    const controller = new AbortController();
 
-    const result = await executeOneDriveAction("download_file", { itemId: "item-1" }, store);
+    const result = await executeOneDriveAction("download_file", { itemId: "item-1" }, store, controller.signal);
 
     expect(result).toEqual({
       ok: true,
@@ -71,6 +73,8 @@ describe("OneDrive transit downloads", () => {
     expect(requests[0]?.authorization).toBe("Bearer onedrive-access-token");
     expect(requests[1]?.authorization).toBe("Bearer onedrive-access-token");
     expect(requests[2]?.authorization).toBeNull();
+    expect(requests[0]?.signal).toBe(controller.signal);
+    expect(requests[1]?.signal).toBe(controller.signal);
     expect(create).toHaveBeenCalledOnce();
     expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
   });
@@ -188,6 +192,7 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
     requests.push({
       url: new URL(request.url),
       authorization: request.headers.get("authorization"),
+      signal: init?.signal ?? (input instanceof Request ? input.signal : null),
     });
     const response = responses.shift();
     if (!response) {
@@ -230,6 +235,7 @@ async function executeOneDriveAction(
   actionName: OneDriveDownloadAction,
   input: Record<string, unknown>,
   transitFiles?: TransitFileStore,
+  signal?: AbortSignal,
 ) {
   const context: ExecutionContext = {
     getCredential: async (service) => {
@@ -239,6 +245,9 @@ async function executeOneDriveAction(
   };
   if (transitFiles) {
     context.transitFiles = transitFiles;
+  }
+  if (signal) {
+    context.signal = signal;
   }
   return executeAction(
     provider.actions.find((action) => action.name === actionName)!,

--- a/src/providers/one_drive/executors.ts
+++ b/src/providers/one_drive/executors.ts
@@ -674,14 +674,15 @@ async function downloadDriveItem(input: {
     signal: input.deps.signal,
   });
 
-  const name = resolveDownloadFileName(metadata, input.fileName, input.format);
+  const name = resolveDownloadFileName(metadata, input.format);
+  const transitName = input.fileName ?? name;
   const mimeType = resolveDownloadMimeType(metadata, response, input.format);
   const bytes = await readBoundedResponseBytes(response, {
     maxBytes: transitFiles.maxBytes,
     fieldName: "OneDrive download",
     createError: (message) => new ProviderRequestError(413, message),
   });
-  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], transitName, { type: mimeType }));
 
   return {
     fileId,
@@ -1357,15 +1358,7 @@ function compactStringRecord(value: Record<string, string | undefined>) {
   return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => entry[1] !== undefined));
 }
 
-function resolveDownloadFileName(
-  metadata: Record<string, unknown>,
-  overrideName: string | undefined,
-  format: OneDriveDownloadFormat | undefined,
-) {
-  if (overrideName) {
-    return overrideName;
-  }
-
+function resolveDownloadFileName(metadata: Record<string, unknown>, format: OneDriveDownloadFormat | undefined) {
   const metadataName = readOptionalString(metadata.name) ?? "file";
   if (!format) {
     return metadataName;

--- a/src/providers/one_drive/executors.ts
+++ b/src/providers/one_drive/executors.ts
@@ -682,7 +682,7 @@ async function downloadDriveItem(input: {
     fieldName: "OneDrive download",
     createError: (message) => new ProviderRequestError(413, message),
   });
-  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], transitName, { type: mimeType }));
+  const file = await transitFiles.create(new File([toArrayBuffer(bytes)], transitName, { type: mimeType }));
 
   return {
     fileId,

--- a/src/providers/one_drive/executors.ts
+++ b/src/providers/one_drive/executors.ts
@@ -3,12 +3,13 @@ import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, requiredRecord } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError, readTransitFileInput } from "../provider-runtime.ts";
 
 const graphBaseUrl = "https://graph.microsoft.com/v1.0";
 const graphOrigin = new URL(graphBaseUrl).origin;
 const oneDriveUploadChunkSizeBytes = 10 * 1024 * 1024;
-const oneDriveDownloadSelectFields = ["id", "name", "file", "folder"] as const;
+const oneDriveDownloadSelectFields = ["id", "name", "size", "file", "folder"] as const;
 const oneDriveDownloadFormatMimeTypes = {
   pdf: "application/pdf",
   html: "text/html",
@@ -32,6 +33,7 @@ type OneDriveRequestInput = {
   rawBody?: BodyInit;
   absoluteUrlPolicy?: "children" | "search";
   allowStatuses?: number[];
+  signal?: AbortSignal;
 };
 
 type OneDriveGraphCollection<T> = {
@@ -169,6 +171,7 @@ async function oneDriveRequest(pathOrUrl: string, input: OneDriveRequestInput) {
         : headers,
     ...(hasJsonBody ? { body: JSON.stringify(input.body) } : {}),
     ...(hasRawBody ? { body: input.rawBody } : {}),
+    signal: input.signal,
   });
 
   if (!response.ok && !input.allowStatuses?.includes(response.status)) {
@@ -501,7 +504,6 @@ async function downloadFile(input: Record<string, unknown>, deps: OneDriveRuntim
     contentPath: `${itemPath}/content`,
     format: readDownloadFormat(input),
     fileName: readOptionalString(input.fileName),
-    ifNoneMatch: readOptionalString(input.ifNoneMatch),
     deps,
   });
 }
@@ -515,7 +517,6 @@ async function downloadFileByPath(input: Record<string, unknown>, deps: OneDrive
     metadataPath: drivePath,
     contentPath: `${drivePath}/content`,
     fileName: readOptionalString(input.fileName),
-    ifNoneMatch: readOptionalString(input.ifNoneMatch),
     deps,
   });
 }
@@ -647,44 +648,47 @@ async function downloadDriveItem(input: {
   contentPath: string;
   fileName?: string;
   format?: OneDriveDownloadFormat;
-  ifNoneMatch?: string;
   deps: OneDriveRuntimeDeps;
 }) {
+  const transitFiles = input.deps.transitFiles;
+  if (!transitFiles) {
+    throw new ProviderRequestError(400, "one_drive downloads require local transit file storage");
+  }
+
   const metadata = await fetchDriveItemMetadata(input.metadataPath, input.deps);
   if (!isFileDriveItem(metadata)) {
     throw new ProviderRequestError(400, "drive item must be a file");
+  }
+  const fileId = requireString(metadata.id, "drive item id");
+  const reportedSizeBytes = readOptionalNumber(metadata.size);
+  if (!input.format && reportedSizeBytes != null && reportedSizeBytes > transitFiles.maxBytes) {
+    throw new ProviderRequestError(413, `OneDrive download exceeds ${transitFiles.maxBytes} bytes`);
   }
 
   const response = await oneDriveRequest(input.contentPath, {
     accessToken: input.deps.accessToken,
     fetcher: input.deps.fetcher,
-    headers: compactStringRecord({
-      "if-none-match": input.ifNoneMatch,
-    }),
     query: compactObject({
       format: input.format,
     }),
-    allowStatuses: [304],
+    signal: input.deps.signal,
   });
-
-  if (response.status === 304) {
-    return {
-      content: null,
-      notModified: true,
-    };
-  }
 
   const name = resolveDownloadFileName(metadata, input.fileName, input.format);
   const mimeType = resolveDownloadMimeType(metadata, response, input.format);
-  const bytes = Buffer.from(await response.arrayBuffer());
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: transitFiles.maxBytes,
+    fieldName: "OneDrive download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
   return {
-    content: {
-      name,
-      mimeType,
-      contentBase64: bytes.toString("base64"),
-    },
-    notModified: false,
+    fileId,
+    name,
+    mimeType,
+    sizeBytes: file.sizeBytes,
+    file,
   };
 }
 
@@ -696,6 +700,7 @@ async function fetchDriveItemMetadata(path: string, deps: OneDriveRuntimeDeps) {
       query: {
         $select: oneDriveDownloadSelectFields.join(","),
       },
+      signal: deps.signal,
     }),
   );
 }


### PR DESCRIPTION
## Summary
- replace Base64/conditional wrappers from all three OneDrive download actions with the standard local transit file result
- preflight raw downloads using Graph metadata and enforce streamed byte limits for every download and conversion
- preserve Graph format conversion naming/MIME behavior and forward cancellation
- verify guarded `/content` redirects drop OAuth authorization on the preauthenticated cross-origin URL
- cover item-ID, path, and format downloads, exact bytes, both size-limit paths, and missing transit storage

## Breaking change
- download outputs no longer return `{ content, notModified }` or `contentBase64`; `ifNoneMatch` is removed from download inputs because a 304 response cannot produce the required transit file

## Verification
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test`
- `git diff --check`