### PR TITLE
feat(vonage): add SMS report actions

### DIFF
--- a/src/providers/vonage/actions.ts
+++ b/src/providers/vonage/actions.ts
@@ -49,9 +49,7 @@ const reportOutputSchema = s.actionOutput(
 );
 
 const reportDirectionSchema = s.stringEnum("The communication direction.", ["inbound", "outbound"]);
-const reportDateSchema = s.nonEmptyString(
-  "An ISO-8601 timestamp used as an inclusive start or exclusive end boundary.",
-);
+const reportDateSchema = s.dateTime("An ISO-8601 timestamp used as an inclusive start or exclusive end boundary.");
 
 export const vonageActions: ActionDefinition[] = [
   defineProviderAction("vonage", {

--- a/src/providers/vonage/actions.ts
+++ b/src/providers/vonage/actions.ts
@@ -33,6 +33,7 @@ const smsRecordSchema = s.object("One normalized Vonage SMS report record.", {
   messageBody: s.nullableString("The message body when requested with includeMessage."),
   errorCode: s.nullableString("The Vonage delivery or handoff error code."),
   errorCodeDescription: s.nullableString("The description of the delivery or handoff error."),
+  concatenated: s.nullableString("Whether the outbound SMS was split into multiple parts when requested."),
 });
 
 const reportOutputSchema = s.actionOutput(

--- a/src/providers/vonage/actions.ts
+++ b/src/providers/vonage/actions.ts
@@ -13,6 +13,46 @@ const smsMessageSchema = s.object("One normalized Vonage SMS submission result."
   clientRef: s.nullable(s.string("The caller-supplied client reference.")),
 });
 
+const smsRecordSchema = s.object("One normalized Vonage SMS report record.", {
+  recordId: s.nullableString("The Vonage report record identifier."),
+  messageId: s.nullableString("The Vonage message identifier."),
+  accountId: s.nullableString("The Vonage account identifier."),
+  direction: s.nullableString("The communication direction."),
+  from: s.nullableString("The sender number or sender ID."),
+  to: s.nullableString("The destination phone number."),
+  status: s.nullableString("The final delivery status."),
+  dateReceived: s.nullableString("When Vonage received the SMS request."),
+  dateFinalized: s.nullableString("When the SMS reached its final state."),
+  totalPrice: s.nullableString("The total price charged for the SMS request."),
+  currency: s.nullableString("The currency for the SMS price."),
+  clientRef: s.nullableString("The caller-supplied client reference."),
+  network: s.nullableString("The destination mobile network code."),
+  networkName: s.nullableString("The destination mobile network name."),
+  country: s.nullableString("The destination country code."),
+  countryName: s.nullableString("The destination country name."),
+  messageBody: s.nullableString("The message body when requested with includeMessage."),
+  errorCode: s.nullableString("The Vonage delivery or handoff error code."),
+  errorCodeDescription: s.nullableString("The description of the delivery or handoff error."),
+});
+
+const reportOutputSchema = s.actionOutput(
+  {
+    records: s.array("The normalized SMS report records.", smsRecordSchema),
+    requestId: s.nullableString("The synchronous Reports API request identifier."),
+    requestStatus: s.nullableString("The synchronous Reports API request status."),
+    itemsCount: s.nullableInteger("The number of records returned in this response."),
+    idsNotFound: s.nullableString("Comma-separated message IDs that were not found, if any."),
+    nextCursor: s.nullableString("The cursor for the next date-based result page, if any."),
+    iv: s.nullableString("The initialization vector required with the next cursor, if any."),
+  },
+  "The normalized Vonage SMS report response.",
+);
+
+const reportDirectionSchema = s.stringEnum("The communication direction.", ["inbound", "outbound"]);
+const reportDateSchema = s.nonEmptyString(
+  "An ISO-8601 timestamp used as an inclusive start or exclusive end boundary.",
+);
+
 export const vonageActions: ActionDefinition[] = [
   defineProviderAction("vonage", {
     name: "get_balance",
@@ -60,5 +100,46 @@ export const vonageActions: ActionDefinition[] = [
       messageCount: s.integer("The number of SMS submission results returned by Vonage."),
       messages: s.array("The submitted SMS results.", smsMessageSchema),
     }),
+  }),
+  defineProviderAction("vonage", {
+    name: "list_sms_records",
+    description: "List Vonage SMS delivery records for a date range and optional delivery filters.",
+    requiredScopes: [],
+    inputSchema: s.actionInput(
+      {
+        direction: reportDirectionSchema,
+        dateStart: reportDateSchema,
+        dateEnd: reportDateSchema,
+        cursor: s.nonEmptyString("The cursor returned by a previous date-based report response."),
+        iv: s.nonEmptyString("The initialization vector returned with a previous report cursor."),
+        status: s.nonEmptyString("Filter records by final delivery status."),
+        from: s.nonEmptyString("Filter records by sender number or sender ID."),
+        to: s.nonEmptyString("Filter records by destination phone number."),
+        country: s.nonEmptyString("Filter records by destination country code."),
+        network: s.nonEmptyString("Filter records by destination mobile network code."),
+        accountRef: s.nonEmptyString("Filter records by the caller-supplied account reference."),
+        includeMessage: s.boolean("Include the SMS body in each returned record."),
+        showConcatenated: s.boolean("Include whether an outbound SMS was split into multiple parts."),
+      },
+      ["direction"],
+      "The input payload for listing Vonage SMS records.",
+    ),
+    outputSchema: reportOutputSchema,
+  }),
+  defineProviderAction("vonage", {
+    name: "get_sms_record",
+    description: "Retrieve a Vonage SMS delivery record by message ID.",
+    requiredScopes: [],
+    inputSchema: s.actionInput(
+      {
+        messageId: s.nonEmptyString("The Vonage message ID to retrieve."),
+        direction: reportDirectionSchema,
+        includeMessage: s.boolean("Include the SMS body in the returned record."),
+        showConcatenated: s.boolean("Include whether the outbound SMS was split into multiple parts."),
+      },
+      ["messageId", "direction"],
+      "The input payload for retrieving one Vonage SMS record.",
+    ),
+    outputSchema: reportOutputSchema,
   }),
 ];

--- a/src/providers/vonage/runtime.test.ts
+++ b/src/providers/vonage/runtime.test.ts
@@ -1,0 +1,99 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { createVonageContext, vonageActionHandlers } from "./runtime.ts";
+
+describe("Vonage SMS report actions", () => {
+  it("lists SMS records through the Reports API with cursor pagination", async () => {
+    let requestUrl = "";
+    let authorization = "";
+    const fetcher: ProviderFetch = async (url, init) => {
+      requestUrl = String(url);
+      authorization = String(new Headers(init?.headers).get("authorization"));
+      return new Response(
+        JSON.stringify({
+          request_id: "request-1",
+          request_status: "SUCCESS",
+          items_count: 1,
+          cursor: "cursor-2",
+          iv: "iv-2",
+          records: [
+            {
+              id: "record-1",
+              message_id: "message-1",
+              account_id: "api-key",
+              direction: "outbound",
+              from: "Vonage",
+              to: "447700900000",
+              status: "delivered",
+              date_received: "2026-01-01T00:00:00Z",
+              date_finalized: "2026-01-01T00:00:01Z",
+              total_price: "0.0333",
+              currency: "EUR",
+              message_body: "Hello",
+              error_code: "0",
+              error_code_description: "Delivered",
+            },
+          ],
+        }),
+      );
+    };
+    const context = createVonageContext({ apiKey: "api-key", apiSecret: "api-secret" }, fetcher);
+
+    await expect(
+      vonageActionHandlers.list_sms_records(
+        {
+          direction: "outbound",
+          dateStart: "2026-01-01T00:00:00Z",
+          dateEnd: "2026-01-02T00:00:00Z",
+          includeMessage: true,
+          showConcatenated: true,
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({
+      requestId: "request-1",
+      requestStatus: "SUCCESS",
+      itemsCount: 1,
+      nextCursor: "cursor-2",
+      iv: "iv-2",
+      records: [
+        {
+          recordId: "record-1",
+          messageId: "message-1",
+          status: "delivered",
+          messageBody: "Hello",
+        },
+      ],
+    });
+
+    const url = new URL(requestUrl);
+    expect(url.origin).toBe("https://api.nexmo.com");
+    expect(url.pathname).toBe("/v2/reports/records");
+    expect(url.searchParams.get("product")).toBe("SMS");
+    expect(url.searchParams.get("account_id")).toBe("api-key");
+    expect(url.searchParams.get("direction")).toBe("outbound");
+    expect(url.searchParams.get("date_start")).toBe("2026-01-01T00:00:00Z");
+    expect(url.searchParams.get("include_message")).toBe("true");
+    expect(url.searchParams.get("show_concatenated")).toBe("true");
+    expect(authorization).toMatch(/^Basic /);
+  });
+
+  it("retrieves a single SMS record by message ID", async () => {
+    let requestUrl = "";
+    const fetcher: ProviderFetch = async (url) => {
+      requestUrl = String(url);
+      return new Response(JSON.stringify({ records: [], ids_not_found: "message-404" }));
+    };
+    const context = createVonageContext({ apiKey: "api-key", apiSecret: "api-secret" }, fetcher);
+
+    await expect(
+      vonageActionHandlers.get_sms_record({ messageId: "message-404", direction: "inbound" }, context),
+    ).resolves.toMatchObject({ records: [], idsNotFound: "message-404" });
+
+    const url = new URL(requestUrl);
+    expect(url.searchParams.get("product")).toBe("SMS");
+    expect(url.searchParams.get("id")).toBe("message-404");
+    expect(url.searchParams.get("direction")).toBe("inbound");
+  });
+});

--- a/src/providers/vonage/runtime.test.ts
+++ b/src/providers/vonage/runtime.test.ts
@@ -33,6 +33,7 @@ describe("Vonage SMS report actions", () => {
               message_body: "Hello",
               error_code: "0",
               error_code_description: "Delivered",
+              concatenated: "FALSE",
             },
           ],
         }),
@@ -63,6 +64,7 @@ describe("Vonage SMS report actions", () => {
           messageId: "message-1",
           status: "delivered",
           messageBody: "Hello",
+          concatenated: "FALSE",
         },
       ],
     });
@@ -95,5 +97,25 @@ describe("Vonage SMS report actions", () => {
     expect(url.searchParams.get("product")).toBe("SMS");
     expect(url.searchParams.get("id")).toBe("message-404");
     expect(url.searchParams.get("direction")).toBe("inbound");
+  });
+
+  it("rejects showConcatenated for inbound SMS records", async () => {
+    const fetcher: ProviderFetch = async () => {
+      throw new Error("the invalid request must not be fetched");
+    };
+    const context = createVonageContext({ apiKey: "api-key", apiSecret: "api-secret" }, fetcher);
+
+    await expect(
+      vonageActionHandlers.list_sms_records({ direction: "inbound", showConcatenated: true }, context),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects malformed report responses without a records array", async () => {
+    const fetcher: ProviderFetch = async () => new Response(JSON.stringify({ records: {} }));
+    const context = createVonageContext({ apiKey: "api-key", apiSecret: "api-secret" }, fetcher);
+
+    await expect(vonageActionHandlers.list_sms_records({ direction: "outbound" }, context)).rejects.toMatchObject({
+      status: 502,
+    });
   });
 });

