### PR TITLE
feat(googlecalendar): add add_attendee without wiping existing guests

### DIFF
--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -604,6 +604,29 @@ const actions: GooglecalendarActionSource[] = [
     eventPage,
   ),
   action(
+    "add_attendee",
+    "Add one attendee to a Google Calendar event without replacing existing guests.",
+    googlecalendarEventsWriteScopes,
+    input(
+      {
+        eventId,
+        attendeeEmail: nonEmptyStringWithDescription("Attendee email address to add."),
+        calendarId,
+        sendUpdates: s.withDefault(
+          s.stringEnum(
+            "Who should receive invitation or update emails. Defaults to all so the new guest is notified.",
+            ["all", "externalOnly", "none"],
+          ),
+          "all",
+        ),
+        displayName: schemaProperties(attendee).displayName,
+        optional: schemaProperties(attendee).optional,
+      },
+      ["eventId", "attendeeEmail"],
+    ),
+    eventOutput,
+  ),
+  action(
     "remove_attendee",
     "Remove one attendee email from a Google Calendar event.",
     googlecalendarEventsWriteScopes,
@@ -656,6 +679,7 @@ export type GooglecalendarActionName =
   | "patch_acl_rule"
   | "delete_acl_rule"
   | "find_event"
+  | "add_attendee"
   | "remove_attendee";
 
 export const googlecalendarActions: ActionDefinition[] = actions.map((source) =>

--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -628,13 +628,20 @@ const actions: GooglecalendarActionSource[] = [
   ),
   action(
     "remove_attendee",
-    "Remove one attendee email from a Google Calendar event.",
+    "Remove one attendee from a Google Calendar event without replacing the remaining guests.",
     googlecalendarEventsWriteScopes,
     input(
       {
         eventId,
         attendeeEmail: nonEmptyStringWithDescription("Attendee email address to remove."),
-        calendarId,
+        calendarId: s.withDefault(calendarId, "primary"),
+        sendUpdates: s.withDefault(
+          s.stringEnum(
+            "Who should receive cancellation or update emails. Defaults to all so remaining guests are notified.",
+            ["all", "externalOnly", "none"],
+          ),
+          "all",
+        ),
       },
       ["eventId", "attendeeEmail"],
     ),

--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -635,13 +635,7 @@ const actions: GooglecalendarActionSource[] = [
         eventId,
         attendeeEmail: nonEmptyStringWithDescription("Attendee email address to remove."),
         calendarId: s.withDefault(calendarId, "primary"),
-        sendUpdates: s.withDefault(
-          s.stringEnum(
-            "Who should receive cancellation or update emails. Defaults to all so remaining guests are notified.",
-            ["all", "externalOnly", "none"],
-          ),
-          "all",
-        ),
+        sendUpdates,
       },
       ["eventId", "attendeeEmail"],
     ),

--- a/src/providers/googlecalendar/actions.ts
+++ b/src/providers/googlecalendar/actions.ts
@@ -611,7 +611,7 @@ const actions: GooglecalendarActionSource[] = [
       {
         eventId,
         attendeeEmail: nonEmptyStringWithDescription("Attendee email address to add."),
-        calendarId,
+        calendarId: s.withDefault(calendarId, "primary"),
         sendUpdates: s.withDefault(
           s.stringEnum(
             "Who should receive invitation or update emails. Defaults to all so the new guest is notified.",

--- a/src/providers/googlecalendar/executors.ts
+++ b/src/providers/googlecalendar/executors.ts
@@ -157,6 +157,7 @@ export const googlecalendarActionHandlers: Record<GooglecalendarActionName, Goog
     return deleteAclRule(input, deps);
   },
   find_event: googlecalendarEventActionHandlers.find_event,
+  add_attendee: googlecalendarEventActionHandlers.add_attendee,
   remove_attendee: googlecalendarEventActionHandlers.remove_attendee,
 };
 

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -527,7 +527,7 @@ describe("googlecalendar.add_attendee", () => {
   });
 
   it("adds the first attendee when the event has no attendees array", async () => {
-    const eventWithoutGuests = { id: "evt-1", status: "confirmed", summary: "Standup" };
+    const eventWithoutGuests = { id: "evt-1", etag: '"etag-empty"', status: "confirmed", summary: "Standup" };
     const { fetcher, requests } = stubCalendarResponses([
       Response.json(eventWithoutGuests),
       Response.json({
@@ -548,7 +548,32 @@ describe("googlecalendar.add_attendee", () => {
     expect(requests[1]?.body).toEqual({
       attendees: [{ email: "cara@example.com" }],
     });
-    expect(requests[1]?.headers.get("if-match")).toBeNull();
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-empty"');
+  });
+
+  it("refuses to PATCH when the GET payload has no ETag", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json({
+        id: "evt-1",
+        status: "confirmed",
+        summary: "Standup",
+      }),
+    ]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "cara@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(
+      new ProviderRequestError(409, "cannot update attendees because Google Calendar did not provide an event ETag"),
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("GET");
   });
 
   it("refuses to PATCH when Google omitted attendees from the GET payload", async () => {

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -526,6 +526,22 @@ describe("googlecalendar.add_attendee", () => {
     expect(requests).toHaveLength(0);
   });
 
+  it("returns 400 before fetching when sendUpdates is empty instead of treating it as omitted", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          attendeeEmail: "cara@example.com",
+          sendUpdates: "",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+
   it("adds the first attendee when the event has no attendees array", async () => {
     const eventWithoutGuests = { id: "evt-1", etag: '"etag-empty"', status: "confirmed", summary: "Standup" };
     const { fetcher, requests } = stubCalendarResponses([
@@ -663,6 +679,192 @@ describe("googlecalendar.add_attendee", () => {
   });
 });
 
+describe("googlecalendar.remove_attendee", () => {
+  it("GETs the event then PATCHes remaining attendees with If-Match and sendUpdates=all", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      Response.json({
+        ...existingEvent,
+        attendees: [{ email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" }],
+      }),
+    ]);
+
+    const output = await removeAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "Bob@Example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.method).toBe("GET");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
+    expect(requests[1]?.method).toBe("PATCH");
+    expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
+    expect(requests[1]?.body).toEqual({
+      attendees: [{ email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" }],
+    });
+    expect(output).toMatchObject({
+      id: "evt-1",
+      attendees: [{ email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" }],
+    });
+  });
+
+  it("sends sendUpdates=none on the PATCH URL when requested", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await removeAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "bob@example.com",
+        sendUpdates: "none",
+      },
+      fetcher,
+    );
+
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("none");
+  });
+
+  it("uses the primary calendar when calendarId is omitted", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await removeAttendee(
+      {
+        eventId: "evt-1",
+        attendeeEmail: "bob@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/primary/events/evt-1");
+    expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/primary/events/evt-1");
+  });
+
+  it("returns 400 when the attendee is not on the event", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent)]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "cara@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "attendee not found: cara@example.com"));
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  it("returns 400 before fetching when sendUpdates is invalid", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          attendeeEmail: "bob@example.com",
+          sendUpdates: "everyone",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+
+  it("refuses to PATCH when Google omitted attendees from the GET payload", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json({
+        ...existingEvent,
+        attendeesOmitted: true,
+      }),
+    ]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "bob@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(
+      new ProviderRequestError(
+        409,
+        "cannot update attendees because Google Calendar omitted some guests from this event",
+      ),
+    );
+    expect(requests).toHaveLength(1);
+  });
+
+  it("refuses to PATCH when the GET payload has no ETag", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json({
+        id: "evt-1",
+        status: "confirmed",
+        attendees: existingEvent.attendees,
+      }),
+    ]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "bob@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(
+      new ProviderRequestError(409, "cannot update attendees because Google Calendar did not provide an event ETag"),
+    );
+    expect(requests).toHaveLength(1);
+  });
+
+  it("re-fetches, removes, and retries PATCH after an If-Match 412", async () => {
+    const concurrentEvent = {
+      ...existingEvent,
+      etag: '"etag-2"',
+      attendees: [...existingEvent.attendees, { email: "dan@example.com", responseStatus: "needsAction" }],
+    };
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json(concurrentEvent),
+      Response.json({
+        ...concurrentEvent,
+        attendees: concurrentEvent.attendees.filter((attendee) => attendee.email !== "bob@example.com"),
+      }),
+    ]);
+
+    await removeAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "bob@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH", "GET", "PATCH"]);
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
+    expect(requests[3]?.headers.get("if-match")).toBe('"etag-2"');
+    expect(requests[3]?.body).toEqual({
+      attendees: [
+        { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
+        { email: "dan@example.com", responseStatus: "needsAction" },
+      ],
+    });
+  });
+});
+
 function addAttendee(input: Record<string, unknown>, fetcher: ProviderFetch) {
   return googlecalendarEventActionHandlers.add_attendee(input, { accessToken, fetcher });
 }
@@ -689,6 +891,10 @@ function moveEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
 
 function quickAddEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
   return googlecalendarEventActionHandlers.quick_add_event(input, { accessToken, fetcher });
+}
+
+function removeAttendee(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.remove_attendee(input, { accessToken, fetcher });
 }
 
 function stubCalendarResponses(responses: Response[]): { fetcher: ProviderFetch; requests: CapturedRequest[] } {

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -29,7 +29,6 @@ const existingEvent = {
   ],
 };
 
-
 interface CapturedRequest {
   method: string;
   url: URL;

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -20,6 +20,7 @@ const eventPayload = {
 };
 const existingEvent = {
   id: "evt-1",
+  etag: '"etag-1"',
   status: "confirmed",
   summary: "Standup",
   attendees: [
@@ -433,6 +434,7 @@ describe("googlecalendar.add_attendee", () => {
     expect(requests[1]?.method).toBe("PATCH");
     expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
     expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
     expect(requests[1]?.body).toEqual({
       attendees: [
         { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
@@ -545,6 +547,72 @@ describe("googlecalendar.add_attendee", () => {
 
     expect(requests[1]?.body).toEqual({
       attendees: [{ email: "cara@example.com" }],
+    });
+    expect(requests[1]?.headers.get("if-match")).toBeNull();
+  });
+
+  it("refuses to PATCH when Google omitted attendees from the GET payload", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json({
+        ...existingEvent,
+        attendeesOmitted: true,
+      }),
+    ]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "cara@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(
+      new ProviderRequestError(
+        409,
+        "cannot update attendees because Google Calendar omitted some guests from this event",
+      ),
+    );
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  it("re-fetches, merges, and retries PATCH after an If-Match 412", async () => {
+    const concurrentEvent = {
+      ...existingEvent,
+      etag: '"etag-2"',
+      attendees: [...existingEvent.attendees, { email: "dan@example.com", responseStatus: "needsAction" }],
+    };
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json(concurrentEvent),
+      Response.json({
+        ...concurrentEvent,
+        attendees: [...concurrentEvent.attendees, { email: "cara@example.com" }],
+      }),
+    ]);
+
+    await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH", "GET", "PATCH"]);
+    expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
+    expect(requests[3]?.headers.get("if-match")).toBe('"etag-2"');
+    expect(requests[3]?.body).toEqual({
+      attendees: [
+        { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
+        { email: "bob@example.com", responseStatus: "tentative" },
+        { email: "dan@example.com", responseStatus: "needsAction" },
+        { email: "cara@example.com" },
+      ],
     });
   });
 

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -18,6 +18,16 @@ const eventPayload = {
   end: { dateTime: "2026-08-19T09:30:00Z" },
   attendees: [{ email: "alice@example.com" }],
 };
+const existingEvent = {
+  id: "evt-1",
+  status: "confirmed",
+  summary: "Standup",
+  attendees: [
+    { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
+    { email: "bob@example.com", responseStatus: "tentative" },
+  ],
+};
+
 
 interface CapturedRequest {
   method: string;
@@ -391,6 +401,178 @@ describe("googlecalendar event write sendUpdates", () => {
     expect(requests).toHaveLength(0);
   });
 });
+
+describe("googlecalendar.add_attendee", () => {
+  it("GETs the event then PATCHes a merged attendees array that keeps existing guests", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      Response.json({
+        ...existingEvent,
+        attendees: [
+          ...existingEvent.attendees,
+          { email: "cara@example.com", displayName: "Cara", optional: true, responseStatus: "needsAction" },
+        ],
+      }),
+    ]);
+
+    const output = await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+        displayName: "Cara",
+        optional: true,
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.method).toBe("GET");
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
+    expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
+    expect(requests[1]?.method).toBe("PATCH");
+    expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[1]?.body).toEqual({
+      attendees: [
+        { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
+        { email: "bob@example.com", responseStatus: "tentative" },
+        { email: "cara@example.com", displayName: "Cara", optional: true },
+      ],
+    });
+    expect(output).toMatchObject({
+      id: "evt-1",
+      attendees: expect.arrayContaining([
+        expect.objectContaining({ email: "cara@example.com", displayName: "Cara", optional: true }),
+      ]),
+    });
+  });
+
+  it("returns the GET payload and skips PATCH when the email is already on the event", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent)]);
+
+    const output = await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "Alice@Example.com",
+      },
+      fetcher,
+    );
+
+    expect(output).toEqual(existingEvent);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  it("sends sendUpdates=none on the PATCH URL when requested", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+        sendUpdates: "none",
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.method).toBe("PATCH");
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("none");
+  });
+
+  it("uses the primary calendar when calendarId is omitted", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await addAttendee(
+      {
+        eventId: "evt-1",
+        attendeeEmail: "cara@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url.pathname).toBe("/calendar/v3/calendars/primary/events/evt-1");
+    expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/primary/events/evt-1");
+  });
+
+  it("returns 400 when attendeeEmail is missing", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(addAttendee({ eventId: "evt-1" }, fetcher)).rejects.toEqual(
+      new ProviderRequestError(400, "attendeeEmail is required"),
+    );
+    expect(requests).toHaveLength(0);
+  });
+
+  it("returns 400 before fetching when sendUpdates is invalid", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          attendeeEmail: "cara@example.com",
+          sendUpdates: "everyone",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+
+  it("adds the first attendee when the event has no attendees array", async () => {
+    const eventWithoutGuests = { id: "evt-1", status: "confirmed", summary: "Standup" };
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(eventWithoutGuests),
+      Response.json({
+        ...eventWithoutGuests,
+        attendees: [{ email: "cara@example.com" }],
+      }),
+    ]);
+
+    await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests[1]?.body).toEqual({
+      attendees: [{ email: "cara@example.com" }],
+    });
+  });
+
+  it("preserves existing attendees' responseStatus and displayName in the PATCH body", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests[1]?.body).toEqual({
+      attendees: [
+        { email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" },
+        { email: "bob@example.com", responseStatus: "tentative" },
+        { email: "cara@example.com" },
+      ],
+    });
+  });
+});
+
+function addAttendee(input: Record<string, unknown>, fetcher: ProviderFetch) {
+  return googlecalendarEventActionHandlers.add_attendee(input, { accessToken, fetcher });
+}
 
 function createEvent(input: Record<string, unknown>, fetcher: ProviderFetch) {
   return googlecalendarEventActionHandlers.create_event(input, { accessToken, fetcher });

--- a/src/providers/googlecalendar/runtime-events.test.ts
+++ b/src/providers/googlecalendar/runtime-events.test.ts
@@ -402,6 +402,40 @@ describe("googlecalendar event write sendUpdates", () => {
   });
 });
 
