### PR TITLE
feat(twilio): add voice call actions

### DIFF
--- a/src/providers/twilio/actions.ts
+++ b/src/providers/twilio/actions.ts
@@ -65,6 +65,12 @@ const callStatusSchema = s.stringEnum("The Twilio call status to filter by.", [
   "failed",
 ]);
 const httpMethodSchema = s.stringEnum("The HTTP method Twilio should use.", ["GET", "POST"]);
+const callProgressEventSchema = s.stringEnum("One Twilio call progress event.", [
+  "initiated",
+  "ringing",
+  "answered",
+  "completed",
+]);
 
 const createCallInputSchema = s.actionInput(
   {
@@ -76,9 +82,7 @@ const createCallInputSchema = s.actionInput(
     fallbackUrl: s.url("The fallback URL to request when the primary TwiML URL fails."),
     fallbackMethod: httpMethodSchema,
     statusCallback: s.url("The URL that receives asynchronous call status callbacks."),
-    statusCallbackEvent: s.stringArray("Call progress events to send to the status callback.", {
-      itemDescription: "One Twilio call progress event.",
-    }),
+    statusCallbackEvent: s.array("Call progress events to send to the status callback.", callProgressEventSchema),
     statusCallbackMethod: httpMethodSchema,
   },
   ["to", "from"],

--- a/src/providers/twilio/actions.ts
+++ b/src/providers/twilio/actions.ts
@@ -34,7 +34,57 @@ const messageSchema = s.object("The normalized Twilio message payload.", {
   from: s.nullableString("The sender phone number."),
   body: s.nullableString("The text body of the message."),
 });
+const callSchema = s.object("The normalized Twilio call payload.", {
+  callSid: s.string("The Twilio call SID."),
+  accountSid: s.nullableString("The Twilio account SID that owns the call."),
+  status: s.nullableString("The current or final call status."),
+  direction: s.nullableString("The direction of the call."),
+  to: s.nullableString("The called phone number, SIP address, or client identifier."),
+  from: s.nullableString("The caller phone number or client identifier."),
+  duration: s.nullableString("The call duration in seconds."),
+  price: s.nullableString("The price charged for the call."),
+  priceUnit: s.nullableString("The currency used for the call price."),
+  startTime: s.nullableString("The time when the call started."),
+  endTime: s.nullableString("The time when the call ended."),
+  dateCreated: s.nullableString("The time when the call resource was created."),
+  dateUpdated: s.nullableString("The time when the call resource was last updated."),
+  phoneNumberSid: s.nullableString("The SID of the Twilio phone number used for the call."),
+  parentCallSid: s.nullableString("The parent call SID when this is a child call."),
+  queueTime: s.nullableString("The estimated queue time in milliseconds."),
+  uri: s.nullableString("The relative URI of the Twilio call resource."),
+});
 const pageSizeSchema = s.integer("The maximum number of records to return in one page.", { minimum: 1 });
+const callStatusSchema = s.stringEnum("The Twilio call status to filter by.", [
+  "queued",
+  "ringing",
+  "in-progress",
+  "canceled",
+  "completed",
+  "busy",
+  "no-answer",
+  "failed",
+]);
+const httpMethodSchema = s.stringEnum("The HTTP method Twilio should use.", ["GET", "POST"]);
+
+const createCallInputSchema = s.actionInput(
+  {
+    to: s.nonEmptyString("The phone number, SIP address, or client identifier to call."),
+    from: s.nonEmptyString("The Twilio phone number or client identifier to use as caller ID."),
+    url: s.url("The absolute URL that returns TwiML instructions for the call."),
+    twiml: s.nonWhitespaceString("Inline TwiML instructions for the call."),
+    method: httpMethodSchema,
+    fallbackUrl: s.url("The fallback URL to request when the primary TwiML URL fails."),
+    fallbackMethod: httpMethodSchema,
+    statusCallback: s.url("The URL that receives asynchronous call status callbacks."),
+    statusCallbackEvent: s.stringArray("Call progress events to send to the status callback.", {
+      itemDescription: "One Twilio call progress event.",
+    }),
+    statusCallbackMethod: httpMethodSchema,
+  },
+  ["to", "from"],
+  "The input payload for creating a Twilio call.",
+);
+createCallInputSchema.oneOf = [{ required: ["url"] }, { required: ["twiml"] }];
 
 export const twilioActions: ActionDefinition[] = [
   defineProviderAction(service, {
@@ -116,6 +166,61 @@ export const twilioActions: ActionDefinition[] = [
     ),
     outputSchema: messageSchema,
   }),
+  defineProviderAction(service, {
+    name: "list_calls",
+    description: "List Twilio voice calls with optional recipient, status, date, and pagination filters.",
+    requiredScopes: [],
+    inputSchema: s.actionInput(
+      {
+        to: s.string("Only include calls made to this phone number, SIP address, or client identifier."),
+        from: s.string("Only include calls made from this phone number, SIP address, or client identifier."),
+        status: callStatusSchema,
+        startTime: s.date("Only include calls that started on or after this date."),
+        endTime: s.date("Only include calls that started before this date."),
+        parentCallSid: s.string("Only include child calls of this parent call SID."),
+        pageSize: pageSizeSchema,
+        pageToken: s.string("The Twilio page token used to continue a previous listing."),
+      },
+      [],
+      "The input payload for listing Twilio calls.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        calls: s.array("The normalized Twilio calls.", callSchema),
+        page: s.nullableInteger("The current Twilio result page."),
+        pageSize: s.nullableInteger("The Twilio page size for this result."),
+        nextPageUri: s.nullableString("The next page URI returned by Twilio, if any."),
+        previousPageUri: s.nullableString("The previous page URI returned by Twilio, if any."),
+      },
+      "The output payload for listing Twilio calls.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_call",
+    description: "Fetch one Twilio voice call by call SID.",
+    requiredScopes: [],
+    inputSchema: s.actionInput(
+      { callSid: s.nonEmptyString("The Twilio call SID to fetch.") },
+      ["callSid"],
+      "The input payload for fetching one Twilio call.",
+    ),
+    outputSchema: callSchema,
+  }),
+  defineProviderAction(service, {
+    name: "create_call",
+    description: "Create an outbound Twilio voice call using a TwiML URL or inline TwiML.",
+    requiredScopes: [],
+    inputSchema: createCallInputSchema,
+    outputSchema: callSchema,
+  }),
 ];
 
-export type TwilioActionName = "get_account" | "list_usage_records" | "list_messages" | "get_message" | "send_message";
+export type TwilioActionName =
+  | "get_account"
+  | "list_usage_records"
+  | "list_messages"
+  | "get_message"
+  | "send_message"
+  | "list_calls"
+  | "get_call"
+  | "create_call";

--- a/src/providers/twilio/runtime.test.ts
+++ b/src/providers/twilio/runtime.test.ts
@@ -1,0 +1,110 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { twilioActionHandlers } from "./runtime.ts";
+
+const context = {
+  accountSid: "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  authToken: "auth-token",
+};
+
+describe("Twilio call actions", () => {
+  it("lists calls with the documented query parameter names", async () => {
+    let requestUrl = "";
+    const fetcher: ProviderFetch = async (url) => {
+      requestUrl = String(url);
+      return new Response(
+        JSON.stringify({
+          calls: [
+            {
+              sid: "CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              account_sid: context.accountSid,
+              status: "completed",
+              direction: "outbound-api",
+              to: "+14155551212",
+              from: "+14155550100",
+              duration: "4",
+              price: "-0.200",
+              price_unit: "USD",
+            },
+          ],
+          page: 0,
+          page_size: 1,
+          next_page_uri: "/2010-04-01/Accounts/AC/Calls.json?PageToken=next",
+          previous_page_uri: null,
+        }),
+      );
+    };
+
+    await expect(
+      twilioActionHandlers.list_calls(
+        {
+          to: "+14155551212",
+          status: "completed",
+          startTime: "2026-01-01",
+          pageSize: 1,
+          pageToken: "previous",
+        },
+        { ...context, fetcher },
+      ),
+    ).resolves.toMatchObject({
+      calls: [
+        {
+          callSid: "CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          status: "completed",
+          to: "+14155551212",
+          price: "-0.200",
+        },
+      ],
+      page: 0,
+      pageSize: 1,
+      nextPageUri: "/2010-04-01/Accounts/AC/Calls.json?PageToken=next",
+      previousPageUri: null,
+    });
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json");
+    expect(url.searchParams.get("To")).toBe("+14155551212");
+    expect(url.searchParams.get("Status")).toBe("completed");
+    expect(url.searchParams.get("StartTime")).toBe("2026-01-01");
+    expect(url.searchParams.get("PageSize")).toBe("1");
+    expect(url.searchParams.get("PageToken")).toBe("previous");
+  });
+
+  it("creates a call with inline TwiML and repeated callback events", async () => {
+    let requestBody = "";
+    const fetcher: ProviderFetch = async (_url, init) => {
+      requestBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ sid: "CAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }));
+    };
+
+    await twilioActionHandlers.create_call(
+      {
+        to: "+14155551212",
+        from: "+14155550100",
+        twiml: "<Response><Say>Hello</Say></Response>",
+        statusCallback: "https://example.com/twilio/status",
+        statusCallbackEvent: ["initiated", "completed"],
+      },
+      { ...context, fetcher },
+    );
+
+    const body = new URLSearchParams(requestBody);
+    expect(body.get("To")).toBe("+14155551212");
+    expect(body.get("From")).toBe("+14155550100");
+    expect(body.get("Twiml")).toBe("<Response><Say>Hello</Say></Response>");
+    expect(body.get("StatusCallback")).toBe("https://example.com/twilio/status");
+    expect(body.getAll("StatusCallbackEvent")).toEqual(["initiated", "completed"]);
+    expect(body.get("Url")).toBeNull();
+  });
+
+  it("rejects a call request that omits both TwiML sources", async () => {
+    const fetcher: ProviderFetch = async () => {
+      throw new Error("the invalid request must not be fetched");
+    };
+
+    await expect(
+      twilioActionHandlers.create_call({ to: "+14155551212", from: "+14155550100" }, { ...context, fetcher }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/src/providers/twilio/runtime.ts
+++ b/src/providers/twilio/runtime.ts
@@ -2,7 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 import type { TwilioActionName } from "./actions.ts";
 
-import { optionalInteger, optionalString, requiredString } from "../../core/cast.ts";
+import { optionalInteger, optionalString, optionalStringArray, requiredString } from "../../core/cast.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const twilioApiBaseUrl: string = "https://api.twilio.com/2010-04-01";
@@ -51,6 +51,26 @@ interface TwilioMessagePayload {
   body?: unknown;
 }
 
+interface TwilioCallPayload {
+  sid?: unknown;
+  account_sid?: unknown;
+  status?: unknown;
+  direction?: unknown;
+  to?: unknown;
+  from?: unknown;
+  duration?: unknown;
+  price?: unknown;
+  price_unit?: unknown;
+  start_time?: unknown;
+  end_time?: unknown;
+  date_created?: unknown;
+  date_updated?: unknown;
+  phone_number_sid?: unknown;
+  parent_call_sid?: unknown;
+  queue_time?: unknown;
+  uri?: unknown;
+}
+
 type TwilioActionHandler = (input: Record<string, unknown>, context: TwilioActionContext) => Promise<unknown>;
 
 export const twilioActionHandlers: Record<TwilioActionName, TwilioActionHandler> = {
@@ -68,6 +88,15 @@ export const twilioActionHandlers: Record<TwilioActionName, TwilioActionHandler>
   },
   send_message(input, context) {
     return twilioSendMessage(input, context);
+  },
+  list_calls(input, context) {
+    return twilioListCalls(input, context);
+  },
+  get_call(input, context) {
+    return twilioGetCall(input, context);
+  },
+  create_call(input, context) {
+    return twilioCreateCall(input, context);
   },
 };
 
@@ -179,6 +208,80 @@ async function twilioSendMessage(input: Record<string, unknown>, context: Twilio
   return normalizeTwilioMessage(payload);
 }
 
+async function twilioListCalls(input: Record<string, unknown>, context: TwilioActionContext): Promise<unknown> {
+  const payload = await twilioRequest<{
+    calls?: TwilioCallPayload[];
+    page?: unknown;
+    page_size?: unknown;
+    next_page_uri?: unknown;
+    previous_page_uri?: unknown;
+  }>({
+    ...context,
+    path: `/Accounts/${encodeURIComponent(context.accountSid)}/Calls.json`,
+    query: [
+      ["To", optionalString(input.to)],
+      ["From", optionalString(input.from)],
+      ["Status", optionalString(input.status)],
+      ["StartTime", optionalString(input.startTime)],
+      ["EndTime", optionalString(input.endTime)],
+      ["ParentCallSid", optionalString(input.parentCallSid)],
+      ["PageSize", optionalPositiveInteger(input.pageSize, "pageSize")],
+      ["PageToken", optionalString(input.pageToken)],
+    ],
+    phase: "execute",
+  });
+
+  return {
+    calls: (payload.calls ?? []).map((call) => normalizeTwilioCall(call)),
+    page: optionalInteger(payload.page) ?? null,
+    pageSize: optionalInteger(payload.page_size) ?? null,
+    nextPageUri: optionalString(payload.next_page_uri) ?? null,
+    previousPageUri: optionalString(payload.previous_page_uri) ?? null,
+  };
+}
+
+async function twilioGetCall(input: Record<string, unknown>, context: TwilioActionContext): Promise<unknown> {
+  const callSid = requireTwilioField(input.callSid, "callSid");
+  const payload = await twilioRequest<TwilioCallPayload>({
+    ...context,
+    path: `/Accounts/${encodeURIComponent(context.accountSid)}/Calls/${encodeURIComponent(callSid)}.json`,
+    phase: "execute",
+  });
+  return normalizeTwilioCall(payload);
+}
+
+async function twilioCreateCall(input: Record<string, unknown>, context: TwilioActionContext): Promise<unknown> {
+  const body = new URLSearchParams();
+  body.append("To", requireTwilioField(input.to, "to"));
+  body.append("From", requireTwilioField(input.from, "from"));
+
+  const url = optionalString(input.url);
+  const twiml = optionalString(input.twiml);
+  if ((url === undefined) === (twiml === undefined)) {
+    throw new ProviderRequestError(400, "Exactly one of url or twiml is required");
+  }
+  if (url !== undefined) body.append("Url", url);
+  if (twiml !== undefined) body.append("Twiml", twiml);
+
+  appendTwilioBodyField(body, "Method", optionalString(input.method));
+  appendTwilioBodyField(body, "FallbackUrl", optionalString(input.fallbackUrl));
+  appendTwilioBodyField(body, "FallbackMethod", optionalString(input.fallbackMethod));
+  appendTwilioBodyField(body, "StatusCallback", optionalString(input.statusCallback));
+  appendTwilioBodyField(body, "StatusCallbackMethod", optionalString(input.statusCallbackMethod));
+  for (const event of optionalStringArray(input.statusCallbackEvent) ?? []) {
+    body.append("StatusCallbackEvent", event);
+  }
+
+  const payload = await twilioRequest<TwilioCallPayload>({
+    ...context,
+    method: "POST",
+    path: `/Accounts/${encodeURIComponent(context.accountSid)}/Calls.json`,
+    body,
+    phase: "execute",
+  });
+  return normalizeTwilioCall(payload);
+}
+
 async function twilioRequest<T>(input: TwilioRequestInput): Promise<T> {
   const url = new URL(`${twilioApiBaseUrl}${input.path}`);
   for (const [key, value] of input.query ?? []) {
@@ -248,6 +351,32 @@ function normalizeTwilioMessage(payload: TwilioMessagePayload): Record<string, u
     from: optionalString(payload.from) ?? null,
     body: optionalString(payload.body) ?? null,
   };
+}
+
+function normalizeTwilioCall(payload: TwilioCallPayload): Record<string, unknown> {
+  return {
+    callSid: optionalString(payload.sid) ?? "",
+    accountSid: optionalString(payload.account_sid) ?? null,
+    status: optionalString(payload.status) ?? null,
+    direction: optionalString(payload.direction) ?? null,
+    to: optionalString(payload.to) ?? null,
+    from: optionalString(payload.from) ?? null,
+    duration: optionalString(payload.duration) ?? null,
+    price: optionalString(payload.price) ?? null,
+    priceUnit: optionalString(payload.price_unit) ?? null,
+    startTime: optionalString(payload.start_time) ?? null,
+    endTime: optionalString(payload.end_time) ?? null,
+    dateCreated: optionalString(payload.date_created) ?? null,
+    dateUpdated: optionalString(payload.date_updated) ?? null,
+    phoneNumberSid: optionalString(payload.phone_number_sid) ?? null,
+    parentCallSid: optionalString(payload.parent_call_sid) ?? null,
+    queueTime: optionalString(payload.queue_time) ?? null,
+    uri: optionalString(payload.uri) ?? null,
+  };
+}
+
+function appendTwilioBodyField(body: URLSearchParams, key: string, value: string | undefined): void {
+  if (value !== undefined) body.append(key, value);
 }
 
 async function readTwilioError(response: Response): Promise<string> {


### PR DESCRIPTION
## What changed

Added three locally executable Twilio Voice actions:

- `list_calls`
- `get_call`
- `create_call`

They use the existing Account SID + Auth Token custom credential and do not add or change OAuth scopes.

## API documentation

- [Twilio Call resource](https://www.twilio.com/docs/voice/api/call-resource)
- [Twilio API authentication](https://www.twilio.com/docs/usage/requests-to-twilio)

## Verification

- `npx vitest run src/providers/twilio/runtime.test.ts`
- `npm run fix-check`