### PR TITLE
feat(vercel): add optional teamId and slug request scope

### DIFF
--- a/src/providers/vercel/actions.ts
+++ b/src/providers/vercel/actions.ts
@@ -226,8 +226,14 @@ const unscopedInput = (properties: Record<string, JsonSchema>, required: string[
   s.actionInput(properties, required, "Vercel action input.");
 
 const emptyInput = unscopedInput({});
-const input = (properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema =>
-  unscopedInput({ ...teamScopeFields, ...properties }, required);
+const getTeamInput = unscopedInput(teamScopeFields);
+getTeamInput.oneOf = [{ required: ["teamId"] }, { required: ["slug"] }];
+
+const input = (properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema => {
+  const schema = unscopedInput({ ...teamScopeFields, ...properties }, required);
+  schema.not = { required: ["teamId", "slug"] };
+  return schema;
+};
 
 const actionSources: readonly VercelActionSource[] = [
   {
@@ -248,10 +254,7 @@ const actionSources: readonly VercelActionSource[] = [
   {
     name: "get_team",
     description: "Get a Vercel team by team ID or slug.",
-    inputSchema: unscopedInput({
-      teamId: s.nonEmptyString("The Team identifier to perform the request on behalf of."),
-      slug: s.nonEmptyString("The Team slug to perform the request on behalf of."),
-    }),
+    inputSchema: getTeamInput,
     outputSchema: s.object({ team }, { required: ["team"] }),
   },
   {

--- a/src/providers/vercel/actions.ts
+++ b/src/providers/vercel/actions.ts
@@ -247,8 +247,11 @@ const actionSources: readonly VercelActionSource[] = [
   },
   {
     name: "get_team",
-    description: "Get a Vercel team by id or slug.",
-    inputSchema: unscopedInput({ teamId: s.nonEmptyString("Vercel team ID or team slug.") }, ["teamId"]),
+    description: "Get a Vercel team by team ID or slug.",
+    inputSchema: unscopedInput({
+      teamId: s.nonEmptyString("The Team identifier to perform the request on behalf of."),
+      slug: s.nonEmptyString("The Team slug to perform the request on behalf of."),
+    }),
     outputSchema: s.object({ team }, { required: ["team"] }),
   },
   {

--- a/src/providers/vercel/actions.ts
+++ b/src/providers/vercel/actions.ts
@@ -217,9 +217,17 @@ const envWriteFields = {
   customEnvironmentIds: s.stringArray("Custom environment IDs that should receive this environment variable."),
 };
 
-const emptyInput = s.object({}, { description: "Vercel action input." });
-const input = (properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema =>
+const teamScopeFields = {
+  teamId: s.nonEmptyString("The Team identifier to perform the request on behalf of."),
+  slug: s.nonEmptyString("The Team slug to perform the request on behalf of."),
+};
+
+const unscopedInput = (properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema =>
   s.actionInput(properties, required, "Vercel action input.");
+
+const emptyInput = unscopedInput({});
+const input = (properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema =>
+  unscopedInput({ ...teamScopeFields, ...properties }, required);
 
 const actionSources: readonly VercelActionSource[] = [
   {
@@ -231,7 +239,7 @@ const actionSources: readonly VercelActionSource[] = [
   {
     name: "list_teams",
     description: "List Vercel teams available to the authenticated user.",
-    inputSchema: input({ limit: pageSize, since }),
+    inputSchema: unscopedInput({ limit: pageSize, since }),
     outputSchema: s.object({
       teams: s.array(team, { description: "Vercel teams available to the authenticated user." }),
       pagination: pagination,
@@ -240,7 +248,7 @@ const actionSources: readonly VercelActionSource[] = [
   {
     name: "get_team",
     description: "Get a Vercel team by id or slug.",
-    inputSchema: input({ teamId: s.nonEmptyString("Vercel team ID or team slug.") }, ["teamId"]),
+    inputSchema: unscopedInput({ teamId: s.nonEmptyString("Vercel team ID or team slug.") }, ["teamId"]),
     outputSchema: s.object({ team }, { required: ["team"] }),
   },
   {
@@ -422,7 +430,7 @@ const actionSources: readonly VercelActionSource[] = [
   {
     name: "list_webhooks",
     description: "List Vercel webhooks.",
-    inputSchema: emptyInput,
+    inputSchema: input({}),
     outputSchema: s.object({ webhooks: s.array(webhook, { description: "Vercel webhooks." }) }),
   },
   {

--- a/src/providers/vercel/definition.ts
+++ b/src/providers/vercel/definition.ts
@@ -18,7 +18,29 @@ export const provider: ProviderDefinition = {
       label: "Access token",
       placeholder: "vercel_access_token",
       description:
-        "Vercel personal access token used with the Authorization Bearer header. Create it in your Vercel Account Tokens settings.",
+        "Vercel personal access token used with the Authorization Bearer header. Create it in your Vercel Account Tokens settings. Team-owned resources also need Team ID or Team slug.",
+      extraFields: [
+        {
+          key: "teamId",
+          label: "Team ID",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "team_...",
+          description:
+            "Optional Vercel team ID sent as the teamId query parameter on team-scoped REST API requests. Use this or Team slug, not both. Find it under the team Settings page.",
+        },
+        {
+          key: "slug",
+          label: "Team slug",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "my-team",
+          description:
+            "Optional Vercel team slug sent as the slug query parameter on team-scoped REST API requests. Use this or Team ID, not both.",
+        },
+      ],
     },
   ],
   homepageUrl: "https://vercel.com",

--- a/src/providers/vercel/executors.ts
+++ b/src/providers/vercel/executors.ts
@@ -1,14 +1,26 @@
-import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { VercelActionContext } from "./runtime.ts";
 
-import { defineApiKeyProviderExecutors } from "../provider-runtime.ts";
-import { validateVercelCredential, vercelActionHandlers } from "./runtime.ts";
+import { defineProviderExecutors, requireApiKeyCredential } from "../provider-runtime.ts";
+import { readVercelTeamScope, validateVercelCredential, vercelActionHandlers } from "./runtime.ts";
 
 const service = "vercel";
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, vercelActionHandlers);
+export const executors: ProviderExecutors = defineProviderExecutors<VercelActionContext>({
+  service,
+  handlers: vercelActionHandlers,
+  async createContext(context: ExecutionContext, fetcher): Promise<VercelActionContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return {
+      apiKey: credential.apiKey,
+      fetcher,
+      ...readVercelTeamScope(credential.values),
+    };
+  },
+});
 
 export const credentialValidators: CredentialValidators = {
-  async apiKey(input, { fetcher }) {
-    return validateVercelCredential(input.apiKey, fetcher);
+  apiKey(input, { fetcher }) {
+    return validateVercelCredential(input, fetcher);
   },
 };

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -1,16 +1,282 @@
 import { describe, expect, it } from "vitest";
-import { vercelActionHandlers } from "./runtime.ts";
+import { credentialValidators } from "./executors.ts";
+import { readVercelTeamScope, validateVercelCredential, vercelActionHandlers } from "./runtime.ts";
 
-function actionContext(fetcher: typeof fetch) {
-  return {
-    apiKey: "vercel-token",
-    fetcher,
+const apiKey = "vercel-token";
+
+function actionContext(fetcher: typeof fetch, team?: { teamId?: string; slug?: string }) {
+  return { apiKey, fetcher, ...team };
+}
+
+function jsonFetcher(handler: (url: URL, init?: RequestInit) => unknown): typeof fetch {
+  return async (input, init) => {
+    const payload = handler(new URL(String(input)), init);
+    return Response.json(payload);
   };
 }
 
 function vercelError(status: number, message: string): Response {
   return Response.json({ error: { code: "not_found", message } }, { status });
 }
+
+describe("Vercel team scope", () => {
+  it("rejects credential extra fields that set both teamId and slug", () => {
+    expect(() => readVercelTeamScope({ teamId: "team_123", slug: "acme" })).toThrowError(
+      "teamId and slug cannot both be provided",
+    );
+  });
+
+  it("validates a personal token against /v2/user without team query parameters", async () => {
+    const result = await validateVercelCredential(
+      { apiKey, values: {} },
+      jsonFetcher((url, init) => {
+        expect(url.toString()).toBe("https://api.vercel.com/v2/user");
+        expect(url.searchParams.has("teamId")).toBe(false);
+        expect(url.searchParams.has("slug")).toBe(false);
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer vercel-token");
+        return { user: { id: "usr_1", username: "alice", name: "Alice" } };
+      }),
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "usr_1", displayName: "Alice" },
+      metadata: { validationEndpoint: "/v2/user", userId: "usr_1", username: "alice" },
+    });
+    expect(result.metadata.teamId).toBeUndefined();
+  });
+
+  it("validates an optional team ID after the user endpoint succeeds", async () => {
+    const urls: string[] = [];
+    const result = await credentialValidators.apiKey!(
+      { apiKey, values: { teamId: "team_123" } },
+      {
+        fetcher: jsonFetcher((url) => {
+          urls.push(`${url.pathname}${url.search}`);
+          if (url.pathname === "/v2/user") {
+            return { user: { id: "usr_1", username: "alice", name: "Alice" } };
+          }
+          expect(url.pathname).toBe("/v2/teams/team_123");
+          return { id: "team_123", slug: "acme", name: "Acme" };
+        }),
+      },
+    );
+
+    expect(urls).toEqual(["/v2/user", "/v2/teams/team_123"]);
+    expect(result).toMatchObject({
+      profile: { accountId: "team_123", displayName: "Acme" },
+      metadata: {
+        validationEndpoint: "/v2/teams/team_123",
+        userId: "usr_1",
+        teamId: "team_123",
+        teamSlug: "acme",
+        teamName: "Acme",
+      },
+    });
+  });
+
+  it("validates an optional team slug through the teams path", async () => {
+    const result = await validateVercelCredential(
+      { apiKey, values: { slug: "acme" } },
+      jsonFetcher((url) => {
+        if (url.pathname === "/v2/user") {
+          return { user: { id: "usr_1", name: "Alice" } };
+        }
+        expect(url.pathname).toBe("/v2/teams/acme");
+        return { id: "team_123", slug: "acme", name: "Acme" };
+      }),
+    );
+
+    expect(result.profile).toEqual({ accountId: "team_123", displayName: "Acme" });
+    expect(result.metadata.teamSlug).toBe("acme");
+  });
+});
+
+describe("Vercel team-scoped REST queries", () => {
+  it("lists personal projects without teamId or slug", async () => {
+    let requestUrl = "";
+    const result = await vercelActionHandlers.list_projects(
+      { limit: 5 },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { projects: [{ id: "prj_1", name: "app" }], pagination: { count: 1, next: null, prev: null } };
+        }),
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v10/projects");
+    expect(url.searchParams.get("limit")).toBe("5");
+    expect(url.searchParams.has("teamId")).toBe(false);
+    expect(url.searchParams.has("slug")).toBe(false);
+    expect(result).toEqual({
+      projects: [{ id: "prj_1", name: "app" }],
+      pagination: { count: 1, next: null, prev: null },
+    });
+  });
+
+  it("sends teamId as a query parameter on team-owned project lists", async () => {
+    let requestUrl = "";
+    await vercelActionHandlers.list_projects(
+      { teamId: "team_123", repoUrl: "https://github.com/acme/app" },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { projects: [{ id: "prj_1", name: "app" }] };
+        }),
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v10/projects");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      teamId: "team_123",
+      repoUrl: "https://github.com/acme/app",
+    });
+  });
+
+  it("sends slug as a query parameter when listing deployments", async () => {
+    let requestUrl = "";
+    await vercelActionHandlers.list_deployments(
+      { slug: "acme", projectId: "prj_1" },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { deployments: [{ id: "dpl_1", name: "app" }] };
+        }),
+      ),
+    );
+
+    expect(Object.fromEntries(new URL(requestUrl).searchParams)).toEqual({
+      slug: "acme",
+      projectId: "prj_1",
+    });
+  });
+
+  it("uses the credential team scope when action input omits teamId and slug", async () => {
+    let requestUrl = "";
+    await vercelActionHandlers.create_project(
+      { name: "docs" },
+      actionContext(
+        jsonFetcher((url, init) => {
+          requestUrl = url.toString();
+          expect(init?.method).toBe("POST");
+          expect(JSON.parse(String(init?.body))).toEqual({ name: "docs" });
+          return { id: "prj_2", name: "docs" };
+        }),
+        { teamId: "team_123" },
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v11/projects");
+    expect(url.searchParams.get("teamId")).toBe("team_123");
+  });
+
+  it("lets action input override the credential team scope", async () => {
+    let requestUrl = "";
+    await vercelActionHandlers.get_project(
+      { idOrName: "app", slug: "other-team" },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { id: "prj_1", name: "app" };
+        }),
+        { teamId: "team_123" },
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v9/projects/app");
+    expect(url.searchParams.get("slug")).toBe("other-team");
+    expect(url.searchParams.has("teamId")).toBe(false);
+  });
+
+  it("rejects listing projects when both teamId and slug are provided", async () => {
+    await expect(
+      vercelActionHandlers.list_projects(
+        { teamId: "team_123", slug: "acme" },
+        actionContext(async () => {
+          throw new Error("fetch should not run");
+        }),
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "teamId and slug cannot both be provided",
+    });
+  });
+
+  it("does not attach team query parameters to get_auth_user or list_teams", async () => {
+    const urls: string[] = [];
+    const fetcher = jsonFetcher((url) => {
+      urls.push(`${url.pathname}${url.search}`);
+      if (url.pathname === "/v2/user") {
+        return { user: { id: "usr_1", name: "Alice" } };
+      }
+      return { teams: [{ id: "team_123", slug: "acme", name: "Acme" }] };
+    });
+
+    await vercelActionHandlers.get_auth_user({}, actionContext(fetcher, { teamId: "team_123" }));
+    await vercelActionHandlers.list_teams({ limit: 2 }, actionContext(fetcher, { teamId: "team_123" }));
+
+    expect(urls).toEqual(["/v2/user", "/v2/teams?limit=2"]);
+  });
+
+  it("looks up get_team by path and leaves team query parameters off", async () => {
+    let requestUrl = "";
+    const result = await vercelActionHandlers.get_team(
+      { teamId: "acme" },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { id: "team_123", slug: "acme", name: "Acme" };
+        }),
+        { teamId: "team_default" },
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v2/teams/acme");
+    expect(url.search).toBe("");
+    expect(result).toEqual({
+      team: { id: "team_123", slug: "acme", name: "Acme" },
+    });
+  });
+
+  it("sends teamId as a query parameter when listing team webhooks", async () => {
+    let requestUrl = "";
+    await vercelActionHandlers.list_webhooks(
+      { teamId: "team_123" },
+      actionContext(
+        jsonFetcher((url) => {
+          requestUrl = url.toString();
+          return { webhooks: [{ id: "hook_1", url: "https://example.com/hook" }] };
+        }),
+      ),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v1/webhooks");
+    expect(url.searchParams.get("teamId")).toBe("team_123");
+  });
+
+  it("sends teamId as a query parameter when deleting a team webhook", async () => {
+    let requestUrl = "";
+    const deleted = await vercelActionHandlers.delete_webhook(
+      { id: "account_hook_abc", teamId: "team_123" },
+      actionContext(async (url, init) => {
+        requestUrl = String(url);
+        expect(init?.method).toBe("DELETE");
+        return new Response(null, { status: 204 });
+      }),
+    );
+
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/v1/webhooks/account_hook_abc");
+    expect(url.searchParams.get("teamId")).toBe("team_123");
+    expect(deleted).toEqual({ deleted: true });
+  });
+});
 
 describe("Vercel webhook actions", () => {
   it("deletes a webhook and normalizes a 204 No Content response", async () => {

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -74,20 +74,42 @@ describe("Vercel team scope", () => {
     });
   });
 
-  it("validates an optional team slug through the teams path", async () => {
+  it("validates an optional team slug with the slug query parameter", async () => {
     const result = await validateVercelCredential(
       { apiKey, values: { slug: "acme" } },
       jsonFetcher((url) => {
         if (url.pathname === "/v2/user") {
           return { user: { id: "usr_1", name: "Alice" } };
         }
-        expect(url.pathname).toBe("/v2/teams/acme");
+        expect(url.pathname).toBe("/v2/teams");
+        expect(url.searchParams.get("slug")).toBe("acme");
         return { id: "team_123", slug: "acme", name: "Acme" };
       }),
     );
 
     expect(result.profile).toEqual({ accountId: "team_123", displayName: "Acme" });
     expect(result.metadata.teamSlug).toBe("acme");
+  });
+
+  it("selects the matching team when slug lookup returns a team list", async () => {
+    const result = await validateVercelCredential(
+      { apiKey, values: { slug: "acme" } },
+      jsonFetcher((url) => {
+        if (url.pathname === "/v2/user") {
+          return { user: { id: "usr_1", name: "Alice" } };
+        }
+        expect(url.pathname).toBe("/v2/teams");
+        expect(url.searchParams.get("slug")).toBe("acme");
+        return {
+          teams: [
+            { id: "team_other", slug: "other", name: "Other" },
+            { id: "team_123", slug: "acme", name: "Acme" },
+          ],
+        };
+      }),
+    );
+
+    expect(result.profile).toEqual({ accountId: "team_123", displayName: "Acme" });
   });
 });
 

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { vercelActions } from "./actions.ts";
 import { credentialValidators } from "./executors.ts";
 import { readVercelTeamScope, validateVercelCredential, vercelActionHandlers } from "./runtime.ts";
 
@@ -18,6 +20,26 @@ function jsonFetcher(handler: (url: URL, init?: RequestInit) => unknown): typeof
 function vercelError(status: number, message: string): Response {
   return Response.json({ error: { code: "not_found", message } }, { status });
 }
+
+describe("Vercel team scope schemas", () => {
+  it("requires exactly one team selector for get_team", () => {
+    const action = vercelActions.find(({ name }) => name === "get_team")!;
+
+    expect(validateActionInput(action, {}).valid).toBe(false);
+    expect(validateActionInput(action, { teamId: "team_123" }).valid).toBe(true);
+    expect(validateActionInput(action, { slug: "acme" }).valid).toBe(true);
+    expect(validateActionInput(action, { teamId: "team_123", slug: "acme" }).valid).toBe(false);
+  });
+
+  it("allows at most one team selector for team-scoped actions", () => {
+    const action = vercelActions.find(({ name }) => name === "list_projects")!;
+
+    expect(validateActionInput(action, {}).valid).toBe(true);
+    expect(validateActionInput(action, { teamId: "team_123" }).valid).toBe(true);
+    expect(validateActionInput(action, { slug: "acme" }).valid).toBe(true);
+    expect(validateActionInput(action, { teamId: "team_123", slug: "acme" }).valid).toBe(false);
+  });
+});
 
 describe("Vercel team scope", () => {
   it("rejects credential extra fields that set both teamId and slug", () => {

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -255,6 +255,23 @@ describe("Vercel team-scoped REST queries", () => {
     });
   });
 
+  it("rejects credential context that sets both teamId and slug when action input omits both", async () => {
+    await expect(
+      vercelActionHandlers.list_projects(
+        { limit: 5 },
+        actionContext(
+          async () => {
+            throw new Error("fetch should not run");
+          },
+          { teamId: "team_123", slug: "acme" },
+        ),
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "teamId and slug cannot both be provided",
+    });
+  });
+
   it("does not attach team query parameters to get_auth_user or list_teams", async () => {
     const urls: string[] = [];
     const fetcher = jsonFetcher((url) => {

--- a/src/providers/vercel/runtime.test.ts
+++ b/src/providers/vercel/runtime.test.ts
@@ -74,41 +74,68 @@ describe("Vercel team scope", () => {
     });
   });
 
-  it("validates an optional team slug with the slug query parameter", async () => {
+  it("resolves a credential slug through the team list before GET /v2/teams/{teamId}", async () => {
+    const urls: string[] = [];
     const result = await validateVercelCredential(
       { apiKey, values: { slug: "acme" } },
       jsonFetcher((url) => {
+        urls.push(`${url.pathname}${url.search}`);
         if (url.pathname === "/v2/user") {
           return { user: { id: "usr_1", name: "Alice" } };
         }
-        expect(url.pathname).toBe("/v2/teams");
-        expect(url.searchParams.get("slug")).toBe("acme");
+        if (url.pathname === "/v2/teams") {
+          expect(url.searchParams.has("slug")).toBe(false);
+          return {
+            teams: [
+              { id: "team_other", slug: "other", name: "Other" },
+              { id: "team_123", slug: "acme", name: "Acme" },
+            ],
+            pagination: { count: 2, next: null, prev: null },
+          };
+        }
+        expect(url.pathname).toBe("/v2/teams/team_123");
+        expect(url.search).toBe("");
         return { id: "team_123", slug: "acme", name: "Acme" };
       }),
     );
 
+    expect(urls).toEqual(["/v2/user", "/v2/teams?limit=100", "/v2/teams/team_123"]);
     expect(result.profile).toEqual({ accountId: "team_123", displayName: "Acme" });
     expect(result.metadata.teamSlug).toBe("acme");
   });
 
-  it("selects the matching team when slug lookup returns a team list", async () => {
+  it("paginates the team list until the credential slug is found", async () => {
+    const urls: string[] = [];
     const result = await validateVercelCredential(
       { apiKey, values: { slug: "acme" } },
       jsonFetcher((url) => {
+        urls.push(`${url.pathname}${url.search}`);
         if (url.pathname === "/v2/user") {
           return { user: { id: "usr_1", name: "Alice" } };
         }
-        expect(url.pathname).toBe("/v2/teams");
-        expect(url.searchParams.get("slug")).toBe("acme");
-        return {
-          teams: [
-            { id: "team_other", slug: "other", name: "Other" },
-            { id: "team_123", slug: "acme", name: "Acme" },
-          ],
-        };
+        if (url.pathname === "/v2/teams" && !url.searchParams.get("until")) {
+          return {
+            teams: [{ id: "team_other", slug: "other", name: "Other" }],
+            pagination: { count: 1, next: 1_700_000_000_000, prev: null },
+          };
+        }
+        if (url.pathname === "/v2/teams") {
+          expect(url.searchParams.get("until")).toBe("1700000000000");
+          return {
+            teams: [{ id: "team_123", slug: "acme", name: "Acme" }],
+            pagination: { count: 1, next: null, prev: null },
+          };
+        }
+        return { id: "team_123", slug: "acme", name: "Acme" };
       }),
     );
 
+    expect(urls).toEqual([
+      "/v2/user",
+      "/v2/teams?limit=100",
+      "/v2/teams?limit=100&until=1700000000000",
+      "/v2/teams/team_123",
+    ]);
     expect(result.profile).toEqual({ accountId: "team_123", displayName: "Acme" });
   });
 });
@@ -244,10 +271,10 @@ describe("Vercel team-scoped REST queries", () => {
     expect(urls).toEqual(["/v2/user", "/v2/teams?limit=2"]);
   });
 
-  it("looks up get_team by path and leaves team query parameters off", async () => {
+  it("looks up get_team by team ID path and leaves query parameters off", async () => {
     let requestUrl = "";
     const result = await vercelActionHandlers.get_team(
-      { teamId: "acme" },
+      { teamId: "team_123" },
       actionContext(
         jsonFetcher((url) => {
           requestUrl = url.toString();
@@ -258,8 +285,30 @@ describe("Vercel team-scoped REST queries", () => {
     );
 
     const url = new URL(requestUrl);
-    expect(url.pathname).toBe("/v2/teams/acme");
+    expect(url.pathname).toBe("/v2/teams/team_123");
     expect(url.search).toBe("");
+    expect(result).toEqual({
+      team: { id: "team_123", slug: "acme", name: "Acme" },
+    });
+  });
+
+  it("resolves get_team slug through the team list before GET /v2/teams/{teamId}", async () => {
+    const urls: string[] = [];
+    const result = await vercelActionHandlers.get_team(
+      { slug: "acme" },
+      actionContext(
+        jsonFetcher((url) => {
+          urls.push(`${url.pathname}${url.search}`);
+          if (url.pathname === "/v2/teams") {
+            return { teams: [{ id: "team_123", slug: "acme", name: "Acme" }] };
+          }
+          expect(url.pathname).toBe("/v2/teams/team_123");
+          return { id: "team_123", slug: "acme", name: "Acme" };
+        }),
+      ),
+    );
+
+    expect(urls).toEqual(["/v2/teams?limit=100", "/v2/teams/team_123"]);
     expect(result).toEqual({
       team: { id: "team_123", slug: "acme", name: "Acme" },
     });

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -183,20 +183,46 @@ async function validateVercelTeam(
   fetcher: typeof fetch,
   teamScope: VercelTeamScope,
 ): Promise<VercelTeam> {
-  const idOrSlug = teamScope.teamId ?? teamScope.slug;
-  if (!idOrSlug) {
+  if (teamScope.teamId) {
+    const payload = await requestVercelJson<VercelTeamResponse>({
+      path: `/v2/teams/${encodeURIComponent(teamScope.teamId)}`,
+      apiKey,
+      fetcher,
+      mode: "validate",
+      notFoundAsInvalidInput: true,
+    });
+    return normalizeVercelTeam(payload);
+  }
+
+  const slug = teamScope.slug;
+  if (!slug) {
     throw new ProviderRequestError(400, "teamId or slug is required");
   }
 
-  const payload = await requestVercelJson<VercelTeamResponse>({
-    path: `/v2/teams/${encodeURIComponent(idOrSlug)}`,
+  const payload = await requestVercelJson<VercelTeamResponse | { teams?: unknown[] }>({
+    path: "/v2/teams",
     apiKey,
     fetcher,
     mode: "validate",
+    query: queryParams({ slug }),
     notFoundAsInvalidInput: true,
   });
 
-  return normalizeVercelTeam(payload);
+  return readTeamFromSlugLookup(payload, slug);
+}
+
+function readTeamFromSlugLookup(payload: VercelTeamResponse | { teams?: unknown[] }, slug: string): VercelTeam {
+  const record = optionalRecord(payload);
+  const teams = Array.isArray(record?.teams) ? record.teams : undefined;
+  if (teams) {
+    const match = teams.find((item) => optionalString(optionalRecord(item)?.slug) === slug);
+    if (!match) {
+      throw new ProviderRequestError(400, "vercel team slug was not found");
+    }
+    return normalizeVercelTeam(match as VercelTeamResponse);
+  }
+
+  return normalizeVercelTeam(payload as VercelTeamResponse);
 }
 
 function resolveTeamScope(input: VercelActionInput, context: VercelActionContext): VercelTeamScope {

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -178,51 +178,108 @@ export function readVercelTeamScope(source: Record<string, unknown> | undefined)
   return compactObject({ teamId, slug });
 }
 
+const vercelTeamListPageSize = 100;
+const vercelTeamListMaxPages = 20;
+
 async function validateVercelTeam(
   apiKey: string,
   fetcher: typeof fetch,
   teamScope: VercelTeamScope,
 ): Promise<VercelTeam> {
-  if (teamScope.teamId) {
-    const payload = await requestVercelJson<VercelTeamResponse>({
-      path: `/v2/teams/${encodeURIComponent(teamScope.teamId)}`,
-      apiKey,
-      fetcher,
-      mode: "validate",
-      notFoundAsInvalidInput: true,
-    });
-    return normalizeVercelTeam(payload);
-  }
-
-  const slug = teamScope.slug;
-  if (!slug) {
-    throw new ProviderRequestError(400, "teamId or slug is required");
-  }
-
-  const payload = await requestVercelJson<VercelTeamResponse | { teams?: unknown[] }>({
-    path: "/v2/teams",
+  const teamId = await resolveVercelTeamId({
+    teamScope,
     apiKey,
     fetcher,
     mode: "validate",
-    query: queryParams({ slug }),
-    notFoundAsInvalidInput: true,
   });
-
-  return readTeamFromSlugLookup(payload, slug);
+  return requestVercelTeamById({
+    teamId,
+    apiKey,
+    fetcher,
+    mode: "validate",
+  });
 }
 
-function readTeamFromSlugLookup(payload: VercelTeamResponse | { teams?: unknown[] }, slug: string): VercelTeam {
-  const record = optionalRecord(payload);
-  const teams = Array.isArray(record?.teams) ? record.teams : undefined;
-  if (teams) {
-    const match = teams.find((item) => optionalString(optionalRecord(item)?.slug) === slug);
-    if (!match) {
-      throw new ProviderRequestError(400, "vercel team slug was not found");
+async function resolveVercelTeamId(options: {
+  teamScope: VercelTeamScope;
+  apiKey: string;
+  fetcher: typeof fetch;
+  mode: "validate" | "execute";
+}): Promise<string> {
+  if (options.teamScope.teamId) {
+    return options.teamScope.teamId;
+  }
+  if (!options.teamScope.slug) {
+    throw new ProviderRequestError(400, "teamId or slug is required");
+  }
+  return findTeamIdBySlug({
+    slug: options.teamScope.slug,
+    apiKey: options.apiKey,
+    fetcher: options.fetcher,
+    mode: options.mode,
+  });
+}
+
+async function findTeamIdBySlug(options: {
+  slug: string;
+  apiKey: string;
+  fetcher: typeof fetch;
+  mode: "validate" | "execute";
+}): Promise<string> {
+  let until: number | undefined;
+
+  for (let page = 0; page < vercelTeamListMaxPages; page += 1) {
+    const payload = await requestVercelJson<{
+      teams?: unknown[];
+      pagination?: { next?: unknown };
+    }>({
+      path: "/v2/teams",
+      apiKey: options.apiKey,
+      fetcher: options.fetcher,
+      mode: options.mode,
+      query: queryParams({
+        limit: vercelTeamListPageSize,
+        until,
+      }),
+    });
+
+    const teams = normalizeArray(payload.teams);
+    for (const item of teams) {
+      const team = optionalRecord(item);
+      if (optionalString(team?.slug) !== options.slug) {
+        continue;
+      }
+      const teamId = optionalString(team?.id);
+      if (!teamId) {
+        throw new ProviderRequestError(502, "vercel team response is missing id");
+      }
+      return teamId;
     }
-    return normalizeVercelTeam(match as VercelTeamResponse);
+
+    const next = optionalNumber(optionalRecord(payload.pagination)?.next);
+    if (next == null || teams.length === 0) {
+      break;
+    }
+    until = next;
   }
 
-  return normalizeVercelTeam(payload as VercelTeamResponse);
+  throw new ProviderRequestError(400, "vercel team slug was not found");
+}
+
+async function requestVercelTeamById(options: {
+  teamId: string;
+  apiKey: string;
+  fetcher: typeof fetch;
+  mode: "validate" | "execute";
+}): Promise<VercelTeam> {
+  const payload = await requestVercelJson<VercelTeamResponse>({
+    path: `/v2/teams/${encodeURIComponent(options.teamId)}`,
+    apiKey: options.apiKey,
+    fetcher: options.fetcher,
+    mode: options.mode,
+    notFoundAsInvalidInput: true,
+  });
+  return normalizeVercelTeam(payload);
 }
 
 function resolveTeamScope(input: VercelActionInput, context: VercelActionContext): VercelTeamScope {
@@ -284,17 +341,20 @@ async function vercelListTeams(input: VercelActionInput, context: VercelActionCo
 }
 
 async function vercelGetTeam(input: VercelActionInput, context: VercelActionContext) {
-  const teamId = requireString(input.teamId, "teamId");
-  const payload = await requestVercelJson<VercelTeamResponse>({
-    path: `/v2/teams/${encodeURIComponent(teamId)}`,
+  const teamId = await resolveVercelTeamId({
+    teamScope: readVercelTeamScope(input),
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    notFoundAsInvalidInput: true,
   });
 
   return {
-    team: normalizeVercelTeam(payload),
+    team: await requestVercelTeamById({
+      teamId,
+      apiKey: context.apiKey,
+      fetcher: context.fetcher,
+      mode: "execute",
+    }),
   };
 }
 

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -1,3 +1,4 @@
+import type { QueryValue } from "../../core/request.ts";
 import type { VercelActionName } from "./actions.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
@@ -23,7 +24,12 @@ interface VercelTeam {
 
 type VercelActionHandler = (input: VercelActionInput, context: VercelActionContext) => Promise<unknown>;
 
-export interface VercelActionContext {
+export interface VercelTeamScope {
+  teamId?: string;
+  slug?: string;
+}
+
+export interface VercelActionContext extends VercelTeamScope {
   apiKey: string;
   fetcher: typeof fetch;
 }
@@ -106,7 +112,7 @@ export const vercelActionHandlers: Record<VercelActionName, VercelActionHandler>
 };
 
 export async function validateVercelCredential(
-  apiKey: string,
+  input: { apiKey: string; values: Record<string, string> },
   fetcher: typeof fetch,
 ): Promise<{
   profile: {
@@ -116,26 +122,32 @@ export async function validateVercelCredential(
   grantedScopes: string[];
   metadata: Record<string, unknown>;
 }> {
-  // TODO(vercel-team-id): restore default team validation when Team ID support returns.
+  const teamScope = readVercelTeamScope(input.values);
   const user = await requestVercelJson<VercelUserResponse>({
     path: "/v2/user",
-    apiKey,
+    apiKey: input.apiKey,
     fetcher,
     mode: "validate",
   }).then((payload) => normalizeVercelUser(payload));
 
+  const team =
+    teamScope.teamId || teamScope.slug ? await validateVercelTeam(input.apiKey, fetcher, teamScope) : undefined;
+
   return {
     profile: {
-      accountId: user.id,
-      displayName: userLabel(user),
+      accountId: team?.id ?? user.id,
+      displayName: team ? (team.name ?? team.slug ?? userLabel(user)) : userLabel(user),
     },
     grantedScopes: [],
     metadata: compactObject({
-      validationEndpoint: "/v2/user",
+      validationEndpoint: team ? `/v2/teams/${team.id}` : "/v2/user",
       userId: user.id,
       username: user.username,
       email: user.email,
       name: user.name,
+      teamId: team?.id,
+      teamSlug: team?.slug,
+      teamName: team?.name,
     }),
   };
 }
@@ -151,6 +163,64 @@ export async function executeVercelAction(
   }
 
   return handler(input, context);
+}
+
+/**
+ * Read optional Vercel `teamId` or `slug` from credential extra fields or action input.
+ * Official REST APIs accept one of these query parameters, not both.
+ */
+export function readVercelTeamScope(source: Record<string, unknown> | undefined): VercelTeamScope {
+  const teamId = optionalString(source?.teamId);
+  const slug = optionalString(source?.slug);
+  if (teamId && slug) {
+    throw new ProviderRequestError(400, "teamId and slug cannot both be provided");
+  }
+  return compactObject({ teamId, slug });
+}
+
+async function validateVercelTeam(
+  apiKey: string,
+  fetcher: typeof fetch,
+  teamScope: VercelTeamScope,
+): Promise<VercelTeam> {
+  const idOrSlug = teamScope.teamId ?? teamScope.slug;
+  if (!idOrSlug) {
+    throw new ProviderRequestError(400, "teamId or slug is required");
+  }
+
+  const payload = await requestVercelJson<VercelTeamResponse>({
+    path: `/v2/teams/${encodeURIComponent(idOrSlug)}`,
+    apiKey,
+    fetcher,
+    mode: "validate",
+    notFoundAsInvalidInput: true,
+  });
+
+  return normalizeVercelTeam(payload);
+}
+
+function resolveTeamScope(input: VercelActionInput, context: VercelActionContext): VercelTeamScope {
+  const fromInput = readVercelTeamScope(input);
+  if (fromInput.teamId || fromInput.slug) {
+    return fromInput;
+  }
+  return compactObject({
+    teamId: optionalString(context.teamId),
+    slug: optionalString(context.slug),
+  });
+}
+
+function teamQuery(
+  input: VercelActionInput,
+  context: VercelActionContext,
+  extra: Record<string, QueryValue> = {},
+): Record<string, string> {
+  const teamScope = resolveTeamScope(input, context);
+  return queryParams({
+    ...extra,
+    teamId: teamScope.teamId,
+    slug: teamScope.slug,
+  });
 }
 
 async function vercelGetAuthUser(_input: VercelActionInput, context: VercelActionContext) {
@@ -211,7 +281,7 @@ async function vercelListProjects(input: VercelActionInput, context: VercelActio
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       limit: optionalNumber(input.limit),
       since: optionalNumber(input.since),
       until: optionalNumber(input.until),
@@ -232,6 +302,7 @@ async function vercelGetProject(input: VercelActionInput, context: VercelActionC
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -247,6 +318,7 @@ async function vercelCreateProject(input: VercelActionInput, context: VercelActi
     fetcher: context.fetcher,
     mode: "execute",
     method: "POST",
+    query: teamQuery(input, context),
     body: jsonObject({
       name: optionalString(input.name),
       framework: optionalString(input.framework),
@@ -275,6 +347,7 @@ async function vercelUpdateProject(input: VercelActionInput, context: VercelActi
     fetcher: context.fetcher,
     mode: "execute",
     method: "PATCH",
+    query: teamQuery(input, context),
     body: jsonObject({
       name: optionalString(input.name),
       framework: optionalString(input.framework),
@@ -305,7 +378,7 @@ async function vercelListDeployments(input: VercelActionInput, context: VercelAc
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       limit: optionalNumber(input.limit),
       projectId: optionalString(input.projectId),
       since: optionalNumber(input.since),
@@ -328,7 +401,7 @@ async function vercelGetDeployment(input: VercelActionInput, context: VercelActi
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       withGitRepoInfo: optionalBoolean(input.withGitRepoInfo),
     }),
     notFoundAsInvalidInput: true,
@@ -346,7 +419,7 @@ async function vercelGetDeploymentEvents(input: VercelActionInput, context: Verc
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       builds: queryFlag(optionalBoolean(input.builds)),
       direction: optionalString(input.direction),
       limit: optionalNumber(input.limit),
@@ -369,6 +442,7 @@ async function vercelGetRuntimeLogs(input: VercelActionInput, context: VercelAct
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -384,7 +458,7 @@ async function vercelListProjectEnvs(input: VercelActionInput, context: VercelAc
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       customEnvironmentId: optionalString(input.customEnvironmentId),
       gitBranch: optionalString(input.gitBranch),
     }),
@@ -405,6 +479,7 @@ async function vercelCreateProjectEnv(input: VercelActionInput, context: VercelA
     fetcher: context.fetcher,
     mode: "execute",
     method: "POST",
+    query: teamQuery(input, context),
     body: jsonObject({
       key: optionalString(input.key),
       value: optionalString(input.value),
@@ -431,6 +506,7 @@ async function vercelUpdateProjectEnv(input: VercelActionInput, context: VercelA
     fetcher: context.fetcher,
     mode: "execute",
     method: "PATCH",
+    query: teamQuery(input, context),
     body: jsonObject({
       key: optionalString(input.key),
       value: optionalString(input.value),
@@ -457,6 +533,7 @@ async function vercelDeleteProjectEnv(input: VercelActionInput, context: VercelA
     fetcher: context.fetcher,
     mode: "execute",
     method: "DELETE",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -475,7 +552,7 @@ async function vercelListProjectDomains(input: VercelActionInput, context: Verce
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
-    query: queryParams({
+    query: teamQuery(input, context, {
       limit: optionalNumber(input.limit),
       since: optionalNumber(input.since),
       until: optionalNumber(input.until),
@@ -499,6 +576,7 @@ async function vercelGetProjectDomain(input: VercelActionInput, context: VercelA
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -515,6 +593,7 @@ async function vercelAddProjectDomain(input: VercelActionInput, context: VercelA
     fetcher: context.fetcher,
     mode: "execute",
     method: "POST",
+    query: teamQuery(input, context),
     body: jsonObject({
       name: optionalString(input.name),
       redirect: optionalString(input.redirect),
@@ -538,6 +617,7 @@ async function vercelVerifyProjectDomain(input: VercelActionInput, context: Verc
     fetcher: context.fetcher,
     mode: "execute",
     method: "POST",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -553,6 +633,7 @@ async function vercelGetDomainConfig(input: VercelActionInput, context: VercelAc
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -570,6 +651,7 @@ async function vercelListWebhooks(input: VercelActionInput, context: VercelActio
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
   });
 
   return {
@@ -584,6 +666,7 @@ async function vercelGetWebhook(input: VercelActionInput, context: VercelActionC
     apiKey: context.apiKey,
     fetcher: context.fetcher,
     mode: "execute",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 
@@ -599,6 +682,7 @@ async function vercelCreateWebhook(input: VercelActionInput, context: VercelActi
     fetcher: context.fetcher,
     mode: "execute",
     method: "POST",
+    query: teamQuery(input, context),
     body: jsonObject({
       url: optionalString(input.url),
       events: normalizeStringArray(input.events),
@@ -619,6 +703,7 @@ async function vercelDeleteWebhook(input: VercelActionInput, context: VercelActi
     fetcher: context.fetcher,
     mode: "execute",
     method: "DELETE",
+    query: teamQuery(input, context),
     notFoundAsInvalidInput: true,
   });
 

--- a/src/providers/vercel/runtime.ts
+++ b/src/providers/vercel/runtime.ts
@@ -287,10 +287,7 @@ function resolveTeamScope(input: VercelActionInput, context: VercelActionContext
   if (fromInput.teamId || fromInput.slug) {
     return fromInput;
   }
-  return compactObject({
-    teamId: optionalString(context.teamId),
-    slug: optionalString(context.slug),
-  });
+  return readVercelTeamScope({ teamId: context.teamId, slug: context.slug });
 }
 
 function teamQuery(


### PR DESCRIPTION
## Summary
- Add optional `teamId`/`slug` as credential extra fields and per-action inputs, sent as official REST query parameters on team-scoped Vercel APIs.
- Personal-account requests stay unscoped when neither is set; action input fully overrides the credential default; `teamId` and `slug` cannot both be provided.
- Credential slug validation and `get_team` resolve the slug through `GET /v2/teams`, then call `GET /v2/teams/{teamId}`. The slug is never used as the team-detail path segment.

## Test plan
- [x] `npx vitest run src/providers/vercel/runtime.test.ts` (22 tests)
- [ ] Personal account: no team fields → REST URLs have no `teamId`/`slug`
- [ ] Team credential default: project, deployment, env, domain, and webhook calls include `?teamId=` or `?slug=`
- [ ] Action input overrides the credential team scope without mixing `teamId` from the credential with `slug` from the action
- [ ] Providing both `teamId` and `slug` is rejected
- [ ] Slug-only credentials list teams, then fetch `GET /v2/teams/{teamId}`
- [ ] `delete_webhook` includes the team query when scoped