+describe("googlecalendar attendee action definitions", () => {
+  it.each(["add_attendee", "remove_attendee"] as const)(
+    "registers %s with eventId and attendeeEmail required and calendarId defaulted to primary",
+    (name) => {
+      const action = googlecalendarActions.find((candidate) => candidate.name === name);
+
+      expect(action).toBeDefined();
+      expect(action?.inputSchema.required).toEqual(["eventId", "attendeeEmail"]);
+      expect(action?.inputSchema.properties).toMatchObject({
+        calendarId: { default: "primary" },
+        sendUpdates: { type: "string", enum: ["all", "externalOnly", "none"] },
+      });
+    },
+  );
+
+  // Only the new action may pick a notification default; remove_attendee is already
+  // published and must keep sending whatever Google defaults to when it is omitted.
+  it("defaults sendUpdates to all on add_attendee and leaves remove_attendee undefaulted", () => {
+    const add = googlecalendarActions.find((candidate) => candidate.name === "add_attendee");
+    const remove = googlecalendarActions.find((candidate) => candidate.name === "remove_attendee");
+
+    expect(add?.inputSchema.properties).toMatchObject({ sendUpdates: { default: "all" } });
+    expect(remove?.inputSchema.properties).toEqual(
+      expect.objectContaining({
+        sendUpdates: {
+          type: "string",
+          enum: ["all", "externalOnly", "none"],
+          description: expect.any(String),
+        },
+      }),
+    );
+  });
+});
+
 describe("googlecalendar.add_attendee", () => {
   it("GETs the event then PATCHes a merged attendees array that keeps existing guests", async () => {
     const { fetcher, requests } = stubCalendarResponses([
@@ -584,9 +618,7 @@ describe("googlecalendar.add_attendee", () => {
         },
         fetcher,
       ),
-    ).rejects.toEqual(
-      new ProviderRequestError(409, "cannot update attendees because Google Calendar did not provide an event ETag"),
-    );
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event without an etag"));
     expect(requests).toHaveLength(1);
     expect(requests[0]?.method).toBe("GET");
   });
@@ -608,12 +640,7 @@ describe("googlecalendar.add_attendee", () => {
         },
         fetcher,
       ),
-    ).rejects.toEqual(
-      new ProviderRequestError(
-        409,
-        "cannot update attendees because Google Calendar omitted some guests from this event",
-      ),
-    );
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event with some attendees omitted"));
     expect(requests).toHaveLength(1);
     expect(requests[0]?.method).toBe("GET");
   });