--- a/src/providers/vonage/runtime.ts
+++ b/src/providers/vonage/runtime.ts
@@ -12,6 +12,7 @@ import {
 } from "../provider-runtime.ts";
 
 export const vonageApiBaseUrl = "https://rest.nexmo.com";
+export const vonageReportsApiBaseUrl = "https://api.nexmo.com";
 const vonageRequestTimeoutMs = 30_000;
 const invalidInputSmsStatuses = new Set(["2", "3", "6", "7", "12", "15", "17", "22", "23", "29", "33"]);
 
@@ -28,6 +29,8 @@ interface VonageRequestInput {
   phase: "validate" | "execute";
   method?: "GET" | "POST";
   body?: URLSearchParams;
+  baseUrl?: string;
+  query?: Record<string, string | number | boolean | undefined>;
 }
 
 type VonageHandler = (input: Record<string, unknown>, context: VonageContext) => Promise<unknown>;
@@ -47,6 +50,52 @@ export const vonageActionHandlers: Record<string, VonageHandler> = {
     appendOptionalFormField(body, "callback", optionalString(input.callback));
     appendOptionalFormField(body, "client-ref", optionalString(input.clientRef));
     return normalizeSms(await requestVonage({ path: "/sms/json", method: "POST", body, context, phase: "execute" }));
+  },
+  async list_sms_records(input, context) {
+    const direction = requiredString(input.direction, "direction", invalidInput);
+    const payload = await requestVonage({
+      baseUrl: vonageReportsApiBaseUrl,
+      path: "/v2/reports/records",
+      context,
+      phase: "execute",
+      query: {
+        product: "SMS",
+        account_id: context.apiKey,
+        direction,
+        date_start: optionalString(input.dateStart),
+        date_end: optionalString(input.dateEnd),
+        cursor: optionalString(input.cursor),
+        iv: optionalString(input.iv),
+        status: optionalString(input.status),
+        from: optionalString(input.from),
+        to: optionalString(input.to),
+        country: optionalString(input.country),
+        network: optionalString(input.network),
+        account_ref: optionalString(input.accountRef),
+        include_message: optionalBoolean(input.includeMessage),
+        show_concatenated: optionalBoolean(input.showConcatenated),
+      },
+    });
+    return normalizeSmsReport(payload);
+  },
+  async get_sms_record(input, context) {
+    const messageId = requiredString(input.messageId, "messageId", invalidInput);
+    const direction = requiredString(input.direction, "direction", invalidInput);
+    const payload = await requestVonage({
+      baseUrl: vonageReportsApiBaseUrl,
+      path: "/v2/reports/records",
+      context,
+      phase: "execute",
+      query: {
+        product: "SMS",
+        account_id: context.apiKey,
+        direction,
+        id: messageId,
+        include_message: optionalBoolean(input.includeMessage),
+        show_concatenated: optionalBoolean(input.showConcatenated),
+      },
+    });
+    return normalizeSmsReport(payload);
   },
 };
 
