### PR TITLE
ci: add provider runtime conformance checks

### DIFF
--- a/.codex/skills/add-provider/SKILL.md
+++ b/.codex/skills/add-provider/SKILL.md
@@ -111,7 +111,7 @@ Create or update `executors.ts` with `ProviderExecutors`:
 - Keep action handlers keyed by provider action names.
 - Preserve provider request semantics: endpoint paths, methods, auth headers, request bodies, query params, pagination, status handling, error mapping, and output normalization.
 - Use `ProviderRequestError` for provider API failures that should become stable execution errors.
-- Use `context.fetcher` / `providerFetch`; add `skipDnsValidation: true` only when every egress host is a hardcoded code-controlled literal.
+- Use `context.fetcher` / `providerFetch` for provider-owned endpoints. For user-supplied content or download URLs, call `assertPublicHttpUrl` without `allowPrivateNetwork` and use the public-only `providerFetch`. Add `skipDnsValidation: true` only when every egress host is a hardcoded code-controlled literal.
 - Use shared request helpers such as `setSearchParams`, `readProviderJson`, and `readProviderText` when they fit existing patterns.
 - Pass `context.signal` and transit file support through provider contexts when the provider needs cancellation or file output.
 

--- a/.codex/skills/add-provider/SKILL.md
+++ b/.codex/skills/add-provider/SKILL.md
@@ -111,6 +111,7 @@ Create or update `executors.ts` with `ProviderExecutors`:
 - Keep action handlers keyed by provider action names.
 - Preserve provider request semantics: endpoint paths, methods, auth headers, request bodies, query params, pagination, status handling, error mapping, and output normalization.
 - Use `ProviderRequestError` for provider API failures that should become stable execution errors.
+- Use `context.fetcher` / `providerFetch`; add `skipDnsValidation: true` only when every egress host is a hardcoded code-controlled literal.
 - Use shared request helpers such as `setSearchParams`, `readProviderJson`, and `readProviderText` when they fit existing patterns.
 - Pass `context.signal` and transit file support through provider contexts when the provider needs cancellation or file output.
 
@@ -143,9 +144,10 @@ Do not add tests that only mirror static declarations such as provider labels, a
 4. Move genuinely generic helper behavior to shared helper modules only after checking existing APIs and downstream call sites.
 5. Run `npm run generate:catalog`.
 6. Run `npm run fix-check`.
-7. Run targeted tests when you changed shared helpers or added provider logic that is not covered by existing loader tests.
-8. Run `npm run build` when you need CI-parity no-fix typechecking or when the task asks for it.
-9. Review diffs for generated noise, non-public wording, copied assets, placeholder fields, and non-lazy imports.
+7. Run `npm run check:conformance` when action lists, executor wiring, or shared provider runtime changed.
+8. Run targeted tests when you changed shared helpers or added provider logic that is not covered by existing loader tests.
+9. Run `npm run build` when you need CI-parity no-fix typechecking or when the task asks for it.
+10. Review diffs for generated noise, non-public wording, copied assets, placeholder fields, and non-lazy imports.
 
 ## Quality Gate
 
@@ -159,6 +161,7 @@ Before finishing, inspect the result against these checks:
 - Generic helper code has a single owner.
 - Provider-local helper code has provider-specific meaning.
 - No generated files were hand-edited.
+- `npm run check:conformance` passes when action ids or executor modules changed.
 - No third-party rights issue was introduced.
 - No non-public product behavior is mentioned.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
 # PR quality gates for OOMOL Connect, run serially in a single job:
-#   1) Lint (oxlint + oxfmt)  ->  2) Typecheck (build)  ->  3) Unit tests (vitest)
+#   1) Lint (oxlint + oxfmt)
+#   2) Typecheck (build)
+#   3) Provider runtime conformance
+#   4) Unit tests (vitest)
 # Serial keeps it simple and fail-fast: dependencies install once and a failing
 # earlier step short-circuits the rest. Also runs on pushes to main so the default
 # branch stays green and the npm cache stays warm for PR runs.
@@ -59,6 +62,12 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      # 3) Unit tests (vitest): covers src and the web workspace.
+      # 3) Provider runtime conformance: catalog action ids match executor keys,
+      #    guarded egress, skipDns vs literal hosts, private-network ratchet,
+      #    and nodeOnly membership. Imports every executor module.
+      - name: Check provider runtime conformance
+        run: npm run check:conformance
+
+      # 4) Unit tests (vitest): covers src and the web workspace.
       - name: Run tests (vitest)
         run: npm test

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["node_modules", "dist", "coverage", "catalog/apps"],
+  "ignorePatterns": ["node_modules", "dist", "coverage", "catalog/apps", "src/providers/registry*.generated.ts"],
   "printWidth": 120,
   "trailingComma": "all",
   "sortImports": {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,5 +14,5 @@
     "builtin": true
   },
   "globals": {},