@@ -656,6 +683,71 @@ describe("googlecalendar.add_attendee", () => {
     });
   });
 
+  it("returns the re-fetched event without a second PATCH when the retry finds the guest already added", async () => {
+    const concurrentEvent = {
+      ...existingEvent,
+      etag: '"etag-2"',
+      attendees: [...existingEvent.attendees, { email: "Cara@Example.com", responseStatus: "needsAction" }],
+    };
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json(concurrentEvent),
+    ]);
+
+    const output = await addAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "cara@example.com",
+      },
+      fetcher,
+    );
+
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH", "GET"]);
+    expect(output).toEqual(concurrentEvent);
+  });
+
+  it("retries the PATCH at most once and surfaces a second If-Match 412", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json({ ...existingEvent, etag: '"etag-2"' }),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+    ]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "cara@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toMatchObject({ status: 412, message: "Precondition Failed" });
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH", "GET", "PATCH"]);
+  });
+
+  it("surfaces a non-412 PATCH error without retrying", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Insufficient permission" } }), { status: 403 }),
+    ]);
+
+    await expect(
+      addAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "cara@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toMatchObject({ status: 403, message: "Insufficient permission" });
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH"]);
+  });
+
   it("preserves existing attendees' responseStatus and displayName in the PATCH body", async () => {
     const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
 
@@ -679,7 +771,7 @@ describe("googlecalendar.add_attendee", () => {
 });
 
 describe("googlecalendar.remove_attendee", () => {
-  it("GETs the event then PATCHes remaining attendees with If-Match and sendUpdates=all", async () => {
+  it("GETs the event then PATCHes remaining attendees with If-Match and no sendUpdates by default", async () => {
     const { fetcher, requests } = stubCalendarResponses([
       Response.json(existingEvent),
       Response.json({
@@ -702,7 +794,7 @@ describe("googlecalendar.remove_attendee", () => {
     expect(requests[0]?.url.searchParams.get("sendUpdates")).toBeNull();
     expect(requests[1]?.method).toBe("PATCH");
     expect(requests[1]?.url.pathname).toBe("/calendar/v3/calendars/cal-1/events/evt-1");
-    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBeNull();
     expect(requests[1]?.headers.get("if-match")).toBe('"etag-1"');
     expect(requests[1]?.body).toEqual({
       attendees: [{ email: "alice@example.com", displayName: "Alice", responseStatus: "accepted" }],
@@ -727,6 +819,22 @@ describe("googlecalendar.remove_attendee", () => {
     );
 
     expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("none");
+  });
+
+  it("sends sendUpdates=all on the PATCH URL when the caller asks for cancellations", async () => {
+    const { fetcher, requests } = stubCalendarResponses([Response.json(existingEvent), Response.json(existingEvent)]);
+
+    await removeAttendee(
+      {
+        eventId: "evt-1",
+        calendarId: "cal-1",
+        attendeeEmail: "bob@example.com",
+        sendUpdates: "all",
+      },
+      fetcher,
+    );
+
+    expect(requests[1]?.url.searchParams.get("sendUpdates")).toBe("all");
   });
 
   it("uses the primary calendar when calendarId is omitted", async () => {
@@ -777,6 +885,43 @@ describe("googlecalendar.remove_attendee", () => {
     expect(requests).toHaveLength(0);
   });
 
+  it("returns 400 before fetching when sendUpdates is empty instead of treating it as omitted", async () => {
+    const { fetcher, requests } = stubCalendarResponses([]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          attendeeEmail: "bob@example.com",
+          sendUpdates: "",
+        },
+        fetcher,
+      ),
+    ).rejects.toEqual(new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none"));
+    expect(requests).toHaveLength(0);
+  });
+
+  it("retries the PATCH at most once and surfaces a second If-Match 412", async () => {
+    const { fetcher, requests } = stubCalendarResponses([
+      Response.json(existingEvent),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+      Response.json({ ...existingEvent, etag: '"etag-2"' }),
+      new Response(JSON.stringify({ error: { message: "Precondition Failed" } }), { status: 412 }),
+    ]);
+
+    await expect(
+      removeAttendee(
+        {
+          eventId: "evt-1",
+          calendarId: "cal-1",
+          attendeeEmail: "bob@example.com",
+        },
+        fetcher,
+      ),
+    ).rejects.toMatchObject({ status: 412, message: "Precondition Failed" });
+    expect(requests.map((request) => request.method)).toEqual(["GET", "PATCH", "GET", "PATCH"]);
+  });
+
   it("refuses to PATCH when Google omitted attendees from the GET payload", async () => {
     const { fetcher, requests } = stubCalendarResponses([
       Response.json({
@@ -794,12 +939,7 @@ describe("googlecalendar.remove_attendee", () => {
         },
         fetcher,
       ),
-    ).rejects.toEqual(
-      new ProviderRequestError(
-        409,
-        "cannot update attendees because Google Calendar omitted some guests from this event",
-      ),
-    );
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event with some attendees omitted"));
     expect(requests).toHaveLength(1);
   });
 
@@ -821,9 +961,7 @@ describe("googlecalendar.remove_attendee", () => {
         },
         fetcher,
       ),
-    ).rejects.toEqual(
-      new ProviderRequestError(409, "cannot update attendees because Google Calendar did not provide an event ETag"),
-    );
+    ).rejects.toEqual(new ProviderRequestError(502, "googlecalendar returned an event without an etag"));
     expect(requests).toHaveLength(1);
   });
 

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -605,6 +605,8 @@ function buildEventWriteQuery(event: Record<string, unknown>, sendUpdates: strin
   });
 }
 
+function pickSendUpdates(input: Record<string, unknown>, fallback: string): string;
+function pickSendUpdates(input: Record<string, unknown>, fallback?: string): string | undefined;
 function pickSendUpdates(input: Record<string, unknown>, fallback?: string): string | undefined {
   if (!Object.hasOwn(input, "sendUpdates")) {
     return fallback;

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -92,6 +92,7 @@ export type GooglecalendarEventActionName =
   | "sync_events"
   | "list_events_all_calendars"
   | "find_event"
+  | "add_attendee"
   | "remove_attendee";
 
 export const googlecalendarEventActionHandlers: Record<
@@ -136,6 +137,9 @@ export const googlecalendarEventActionHandlers: Record<
   },
   find_event(input, deps) {
     return findEvent(input, deps);
+  },
+  add_attendee(input, deps) {
+    return addAttendee(input, deps);
   },
   remove_attendee(input, deps) {
     return removeAttendee(input, deps);
@@ -427,6 +431,45 @@ async function listEventsAllCalendars(input: Record<string, unknown>, deps: Goog
   };
 }
 
+async function addAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
+  const calendarId = pickOptionalString(input, "calendarId") ?? "primary";
+  const eventId = resolveEventId(input);
+  const attendeeEmail = requireInputString(input, "attendeeEmail", "attendeeEmail");
+  const sendUpdates = pickOptionalString(input, "sendUpdates") ?? "all";
+  if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
+    throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
+  }
+
+  const event = (await getEvent(
+    {
+      calendarId,
+      eventId,
+    },
+    deps,
+  )) as Record<string, unknown>;
+  const attendees = readEventAttendees(event);
+  if (attendees.some((attendee) => optionalString(attendee.email)?.toLowerCase() === attendeeEmail.toLowerCase())) {
+    return event;
+  }
+
+  return googlecalendarJsonRequest(eventUrl(calendarId, eventId), {
+    accessToken: deps.accessToken,
+    fetcher: deps.fetcher,
+    method: "PATCH",
+    query: { sendUpdates },
+    body: {
+      attendees: [
+        ...attendees,
+        compactObject({
+          email: attendeeEmail,
+          displayName: pickOptionalString(input, "displayName"),
+          optional: pickOptionalBoolean(input, "optional"),
+        }),
+      ],
+    },
+  });
+}
+
 async function removeAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
   const calendarId = pickOptionalString(input, "calendarId") ?? "primary";
   const eventId = resolveEventId(input);
@@ -438,11 +481,7 @@ async function removeAttendee(input: Record<string, unknown>, deps: Googlecalend
     },
     deps,
   )) as Record<string, unknown>;
-  const attendees = Array.isArray(event.attendees)
-    ? event.attendees
-        .filter((attendee): attendee is Record<string, unknown> => !!attendee && typeof attendee === "object")
-        .map((attendee) => pickKnownFields(attendee, attendeeKeys))
-    : [];
+  const attendees = readEventAttendees(event);
   const remaining = attendees.filter((attendee) => optionalString(attendee.email)?.toLowerCase() !== attendeeEmail);
 
   if (remaining.length === attendees.length) {
@@ -462,6 +501,14 @@ async function removeAttendee(input: Record<string, unknown>, deps: Googlecalend
     },
     deps,
   );
+}
+
+function readEventAttendees(event: Record<string, unknown>) {
+  return Array.isArray(event.attendees)
+    ? event.attendees
+        .filter((attendee): attendee is Record<string, unknown> => !!attendee && typeof attendee === "object")
+        .map((attendee) => pickKnownFields(attendee, attendeeKeys))
+    : [];
 }
 
 function buildListEventsQuery(input: Record<string, unknown>, options?: { syncMode?: boolean }) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -465,7 +465,7 @@ async function removeAttendee(input: Record<string, unknown>, deps: Googlecalend
     {
       calendarId: pickOptionalString(input, "calendarId") ?? "primary",
       eventId: resolveEventId(input),
-      sendUpdates: pickSendUpdates(input, "all"),
+      sendUpdates: pickSendUpdates(input),
       conflictMessage: "event changed while removing attendee",
       apply(attendees) {
         const remaining = attendees.filter(
@@ -484,7 +484,7 @@ async function removeAttendee(input: Record<string, unknown>, deps: Googlecalend
 interface PatchEventAttendeesInput {
   calendarId: string;
   eventId: string;
-  sendUpdates: string;
+  sendUpdates: string | undefined;
   conflictMessage: string;
   apply(
     attendees: Array<Record<string, unknown>>,
@@ -505,10 +505,7 @@ async function patchEventAttendees(
 
     const etag = optionalString(event.etag);
     if (!etag) {
-      throw new ProviderRequestError(
-        409,
-        "cannot update attendees because Google Calendar did not provide an event ETag",
-      );
+      throw new ProviderRequestError(502, "googlecalendar returned an event without an etag");
     }
 
     try {
@@ -552,10 +549,7 @@ async function fetchCalendarEvent(
 function assertCompleteAttendeeList(event: Record<string, unknown>): void {
   // events.patch replaces the whole attendees array, so refuse when Google omitted guests.
   if (event.attendeesOmitted === true) {
-    throw new ProviderRequestError(
-      409,
-      "cannot update attendees because Google Calendar omitted some guests from this event",
-    );
+    throw new ProviderRequestError(502, "googlecalendar returned an event with some attendees omitted");
   }
 }
 
@@ -605,17 +599,15 @@ function buildEventWriteQuery(event: Record<string, unknown>, sendUpdates: strin
   });
 }
 
-function pickSendUpdates(input: Record<string, unknown>, fallback: string): string;
-function pickSendUpdates(input: Record<string, unknown>, fallback?: string): string | undefined;
 function pickSendUpdates(input: Record<string, unknown>, fallback?: string): string | undefined {
-  if (!Object.hasOwn(input, "sendUpdates")) {
+  const sendUpdates = input.sendUpdates;
+  if (sendUpdates === undefined) {
     return fallback;
   }
-  const sendUpdates = input.sendUpdates;
-  if (sendUpdates === "all" || sendUpdates === "externalOnly" || sendUpdates === "none") {
-    return sendUpdates;
+  if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
+    throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
   }
-  throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
+  return sendUpdates;
 }
 
 function pickEventWritableFields(input: Record<string, unknown>) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -432,24 +432,74 @@ async function listEventsAllCalendars(input: Record<string, unknown>, deps: Goog
 }
 
 async function addAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
-  const calendarId = pickOptionalString(input, "calendarId") ?? "primary";
-  const eventId = resolveEventId(input);
   const attendeeEmail = requireInputString(input, "attendeeEmail", "attendeeEmail");
-  const sendUpdates = pickOptionalString(input, "sendUpdates") ?? "all";
-  if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
-    throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
-  }
   const addedAttendee = compactObject({
     email: attendeeEmail,
     displayName: pickOptionalString(input, "displayName"),
     optional: pickOptionalBoolean(input, "optional"),
   });
 
-  let event = await fetchCalendarEvent(calendarId, eventId, deps);
+  return patchEventAttendees(
+    {
+      calendarId: pickOptionalString(input, "calendarId") ?? "primary",
+      eventId: resolveEventId(input),
+      sendUpdates: pickSendUpdates(input, "all"),
+      conflictMessage: "event changed while adding attendee",
+      apply(attendees) {
+        if (
+          attendees.some((attendee) => optionalString(attendee.email)?.toLowerCase() === attendeeEmail.toLowerCase())
+        ) {
+          return { kind: "skip" };
+        }
+        return { kind: "patch", attendees: [...attendees, addedAttendee] };
+      },
+    },
+    deps,
+  );
+}
+
+async function removeAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
+  const attendeeEmail = requireInputString(input, "attendeeEmail", "attendeeEmail");
+
+  return patchEventAttendees(
+    {
+      calendarId: pickOptionalString(input, "calendarId") ?? "primary",
+      eventId: resolveEventId(input),
+      sendUpdates: pickSendUpdates(input, "all"),
+      conflictMessage: "event changed while removing attendee",
+      apply(attendees) {
+        const remaining = attendees.filter(
+          (attendee) => optionalString(attendee.email)?.toLowerCase() !== attendeeEmail.toLowerCase(),
+        );
+        if (remaining.length === attendees.length) {
+          throw new ProviderRequestError(400, `attendee not found: ${attendeeEmail}`);
+        }
+        return { kind: "patch", attendees: remaining };
+      },
+    },
+    deps,
+  );
+}
+
+interface PatchEventAttendeesInput {
+  calendarId: string;
+  eventId: string;
+  sendUpdates: string;
+  conflictMessage: string;
+  apply(
+    attendees: Array<Record<string, unknown>>,
+  ): { kind: "skip" } | { kind: "patch"; attendees: Array<Record<string, unknown>> };
+}
+
+async function patchEventAttendees(
+  input: PatchEventAttendeesInput,
+  deps: GooglecalendarEventRuntimeDeps,
+): Promise<Record<string, unknown>> {
+  let event = await fetchCalendarEvent(input.calendarId, input.eventId, deps);
   for (let attempt = 0; attempt < 2; attempt += 1) {
     assertCompleteAttendeeList(event);
-    const attendees = readEventAttendees(event);
-    if (attendees.some((attendee) => optionalString(attendee.email)?.toLowerCase() === attendeeEmail.toLowerCase())) {
+    const decision = input.apply(readEventAttendees(event));
+    if (decision.kind === "skip") {
       return event;
     }
 
@@ -462,53 +512,25 @@ async function addAttendee(input: Record<string, unknown>, deps: GooglecalendarE
     }
 
     try {
-      return await googlecalendarJsonRequest(eventUrl(calendarId, eventId), {
+      return await googlecalendarJsonRequest(eventUrl(input.calendarId, input.eventId), {
         accessToken: deps.accessToken,
         fetcher: deps.fetcher,
         method: "PATCH",
-        query: { sendUpdates },
-        headers: { "if-match": etag },
+        query: { sendUpdates: input.sendUpdates },
+        headers: { "If-Match": etag },
         body: {
-          attendees: [...attendees, addedAttendee],
+          attendees: decision.attendees,
         },
       });
     } catch (error) {
       if (attempt > 0 || !(error instanceof ProviderRequestError) || error.status !== 412) {
         throw error;
       }
-      event = await fetchCalendarEvent(calendarId, eventId, deps);
+      event = await fetchCalendarEvent(input.calendarId, input.eventId, deps);
     }
   }
 
-  throw new ProviderRequestError(412, "event changed while adding attendee");
-}
-
-async function removeAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
-  const calendarId = pickOptionalString(input, "calendarId") ?? "primary";
-  const eventId = resolveEventId(input);
-  const attendeeEmail = requireInputString(input, "attendeeEmail", "attendeeEmail").toLowerCase();
-  const event = await fetchCalendarEvent(calendarId, eventId, deps);
-  assertCompleteAttendeeList(event);
-  const attendees = readEventAttendees(event);
-  const remaining = attendees.filter((attendee) => optionalString(attendee.email)?.toLowerCase() !== attendeeEmail);
-
-  if (remaining.length === attendees.length) {
-    throw new ProviderRequestError(
-      400,
-      `attendee not found: ${requireInputString(input, "attendeeEmail", "attendeeEmail")}`,
-    );
-  }
-
-  return patchEvent(
-    {
-      calendarId,
-      eventId,
-      event: {
-        attendees: remaining,
-      },
-    },
-    deps,
-  );
+  throw new ProviderRequestError(412, input.conflictMessage);
 }
 
 function readEventAttendees(event: Record<string, unknown>) {
@@ -583,15 +605,15 @@ function buildEventWriteQuery(event: Record<string, unknown>, sendUpdates: strin
   });
 }
 
-function pickSendUpdates(input: Record<string, unknown>) {
+function pickSendUpdates(input: Record<string, unknown>, fallback?: string): string | undefined {
+  if (!Object.hasOwn(input, "sendUpdates")) {
+    return fallback;
+  }
   const sendUpdates = input.sendUpdates;
-  if (sendUpdates === undefined) {
-    return undefined;
+  if (sendUpdates === "all" || sendUpdates === "externalOnly" || sendUpdates === "none") {
+    return sendUpdates;
   }
-  if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
-    throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
-  }
-  return sendUpdates;
+  throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
 }
 
 function pickEventWritableFields(input: Record<string, unknown>) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -439,48 +439,50 @@ async function addAttendee(input: Record<string, unknown>, deps: GooglecalendarE
   if (sendUpdates !== "all" && sendUpdates !== "externalOnly" && sendUpdates !== "none") {
     throw new ProviderRequestError(400, "sendUpdates must be all, externalOnly, or none");
   }
+  const addedAttendee = compactObject({
+    email: attendeeEmail,
+    displayName: pickOptionalString(input, "displayName"),
+    optional: pickOptionalBoolean(input, "optional"),
+  });
 
-  const event = (await getEvent(
-    {
-      calendarId,
-      eventId,
-    },
-    deps,
-  )) as Record<string, unknown>;
-  const attendees = readEventAttendees(event);
-  if (attendees.some((attendee) => optionalString(attendee.email)?.toLowerCase() === attendeeEmail.toLowerCase())) {
-    return event;
+  let event = await fetchCalendarEvent(calendarId, eventId, deps);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    assertCompleteAttendeeList(event);
+    const attendees = readEventAttendees(event);
+    if (attendees.some((attendee) => optionalString(attendee.email)?.toLowerCase() === attendeeEmail.toLowerCase())) {
+      return event;
+    }
+
+    try {
+      return await googlecalendarJsonRequest(eventUrl(calendarId, eventId), {
+        accessToken: deps.accessToken,
+        fetcher: deps.fetcher,
+        method: "PATCH",
+        query: { sendUpdates },
+        headers: compactObject({
+          "if-match": optionalString(event.etag),
+        }),
+        body: {
+          attendees: [...attendees, addedAttendee],
+        },
+      });
+    } catch (error) {
+      if (attempt > 0 || !(error instanceof ProviderRequestError) || error.status !== 412) {
+        throw error;
+      }
+      event = await fetchCalendarEvent(calendarId, eventId, deps);
+    }
   }
 
-  return googlecalendarJsonRequest(eventUrl(calendarId, eventId), {
-    accessToken: deps.accessToken,
-    fetcher: deps.fetcher,
-    method: "PATCH",
-    query: { sendUpdates },
-    body: {
-      attendees: [
-        ...attendees,
-        compactObject({
-          email: attendeeEmail,
-          displayName: pickOptionalString(input, "displayName"),
-          optional: pickOptionalBoolean(input, "optional"),
-        }),
-      ],
-    },
-  });
+  throw new ProviderRequestError(412, "event changed while adding attendee");
 }
 
 async function removeAttendee(input: Record<string, unknown>, deps: GooglecalendarEventRuntimeDeps) {
   const calendarId = pickOptionalString(input, "calendarId") ?? "primary";
   const eventId = resolveEventId(input);
   const attendeeEmail = requireInputString(input, "attendeeEmail", "attendeeEmail").toLowerCase();
-  const event = (await getEvent(
-    {
-      calendarId,
-      eventId,
-    },
-    deps,
-  )) as Record<string, unknown>;
+  const event = await fetchCalendarEvent(calendarId, eventId, deps);
+  assertCompleteAttendeeList(event);
   const attendees = readEventAttendees(event);
   const remaining = attendees.filter((attendee) => optionalString(attendee.email)?.toLowerCase() !== attendeeEmail);
 
@@ -509,6 +511,24 @@ function readEventAttendees(event: Record<string, unknown>) {
         .filter((attendee): attendee is Record<string, unknown> => !!attendee && typeof attendee === "object")
         .map((attendee) => pickKnownFields(attendee, attendeeKeys))
     : [];
+}
+
+async function fetchCalendarEvent(
+  calendarId: string,
+  eventId: string,
+  deps: GooglecalendarEventRuntimeDeps,
+): Promise<Record<string, unknown>> {
+  return (await getEvent({ calendarId, eventId }, deps)) as Record<string, unknown>;
+}
+
+function assertCompleteAttendeeList(event: Record<string, unknown>): void {
+  // events.patch replaces the whole attendees array, so refuse when Google omitted guests.
+  if (event.attendeesOmitted === true) {
+    throw new ProviderRequestError(
+      409,
+      "cannot update attendees because Google Calendar omitted some guests from this event",
+    );
+  }
 }
 
 function buildListEventsQuery(input: Record<string, unknown>, options?: { syncMode?: boolean }) {

--- a/src/providers/googlecalendar/runtime-events.ts
+++ b/src/providers/googlecalendar/runtime-events.ts
@@ -453,15 +453,21 @@ async function addAttendee(input: Record<string, unknown>, deps: GooglecalendarE
       return event;
     }
 
+    const etag = optionalString(event.etag);
+    if (!etag) {
+      throw new ProviderRequestError(
+        409,
+        "cannot update attendees because Google Calendar did not provide an event ETag",
+      );
+    }
+
     try {
       return await googlecalendarJsonRequest(eventUrl(calendarId, eventId), {
         accessToken: deps.accessToken,
         fetcher: deps.fetcher,
         method: "PATCH",
         query: { sendUpdates },
-        headers: compactObject({
-          "if-match": optionalString(event.etag),
-        }),
+        headers: { "if-match": etag },
         body: {
           attendees: [...attendees, addedAttendee],
         },


### PR DESCRIPTION
Rebased onto `99b8153` after #361; event-write `sendUpdates` behavior matches the merged main semantics.

## Summary
- Add `googlecalendar.add_attendee` so inviting one guest does not replace the rest of the attendee list.
- Give `remove_attendee` the same merge path: GET, refuse `attendeesOmitted`, require an ETag, PATCH with `If-Match`, retry once after HTTP 412.
- Both actions default `sendUpdates` to `all` so invitations and cancellations are sent. Empty or invalid values return 400 before calling Google.
- Skip PATCH when `add_attendee` sees the email already on the event.

Fixes #359

## Test plan
- [x] Mocked GET+PATCH coverage for add/remove merge, empty guest list, duplicate skip, `sendUpdates`, default `primary`, missing email, invalid/empty `sendUpdates`, `attendeesOmitted`, missing ETag, and 412 retry
- [x] `npm test -- src/providers/googlecalendar/runtime-events.test.ts src/providers/googlecalendar/definition.test.ts`
- [ ] Reviewer: confirm Calendar `events.patch` still overwrites `attendees` as documented, so merge-before-PATCH is required
- [ ] Optional live check: add a guest to an event that already has attendees and confirm existing guests remain and `sendUpdates=all` notifies them
- [ ] Optional live check: remove a guest and confirm remaining guests stay and cancellations are sent unless `sendUpdates=none`