### PR TITLE
feat(vercel): add delete_webhook action

### DIFF
--- a/src/providers/vercel/actions.ts
+++ b/src/providers/vercel/actions.ts
@@ -28,7 +28,8 @@ export type VercelActionName =
   | "get_domain_config"
   | "list_webhooks"
   | "get_webhook"
-  | "create_webhook";
+  | "create_webhook"
+  | "delete_webhook";
 
 interface VercelActionSource {
   name: VercelActionName;
@@ -444,6 +445,20 @@ const actionSources: readonly VercelActionSource[] = [
       ["url", "events"],
     ),
     outputSchema: s.object({ webhook }, { required: ["webhook"] }),
+  },
+  {
+    name: "delete_webhook",
+    description:
+      "Delete a Vercel webhook. The returned acknowledgement is generated locally because Vercel responds with 204 No Content.",
+    inputSchema: input({ id: s.nonEmptyString("Vercel webhook ID.") }, ["id"]),
+    outputSchema: s.object(
+      {
+        deleted: s.boolean({
+          description: "Whether Vercel accepted the deletion request. True when the API returns 204 No Content.",
+        }),
+      },
+      { required: ["deleted"], description: "A normalized Vercel webhook deletion response." },
+    ),
   },
 ];
 

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { vercelActionHandlers } from "./runtime.ts";
+
+function actionContext(fetcher: typeof fetch) {
+  return {
+    apiKey: "vercel-token",
+    fetcher,
+  };
+}
+
+function vercelError(status: number, message: string): Response {
+  return Response.json({ error: { code: "not_found", message } }, { status });
+}
+
+describe("Vercel webhook actions", () => {
+  it("deletes a webhook and normalizes a 204 No Content response", async () => {
+    let requestUrl = "";
+    let requestMethod = "";
+    let authorization = "";
+    let contentType: string | null = "";
+
+    const deleted = await vercelActionHandlers.delete_webhook(
+      { id: "account_hook_abc" },
+      actionContext(async (url, init) => {
+        requestUrl = String(url);
+        requestMethod = String(init?.method);
+        const headers = new Headers(init?.headers);
+        authorization = String(headers.get("authorization"));
+        contentType = headers.get("content-type");
+        return new Response(null, { status: 204 });
+      }),
+    );
+
+    expect(deleted).toEqual({ deleted: true });
+    expect(requestMethod).toBe("DELETE");
+    expect(requestUrl).toBe("https://api.vercel.com/v1/webhooks/account_hook_abc");
+    expect(authorization).toBe("Bearer vercel-token");
+    expect(contentType).toBeNull();
+  });
+
+  it("encodes the webhook id in the delete path", async () => {
+    let requestUrl = "";
+
+    await vercelActionHandlers.delete_webhook(
+      { id: "hook/with spaces" },
+      actionContext(async (url) => {
+        requestUrl = String(url);
+        return new Response(null, { status: 204 });
+      }),
+    );
+
+    expect(requestUrl).toBe("https://api.vercel.com/v1/webhooks/hook%2Fwith%20spaces");
+  });
+
+  it("maps missing webhook responses to invalid input", async () => {
+    await expect(
+      vercelActionHandlers.delete_webhook(
+        { id: "missing" },
+        actionContext(async () => vercelError(404, "Not Found")),
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "Not Found" });
+
+    await expect(
+      vercelActionHandlers.delete_webhook(
+        { id: "gone" },
+        actionContext(async () => vercelError(410, "Gone")),
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "Gone" });
+  });
+
+  it("rejects a missing webhook id before making a request", async () => {
+    await expect(
+      vercelActionHandlers.delete_webhook(
+        {},
+        actionContext(async () => {
+          throw new Error("no request expected");
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "id must be a string" });
+  });
+
+  it("still parses JSON webhook payloads after empty-body handling", async () => {
+    const result = await vercelActionHandlers.get_webhook(
+      { id: "account_hook_abc" },
+      actionContext(async (url) => {
+        expect(String(url)).toBe("https://api.vercel.com/v1/webhooks/account_hook_abc");
+        return Response.json({
+          id: "account_hook_abc",
+          url: "https://example.com/hooks/vercel",
+          events: ["deployment.created"],
+          createdAt: 1_700_000_000_000,
+        });
+      }),
+    );
+
+    expect(result).toEqual({
+      webhook: {
+        id: "account_hook_abc",
+        url: "https://example.com/hooks/vercel",
+        events: ["deployment.created"],
+        createdAt: 1_700_000_000_000,
+      },
+    });
+  });
+});

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -102,4 +102,13 @@ describe("Vercel webhook actions", () => {
       },
     });
   });