-  "ignorePatterns": ["dist", "node_modules", "catalog/apps"]
+  "ignorePatterns": ["dist", "node_modules", "catalog/apps", "src/providers/registry*.generated.ts"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@
 ## Verification
 
 - Before finishing code changes, run `npm run fix-check`. It runs lint fixes, formatting fixes, and the `src` typecheck.
+- Run `npm run check:conformance` when changing provider definitions, executors, catalog generation, or shared provider runtime. It compares catalog action ids to executor keys, scans provider sources for unguarded egress, rejects `skipDnsValidation` unless every egress host is a code-controlled literal, and ratchets `allowPrivateNetwork` providers that still lack `assertPublicHttpUrl` / `assertGuardedEgressUrl`.
 - Run `npm run build` only when you need a separate no-fix typecheck, for example after generated files changed or for CI parity.
 - Run `npm run generate:catalog` when provider definitions or actions change.
 - Run provider examples manually when the task changes user-facing example behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Run:
 ```bash
 npm run fix-check
 npm test
+npm run check:conformance
 ```
 
 ## Adding Providers
@@ -27,8 +28,9 @@ Generated files are updated through:
 npm run generate:catalog
 ```
 
-Generated `src/providers/registry.generated.ts` and `catalog/apps/*.json` files are local runtime
-data and are ignored by git.
+Generated `src/providers/registry*.generated.ts` files include lazy executor imports and the
+`executableActionIds` list used to mark actions as locally executable at runtime. Do not hand-edit
+them. `catalog/apps/*.json` files are local runtime data and are ignored by git.
 
 If you use an agent to add providers, the optional workflow in
 [.codex/skills/add-provider/SKILL.md](.codex/skills/add-provider/SKILL.md) follows the same rules.

--- a/docs/catalog-format.md
+++ b/docs/catalog-format.md
@@ -13,12 +13,18 @@ Do not hand-edit generated catalog files as source. Update provider definitions 
 npm run generate:catalog
 ```
 
-At runtime, catalog responses add execution status that is not stored in generated catalog JSON:
+At runtime, catalog responses add execution status that is not stored in generated catalog JSON.
+The Node and Cloudflare servers pass `executableActionIds` from the generated executor registry:
 
-- `locallyExecutable`: the open-source runtime has a local executor for the action.
-- `catalogOnly`: schemas and metadata are available, but no local executor is wired yet.
+- `locallyExecutable`: the action id is in that generated list, so the open-source runtime has a local executor.
+- `catalogOnly`: schemas and metadata are available, but the action id is not in the generated executor list.
 - `needsCredential`: the provider needs a configured local connection before execution.
 - `noAuthRunnable`: the action belongs to a provider that can run without stored credentials.
+
+This repository requires every catalog action to have a matching executor key. `npm run check:conformance`
+compares those sets, scans provider sources for unguarded `fetch` / `WebSocket` usage, rejects
+`skipDnsValidation` unless every egress host is a code-controlled literal, and ratchets
+`allowPrivateNetwork` providers that still lack `assertPublicHttpUrl` / `assertGuardedEgressUrl`.
 
 Action definitions also declare provider-native `requiredScopes` and `providerPermissions`. The
 runtime exposes those fields through HTTP and MCP discovery together with the current connection

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -8,6 +8,12 @@ When documenting a provider, distinguish:
 - Locally executable actions: the open source runtime has an executor for the action.
 - Verified coverage: maintainers have current evidence that the action or provider works against the real upstream API.
 
+This repository requires every catalog action to have a matching local executor. `npm run check:conformance`
+enforces that on Node, rejects `skipDnsValidation` unless every egress host is a
+code-controlled literal, and ratchets `allowPrivateNetwork` providers that still lack
+`assertPublicHttpUrl` or `assertGuardedEgressUrl` (Dokploy is the reference). Cloudflare omits
+`nodeOnly` providers, so those actions appear catalog-only on Workers.
+
 Do not imply that every catalog action is end-to-end verified unless that evidence is available in
 public project artifacts. Prefer verification notes that users can reproduce from this repository,
 such as example scripts, smoke tests, or public status pages.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "vitest": "^4.1.9",
     "wrangler": "^4.114.0"
   },
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "allowScripts": {
     "fsevents@2.3.3": true,
     "esbuild@0.28.1": true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "export:feishu-permissions": "node scripts/export-feishu-permissions.ts",
     "generate:provider": "node scripts/generate-provider.ts",
     "runtime:data": "node scripts/runtime-data.ts",
+    "check:conformance": "node scripts/check-provider-conformance.ts",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt --check .",

--- a/scripts/check-provider-conformance.ts
+++ b/scripts/check-provider-conformance.ts
@@ -1,0 +1,129 @@
+import type { ProviderConformanceFinding } from "../src/providers/provider-conformance.ts";
+import type { ExecutorModule } from "../src/providers/provider-loader.ts";
+
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  assertProviderActionIdentity,
+  diffCatalogAndExecutorKeys,
+  findMissingPrivateNetworkRatchetProviders,
+  findingFromActionExecutorGap,
+  formatConformanceFindings,
+  scanProviderEgressPolicy,
+  scanProviderRuntimeSource,
+  scanProviderSkipDnsPolicy,
+} from "../src/providers/provider-conformance.ts";
+import { loadProviderSources } from "./provider-source.ts";
+
+const providersDir = join(process.cwd(), "src/providers");
+
+const findings: ProviderConformanceFinding[] = [];
+const sources = await loadProviderSources();
+
+for (const source of sources) {
+  assertProviderActionIdentity(source.definition);
+
+  let executorModule: ExecutorModule;
+  try {
+    executorModule = (await import(`../src/providers/${source.service}/executors.ts`)) as ExecutorModule;
+  } catch (error) {
+    findings.push({
+      service: source.service,
+      file: "executors.ts",
+      kind: "catalog_action_mismatch",
+      detail: `failed to import executors.ts: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    continue;
+  }
+
+  if (!executorModule.executors || typeof executorModule.executors !== "object") {
+    findings.push({
+      service: source.service,
+      file: "executors.ts",
+      kind: "catalog_action_mismatch",
+      detail: "executors.ts must export an executors object",
+    });
+    continue;
+  }
+
+  const gap = diffCatalogAndExecutorKeys({
+    service: source.service,
+    catalogActionIds: source.definition.actions.map((action) => action.id),
+    executorKeys: Object.keys(executorModule.executors),
+  });
+  if (gap) {
+    findings.push(findingFromActionExecutorGap(gap));
+  }
+
+  const files = await listProviderTypeScriptFiles(source.service);
+  const sourceFiles = await Promise.all(
+    files.map(async (fileName) => ({
+      fileName,
+      text: await readFile(join(providersDir, source.service, fileName), "utf8"),
+    })),
+  );
+  for (const file of sourceFiles) {
+    findings.push(
+      ...scanProviderRuntimeSource({
+        service: source.service,
+        fileName: file.fileName,
+        nodeOnly: source.nodeOnly,
+        text: file.text,
+      }),
+    );
+  }
+  findings.push(
+    ...scanProviderSkipDnsPolicy({
+      service: source.service,
+      files: sourceFiles.map((file) => ({
+        service: source.service,
+        fileName: file.fileName,
+        nodeOnly: source.nodeOnly,
+        text: file.text,
+      })),
+    }),
+    ...scanProviderEgressPolicy({
+      service: source.service,
+      files: sourceFiles.map((file) => ({
+        service: source.service,
+        fileName: file.fileName,
+        nodeOnly: source.nodeOnly,
+        text: file.text,
+      })),
+    }),
+  );
+}
+
+findings.push(
+  ...findMissingPrivateNetworkRatchetProviders({
+    scannedServices: sources.map((source) => source.service),
+  }),
+);
+
+if (findings.length > 0) {
+  console.error(`Provider runtime conformance failed (${findings.length} finding(s)):`);
+  console.error(formatConformanceFindings(findings));
+  process.exitCode = 1;
+} else {
+  console.log(`Provider runtime conformance passed for ${sources.length} providers.`);
+}
+
+async function listProviderTypeScriptFiles(service: string): Promise<string[]> {
+  return listTypeScriptFiles(join(providersDir, service), "");
+}
+
+async function listTypeScriptFiles(directory: string, relativePrefix: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relativePath = relativePrefix ? `${relativePrefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...(await listTypeScriptFiles(join(directory, entry.name), relativePath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
+}

--- a/scripts/check-provider-conformance.ts
+++ b/scripts/check-provider-conformance.ts
@@ -21,7 +21,16 @@ const findings: ProviderConformanceFinding[] = [];
 const sources = await loadProviderSources();
 
 for (const source of sources) {
-  assertProviderActionIdentity(source.definition);
+  try {
+    assertProviderActionIdentity(source.definition);
+  } catch (error) {
+    findings.push({
+      service: source.service,
+      file: "definition.ts",
+      kind: "catalog_action_mismatch",
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   let executorModule: ExecutorModule;
   try {
@@ -58,39 +67,18 @@ for (const source of sources) {
   const files = await listProviderTypeScriptFiles(source.service);
   const sourceFiles = await Promise.all(
     files.map(async (fileName) => ({
+      service: source.service,
       fileName,
+      nodeOnly: source.nodeOnly,
       text: await readFile(join(providersDir, source.service, fileName), "utf8"),
     })),
   );
   for (const file of sourceFiles) {
-    findings.push(
-      ...scanProviderRuntimeSource({
-        service: source.service,
-        fileName: file.fileName,
-        nodeOnly: source.nodeOnly,
-        text: file.text,
-      }),
-    );
+    findings.push(...scanProviderRuntimeSource(file));
   }
   findings.push(
-    ...scanProviderSkipDnsPolicy({
-      service: source.service,
-      files: sourceFiles.map((file) => ({
-        service: source.service,
-        fileName: file.fileName,
-        nodeOnly: source.nodeOnly,
-        text: file.text,
-      })),
-    }),
-    ...scanProviderEgressPolicy({
-      service: source.service,
-      files: sourceFiles.map((file) => ({
-        service: source.service,
-        fileName: file.fileName,
-        nodeOnly: source.nodeOnly,
-        text: file.text,
-      })),
-    }),
+    ...scanProviderSkipDnsPolicy({ service: source.service, files: sourceFiles }),
+    ...scanProviderEgressPolicy({ service: source.service, files: sourceFiles }),
   );
 }
 

--- a/scripts/generate-provider-registry.ts
+++ b/scripts/generate-provider-registry.ts
@@ -2,6 +2,10 @@ import type { ProviderSource } from "./provider-source.ts";
 
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  assertProviderActionIdentity,
+  executableActionIdsFromProviders,
+} from "../src/providers/provider-conformance.ts";
 import { loadProviderSources } from "./provider-source.ts";
 
 const providersDir = join(process.cwd(), "src/providers");
@@ -10,6 +14,10 @@ const providersDir = join(process.cwd(), "src/providers");
  * Generate provider registries from definitions already loaded by the caller.
  */
 export async function generateProviderRegistries(providerSources: ProviderSource[]): Promise<void> {
+  for (const source of providerSources) {
+    assertProviderActionIdentity(source.definition);
+  }
+
   await Promise.all([
     writeRegistry("registry.generated.ts", providerSources),
     writeRegistry(
@@ -29,6 +37,7 @@ function propertyName(service: string): string {
 
 async function writeRegistry(filename: string, sources: ProviderSource[]): Promise<void> {
   const services = sources.map((source) => source.service);
+  const actionIds = executableActionIdsFromProviders(sources.map((source) => source.definition));
   const lines = [
     'import type { ExecutorModule } from "./provider-loader.ts";',
     "",
@@ -38,6 +47,11 @@ async function writeRegistry(filename: string, sources: ProviderSource[]): Promi
       (service) => `  ${propertyName(service)}: (): Promise<ExecutorModule> => import("./${service}/executors.ts"),`,
     ),
     "};",
+    "",
+    "/** Catalog action ids that have a local executor in this runtime. Do not hand-edit. */",
+    "export const executableActionIds: readonly string[] = [",
+    ...actionIds.map((actionId) => `  ${JSON.stringify(actionId)},`),
+    "];",
   ];
 
   const path = join(providersDir, filename);

--- a/src/catalog-store.test.ts
+++ b/src/catalog-store.test.ts
@@ -73,6 +73,18 @@ describe("catalog store", () => {
     });
   });
 
+  it("marks only listed action ids as locally executable", () => {
+    const catalog = createCatalogStore([providerFixture("example", ["ping", "pong"])], {
+      executableActionIds: ["example.ping"],
+    });
+
+    expect(catalog.actionsById.get("example.ping")?.execution.locallyExecutable).toBe(true);
+    expect(catalog.actionsById.get("example.pong")?.execution).toMatchObject({
+      locallyExecutable: false,
+      catalogOnly: true,
+    });
+  });
+
   it("resolves every action from executable services alongside explicit action ids", () => {
     const providers = [providerFixture("example", ["ping", "pong"]), providerFixture("remote", ["ping"])];
 

--- a/src/catalog-store.ts
+++ b/src/catalog-store.ts
@@ -74,7 +74,12 @@ export interface CreateCatalogStoreOptions {
 }
 
 export interface LoadCatalogOptions extends CreateCatalogStoreOptions {
-  /** Mark every catalog action owned by these locally loaded provider services as executable. */
+  /**
+   * Mark every catalog action owned by these services as executable.
+   *
+   * Production bootstraps pass {@link CreateCatalogStoreOptions.executableActionIds}
+   * generated from the executor registry instead of expanding a whole service.
+   */
   executableServices?: Iterable<string>;
 }
 

--- a/src/providers/aliyun_oss/definition.ts
+++ b/src/providers/aliyun_oss/definition.ts
@@ -2,11 +2,15 @@ import type { ProviderDefinition } from "../../core/types.ts";
 
 import { aliyunOssActions } from "./actions.ts";
 
+export const nodeOnly = true;
+
 const service = "aliyun_oss";
 
 export const provider: ProviderDefinition = {
   service,
   displayName: "Alibaba Cloud OSS",
+  description:
+    "Unavailable on Cloudflare Workers. Alibaba Cloud OSS uses the Node.js ali-oss SDK, so run this provider from the Node.js runtime.",
   categories: ["Storage", "Developer Tools"],
   authTypes: ["custom_credential"],
   auth: [

--- a/src/providers/amplitude/executors.ts
+++ b/src/providers/amplitude/executors.ts
@@ -21,7 +21,6 @@ const service = "amplitude";
 export const executors: ProviderExecutors = defineProviderExecutors<AmplitudeActionContext>({
   service,
   handlers: amplitudeActionHandlers,
-  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<AmplitudeActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =
@@ -44,7 +43,6 @@ export const credentialValidators: CredentialValidators = {
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  skipDnsValidation: true,
   baseUrl: async (context) => {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =

--- a/src/providers/appcues/executors.ts
+++ b/src/providers/appcues/executors.ts
@@ -31,7 +31,6 @@ async function request(suffix: string, method: string, context: Context): Promis
 }
 export const executors: ProviderExecutors = defineProviderExecutors<Context>({
   service: "appcues",
-  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireApiKeyCredential(context, "appcues");
     const apiSecret = credential.values.apiSecret;
@@ -118,5 +117,4 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     if (!headers.has("accept")) headers.set("accept", "application/json");
     if (!headers.has("user-agent")) headers.set("user-agent", providerUserAgent);
   },
-  skipDnsValidation: true,
 });

--- a/src/providers/aws_sts/executors.ts
+++ b/src/providers/aws_sts/executors.ts
@@ -30,7 +30,7 @@ const stsApiVersion = "2011-06-15";
 const awsServiceName = "sts";
 const defaultRegion = "ap-southeast-1";
 const defaultRoleSessionName = "oomol-connect";
-const awsStsFetch = createProviderFetch({ skipDnsValidation: true });
+const awsStsFetch = createProviderFetch();
 
 interface AwsStsContext {
   values: Record<string, string>;
@@ -87,7 +87,6 @@ export const awsStsActionHandlers: Record<string, AwsStsActionHandler> = {
 export const executors: ProviderExecutors = defineProviderExecutors<AwsStsContext>({
   service,
   handlers: awsStsActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AwsStsContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {

--- a/src/providers/pixellab/runtime-ui.ts
+++ b/src/providers/pixellab/runtime-ui.ts
@@ -107,7 +107,7 @@ function normalizeSize(value: unknown, fieldName: string): Record<string, number
 }
 
 function paginatedPath(path: string, input: Record<string, unknown>): string {
-  const url = new URL(`https://placeholder.invalid${path}`);
+  const url = new URL(path, "https://placeholder.invalid");
   const limit = optionalInteger(input.limit);
   const offset = optionalInteger(input.offset);
   if (limit !== undefined) url.searchParams.set("limit", String(limit));

--- a/src/providers/provider-conformance.test.ts
+++ b/src/providers/provider-conformance.test.ts
@@ -193,6 +193,25 @@ describe("scanProviderRuntimeSource", () => {
     ).toEqual(["definition_imports_executors"]);
   });
 
+  it("flags qualified global fetch and WebSocket constructors", () => {
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "runtime.ts",
+        nodeOnly: false,
+        text: `await globalThis.fetch(url);\nnew globalThis.WebSocket(url);\n`,
+      }).map((finding) => finding.kind),
+    ).toEqual(["global_fetch", "raw_websocket"]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "runtime.ts",
+        nodeOnly: false,
+        text: `await self.fetch(url);\nnew window.WebSocket(url);\n`,
+      }).map((finding) => finding.kind),
+    ).toEqual(["global_fetch", "raw_websocket"]);
+  });
+
   it("ignores fetch mentioned in comments and schema copy", () => {
     expect(
       scanProviderRuntimeSource({

--- a/src/providers/provider-conformance.test.ts
+++ b/src/providers/provider-conformance.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertProviderActionIdentity,
+  diffCatalogAndExecutorKeys,
+  executableActionIdsFromProviders,
+  findingFromActionExecutorGap,
+  formatConformanceFindings,
+  scanProviderRuntimeSource,
+  scanProviderSkipDnsPolicy,
+  scanProviderEgressPolicy,
+  findMissingPrivateNetworkRatchetProviders,
+} from "./provider-conformance.ts";
+
+describe("diffCatalogAndExecutorKeys", () => {
+  it("returns undefined when catalog ids and executor keys match", () => {
+    expect(
+      diffCatalogAndExecutorKeys({
+        service: "example",
+        catalogActionIds: ["example.ping", "example.pong"],
+        executorKeys: ["example.pong", "example.ping"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reports catalog-only actions and orphan executor keys", () => {
+    const gap = diffCatalogAndExecutorKeys({
+      service: "example",
+      catalogActionIds: ["example.ping", "example.missing"],
+      executorKeys: ["example.ping", "example.extra"],
+    });
+
+    expect(gap).toEqual({
+      service: "example",
+      catalogOnlyActionIds: ["example.missing"],
+      extraExecutorKeys: ["example.extra"],
+    });
+    expect(findingFromActionExecutorGap(gap!).kind).toBe("catalog_action_mismatch");
+  });
+});
+
+describe("assertProviderActionIdentity", () => {
+  it("accepts stable <service>.<name> action ids", () => {
+    expect(() =>
+      assertProviderActionIdentity({
+        service: "example",
+        displayName: "Example",
+        categories: ["Developer Tools"],
+        authTypes: ["no_auth"],
+        auth: [{ type: "no_auth" }],
+        actions: [
+          {
+            id: "example.ping",
+            service: "example",
+            name: "ping",
+            description: "Ping.",
+            requiredScopes: [],
+            providerPermissions: [],
+            inputSchema: {},
+            outputSchema: {},
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects action ids that do not match the provider service and name", () => {
+    expect(() =>
+      assertProviderActionIdentity({
+        service: "example",
+        displayName: "Example",
+        categories: ["Developer Tools"],
+        authTypes: ["no_auth"],
+        auth: [{ type: "no_auth" }],
+        actions: [
+          {
+            id: "other.ping",
+            service: "example",
+            name: "ping",
+            description: "Ping.",
+            requiredScopes: [],
+            providerPermissions: [],
+            inputSchema: {},
+            outputSchema: {},
+          },
+        ],
+      }),
+    ).toThrow("action id other.ping must be example.ping");
+  });
+});
+
+describe("executableActionIdsFromProviders", () => {
+  it("flattens and sorts action ids without expanding by service", () => {
+    expect(
+      executableActionIdsFromProviders([
+        {
+          service: "zulu",
+          displayName: "Zulu",
+          categories: ["Developer Tools"],
+          authTypes: ["no_auth"],
+          auth: [{ type: "no_auth" }],
+          actions: [
+            {
+              id: "zulu.beta",
+              service: "zulu",
+              name: "beta",
+              description: "Beta.",
+              requiredScopes: [],
+              providerPermissions: [],
+              inputSchema: {},
+              outputSchema: {},
+            },
+          ],
+        },
+        {
+          service: "alpha",
+          displayName: "Alpha",
+          categories: ["Developer Tools"],
+          authTypes: ["no_auth"],
+          auth: [{ type: "no_auth" }],
+          actions: [
+            {
+              id: "alpha.ping",
+              service: "alpha",
+              name: "ping",
+              description: "Ping.",
+              requiredScopes: [],
+              providerPermissions: [],
+              inputSchema: {},
+              outputSchema: {},
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["alpha.ping", "zulu.beta"]);
+  });
+});
+
+describe("scanProviderRuntimeSource", () => {
+  it("allows guarded fetch and skips generate.ts", () => {
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "executors.ts",
+        nodeOnly: false,
+        text: `await context.fetcher("https://example.com");\nawait providerFetch(url);\n`,
+      }),
+    ).toEqual([]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "generate.ts",
+        nodeOnly: false,
+        text: `await fetch("https://example.com/openapi.json");\n`,
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags global fetch, raw WebSocket, and definition/executor cycles", () => {
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "runtime.ts",
+        nodeOnly: false,
+        text: `import { provider } from "./definition.ts";\nawait fetch(url);\nnew WebSocket(url);\n`,
+      }),
+    ).toEqual([
+      {
+        service: "example",
+        file: "runtime.ts",
+        kind: "executors_import_definition",
+        detail: "runtime.ts must not import definition.ts to reuse catalog metadata",
+      },
+      {
+        service: "example",
+        file: "runtime.ts",
+        kind: "global_fetch",
+        detail: "use context.fetcher, providerFetch, or createProviderFetch instead of the global fetch",
+      },
+      {
+        service: "example",
+        file: "runtime.ts",
+        kind: "raw_websocket",
+        detail: "use openGuardedWebSocket instead of new WebSocket",
+      },
+    ]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "definition.ts",
+        nodeOnly: false,
+        text: `import { executors } from "./executors.ts";\n`,
+      }).map((finding) => finding.kind),
+    ).toEqual(["definition_imports_executors"]);
+  });
+
+  it("ignores fetch mentioned in comments and schema copy", () => {
+    expect(
+      scanProviderRuntimeSource({
+        service: "example",
+        fileName: "runtime.ts",
+        nodeOnly: false,
+        text: `// the bytes sent by the proxy's fetch(url) match the SN\nawait context.fetcher(url);\n`,
+      }),
+    ).toEqual([]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "googlephotos",
+        fileName: "actions.ts",
+        nodeOnly: false,
+        text: `mediaItemIds: s.stringArray("The list of media item IDs to fetch (1-50)."),\n`,
+      }),
+    ).toEqual([]);
+  });
+
+  it("requires nodeOnly when a Node-only package is imported", () => {
+    expect(
+      scanProviderRuntimeSource({
+        service: "aliyun_oss",
+        fileName: "executors.ts",
+        nodeOnly: false,
+        text: `import AliOss from "ali-oss";\n`,
+      }).map((finding) => finding.kind),
+    ).toEqual(["node_only_package_unmarked"]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "mailer",
+        fileName: "runtime.ts",
+        nodeOnly: false,
+        text: `import nodemailer from "nodemailer";\n`,
+      }).map((finding) => finding.kind),
+    ).toEqual(["node_only_package_unmarked"]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "feishu",
+        fileName: "shared/mail-runtime.ts",
+        nodeOnly: false,
+        text: `import MailComposer from "nodemailer/lib/mail-composer/index.js";\n`,
+      }),
+    ).toEqual([]);
+    expect(
+      scanProviderRuntimeSource({
+        service: "aliyun_oss",
+        fileName: "executors.ts",
+        nodeOnly: true,
+        text: `import AliOss from "ali-oss";\n`,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("scanProviderSkipDnsPolicy", () => {
+  it("allows skipDnsValidation when the host is a code-controlled literal", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "example",
+        files: [
+          {
+            service: "example",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              const exampleApiHost = "api.example.com";
+              const exampleApiBaseUrl = \`https://\${exampleApiHost}\`;
+              export const executors = defineApiKeyProviderExecutors(service, handlers, { skipDnsValidation: true });
+              export const proxy = defineProviderProxy({ service, baseUrl: exampleApiBaseUrl, skipDnsValidation: true, auth: { type: "bearer" } });
+            `,
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags skipDnsValidation combined with allowPrivateNetwork", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "selfhosted",
+        files: [
+          {
+            service: "selfhosted",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `defineProviderExecutors({ skipDnsValidation: true, allowPrivateNetwork: isPrivateNetworkAccessAllowed });\n`,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host"]);
+  });
+
+  it("flags skipDnsValidation with credential resolvers and interpolated hosts", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "example",
+        files: [
+          {
+            service: "example",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              export const proxy = defineProviderProxy({
+                service,
+                skipDnsValidation: true,
+                baseUrl: credentialProviderProxyBaseUrl("instanceUrl"),
+                auth: { type: "bearer" },
+              });
+            `,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host", "skip_dns_dynamic_host"]);
+
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "aws_sts",
+        files: [
+          {
+            service: "aws_sts",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              const awsStsFetch = createProviderFetch({ skipDnsValidation: true });
+              const url = new URL(\`https://sts.\${region}.amazonaws.com/\`);
+            `,
+          },
+        ],
+      }).map((finding) => finding.detail),
+    ).toEqual([
+      "skipDnsValidation used with interpolated hostname `https://sts.${region}.amazonaws.com/`; only literal hosts may skip DNS",
+    ]);
+  });
+
+  it("allows path glue on a literal hostname", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "pixellab",
+        files: [
+          {
+            service: "pixellab",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `defineApiKeyProviderExecutors("pixellab", handlers, { skipDnsValidation: true });\n`,
+          },
+          {
+            service: "pixellab",
+            fileName: "runtime-ui.ts",
+            nodeOnly: false,
+            text: "const url = new URL(`https://placeholder.invalid${path}`);\n",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags skipDnsValidation on a proxy whose base URL is resolved at request time", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "amplitude",
+        files: [
+          {
+            service: "amplitude",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              export const proxy = defineProviderProxy({
+                service,
+                skipDnsValidation: true,
+                baseUrl: async (context) => resolveAmplitudeCredentialBaseUrl(dataResidency),
+                auth: { type: "none" },
+              });
+            `,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host"]);
+
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "saucelabs",
+        files: [
+          {
+            service: "saucelabs",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              export const proxy = defineProviderProxy({
+                service: "saucelabs",
+                skipDnsValidation: true,
+                async baseUrl(context) {
+                  return resolveSaucelabsCredential(values).apiBaseUrl;
+                },
+              });
+            `,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host"]);
+  });
+
+  it("treats exported typed string constants as code-controlled literals", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "sif",
+        files: [
+          {
+            service: "sif",
+            fileName: "runtime.ts",
+            nodeOnly: false,
+            text: `
+              export const sifMcpOrigin: string = "https://mcp.sif.com";
+              export const sifMcpEndpoint: string = \`\${sifMcpOrigin}/mcp\`;
+            `,
+          },
+          {
+            service: "sif",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              export const executors = defineApiKeyProviderExecutors("sif", handlers, { skipDnsValidation: true });
+              export const proxy = defineProviderProxy({ service: "sif", baseUrl: sifMcpOrigin, skipDnsValidation: true, auth: { type: "bearer" } });
+            `,
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("scanProviderEgressPolicy", () => {
+  it("accepts Dokploy-style private-network opt-in paired with assertPublicHttpUrl", () => {
+    expect(
+      scanProviderEgressPolicy({
+        service: "dokploy",
+        files: [
+          {
+            service: "dokploy",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `defineProviderExecutors({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });\n`,
+          },
+          {
+            service: "dokploy",
+            fileName: "runtime.ts",
+            nodeOnly: false,
+            text: `assertPublicHttpUrl(instanceUrl, { allowPrivateNetwork });\n`,
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a new private-network provider that uses a bespoke host check", () => {
+    expect(
+      scanProviderEgressPolicy({
+        service: "new_selfhost",
+        files: [
+          {
+            service: "new_selfhost",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `defineProviderExecutors({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });\n`,
+          },
+          {
+            service: "new_selfhost",
+            fileName: "runtime.ts",
+            nodeOnly: false,
+            text: `function normalizeBaseUrl(value: string) { return new URL(value).toString(); }\n`,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        service: "new_selfhost",
+        file: "executors.ts",
+        kind: "private_network_without_url_assert",
+        detail:
+          "allowPrivateNetwork requires assertPublicHttpUrl or assertGuardedEgressUrl on the instance URL (see Dokploy)",
+      },
+    ]);
+  });
+
+  it("ratchets existing gaps and fails when the list goes stale", () => {
+    const files = [
+      {
+        service: "legacy",
+        fileName: "executors.ts",
+        nodeOnly: false,
+        text: `defineProviderExecutors({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });\n`,
+      },
+    ];
+    expect(
+      scanProviderEgressPolicy({
+        service: "legacy",
+        knownPrivateNetworkWithoutSharedAssert: ["legacy"],
+        files,
+      }),
+    ).toEqual([]);
+    expect(
+      scanProviderEgressPolicy({
+        service: "legacy",
+        knownPrivateNetworkWithoutSharedAssert: ["legacy"],
+        files: [
+          ...files,
+          {
+            service: "legacy",
+            fileName: "runtime.ts",
+            nodeOnly: false,
+            text: `assertPublicHttpUrl(baseUrl, { allowPrivateNetwork });\n`,
+          },
+        ],
+      }).map((finding) => finding.detail),
+    ).toEqual([
+      "remove legacy from knownPrivateNetworkWithoutSharedAssert; it now calls assertPublicHttpUrl or assertGuardedEgressUrl",
+    ]);
+    expect(
+      scanProviderEgressPolicy({
+        service: "legacy",
+        knownPrivateNetworkWithoutSharedAssert: ["legacy"],
+        files: [
+          { service: "legacy", fileName: "executors.ts", nodeOnly: false, text: `defineProviderExecutors({});\n` },
+        ],
+      }).map((finding) => finding.detail),
+    ).toEqual(["remove legacy from knownPrivateNetworkWithoutSharedAssert; it no longer sets allowPrivateNetwork"]);
+    expect(
+      findMissingPrivateNetworkRatchetProviders({
+        knownPrivateNetworkWithoutSharedAssert: ["legacy"],
+        scannedServices: ["dokploy"],
+      }).map((finding) => finding.detail),
+    ).toEqual(["remove legacy from knownPrivateNetworkWithoutSharedAssert; provider is missing"]);
+  });
+});
+
+describe("formatConformanceFindings", () => {
+  it("renders one finding per line", () => {
+    expect(
+      formatConformanceFindings([
+        { service: "example", file: "runtime.ts", kind: "global_fetch", detail: "use providerFetch" },
+      ]),
+    ).toBe("example/runtime.ts: global_fetch: use providerFetch");
+  });
+});

--- a/src/providers/provider-conformance.test.ts
+++ b/src/providers/provider-conformance.test.ts
@@ -305,6 +305,68 @@ describe("scanProviderSkipDnsPolicy", () => {
     ).toEqual(["skip_dns_dynamic_host"]);
   });
 
+  it("flags shorthand allowPrivateNetwork with skipDnsValidation", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "selfhosted",
+        files: [
+          {
+            service: "selfhosted",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `defineProviderExecutors({ allowPrivateNetwork, skipDnsValidation: true });\n`,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host"]);
+  });
+
+  it("rejects mutable let aliases and concatenated proxy base URLs", () => {
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "example",
+        files: [
+          {
+            service: "example",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              let exampleApiHost = "api.example.com";
+              exampleApiHost = credentialHost;
+              export const proxy = defineProviderProxy({
+                service,
+                baseUrl: \`https://\${exampleApiHost}\`,
+                skipDnsValidation: true,
+                auth: { type: "bearer" },
+              });
+            `,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host", "skip_dns_dynamic_host"]);
+
+    expect(
+      scanProviderSkipDnsPolicy({
+        service: "example",
+        files: [
+          {
+            service: "example",
+            fileName: "executors.ts",
+            nodeOnly: false,
+            text: `
+              export const proxy = defineProviderProxy({
+                service,
+                baseUrl: "https://api.example.com" + pathSuffix,
+                skipDnsValidation: true,
+                auth: { type: "bearer" },
+              });
+            `,
+          },
+        ],
+      }).map((finding) => finding.kind),
+    ).toEqual(["skip_dns_dynamic_host"]);
+  });
+
   it("flags skipDnsValidation with credential resolvers and interpolated hosts", () => {
     expect(
       scanProviderSkipDnsPolicy({

--- a/src/providers/provider-conformance.ts
+++ b/src/providers/provider-conformance.ts
@@ -230,7 +230,7 @@ export function scanProviderSkipDnsPolicy(input: {
   const findings: ProviderConformanceFinding[] = [];
   const joined = sources.map((file) => file.source).join("\n");
 
-  if (/\ballowPrivateNetwork\s*:/.test(joined)) {
+  if (hasAllowPrivateNetwork(joined)) {
     findings.push({
       service: input.service,
       file: skipFiles[0]?.fileName,
@@ -377,11 +377,13 @@ function importsRelativeModule(source: string, moduleName: string): boolean {
 }
 
 function hasBareFetchCall(source: string): boolean {
-  return /(?<![.\w$])fetch\s*\(/.test(source);
+  return /(?<![.\w$])fetch\s*\(/.test(source) || /(?:globalThis|self|window)\.fetch\s*\(/.test(source);
 }
 
 function hasRawWebSocketConstructor(source: string): boolean {
-  return /(?<![.\w$])new\s+WebSocket\s*\(/.test(source);
+  return (
+    /(?<![.\w$])new\s+WebSocket\s*\(/.test(source) || /new\s+(?:globalThis|self|window)\.WebSocket\s*\(/.test(source)
+  );
 }
 
 function hasAllowPrivateNetwork(source: string): boolean {

--- a/src/providers/provider-conformance.ts
+++ b/src/providers/provider-conformance.ts
@@ -1,0 +1,579 @@
+import type { ProviderDefinition } from "../core/types.ts";
+
+/**
+ * Packages that pull in Node-only native APIs and must not enter the
+ * Cloudflare executor registry. Providers that import them, or the shared
+ * `mail/imap-smtp` runtime, export `nodeOnly`. A `nodemailer` root import is
+ * treated as Node SMTP; `nodemailer/lib/mail-composer` is allowed on Workers.
+ */
+export const nodeOnlyRuntimePackages: readonly string[] = ["ali-oss", "imapflow", "nodemailer"];
+
+/**
+ * Self-hosted providers that set `allowPrivateNetwork` but still use a local
+ * host check instead of `assertPublicHttpUrl` / `assertGuardedEgressUrl`.
+ * Remove a name when that provider adopts the Dokploy pattern or drops the
+ * private-network opt-in.
+ */
+export const knownPrivateNetworkWithoutSharedAssert: readonly string[] = [
+  "btcpay_server",
+  "clickhouse",
+  "countly",
+  "easy8",
+  "gong",
+  "home_assistant",
+  "mailcoach",
+  "mqtt",
+  "onlyoffice_docspace",
+  "splunk_http_event_collector",
+];
+
+export type ProviderConformanceScanKind =
+  | "catalog_action_mismatch"
+  | "definition_imports_executors"
+  | "executors_import_definition"
+  | "global_fetch"
+  | "node_only_package_unmarked"
+  | "private_network_without_url_assert"
+  | "raw_websocket"
+  | "skip_dns_dynamic_host";
+
+export interface ProviderActionExecutorGap {
+  catalogOnlyActionIds: string[];
+  extraExecutorKeys: string[];
+  service: string;
+}
+
+export interface ProviderConformanceFinding {
+  detail: string;
+  file?: string;
+  kind: ProviderConformanceScanKind;
+  service: string;
+}
+
+export interface ScanProviderRuntimeSourceInput {
+  fileName: string;
+  nodeOnly: boolean;
+  service: string;
+  text: string;
+}
+
+export interface DiffCatalogAndExecutorKeysInput {
+  catalogActionIds: readonly string[];
+  executorKeys: readonly string[];
+  service: string;
+}
+
+/**
+ * Compare catalog action ids with exported executor keys.
+ *
+ * This repository does not ship catalog-only placeholders: every catalog
+ * action must have a local handler, and every handler must be in the catalog.
+ */
+export function diffCatalogAndExecutorKeys(
+  input: DiffCatalogAndExecutorKeysInput,
+): ProviderActionExecutorGap | undefined {
+  const catalog = new Set(input.catalogActionIds);
+  const executors = new Set(input.executorKeys);
+  const catalogOnlyActionIds = [...catalog].filter((id) => !executors.has(id)).sort((a, b) => a.localeCompare(b));
+  const extraExecutorKeys = [...executors].filter((id) => !catalog.has(id)).sort((a, b) => a.localeCompare(b));
+  if (catalogOnlyActionIds.length === 0 && extraExecutorKeys.length === 0) {
+    return undefined;
+  }
+
+  return {
+    service: input.service,
+    catalogOnlyActionIds,
+    extraExecutorKeys,
+  };
+}
+
+export function findingFromActionExecutorGap(gap: ProviderActionExecutorGap): ProviderConformanceFinding {
+  const parts: string[] = [];
+  if (gap.catalogOnlyActionIds.length > 0) {
+    parts.push(`catalog actions without executors: ${gap.catalogOnlyActionIds.join(", ")}`);
+  }
+  if (gap.extraExecutorKeys.length > 0) {
+    parts.push(`executor keys missing from the catalog: ${gap.extraExecutorKeys.join(", ")}`);
+  }
+
+  return {
+    service: gap.service,
+    kind: "catalog_action_mismatch",
+    detail: parts.join("; "),
+  };
+}
+
+/**
+ * Check that each action id is `<service>.<name>` and belongs to this provider.
+ */
+export function assertProviderActionIdentity(provider: ProviderDefinition): void {
+  const seen = new Set<string>();
+  for (const action of provider.actions) {
+    if (action.service !== provider.service) {
+      throw new Error(
+        `provider ${provider.service}: action ${action.id} has service ${action.service} instead of ${provider.service}`,
+      );
+    }
+    const expectedId = `${provider.service}.${action.name}`;
+    if (action.id !== expectedId) {
+      throw new Error(`provider ${provider.service}: action id ${action.id} must be ${expectedId}`);
+    }
+    if (seen.has(action.id)) {
+      throw new Error(`provider ${provider.service}: duplicate action id ${action.id}`);
+    }
+    seen.add(action.id);
+  }
+}
+
+/**
+ * Collect executable action ids from provider definitions in catalog order.
+ */
+export function executableActionIdsFromProviders(providers: readonly ProviderDefinition[]): string[] {
+  return providers
+    .flatMap((provider) => provider.actions.map((action) => action.id))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Scan one provider source file for runtime-contract violations.
+ *
+ * Skips tests and `generate.ts` (codegen may use the global fetch).
+ */
+export function scanProviderRuntimeSource(input: ScanProviderRuntimeSourceInput): ProviderConformanceFinding[] {
+  const baseName = fileNameOf(input.fileName);
+  if (baseName.endsWith(".test.ts") || baseName === "generate.ts") {
+    return [];
+  }
+
+  const findings: ProviderConformanceFinding[] = [];
+  const source = stripComments(input.text);
+  const callSource = stripStringLiterals(source);
+  const isCatalogDefinition = input.fileName === "definition.ts";
+
+  if (isCatalogDefinition && importsRelativeModule(source, "executors")) {
+    findings.push({
+      service: input.service,
+      file: input.fileName,
+      kind: "definition_imports_executors",
+      detail: "definition.ts must not import executors.ts",
+    });
+  }
+
+  if (!isCatalogDefinition && importsRelativeModule(source, "definition")) {
+    findings.push({
+      service: input.service,
+      file: input.fileName,
+      kind: "executors_import_definition",
+      detail: `${input.fileName} must not import definition.ts to reuse catalog metadata`,
+    });
+  }
+
+  if (hasBareFetchCall(callSource)) {
+    findings.push({
+      service: input.service,
+      file: input.fileName,
+      kind: "global_fetch",
+      detail: "use context.fetcher, providerFetch, or createProviderFetch instead of the global fetch",
+    });
+  }
+
+  if (hasRawWebSocketConstructor(callSource)) {
+    findings.push({
+      service: input.service,
+      file: input.fileName,
+      kind: "raw_websocket",
+      detail: "use openGuardedWebSocket instead of new WebSocket",
+    });
+  }
+
+  if (!input.nodeOnly) {
+    const nodeOnlyImport = findNodeOnlyImport(source);
+    if (nodeOnlyImport) {
+      findings.push({
+        service: input.service,
+        file: input.fileName,
+        kind: "node_only_package_unmarked",
+        detail: `imports ${nodeOnlyImport}; export const nodeOnly = true from definition.ts`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Scan a provider's runtime files for `skipDnsValidation` used against a
+ * non-literal host.
+ *
+ * DNS resolved-address checks may be skipped only when every egress host is a
+ * code-controlled string literal. Credential resolvers, user-supplied URLs,
+ * and interpolated hostnames keep the DNS check as the SSRF defense.
+ */
+export function scanProviderSkipDnsPolicy(input: {
+  files: readonly ScanProviderRuntimeSourceInput[];
+  service: string;
+}): ProviderConformanceFinding[] {
+  const files = input.files.filter((file) => {
+    const baseName = fileNameOf(file.fileName);
+    return !baseName.endsWith(".test.ts") && baseName !== "generate.ts";
+  });
+  const sources = files.map((file) => ({
+    fileName: file.fileName,
+    source: stripComments(file.text),
+  }));
+  const skipFiles = sources.filter((file) => /skipDnsValidation\s*:\s*true/.test(file.source));
+  if (skipFiles.length === 0) {
+    return [];
+  }
+
+  const literalBindings = collectLiteralStringBindings(sources.map((file) => file.source).join("\n"));
+  const findings: ProviderConformanceFinding[] = [];
+  const joined = sources.map((file) => file.source).join("\n");
+
+  if (/\ballowPrivateNetwork\s*:/.test(joined)) {
+    findings.push({
+      service: input.service,
+      file: skipFiles[0]?.fileName,
+      kind: "skip_dns_dynamic_host",
+      detail: "skipDnsValidation cannot combine with allowPrivateNetwork; DNS is the SSRF check for self-hosted hosts",
+    });
+  }
+
+  if (/\bcredentialProviderProxyBaseUrl\s*\(/.test(joined)) {
+    findings.push({
+      service: input.service,
+      file: skipFiles[0]?.fileName,
+      kind: "skip_dns_dynamic_host",
+      detail: "skipDnsValidation cannot combine with credentialProviderProxyBaseUrl; the host comes from credentials",
+    });
+  }
+
+  for (const interpolated of findDynamicHostnameInterpolations(joined, literalBindings)) {
+    findings.push({
+      service: input.service,
+      file: skipFiles[0]?.fileName,
+      kind: "skip_dns_dynamic_host",
+      detail: `skipDnsValidation used with interpolated hostname \`${interpolated}\`; only literal hosts may skip DNS`,
+    });
+  }
+
+  for (const file of skipFiles) {
+    for (const detail of findSkipDnsProxyResolvers(file.source, literalBindings)) {
+      findings.push({
+        service: input.service,
+        file: file.fileName,
+        kind: "skip_dns_dynamic_host",
+        detail,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Scan a provider's runtime files for `allowPrivateNetwork` without the shared
+ * instance-URL assert. Known gaps are ratcheted; new providers and stale list
+ * entries fail.
+ */
+export function scanProviderEgressPolicy(input: {
+  files: readonly ScanProviderRuntimeSourceInput[];
+  knownPrivateNetworkWithoutSharedAssert?: readonly string[];
+  service: string;
+}): ProviderConformanceFinding[] {
+  const known = new Set(input.knownPrivateNetworkWithoutSharedAssert ?? knownPrivateNetworkWithoutSharedAssert);
+  const files = input.files.filter((file) => {
+    const baseName = fileNameOf(file.fileName);
+    return !baseName.endsWith(".test.ts") && baseName !== "generate.ts";
+  });
+  const sources = files.map((file) => ({
+    fileName: file.fileName,
+    source: stripComments(file.text),
+  }));
+  const joined = sources.map((file) => file.source).join("\n");
+  const allowFile = sources.find((file) => hasAllowPrivateNetwork(file.source));
+  const hasSharedAssert = hasSharedInstanceUrlAssert(joined);
+  const onKnownList = known.has(input.service);
+
+  if (allowFile && hasSharedAssert && onKnownList) {
+    return [
+      {
+        service: input.service,
+        file: allowFile.fileName,
+        kind: "private_network_without_url_assert",
+        detail: `remove ${input.service} from knownPrivateNetworkWithoutSharedAssert; it now calls assertPublicHttpUrl or assertGuardedEgressUrl`,
+      },
+    ];
+  }
+
+  if (!allowFile && onKnownList) {
+    return [
+      {
+        service: input.service,
+        kind: "private_network_without_url_assert",
+        detail: `remove ${input.service} from knownPrivateNetworkWithoutSharedAssert; it no longer sets allowPrivateNetwork`,
+      },
+    ];
+  }
+
+  if (allowFile && !hasSharedAssert && !onKnownList) {
+    return [
+      {
+        service: input.service,
+        file: allowFile.fileName,
+        kind: "private_network_without_url_assert",
+        detail:
+          "allowPrivateNetwork requires assertPublicHttpUrl or assertGuardedEgressUrl on the instance URL (see Dokploy)",
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function findMissingPrivateNetworkRatchetProviders(input: {
+  knownPrivateNetworkWithoutSharedAssert?: readonly string[];
+  scannedServices: readonly string[];
+}): ProviderConformanceFinding[] {
+  const known = input.knownPrivateNetworkWithoutSharedAssert ?? knownPrivateNetworkWithoutSharedAssert;
+  const scanned = new Set(input.scannedServices);
+  return known
+    .filter((service) => !scanned.has(service))
+    .map((service) => ({
+      service,
+      kind: "private_network_without_url_assert",
+      detail: `remove ${service} from knownPrivateNetworkWithoutSharedAssert; provider is missing`,
+    }));
+}
+
+export function formatConformanceFindings(findings: readonly ProviderConformanceFinding[]): string {
+  return findings
+    .map((finding) => {
+      const location = finding.file ? `${finding.service}/${finding.file}` : finding.service;
+      return `${location}: ${finding.kind}: ${finding.detail}`;
+    })
+    .join("\n");
+}
+
+function fileNameOf(relativePath: string): string {
+  const separator = relativePath.lastIndexOf("/");
+  return separator === -1 ? relativePath : relativePath.slice(separator + 1);
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function stripStringLiterals(text: string): string {
+  return text
+    .replace(/`(?:\\.|[^`\\])*`/g, " ")
+    .replace(/"(?:\\.|[^"\\])*"/g, " ")
+    .replace(/'(?:\\.|[^'\\])*'/g, " ");
+}
+
+function importsRelativeModule(source: string, moduleName: string): boolean {
+  const pattern = new RegExp(`from\\s+["'](?:\\.\\/|\\.\\.\\/)*${moduleName}(?:\\.ts)?["']`);
+  return pattern.test(source);
+}
+
+function hasBareFetchCall(source: string): boolean {
+  return /(?<![.\w$])fetch\s*\(/.test(source);
+}
+
+function hasRawWebSocketConstructor(source: string): boolean {
+  return /(?<![.\w$])new\s+WebSocket\s*\(/.test(source);
+}
+
+function hasAllowPrivateNetwork(source: string): boolean {
+  return /(?<!\?)\ballowPrivateNetwork\s*:/.test(source);
+}
+
+function hasSharedInstanceUrlAssert(source: string): boolean {
+  return /\b(?:assertPublicHttpUrl|assertGuardedEgressUrl)\s*\(/.test(source);
+}
+
+function findNodeOnlyImport(source: string): string | undefined {
+  for (const packageName of nodeOnlyRuntimePackages) {
+    if (hasPackageImport(source, packageName, packageName !== "nodemailer")) {
+      return packageName;
+    }
+  }
+  if (/from\s+["'][^"']*mail\/imap-smtp(?:\/[^"']*)?["']/.test(source)) {
+    return "mail/imap-smtp";
+  }
+  return undefined;
+}
+
+function hasPackageImport(source: string, packageName: string, includeSubpaths: boolean): boolean {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = includeSubpaths
+    ? new RegExp(`from\\s+["']${escaped}(?:\\/[^"']*)?["']`)
+    : new RegExp(`from\\s+["']${escaped}["']`);
+  return pattern.test(source);
+}
+
+function collectLiteralStringBindings(source: string): Set<string> {
+  const bindings = new Map<string, string>();
+  const bindingPrefix = String.raw`(?:export\s+)?(?:const|let)\s+([A-Za-z_][\w]*)(?:\s*:\s*[^=;]+)?\s*=\s*`;
+  const direct = new RegExp(`${bindingPrefix}(?:["']([^"'\\\\]+)["']|\`([^$\`\\\\]+)\`)`, "g");
+  for (const match of source.matchAll(direct)) {
+    bindings.set(match[1]!, match[2] ?? match[3] ?? "");
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const alias = new RegExp(`${bindingPrefix}\`([^\`]*)\``, "g");
+    for (const match of source.matchAll(alias)) {
+      const name = match[1]!;
+      if (bindings.has(name)) {
+        continue;
+      }
+      const template = match[2]!;
+      const interpolations = [...template.matchAll(/\$\{([A-Za-z_][\w]*)\}/g)].map((entry) => entry[1]!);
+      if (interpolations.length === 0 || interpolations.some((ident) => !bindings.has(ident))) {
+        continue;
+      }
+      bindings.set(name, template);
+      changed = true;
+    }
+  }
+
+  return new Set(bindings.keys());
+}
+
+function findDynamicHostnameInterpolations(source: string, literalBindings: ReadonlySet<string>): string[] {
+  const findings: string[] = [];
+  const pattern = /https?:\/\/[^\s"'`]*/g;
+  for (const match of source.matchAll(pattern)) {
+    const url = match[0];
+    const hostAndPath = url.slice(url.indexOf("://") + 3);
+    const host = hostAndPath.split(/[/?#]/, 1)[0] ?? "";
+    if (!host.includes("${") || isTrailingPathGlueOnLiteralHost(host)) {
+      continue;
+    }
+    const interpolations = [...host.matchAll(/\$\{([A-Za-z_][\w]*)\}/g)].map((entry) => entry[1]!);
+    if (interpolations.length > 0 && interpolations.every((ident) => literalBindings.has(ident))) {
+      continue;
+    }
+    findings.push(url.replace(/\s+/g, " ").slice(0, 80));
+  }
+  return findings;
+}
+
+/**
+ * `https://placeholder.invalid${path}` keeps a literal host; the interpolation
+ * is a path suffix, not a hostname component.
+ */
+function isTrailingPathGlueOnLiteralHost(host: string): boolean {
+  const interpolations = [...host.matchAll(/\$\{[A-Za-z_][\w]*\}/g)];
+  if (interpolations.length !== 1) {
+    return false;
+  }
+  const interpolation = interpolations[0]!;
+  if (interpolation.index === undefined || interpolation.index + interpolation[0].length !== host.length) {
+    return false;
+  }
+  return /^[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(host.slice(0, interpolation.index));
+}
+
+function findSkipDnsProxyResolvers(source: string, literalBindings: ReadonlySet<string>): string[] {
+  const findings: string[] = [];
+  for (const block of extractCallObjectLiterals(source, "defineProviderProxy")) {
+    if (!/skipDnsValidation\s*:\s*true/.test(block)) {
+      continue;
+    }
+    const baseUrl = readObjectProperty(block, "baseUrl");
+    if (baseUrl) {
+      if (isLiteralProxyBaseUrl(baseUrl, literalBindings)) {
+        continue;
+      }
+      findings.push(
+        `skipDnsValidation used with proxy baseUrl resolver \`${trimSnippet(baseUrl)}\`; only literal hosts may skip DNS`,
+      );
+      continue;
+    }
+    if (hasProxyBaseUrlMethod(block)) {
+      findings.push("skipDnsValidation used with a proxy baseUrl method; only literal hosts may skip DNS");
+    }
+  }
+  return findings;
+}
+
+function hasProxyBaseUrlMethod(objectLiteral: string): boolean {
+  return /(?:async\s+)?baseUrl\s*\(/.test(objectLiteral);
+}
+
+function isLiteralProxyBaseUrl(expression: string, literalBindings: ReadonlySet<string>): boolean {
+  const trimmed = expression.trim();
+  if (/^["'`]https?:\/\//.test(trimmed) && !trimmed.includes("${")) {
+    return true;
+  }
+  const ident = /^([A-Za-z_][\w]*)$/.exec(trimmed);
+  return ident !== null && literalBindings.has(ident[1]!);
+}
+
+function readObjectProperty(objectLiteral: string, name: string): string | undefined {
+  const assigned = new RegExp(`${name}\\s*:`).exec(objectLiteral);
+  if (assigned) {
+    return readExpression(objectLiteral.slice(assigned.index + assigned[0].length));
+  }
+  const shorthand = new RegExp(`(?:^|\\{|,)\\s*${name}\\s*(,|})`).exec(objectLiteral);
+  return shorthand ? name : undefined;
+}
+
+function readExpression(source: string): string {
+  const text = source.trimStart();
+  if (text.startsWith("{")) {
+    return extractBalanced(text, "{", "}") ?? text.slice(0, 80);
+  }
+  if (text.startsWith("(") || text.startsWith("async")) {
+    const start = text.indexOf("(");
+    const params = start >= 0 ? extractBalanced(text.slice(start), "(", ")") : undefined;
+    const afterParams = params ? text.slice(start + params.length).trimStart() : text;
+    if (afterParams.startsWith("=>")) {
+      const body = afterParams.slice(2).trimStart();
+      if (body.startsWith("{")) {
+        return `${text.slice(0, start)}${params} => ${extractBalanced(body, "{", "}")}`;
+      }
+    }
+  }
+  const end = text.search(/[,}\n]/);
+  return (end === -1 ? text : text.slice(0, end)).trim();
+}
+
+function extractCallObjectLiterals(source: string, callee: string): string[] {
+  const blocks: string[] = [];
+  const pattern = new RegExp(`${callee}\\s*\\(`, "g");
+  for (const match of source.matchAll(pattern)) {
+    const rest = source.slice(match.index! + match[0].length).trimStart();
+    const object = extractBalanced(rest, "{", "}");
+    if (object) {
+      blocks.push(object);
+    }
+  }
+  return blocks;
+}
+
+function extractBalanced(source: string, open: string, close: string): string | undefined {
+  if (!source.startsWith(open)) {
+    return undefined;
+  }
+  let depth = 0;
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index];
+    if (character === open) {
+      depth += 1;
+    } else if (character === close) {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(0, index + 1);
+      }
+    }
+  }
+  return undefined;
+}
+
+function trimSnippet(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 80);
+}

--- a/src/providers/provider-conformance.ts
+++ b/src/providers/provider-conformance.ts
@@ -387,7 +387,7 @@ function hasRawWebSocketConstructor(source: string): boolean {
 }
 
 function hasAllowPrivateNetwork(source: string): boolean {
-  return /(?<!\?)\ballowPrivateNetwork\s*:/.test(source);
+  return /(?<!\?)\ballowPrivateNetwork\s*:/.test(source) || /(?:^|\{|,)\s*allowPrivateNetwork\s*(?:,|})/.test(source);
 }
 
 function hasSharedInstanceUrlAssert(source: string): boolean {
@@ -416,7 +416,10 @@ function hasPackageImport(source: string, packageName: string, includeSubpaths: 
 
 function collectLiteralStringBindings(source: string): Set<string> {
   const bindings = new Map<string, string>();
-  const bindingPrefix = String.raw`(?:export\s+)?(?:const|let)\s+([A-Za-z_][\w]*)(?:\s*:\s*[^=;]+)?\s*=\s*`;
+  // Only immutable `const` aliases count as code-controlled literals. A `let`
+  // binding can be reassigned to credential or user input after the initial
+  // literal, so it must not unlock `skipDnsValidation`.
+  const bindingPrefix = String.raw`(?:export\s+)?const\s+([A-Za-z_][\w]*)(?:\s*:\s*[^=;]+)?\s*=\s*`;
   const direct = new RegExp(`${bindingPrefix}(?:["']([^"'\\\\]+)["']|\`([^$\`\\\\]+)\`)`, "g");
   for (const match of source.matchAll(direct)) {
     bindings.set(match[1]!, match[2] ?? match[3] ?? "");
@@ -508,7 +511,9 @@ function hasProxyBaseUrlMethod(objectLiteral: string): boolean {
 
 function isLiteralProxyBaseUrl(expression: string, literalBindings: ReadonlySet<string>): boolean {
   const trimmed = expression.trim();
-  if (/^["'`]https?:\/\//.test(trimmed) && !trimmed.includes("${")) {
+  // Require the whole expression to be one string/template literal. Prefix
+  // matches like `"https://api.example.com" + suffix` must not count as literal.
+  if (/^["']https?:\/\/[^"'\\]+["']$/.test(trimmed) || /^`https?:\/\/[^$`\\]+`$/.test(trimmed)) {
     return true;
   }
   const ident = /^([A-Za-z_][\w]*)$/.exec(trimmed);

--- a/src/providers/pushover/runtime.ts
+++ b/src/providers/pushover/runtime.ts
@@ -5,6 +5,7 @@ import type { PushoverActionName } from "./actions.ts";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
+import { openGuardedWebSocket } from "../../core/guarded-websocket.ts";
 import {
   defineApiKeyProviderExecutors,
   ProviderRequestError,
@@ -979,18 +980,26 @@ async function listenPushoverClientWebsocket(input: PushoverActionInput) {
     device_id: string;
     timeout?: number;
   };
-  if (typeof globalThis.WebSocket !== "function") {
-    throw pushoverError("provider_not_configured", "WebSocket is unavailable in this runtime");
-  }
 
   const timeoutSeconds = Math.min(
     Math.max(parsed.timeout ?? pushoverDefaultRealtimeTimeoutSeconds, 1),
     pushoverMaxRealtimeTimeoutSeconds,
   );
 
+  const socket = await openGuardedWebSocket(pushoverRealtimeUrl, {
+    // Host is a hardcoded Pushover literal; DNS checks are redundant here.
+    skipDnsValidation: true,
+    createError: (message) => pushoverError("invalid_input", message, 400),
+    createFailure: (kind, message) => {
+      if (kind === "unsupported") {
+        return pushoverError("provider_not_configured", message);
+      }
+      return pushoverError("provider_error", message, 502);
+    },
+  });
+
   return new Promise<{ events: Array<{ code: string; event: string; description: string }> }>((resolve, reject) => {
     const events: Array<{ code: string; event: string; description: string }> = [];
-    const socket = new globalThis.WebSocket(pushoverRealtimeUrl);
     let settled = false;
     const timeoutHandle = globalThis.setTimeout(() => {
       try {
@@ -1018,10 +1027,6 @@ async function listenPushoverClientWebsocket(input: PushoverActionInput) {
       reject(error);
     }
 
-    socket.addEventListener("open", () => {
-      socket.send(`login:${parsed.device_id}:${parsed.secret}\n`);
-    });
-
     socket.addEventListener("message", (event) => {
       const frames = normalizeWebSocketFrames(event.data);
       for (const frame of frames) {
@@ -1046,6 +1051,12 @@ async function listenPushoverClientWebsocket(input: PushoverActionInput) {
     socket.addEventListener("close", () => {
       settleResolve();
     });
+
+    try {
+      socket.send(`login:${parsed.device_id}:${parsed.secret}\n`);
+    } catch {
+      settleReject(pushoverError("provider_error", "pushover realtime websocket connection failed", 502));
+    }
   });
 }
 

--- a/src/providers/saucelabs/executors.ts
+++ b/src/providers/saucelabs/executors.ts
@@ -32,7 +32,6 @@ const handlers: Record<string, (input: Record<string, unknown>, context: Saucela
 export const executors: ProviderExecutors = defineProviderExecutors({
   service: "saucelabs",
   handlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<SaucelabsContext> {
     const credential = await requireApiKeyCredential(context, "saucelabs");
     return { credential: resolveSaucelabsCredential({ apiKey: credential.apiKey, ...credential.values }), fetcher };
@@ -53,7 +52,6 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     if (!headers.has("accept")) headers.set("accept", "application/json");
     if (!headers.has("user-agent")) headers.set("user-agent", providerUserAgent);
   },
-  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {

--- a/src/providers/sonarcloud/executors.ts
+++ b/src/providers/sonarcloud/executors.ts
@@ -14,7 +14,6 @@ const service = "sonarcloud";
 export const executors: ProviderExecutors = defineProviderExecutors<SonarCloudActionContext>({
   service,
   handlers: sonarCloudActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<SonarCloudActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -34,7 +33,6 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     return resolveSonarCloudApiBaseUrl(credential.metadata.apiBaseUrl ?? credential.values.apiBaseUrl);
   },
   auth: { type: "bearer" },
-  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -13,7 +13,7 @@ import {
   setPrivateNetworkAccessAllowed,
 } from "../core/request.ts";
 import { ProviderLoader } from "../providers/provider-loader.ts";
-import { executorModules } from "../providers/registry.cloudflare.generated.ts";
+import { executableActionIds, executorModules } from "../providers/registry.cloudflare.generated.ts";
 import { isConsoleShellPath } from "./api/console-paths.ts";
 import { loadCatalogFromAssets } from "./cloudflare/catalog-assets.ts";
 import { readPositiveInteger, resolvePublicOrigin } from "./cloudflare/cloudflare-env.ts";
@@ -126,7 +126,7 @@ function loadCatalogOnce(assets: AssetsBinding): Promise<CatalogStore> {
   // under a constant key covers every request.
   return catalogCache.get("", () =>
     loadCatalogFromAssets(assets, {
-      executableServices: Object.keys(executorModules),
+      executableActionIds,
     }),
   );
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,7 +13,7 @@ import {
   setPrivateNetworkAccessAllowed,
 } from "../core/request.ts";
 import { ProviderLoader } from "../providers/provider-loader.ts";
-import { executorModules } from "../providers/registry.generated.ts";
+import { executableActionIds, executorModules } from "../providers/registry.generated.ts";
 import { createRuntimeJwtVerifier } from "./api/runtime-jwt.ts";
 import { registerStaticRoutes } from "./api/static-routes.ts";
 import { createConnectApp } from "./connect-app.ts";
@@ -53,7 +53,7 @@ const builtRoot = join(process.cwd(), "dist/web");
 const staticRoot = await resolveStaticRoot(builtRoot);
 await mkdir(dataDir, { recursive: true });
 const catalog = await loadCatalog(undefined, {
-  executableServices: Object.keys(executorModules),
+  executableActionIds,
 });
 const providerLoader = new ProviderLoader(executorModules);
 const runtimeDatabase = new SqliteRuntimeDatabase(join(dataDir, "connect.sqlite"), {


### PR DESCRIPTION
## Summary
- Add `npm run check:conformance` to CI so catalog action ids must match executor keys, and provider sources cannot use unguarded `fetch` / `WebSocket` or unmarked Node-only packages.
- Reject `skipDnsValidation` unless every egress host is a code-controlled literal; keep DNS checks on credential/region resolvers (`amplitude`, `aws_sts`, `appcues`, `saucelabs`, `sonarcloud`).
- Ratchet `allowPrivateNetwork` providers that still lack `assertPublicHttpUrl` / `assertGuardedEgressUrl` (Dokploy is the reference). Known gaps stay on `knownPrivateNetworkWithoutSharedAssert`.

## Test plan
- [ ] `npx vitest run src/providers/provider-conformance.test.ts`
- [ ] `npm run check:conformance` (1,381 providers)
- [ ] CI step **Check provider runtime conformance** is green


Made with [Cursor](https://cursor.com)