@@ -82,9 +131,13 @@ export async function validateVonageCredential(
 }
 
 async function requestVonage(input: VonageRequestInput): Promise<unknown> {
+  const url = new URL(`${input.baseUrl ?? vonageApiBaseUrl}${input.path}`);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, String(value));
+  }
   const timeout = createProviderTimeout(input.context.signal, vonageRequestTimeoutMs);
   try {
-    const response = await input.context.fetcher(`${vonageApiBaseUrl}${input.path}`, {
+    const response = await input.context.fetcher(url.toString(), {
       method: input.method ?? "GET",
       headers: {
         accept: "application/json",
@@ -154,6 +207,46 @@ function normalizeSms(payload: unknown): unknown {
   return {
     messageCount: Number.isFinite(declaredCount) ? declaredCount : normalizedMessages.length,
     messages: normalizedMessages,
+  };
+}
+
+function normalizeSmsReport(payload: unknown): Record<string, unknown> {
+  const record = requireResponseRecord(payload, "Vonage SMS report response");
+  const records = Array.isArray(record.records) ? record.records : [];
+
+  return {
+    records: records.map((item) => normalizeSmsRecord(item)),
+    requestId: optionalString(record.request_id) ?? null,
+    requestStatus: optionalString(record.request_status) ?? null,
+    itemsCount: optionalInteger(record.items_count) ?? null,
+    idsNotFound: optionalString(record.ids_not_found) ?? null,
+    nextCursor: optionalString(record.cursor) ?? null,
+    iv: optionalString(record.iv) ?? null,
+  };
+}
+
+function normalizeSmsRecord(value: unknown): Record<string, unknown> {
+  const record = requireResponseRecord(value, "Vonage SMS report record");
+  return {
+    recordId: optionalString(record.id) ?? null,
+    messageId: optionalString(record.message_id) ?? null,
+    accountId: optionalString(record.account_id) ?? null,
+    direction: optionalString(record.direction) ?? null,
+    from: optionalString(record.from) ?? null,
+    to: optionalString(record.to) ?? null,
+    status: optionalString(record.status) ?? null,
+    dateReceived: optionalString(record.date_received) ?? null,
+    dateFinalized: optionalString(record.date_finalized) ?? null,
+    totalPrice: optionalString(record.total_price) ?? null,
+    currency: optionalString(record.currency) ?? null,
+    clientRef: optionalString(record.client_ref) ?? null,
+    network: optionalString(record.network) ?? null,
+    networkName: optionalString(record.network_name) ?? null,
+    country: optionalString(record.country) ?? null,
+    countryName: optionalString(record.country_name) ?? null,
+    messageBody: optionalString(record.message_body) ?? null,
+    errorCode: optionalString(record.error_code) ?? null,
+    errorCodeDescription: optionalString(record.error_code_description) ?? null,
   };
 }
 

--- a/src/providers/vonage/runtime.ts
+++ b/src/providers/vonage/runtime.ts
@@ -53,6 +53,7 @@ export const vonageActionHandlers: Record<string, VonageHandler> = {
   },
   async list_sms_records(input, context) {
     const direction = requiredString(input.direction, "direction", invalidInput);
+    validateShowConcatenated(direction, input.showConcatenated);
     const payload = await requestVonage({
       baseUrl: vonageReportsApiBaseUrl,
       path: "/v2/reports/records",
@@ -81,6 +82,7 @@ export const vonageActionHandlers: Record<string, VonageHandler> = {
   async get_sms_record(input, context) {
     const messageId = requiredString(input.messageId, "messageId", invalidInput);
     const direction = requiredString(input.direction, "direction", invalidInput);
+    validateShowConcatenated(direction, input.showConcatenated);
     const payload = await requestVonage({
       baseUrl: vonageReportsApiBaseUrl,
       path: "/v2/reports/records",
@@ -212,7 +214,10 @@ function normalizeSms(payload: unknown): unknown {
 
 function normalizeSmsReport(payload: unknown): Record<string, unknown> {
   const record = requireResponseRecord(payload, "Vonage SMS report response");
-  const records = Array.isArray(record.records) ? record.records : [];
+  if (!Array.isArray(record.records)) {
+    throw new ProviderRequestError(502, "Vonage SMS report response records must be an array", payload);
+  }
+  const records = record.records;
 
   return {
     records: records.map((item) => normalizeSmsRecord(item)),
@@ -247,7 +252,14 @@ function normalizeSmsRecord(value: unknown): Record<string, unknown> {
     messageBody: optionalString(record.message_body) ?? null,
     errorCode: optionalString(record.error_code) ?? null,
     errorCodeDescription: optionalString(record.error_code_description) ?? null,
+    concatenated: optionalString(record.concatenated) ?? null,
   };
+}
+
+function validateShowConcatenated(direction: string, value: unknown): void {
+  if (optionalBoolean(value) === true && direction === "inbound") {
+    throw new ProviderRequestError(400, "showConcatenated is only supported for outbound SMS records");
+  }
 }
 
 function mapSmsError(status: string, message?: string): ProviderRequestError {


### PR DESCRIPTION
## What changed

Added two locally executable Vonage SMS report actions:

- `list_sms_records`
- `get_sms_record`

They reuse the existing API Key + API Secret custom credential and do not add or change OAuth scopes.

## API documentation

- [Vonage Reports API](https://developer.vonage.com/en/api/reports)
- [Get specific records by UUID](https://developer.vonage.com/en/reports/code-snippets/load-records-sync-id)

## Verification

- `npx vitest run src/providers/vonage/runtime.test.ts`
- `npm run fix-check`