### PR TITLE
feat(googlecalendar): add sendUpdates to event write actions

### DIFF
--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -38,11 +38,10 @@ const calendarId = nonEmptyStringWithDescription(
 );
 const eventId = nonEmptyStringWithDescription("Google Calendar event ID.");
 const ruleId = nonEmptyStringWithDescription("Google Calendar ACL rule ID.");
-const sendUpdates = s.stringEnum("Who should receive update notifications about this change.", [
-  "all",
-  "externalOnly",
-  "none",
-]);
+const sendUpdates = s.stringEnum(
+  "Who should receive update notifications about this change. none can prevent sync to external calendars; use import_event for migrations.",
+  ["all", "externalOnly", "none"],
+);
 
 const eventDateTime = s.object(
   {

--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -38,6 +38,11 @@ const calendarId = nonEmptyStringWithDescription(
 );
 const eventId = nonEmptyStringWithDescription("Google Calendar event ID.");
 const ruleId = nonEmptyStringWithDescription("Google Calendar ACL rule ID.");
+const sendUpdates = s.stringEnum("Who should receive update notifications about this change.", [
+  "all",
+  "externalOnly",
+  "none",
+]);
 
 const eventDateTime = s.object(
   {
@@ -398,28 +403,28 @@ const actions: GooglecalendarActionSource[] = [
     "create_event",
     "Create a Google Calendar event.",
     googlecalendarEventsWriteScopes,
-    input({ calendarId, event: eventCreate }, ["calendarId", "event"]),
+    input({ calendarId, event: eventCreate, sendUpdates }, ["calendarId", "event"]),
     eventOutput,
   ),
   action(
     "update_event",
     "Replace writable fields on a Google Calendar event.",
     googlecalendarEventsWriteScopes,
-    input({ calendarId, eventId, event: eventWritable }, ["calendarId", "eventId", "event"]),
+    input({ calendarId, eventId, event: eventWritable, sendUpdates }, ["calendarId", "eventId", "event"]),
     eventOutput,
   ),
   action(
     "patch_event",
     "Patch writable fields on a Google Calendar event.",
     googlecalendarEventsWriteScopes,
-    input({ calendarId, eventId, event: eventWritable }, ["calendarId", "eventId", "event"]),
+    input({ calendarId, eventId, event: eventWritable, sendUpdates }, ["calendarId", "eventId", "event"]),
     eventOutput,
   ),
   action(
     "delete_event",
     "Delete a Google Calendar event.",
     googlecalendarEventsWriteScopes,
-    calendarEventIdInput(),
+    input({ calendarId, eventId, sendUpdates }, ["calendarId", "eventId"]),
     success,
   ),
   action(

--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -39,7 +39,7 @@ const calendarId = nonEmptyStringWithDescription(
 const eventId = nonEmptyStringWithDescription("Google Calendar event ID.");
 const ruleId = nonEmptyStringWithDescription("Google Calendar ACL rule ID.");
 const sendUpdates = s.stringEnum(
-  "Who should receive update notifications about this change. none can prevent sync to external calendars; use import_event for migrations.",
+  "Which guests receive notifications about this change. Omit it to keep Google Calendar's default notification behavior. none can stop the change from syncing to external calendars; use import_event for migrations.",
   ["all", "externalOnly", "none"],
 );
 
@@ -437,11 +437,15 @@ const actions: GooglecalendarActionSource[] = [
     "move_event",
     "Move a Google Calendar event to another calendar.",
     googlecalendarEventsWriteScopes,
-    input({ calendarId, eventId, destinationCalendarId: nonEmptyStringWithDescription("Destination calendar ID.") }, [
-      "calendarId",
-      "eventId",
-      "destinationCalendarId",
-    ]),
+    input(
+      {
+        calendarId,
+        eventId,
+        destinationCalendarId: nonEmptyStringWithDescription("Destination calendar ID."),
+        sendUpdates,
+      },
+      ["calendarId", "eventId", "destinationCalendarId"],
+    ),
     eventOutput,
   ),
   action(
@@ -468,7 +472,14 @@ const actions: GooglecalendarActionSource[] = [
     "quick_add_event",
     "Create a Google Calendar event with natural language text.",
     googlecalendarEventsWriteScopes,
-    input({ calendarId, text: nonEmptyStringWithDescription("Natural-language event text.") }, ["calendarId", "text"]),
+    input(
+      {
+        calendarId,
+        text: nonEmptyStringWithDescription("Natural-language event text."),
+        sendUpdates,
+      },
+      ["calendarId", "text"],
+    ),
     eventOutput,
   ),
   action(

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -168,6 +168,39 @@ describe("googlecalendar event write sendUpdates", () => {
     ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
     expect(requests).toHaveLength(0);
   });
+
+  it("rejects invalid update_event sendUpdates before reading the event", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      updateEvent(
+        {
+          calendarId: "cal-1",
+          eventId: "evt-1",
+          sendUpdates: "guests",
+          event: { summary: "Retro" },
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+
+  it("rejects a supplied empty sendUpdates instead of treating it as omitted", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      createEvent(
+        {
+          calendarId: "cal-1",
+          sendUpdates: "",
+          event: eventPayload,
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
 });
 
 function createEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -8,6 +8,7 @@ import { googlecalendarEventActionHandlers } from "./runtime-events.ts";
 const accessToken = "google-calendar-access-token";
 const createdEvent = {
   id: "evt-1",
+  etag: '"etag-1"',
   status: "confirmed",
   summary: "Standup",
 };
@@ -22,6 +23,7 @@ interface CapturedRequest {
   method: string;
   url: URL;
   body: unknown;
+  headers: Headers;
 }
 
 describe("googlecalendar event write sendUpdates", () => {
@@ -111,7 +113,67 @@ describe("googlecalendar event write sendUpdates", () => {
     expect(requests[1]?.method).toBe("PUT");
     expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
     expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("externalOnly");
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
     expect(requests[1]?.body).toMatchObject({ summary: "Retro" });
+  });
+
+  it("refuses update_event when the GET payload has no ETag", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json({
+        id: "evt-1",
+        status: "confirmed",
+        summary: "Standup",
+      }),
+    ]);
+
+    await expect(
+      updateEvent(
+        {
+          calendarId: "cal-1",
+          eventId: "evt-1",
+          event: { summary: "Retro" },
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(
+      new ProviderRequestError(409, "cannot update event because Google Calendar did not provide an event ETag"),
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  it("re-GETs and retries update_event PUT after an If-Match 412", async () => {
+    const concurrentEvent = {
+      ...createdEvent,
+      etag: '"etag-2"',
+      attendees: [{ email: "cara@example.com" }],
+    };
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(createdEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json(concurrentEvent),
+      Response.json({ ...concurrentEvent, summary: "Retro" }),
+    ]);
+
+    await updateEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        sendUpdates: "all",
+        event: { summary: "Retro" },
+      },
+      fetcher,
+    );
+
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PUT", "GET", "PUT"]);
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[3]?.headers.get("if-match")).toBe('"etag-2"');
+    expect(requests[3]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[3]?.body).toMatchObject({
+      summary: "Retro",
+      attendees: [{ email: "cara@example.com" }],
+    });
   });
 
   it("forwards sendUpdates on patch_event", async () => {
@@ -227,6 +289,7 @@ function stubCalendarResponses(responses: Response[]): { fetcher: ProviderFetch;
     requests.push({
       method: request.method,
       url: new URL(request.url),
+      headers: request.headers,
       body:
         request.method === "GET" || request.method === "HEAD" || request.method === "DELETE"
           ? undefined

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -27,7 +27,7 @@ interface CapturedRequest {
 }
 
 describe("googlecalendar event write sendUpdates", () => {
-  it.each(["create_event", "update_event", "patch_event", "delete_event"] as const)(
+  it.each(["create_event", "update_event", "patch_event", "delete_event", "move_event", "quick_add_event"] as const)(
     "exposes optional sendUpdates on %s without changing required fields",
     (name) => {
       const action = googlecalendarActions.find((candidate) => candidate.name === name);
@@ -44,8 +44,9 @@ describe("googlecalendar event write sendUpdates", () => {
     },
   );
 
-  it("does not add sendUpdates to read-only get_event", () => {
-    const action = googlecalendarActions.find((candidate) => candidate.name === "get_event");
+  // events.import is the only event write Google does not accept sendUpdates on.
+  it.each(["get_event", "list_events", "import_event"] as const)("does not add sendUpdates to %s", (name) => {
+    const action = googlecalendarActions.find((candidate) => candidate.name === name);
 
     expect(action?.inputSchema.properties).not.toHaveProperty("sendUpdates");
   });
@@ -114,7 +115,7 @@ describe("googlecalendar event write sendUpdates", () => {
     expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
     expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("externalOnly");
     expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
-    expect(requests[1]?.body).toMatchObject({ summary: "Retro" });
+    expect(requests[1]?.body).toEqual({ status: "confirmed", summary: "Retro" });
   });
 
   it("refuses update_event when the GET payload has no ETag", async () => {
@@ -135,11 +136,69 @@ describe("googlecalendar event write sendUpdates", () => {
         },
         fetcher,
       ),
-    ).rejects.toEqual(
-      new ProviderRequestError(409, "cannot update event because Google Calendar did not provide an event ETag"),
-    );
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event without an etag"));
     expect(requests).toHaveLength(1);
     expect(requests[0]?.method).toBe("GET");
+  });
+
+  it("refuses update_event when the event re-read after a 412 has no ETag", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(createdEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json({ id: "evt-1", status: "confirmed", summary: "Standup" }),
+    ]);
+
+    await expect(
+      updateEvent(
+        {
+          calendarId: "cal-1",
+          eventId: "evt-1",
+          event: { summary: "Retro" },
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event without an etag"));
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PUT", "GET"]);
+  });
+
+  it("does not retry update_event when the PUT fails for a reason other than If-Match", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(createdEvent),
+      new Response(JSON.stringify({ error: { message: "Insufficient permission" } }), { status: 403 }),
+    ]);
+
+    await expect(
+      updateEvent(
+        {
+          calendarId: "cal-1",
+          eventId: "evt-1",
+          event: { summary: "Retro" },
+        },
+        fetcher,
+      ),
+    ).rejects.toMatchObject({ status: 403, message: "Insufficient permission" });
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PUT"]);
+  });
+
+  it("retries the update_event PUT at most once and surfaces a second If-Match 412", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(createdEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json({ ...createdEvent, etag: '"etag-2"' }),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+    ]);
+
+    await expect(
+      updateEvent(
+        {
+          calendarId: "cal-1",
+          eventId: "evt-1",
+          event: { summary: "Retro" },
+        },
+        fetcher,
+      ),
+    ).rejects.toMatchObject({ status: 412, message: "Precondition Failed" });
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PUT", "GET", "PUT"]);
   });
 
   it("re-GETs and retries update_event PUT after an If-Match 412", async () => {
@@ -170,7 +229,8 @@ describe("googlecalendar event write sendUpdates", () => {
     expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
     expect(requests[3]?.headers.get("if-match")).toBe('"etag-2"');
     expect(requests[3]?.url.searchParams.get("sendUpdates")).toBe("all");
-    expect(requests[3]?.body).toMatchObject({
+    expect(requests[3]?.body).toEqual({
+      status: "confirmed",
       summary: "Retro",
       attendees: [{ email: "cara@example.com" }],
     });
@@ -213,6 +273,73 @@ describe("googlecalendar event write sendUpdates", () => {
     expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
     expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("all");
     expect(requests[0]?.body).toBeUndefined();
+  });
+
+  it("still forwards sendUpdates on a delete_event that Google reports as already gone", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      new Response(JSON.stringify({ error: { message: "Not Found" } }), { status: 404 }),
+    ]);
+
+    const output = await deleteEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        sendUpdates: "none",
+      },
+      fetcher,
+    );
+
+    expect(output).toEqual({ success: true });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("none");
+  });
+
+  it("forwards sendUpdates on move_event alongside the destination calendar", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    await moveEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        destinationCalendarId: "cal-2",
+        sendUpdates: "all",
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1/move");
+    expect(requests[0]?.url.searchParams.get("destination")).toBe("cal-2");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("all");
+  });
+
+  it("omits sendUpdates from move_event when the caller does not set a notification policy", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    await moveEvent({ calendarId: "cal-1", eventId: "evt-1", destinationCalendarId: "cal-2" }, fetcher);
+
+    expect(requests[0]?.url.searchParams.get("destination")).toBe("cal-2");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
+  });
+
+  it("forwards sendUpdates on quick_add_event alongside the natural-language text", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    await quickAddEvent(
+      {
+        calendarId: "cal-1",
+        text: "Standup tomorrow 9am",
+        sendUpdates: "externalOnly",
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/quickAdd");
+    expect(requests[0]?.url.searchParams.get("text")).toBe("Standup tomorrow 9am");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("externalOnly");
   });
 
   it("returns 400 when sendUpdates is not a supported notification policy", async () => {
@@ -281,19 +408,27 @@ function deleteEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
   return googlecalendarEventActionHandlers.delete_event(input, { accessToken, fetcher });
 }
 
+function moveEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.move_event(input, { accessToken, fetcher });
+}
+
+function quickAddEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.quick_add_event(input, { accessToken, fetcher });
+}
+
 function stubCalendarResponses(responses: Response[]): { fetcher: ProviderFetch; requests: CapturedRequest[] } {
   const requests: CapturedRequest[] = [];
   const pending = [...responses];
   const fetcher: ProviderFetch = async (input, init) => {
     const request = input instanceof Request ? input : new Request(input, init);
+    // Only GET/HEAD are guaranteed body-less. Reading every other method, DELETE
+    // included, is what makes "this request carried no body" a real assertion.
+    const rawBody = request.method === "GET" || request.method === "HEAD" ? "" : await request.text().catch(() => "");
     requests.push({
       method: request.method,
       url: new URL(request.url),
       headers: request.headers,
-      body:
-        request.method === "GET" || request.method === "HEAD" || request.method === "DELETE"
-          ? undefined
-          : await request.json().catch(() => undefined),
+      body: rawBody === "" ? undefined : parseCapturedBody(rawBody),
     });
     const response = pending.shift();
     if (!response) {
@@ -302,4 +437,12 @@ function stubCalendarResponses(responses: Response[]): { fetcher: ProviderFetch;
     return response;
   };
   return { fetcher, requests };
+}
+
+function parseCapturedBody(rawBody: string): unknown {
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    return rawBody;
+  }
 }

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -1,0 +1,209 @@
+import type { ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { googlecalendarActions } from "./actions.ts";
+import { googlecalendarEventActionHandlers } from "./runtime-events.ts";
+
+const accessToken = "google-calendar-access-token";
+const createdEvent = {
+  id: "evt-1",
+  status: "confirmed",
+  summary: "Standup",
+};
+const eventPayload = {
+  summary: "Standup",
+  start: { dateTime: "2026-08-19T09:00:00Z" },
+  end: { dateTime: "2026-08-19T09:30:00Z" },
+  attendees: [{ email: "alice@example.com" }],
+};
+
+interface CapturedRequest {
+  method: string;
+  url: URL;
+  body: unknown;
+}
+
+describe("googlecalendar event write sendUpdates", () => {
+  it.each(["create_event", "update_event", "patch_event", "delete_event"] as const)(
+    "exposes optional sendUpdates on %s without changing required fields",
+    (name) => {
+      const action = googlecalendarActions.find((candidate) => candidate.name === name);
+
+      expect(action?.inputSchema.properties).toEqual(
+        expect.objectContaining({
+          sendUpdates: expect.objectContaining({
+            type: "string",
+            enum: ["all", "externalOnly", "none"],
+          }),
+        }),
+      );
+      expect(action?.inputSchema.required).not.toContain("sendUpdates");
+    },
+  );
+
+  it("does not add sendUpdates to read-only get_event", () => {
+    const action = googlecalendarActions.find((candidate) => candidate.name === "get_event");
+
+    expect(action?.inputSchema.properties).not.toHaveProperty("sendUpdates");
+  });
+
+  it("forwards sendUpdates on create_event as a query param, not an event body field", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    const output = await createEvent(
+      {
+        calendarId: "cal-1",
+        sendUpdates: "all",
+        event: {
+          ...eventPayload,
+          conferenceData: { createRequest: { requestId: "meet-1" } },
+        },
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[0]?.url.searchParams.get("conferenceDataVersion")).toBe("1");
+    expect(requests[0]?.body).toEqual({
+      ...eventPayload,
+      conferenceData: { createRequest: { requestId: "meet-1" } },
+    });
+    expect(output).toEqual(createdEvent);
+  });
+
+  it("omits sendUpdates from create_event when the caller does not set a notification policy", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    await createEvent(
+      {
+        calendarId: "cal-1",
+        event: eventPayload,
+      },
+      fetcher,
+    );
+
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
+  });
+
+  it("keeps sendUpdates off the update_event GET and puts it on the PUT", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(createdEvent),
+      Response.json({ ...createdEvent, summary: "Retro" }),
+    ]);
+
+    await updateEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        sendUpdates: "externalOnly",
+        event: { summary: "Retro" },
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.method).toBe("GET");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
+    expect(requests[1]?.method).toBe("PUT");
+    expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("externalOnly");
+    expect(requests[1]?.body).toMatchObject({ summary: "Retro" });
+  });
+
+  it("forwards sendUpdates on patch_event", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(createdEvent)]);
+
+    await patchEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        sendUpdates: "none",
+        event: { location: "Room 2" },
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("PATCH");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("none");
+    expect(requests[0]?.body).toEqual({ location: "Room 2" });
+  });
+
+  it("forwards sendUpdates on delete_event", async () => {
+    const { fetcher, requests } = stubCalendarResponses([new Response(null, { status: 204 })]);
+
+    const output = await deleteEvent(
+      {
+        calendarId: "cal-1",
+        eventId: "evt-1",
+        sendUpdates: "all",
+      },
+      fetcher,
+    );
+
+    expect(output).toEqual({ success: true });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("DELETE");
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[0]?.body).toBeUndefined();
+  });
+
+  it("returns 400 when sendUpdates is not a supported notification policy", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      createEvent(
+        {
+          calendarId: "cal-1",
+          sendUpdates: "guests",
+          event: eventPayload,
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+});
+
+function createEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.create_event(input, { accessToken, fetcher });
+}
+
+function updateEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.update_event(input, { accessToken, fetcher });
+}
+
+function patchEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.patch_event(input, { accessToken, fetcher });
+}
+
+function deleteEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.delete_event(input, { accessToken, fetcher });
+}
+
+function stubCalendarResponses(responses: Response[]): { fetcher: ProviderFetch; requests: CapturedRequest[] } {
+  const requests: CapturedRequest[] = [];
+  const pending = [...responses];
+  const fetcher: ProviderFetch = async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      method: request.method,
+      url: new URL(request.url),
+      body:
+        request.method === "GET" || request.method === "HEAD" || request.method === "DELETE"
+          ? undefined
+          : await request.json().catch(() => undefined),
+    });
+    const response = pending.shift();
+    if (!response) {
+      throw new Error(`Unexpected Google Calendar request to ${request.url}`);
+    }
+    return response;
+  };
+  return { fetcher, requests };
+}

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -173,32 +173,40 @@ async function createEvent(input: Record<string, unknown>, { accessToken, fetche
 async function updateEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
   const sendUpdates = pickSendUpdates(input);
   const url = eventUrl(resolveCalendarId(input), resolveEventId(input));
-  const current = await googlecalendarJsonRequest<Record<string, unknown>>(url, {
-    accessToken,
-    fetcher,
-  });
   const next = pickEventWritableFields(asObject(input.event));
-  const currentWritable = pickEventWritableFields(current);
-
-  if (next.conferenceData === undefined && currentWritable.conferenceData !== undefined) {
-    currentWritable.conferenceData = pickKnownFields(asObject(currentWritable.conferenceData), conferenceDataKeys);
-  }
-  if (next.source === undefined && currentWritable.source !== undefined) {
-    currentWritable.source = pickKnownFields(asObject(currentWritable.source), sourceKeys);
-  }
-
-  const body = {
-    ...currentWritable,
-    ...next,
-  };
-
-  return googlecalendarJsonRequest(url, {
+  let current = await googlecalendarJsonRequest<Record<string, unknown>>(url, {
     accessToken,
     fetcher,
-    method: "PUT",
-    query: buildEventWriteQuery(body, sendUpdates),
-    body,
   });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const etag = optionalString(current.etag);
+    if (!etag) {
+      throw new ProviderRequestError(409, "cannot update event because Google Calendar did not provide an event ETag");
+    }
+
+    const body = mergeEventUpdate(current, next);
+    try {
+      return await googlecalendarJsonRequest(url, {
+        accessToken,
+        fetcher,
+        method: "PUT",
+        query: buildEventWriteQuery(body, sendUpdates),
+        headers: { "If-Match": etag },
+        body,
+      });
+    } catch (error) {
+      if (attempt > 0 || !(error instanceof ProviderRequestError) || error.status !== 412) {
+        throw error;
+      }
+      current = await googlecalendarJsonRequest<Record<string, unknown>>(url, {
+        accessToken,
+        fetcher,
+      });
+    }
+  }
+
+  throw new ProviderRequestError(412, "event changed while updating");
 }
 
 async function patchEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
@@ -512,6 +520,22 @@ function pickSendUpdates(input: Record<string, unknown>) {
 
 function pickEventWritableFields(input: Record<string, unknown>) {
   return pickKnownFields(input, eventWritableKeys);
+}
+
+function mergeEventUpdate(current: Record<string, unknown>, next: Record<string, unknown>) {
+  const currentWritable = pickEventWritableFields(current);
+
+  if (next.conferenceData === undefined && currentWritable.conferenceData !== undefined) {
+    currentWritable.conferenceData = pickKnownFields(asObject(currentWritable.conferenceData), conferenceDataKeys);
+  }
+  if (next.source === undefined && currentWritable.source !== undefined) {
+    currentWritable.source = pickKnownFields(asObject(currentWritable.source), sourceKeys);
+  }
+
+  return {
+    ...currentWritable,
+    ...next,
+  };
 }
 
 function pickKnownFields<const T extends readonly string[]>(input: Record<string, unknown>, keys: T) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -160,16 +160,18 @@ async function getEvent(input: Record<string, unknown>, { accessToken, fetcher }
 }
 
 async function createEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   const event = pickEventWritableFields(asObject(input.event));
   return googlecalendarJsonRequest(eventsUrl(resolveCalendarId(input)), {
     accessToken,
     fetcher,
-    query: buildEventWriteQuery(event, input),
+    query: buildEventWriteQuery(event, sendUpdates),
     body: event,
   });
 }
 
 async function updateEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   const url = eventUrl(resolveCalendarId(input), resolveEventId(input));
   const current = await googlecalendarJsonRequest<Record<string, unknown>>(url, {
     accessToken,
@@ -194,18 +196,19 @@ async function updateEvent(input: Record<string, unknown>, { accessToken, fetche
     accessToken,
     fetcher,
     method: "PUT",
-    query: buildEventWriteQuery(body, input),
+    query: buildEventWriteQuery(body, sendUpdates),
     body,
   });
 }
 
 async function patchEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   const event = pickEventWritableFields(asObject(input.event));
   return googlecalendarJsonRequest(eventUrl(resolveCalendarId(input), resolveEventId(input)), {
     accessToken,
     fetcher,
     method: "PATCH",
-    query: buildEventWriteQuery(event, input),
+    query: buildEventWriteQuery(event, sendUpdates),
     body: event,
   });
 }
@@ -488,16 +491,16 @@ function buildListEventsQuery(input: Record<string, unknown>, options?: { syncMo
   });
 }
 
-function buildEventWriteQuery(event: Record<string, unknown>, input: Record<string, unknown>) {
+function buildEventWriteQuery(event: Record<string, unknown>, sendUpdates: string | undefined) {
   return compactObject({
     conferenceDataVersion: event.conferenceData === undefined ? undefined : "1",
     supportsAttachments: event.attachments === undefined ? undefined : "true",
-    sendUpdates: pickSendUpdates(input),
+    sendUpdates,
   });
 }
 
 function pickSendUpdates(input: Record<string, unknown>) {
-  const sendUpdates = pickOptionalString(input, "sendUpdates");
+  const sendUpdates = input.sendUpdates;
   if (sendUpdates === undefined) {
     return undefined;
   }

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -164,7 +164,7 @@ async function createEvent(input: Record<string, unknown>, { accessToken, fetche
   return googlecalendarJsonRequest(eventsUrl(resolveCalendarId(input)), {
     accessToken,
     fetcher,
-    query: buildEventWriteQuery(event),
+    query: buildEventWriteQuery(event, input),
     body: event,
   });
 }
@@ -194,7 +194,7 @@ async function updateEvent(input: Record<string, unknown>, { accessToken, fetche
     accessToken,
     fetcher,
     method: "PUT",
-    query: buildEventWriteQuery(body),
+    query: buildEventWriteQuery(body, input),
     body,
   });
 }
@@ -205,7 +205,7 @@ async function patchEvent(input: Record<string, unknown>, { accessToken, fetcher
     accessToken,
     fetcher,
     method: "PATCH",
-    query: buildEventWriteQuery(event),
+    query: buildEventWriteQuery(event, input),
     body: event,
   });
 }
@@ -216,6 +216,9 @@ async function deleteEvent(input: Record<string, unknown>, { accessToken, fetche
       accessToken,
       fetcher,
       method: "DELETE",
+      query: compactObject({
+        sendUpdates: pickSendUpdates(input),
+      }),
     });
   } catch (error) {
     if (error instanceof ProviderRequestError && error.status === 404) {
@@ -485,11 +488,23 @@ function buildListEventsQuery(input: Record<string, unknown>, options?: { syncMo
   });
 }
 
-function buildEventWriteQuery(event: Record<string, unknown>) {
+function buildEventWriteQuery(event: Record<string, unknown>, input: Record<string, unknown>) {
   return compactObject({
     conferenceDataVersion: event.conferenceData === undefined ? undefined : "1",
     supportsAttachments: event.attachments === undefined ? undefined : "true",
+    sendUpdates: pickSendUpdates(input),
   });
+}
+
+function pickSendUpdates(input: Record<string, unknown>) {
+  const sendUpdates = pickOptionalString(input, "sendUpdates");
+  if (sendUpdates === undefined) {
+    return undefined;
+  }
+  if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
+    throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
+  }
+  return sendUpdates;
 }
 
 function pickEventWritableFields(input: Record<string, unknown>) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -182,7 +182,7 @@ async function updateEvent(input: Record<string, unknown>, { accessToken, fetche
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const etag = optionalString(current.etag);
     if (!etag) {
-      throw new ProviderRequestError(409, "cannot update event because Google Calendar did not provide an event ETag");
+      throw new ProviderRequestError(502, "googlecalendar returned an event without an etag");
     }
 
     const body = mergeEventUpdate(current, next);
@@ -222,14 +222,13 @@ async function patchEvent(input: Record<string, unknown>, { accessToken, fetcher
 }
 
 async function deleteEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   try {
     await googlecalendarRequest(eventUrl(resolveCalendarId(input), resolveEventId(input)), {
       accessToken,
       fetcher,
       method: "DELETE",
-      query: compactObject({
-        sendUpdates: pickSendUpdates(input),
-      }),
+      query: { sendUpdates },
     });
   } catch (error) {
     if (error instanceof ProviderRequestError && error.status === 404) {
@@ -250,12 +249,14 @@ async function importEvent(input: Record<string, unknown>, { accessToken, fetche
 }
 
 async function moveEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   return googlecalendarJsonRequest(`${eventUrl(resolveCalendarId(input), resolveEventId(input))}/move`, {
     accessToken,
     fetcher,
     method: "POST",
     query: {
       destination: requireInputString(input, "destinationCalendarId", "destinationCalendarId"),
+      sendUpdates,
     },
   });
 }
@@ -280,12 +281,14 @@ async function listEventInstances(
 }
 
 async function quickAddEvent(input: Record<string, unknown>, { accessToken, fetcher }: GooglecalendarEventRuntimeDeps) {
+  const sendUpdates = pickSendUpdates(input);
   return googlecalendarJsonRequest(`${eventsUrl(resolveCalendarId(input))}/quickAdd`, {
     accessToken,
     fetcher,
     method: "POST",
     query: {
       text: requireInputString(input, "text", "text"),
+      sendUpdates,
     },
   });
 }


### PR DESCRIPTION
## Summary
- Add optional `sendUpdates` (`all` | `externalOnly` | `none`) to `create_event`, `update_event`, `patch_event`, and `delete_event`.
- Forward it as Google Calendar's official query parameter, not an event body field; omit it by default so existing callers still do not notify guests.
- Send `If-Match` on `update_event`'s GET-then-PUT and retry the merge once after HTTP 412, so a concurrent attendee change is not overwritten.
- Follow-up to #359, which deferred `sendUpdates` on the existing event write actions.

## Test plan
- [x] `npx vitest run src/providers/googlecalendar/runtime-events.test.ts src/providers/googlecalendar/definition.test.ts`
- [x] `npm run fix-check`
- [ ] Confirm omitted `sendUpdates` is absent from request URLs
- [ ] Confirm `all` / `externalOnly` / `none` appear as query params on create, update PUT (not GET), patch, and delete
- [ ] Confirm invalid `sendUpdates` returns 400 without calling Google
- [ ] Confirm update PUT sends `If-Match` and retries once after 412 with the newer attendee list