+
+  it("rejects a blank 200 OK list response instead of returning an empty webhook list", async () => {
+    await expect(
+      vercelActionHandlers.list_webhooks(
+        {},
+        actionContext(async () => new Response("", { status: 200 })),
+      ),
+    ).rejects.toMatchObject({ status: 502, message: "vercel returned an empty response" });
+  });
 });

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -613,7 +613,7 @@ async function vercelCreateWebhook(input: VercelActionInput, context: VercelActi
 
 async function vercelDeleteWebhook(input: VercelActionInput, context: VercelActionContext) {
   const id = requireString(input.id, "id");
-  await requestVercelJson({
+  await requestVercelNoContent({
     path: `/v1/webhooks/${encodeURIComponent(id)}`,
     apiKey: context.apiKey,
     fetcher: context.fetcher,
@@ -665,36 +665,53 @@ interface VercelTeamResponse {
 }
 
 async function requestVercelJson<T>(options: VercelRequestOptions): Promise<T> {
-  const url = buildVercelUrl(options.path, options.query);
-
-  let response: Response;
-  try {
-    response = await options.fetcher(url, {
-      method: options.method ?? "GET",
-      headers: vercelHeaders(options.apiKey, options.body !== undefined),
-      ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
-    });
-  } catch (error) {
-    throw new ProviderRequestError(502, error instanceof Error ? error.message : "vercel request failed");
-  }
+  const response = await requestVercel(options);
 
   if (!response.ok) {
     throw await mapVercelError(response, options.mode, options.notFoundAsInvalidInput ?? false);
   }
 
   if (response.status === 204) {
-    return undefined as T;
+    throw new ProviderRequestError(502, "vercel returned 204 No Content for a JSON request");
   }
 
   const text = await response.text();
   if (!text.trim()) {
-    return undefined as T;
+    throw new ProviderRequestError(502, "vercel returned an empty response");
   }
 
   try {
     return JSON.parse(text) as T;
   } catch {
     throw new ProviderRequestError(502, "vercel returned an invalid JSON response");
+  }
+}
+
+async function requestVercelNoContent(options: VercelRequestOptions & { method: "DELETE" }): Promise<void> {
+  const response = await requestVercel(options);
+
+  if (response.status === 204) {
+    return;
+  }
+
+  if (!response.ok) {
+    throw await mapVercelError(response, options.mode, options.notFoundAsInvalidInput ?? false);
+  }
+
+  throw new ProviderRequestError(502, "vercel returned a response body for a no-content request");
+}
+
+async function requestVercel(options: VercelRequestOptions): Promise<Response> {
+  const url = buildVercelUrl(options.path, options.query);
+
+  try {
+    return await options.fetcher(url, {
+      method: options.method ?? "GET",
+      headers: vercelHeaders(options.apiKey, options.body !== undefined),
+      ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+    });
+  } catch (error) {
+    throw new ProviderRequestError(502, error instanceof Error ? error.message : "vercel request failed");
   }
 }
 

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -100,6 +100,9 @@ export const vercelActionHandlers: Record<VercelActionName, VercelActionHandler>
   create_webhook(input: VercelActionInput, context: VercelActionContext): Promise<unknown> {
     return vercelCreateWebhook(input, context);
   },
+  delete_webhook(input: VercelActionInput, context: VercelActionContext): Promise<unknown> {
+    return vercelDeleteWebhook(input, context);
+  },
 };
 
 export async function validateVercelCredential(
@@ -608,6 +611,20 @@ async function vercelCreateWebhook(input: VercelActionInput, context: VercelActi
   };
 }
 
+async function vercelDeleteWebhook(input: VercelActionInput, context: VercelActionContext) {
+  const id = requireString(input.id, "id");
+  await requestVercelJson({
+    path: `/v1/webhooks/${encodeURIComponent(id)}`,
+    apiKey: context.apiKey,
+    fetcher: context.fetcher,
+    mode: "execute",
+    method: "DELETE",
+    notFoundAsInvalidInput: true,
+  });
+
+  return { deleted: true };
+}
+
 interface VercelRequestOptions {
   path: string;
   apiKey: string;
@@ -665,7 +682,20 @@ async function requestVercelJson<T>(options: VercelRequestOptions): Promise<T> {
     throw await mapVercelError(response, options.mode, options.notFoundAsInvalidInput ?? false);
   }
 
-  return response.json() as Promise<T>;
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const text = await response.text();
+  if (!text.trim()) {
+    return undefined as T;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new ProviderRequestError(502, "vercel returned an invalid JSON response");
+  }
 }
 
 function buildVercelUrl(path: string, query?: Record<string, string>): string {
@@ -699,7 +729,7 @@ async function mapVercelError(
   if (response.status === 401) {
     return new ProviderRequestError(mode === "validate" ? 400 : 401, error.message, error);
   }
-  if (response.status === 404 && notFoundAsInvalidInput) {
+  if ((response.status === 404 || response.status === 410) && notFoundAsInvalidInput) {
     return new ProviderRequestError(400, error.message, error);
   }
   if (response.status === 429) {


### PR DESCRIPTION
## Summary
- Add `delete_webhook` so Vercel webhooks cover list, get, create, and delete.
- Call the official `DELETE /v1/webhooks/{id}` endpoint and normalize `204 No Content` to `{ deleted: true }`.
- Map `404`/`410` to invalid input, matching the official delete-webhook error responses.

## Test plan
- [x] `npx vitest run src/providers/vercel/runtime.test.ts`
- [ ] Confirm delete sends `DELETE` to `https://api.vercel.com/v1/webhooks/{id}` with a Bearer token
- [ ] Confirm a `204` response returns `{ deleted: true }` without JSON parsing
- [ ] Confirm missing webhook `id` is rejected before the request
- [ ] Confirm `404` and `410` map to status `400`


Made with [Cursor](https://cursor.com)