### PR TITLE
fix(oauth): validate credentials with identity endpoints, not resource lists

### DIFF
--- a/src/providers/asana/executors.test.ts
+++ b/src/providers/asana/executors.test.ts
@@ -20,7 +20,6 @@ describe("Asana credentials", () => {
               gid: "123",
               name: "Ada Lovelace",
               email: "ada@example.com",
-              workspaces: [{ gid: "456", name: "Analytical Engine" }],
             },
           });
         },
@@ -32,8 +31,8 @@ describe("Asana credentials", () => {
       grantedScopes: ["default"],
       metadata: {
         validationEndpoint: "/users/me",
-        workspaceCount: 1,
-        workspaceNames: ["Analytical Engine"],
+        userId: "123",
+        email: "ada@example.com",
       },
     });
   });

--- a/src/providers/asana/executors.ts
+++ b/src/providers/asana/executors.ts
@@ -1,7 +1,7 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { AsanaActionHandler } from "./runtime.ts";
 
-import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
+import { compactObject, optionalString, requiredRecord } from "../../core/cast.ts";
 import {
   combineProviderActionHandlers,
   defineBearerProviderExecutors,

--- a/src/providers/asana/executors.ts
+++ b/src/providers/asana/executors.ts
@@ -56,7 +56,7 @@ async function validateAsanaCredential(
     },
     phase: "validate",
     query: {
-      opt_fields: ["name", "email", "workspaces", "workspaces.name"].join(","),
+      opt_fields: ["name", "email"].join(","),
     },
   });
 
@@ -64,12 +64,6 @@ async function validateAsanaCredential(
   const userId = optionalString(user.gid);
   const name = optionalString(user.name);
   const email = optionalString(user.email);
-  const workspaces = Array.isArray(user.workspaces)
-    ? user.workspaces.map((workspace) => optionalRecord(workspace)).filter((workspace) => !!workspace)
-    : [];
-  const workspaceNames = workspaces
-    .map((workspace) => optionalString(workspace.name))
-    .filter((workspaceName) => !!workspaceName);
 
   return {
     profile: {
@@ -83,8 +77,6 @@ async function validateAsanaCredential(
       userId,
       name,
       email,
-      workspaceCount: workspaces.length,
-      workspaceNames,
     }),
   };
 }

--- a/src/providers/baidu_netdisk/runtime-mcp.ts
+++ b/src/providers/baidu_netdisk/runtime-mcp.ts
@@ -25,6 +25,23 @@ const baiduNetdiskListToolByType = {
   image: "file_image_list",
   video: "file_video_list",
 } as const satisfies Record<BaiduNetdiskListType, string>;
+const requiredToolNames = [
+  "file_list",
+  "file_keyword_search",
+  "file_semantics_search",
+  "file_upload_by_content",
+  "file_upload_by_url",
+  "make_dir",
+  "file_copy",
+  "file_move",
+  "file_rename",
+] as const;
+const requiredToolInputProperties = new Map<string, Readonly<Record<string, string>>>([
+  ["file_list", { dir: "string", page: "number" }],
+  ["file_upload_by_content", { content: "string", dir: "string", filename: "string" }],
+  ["file_upload_by_url", { url: "string", dir: "string", filename: "string" }],
+  ["make_dir", { path: "string", rtype: "string" }],
+]);
 const semanticSourceByCode = new Map<number, (typeof baiduNetdiskSemanticMatchSources)[number]>([
   [4, "filename"],
   [5, "image_ocr"],
@@ -40,6 +57,32 @@ export type BaiduNetdiskMcpContext = {
   accessToken: string;
   fetcher: ProviderFetch;
 };
+
+export async function verifyBaiduNetdiskMcpConnection(accessToken: string, fetcher: ProviderFetch): Promise<void> {
+  await withBaiduNetdiskMcpClient(accessToken, fetcher, async (client) => {
+    const result = await client.listTools({}, { timeout: requestTimeoutMs });
+    const toolsByName = new Map(result.tools.map((tool) => [tool.name, tool]));
+    for (const toolName of requiredToolNames) {
+      const tool = toolsByName.get(toolName);
+      if (!tool) {
+        throw new ProviderRequestError(502, `baidu_netdisk MCP server is missing required tool: ${toolName}`);
+      }
+      const properties = tool.inputSchema.properties;
+      for (const [property, expectedType] of Object.entries(requiredToolInputProperties.get(toolName) ?? {})) {
+        const schema = properties?.[property];
+        if (
+          !schema ||
+          typeof schema !== "object" ||
+          Array.isArray(schema) ||
+          !("type" in schema) ||
+          schema.type !== expectedType
+        ) {
+          throw new ProviderRequestError(502, `baidu_netdisk MCP tool ${toolName} has an incompatible input schema`);
+        }
+      }
+    }
+  });
+}
 
 export async function executeBaiduNetdiskMcpAction(
   actionName: string,

--- a/src/providers/baidu_netdisk/runtime-mcp.ts
+++ b/src/providers/baidu_netdisk/runtime-mcp.ts
@@ -25,23 +25,6 @@ const baiduNetdiskListToolByType = {
   image: "file_image_list",
   video: "file_video_list",
 } as const satisfies Record<BaiduNetdiskListType, string>;
-const requiredToolNames = [
-  "file_list",
-  "file_keyword_search",
-  "file_semantics_search",
-  "file_upload_by_content",
-  "file_upload_by_url",
-  "make_dir",
-  "file_copy",
-  "file_move",
-  "file_rename",
-] as const;
-const requiredToolInputProperties = new Map<string, Readonly<Record<string, string>>>([
-  ["file_list", { dir: "string", page: "number" }],
-  ["file_upload_by_content", { content: "string", dir: "string", filename: "string" }],
-  ["file_upload_by_url", { url: "string", dir: "string", filename: "string" }],
-  ["make_dir", { path: "string", rtype: "string" }],
-]);
 const semanticSourceByCode = new Map<number, (typeof baiduNetdiskSemanticMatchSources)[number]>([
   [4, "filename"],
   [5, "image_ocr"],
@@ -57,32 +40,6 @@ export type BaiduNetdiskMcpContext = {
   accessToken: string;
   fetcher: ProviderFetch;
 };
-
-export async function verifyBaiduNetdiskMcpConnection(accessToken: string, fetcher: ProviderFetch): Promise<void> {
-  await withBaiduNetdiskMcpClient(accessToken, fetcher, async (client) => {
-    const result = await client.listTools({}, { timeout: requestTimeoutMs });
-    const toolsByName = new Map(result.tools.map((tool) => [tool.name, tool]));
-    for (const toolName of requiredToolNames) {
-      const tool = toolsByName.get(toolName);
-      if (!tool) {
-        throw new ProviderRequestError(502, `baidu_netdisk MCP server is missing required tool: ${toolName}`);
-      }
-      const properties = tool.inputSchema.properties;
-      for (const [property, expectedType] of Object.entries(requiredToolInputProperties.get(toolName) ?? {})) {
-        const schema = properties?.[property];
-        if (
-          !schema ||
-          typeof schema !== "object" ||
-          Array.isArray(schema) ||
-          !("type" in schema) ||
-          schema.type !== expectedType
-        ) {
-          throw new ProviderRequestError(502, `baidu_netdisk MCP tool ${toolName} has an incompatible input schema`);
-        }
-      }
-    }
-  });
-}
 
 export async function executeBaiduNetdiskMcpAction(
   actionName: string,

--- a/src/providers/canva/executors.test.ts
+++ b/src/providers/canva/executors.test.ts
@@ -67,13 +67,17 @@ describe("Canva regional executors", () => {
       return Response.json({ team_user: { user_id: "user-1", team_id: "team-1" } });
     };
 
-    const result = await createCanvaCredentialValidators("https://api.canva.com/rest").oauth2!(credential, { fetcher });
+    const result = await createCanvaCredentialValidators("https://api.canva.com/rest").oauth2!(
+      { ...credential, metadata: { scope: "profile:read design:meta:read" } },
+      { fetcher },
+    );
 
     expect(calls).toEqual([
       { url: "https://api.canva.com/rest/v1/users/me", authorization: "Bearer test-access-token" },
     ]);
     expect(result).toMatchObject({
       profile: { accountId: "user-1", displayName: "user-1" },
+      grantedScopes: ["profile:read", "design:meta:read"],
       metadata: { validationEndpoint: "/v1/users/me", userId: "user-1", teamId: "team-1" },
     });
   });

--- a/src/providers/canva/executors.test.ts
+++ b/src/providers/canva/executors.test.ts
@@ -2,7 +2,7 @@ import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
-import { createCanvaExecutors } from "./executors.ts";
+import { createCanvaCredentialValidators, createCanvaExecutors } from "./executors.ts";
 
 interface FetchCall {
   url: string;
@@ -55,5 +55,23 @@ describe("Canva regional executors", () => {
       { url: "https://api.canva.cn/rest/v1/users/me", authorization: "Bearer test-access-token" },
       { url: "https://api.canva.cn/rest/v1/users/me/profile", authorization: "Bearer test-access-token" },
     ]);
+  });
+
+  it("validates OAuth with the unscoped current-user endpoint", async () => {
+    const calls: FetchCall[] = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      calls.push({ url: request.url, authorization: request.headers.get("authorization") });
+      expect(request.url).toBe("https://api.canva.com/rest/v1/users/me");
+      return Response.json({ team_user: { user_id: "user-1", team_id: "team-1" } });
+    };
+
+    const result = await createCanvaCredentialValidators("https://api.canva.com/rest").oauth2!(credential, { fetcher });
+
+    expect(calls).toHaveLength(1);
+    expect(result).toMatchObject({
+      profile: { accountId: "user-1", displayName: "user-1" },
+      metadata: { validationEndpoint: "/v1/users/me", userId: "user-1", teamId: "team-1" },
+    });
   });
 });

--- a/src/providers/canva/executors.test.ts
+++ b/src/providers/canva/executors.test.ts
@@ -63,12 +63,15 @@ describe("Canva regional executors", () => {
       const request = input instanceof Request ? input : new Request(input, init);
       calls.push({ url: request.url, authorization: request.headers.get("authorization") });
       expect(request.url).toBe("https://api.canva.com/rest/v1/users/me");
+      expect(request.headers.get("authorization")).toBe("Bearer test-access-token");
       return Response.json({ team_user: { user_id: "user-1", team_id: "team-1" } });
     };
 
     const result = await createCanvaCredentialValidators("https://api.canva.com/rest").oauth2!(credential, { fetcher });
 
-    expect(calls).toHaveLength(1);
+    expect(calls).toEqual([
+      { url: "https://api.canva.com/rest/v1/users/me", authorization: "Bearer test-access-token" },
+    ]);
     expect(result).toMatchObject({
       profile: { accountId: "user-1", displayName: "user-1" },
       metadata: { validationEndpoint: "/v1/users/me", userId: "user-1", teamId: "team-1" },

--- a/src/providers/canva/executors.ts
+++ b/src/providers/canva/executors.ts
@@ -9,6 +9,11 @@ const canvaApiBaseUrl = "https://api.canva.com/rest";
 
 type CanvaActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
 
+interface CanvaUserIdentity {
+  userId?: string;
+  teamId?: string;
+}
+
 /** Build Canva executors for one regional OAuth service and API base URL. */
 export function createCanvaExecutors(service: string, apiBaseUrl: string): ProviderExecutors {
   return defineOAuthProviderExecutors(service, createCanvaActionHandlers(apiBaseUrl));
@@ -34,26 +39,21 @@ export function createCanvaCredentialValidators(apiBaseUrl: string): CredentialV
         },
         apiBaseUrl,
       );
-      const teamUser = optionalRecord(account.team_user) ?? optionalRecord(account.user) ?? {};
-      const userId =
-        optionalString(teamUser.user_id) ??
-        optionalString(teamUser.userId) ??
-        optionalString(teamUser.id) ??
-        optionalString(account.id);
-      if (!userId) {
+      const identity = readCanvaUserIdentity(account);
+      if (!identity.userId) {
         throw new ProviderRequestError(502, "canva current user response is missing user id");
       }
-      const teamId = optionalString(teamUser.team_id) ?? optionalString(teamUser.teamId);
       return {
         profile: {
-          accountId: userId,
-          displayName: userId,
+          accountId: identity.userId,
+          displayName: identity.userId,
         },
+        grantedScopes: readCanvaGrantedScopes(input.metadata.scope),
         metadata: compactObject({
           apiBaseUrl,
           validationEndpoint: "/v1/users/me",
-          userId,
-          teamId,
+          userId: identity.userId,
+          teamId: identity.teamId,
         }),
       };
     },
@@ -286,18 +286,30 @@ function normalizeHttpError(status: number, payload: Record<string, unknown>, fa
 }
 
 function normalizeCurrentUser(accountPayload: Record<string, unknown>, profilePayload: Record<string, unknown>) {
-  const teamUser = optionalRecord(accountPayload.team_user) ?? optionalRecord(accountPayload.user) ?? {};
+  const identity = readCanvaUserIdentity(accountPayload);
   const profile = optionalRecord(profilePayload.profile) ?? {};
-  const userId =
-    optionalString(teamUser.user_id) ??
-    optionalString(teamUser.userId) ??
-    optionalString(teamUser.id) ??
-    requireCanvaString(accountPayload.id, "canva user id");
   return {
-    userId,
-    teamId: optionalString(teamUser.team_id) ?? optionalString(teamUser.teamId) ?? null,
+    userId: identity.userId ?? requireCanvaString(accountPayload.id, "canva user id"),
+    teamId: identity.teamId ?? null,
     displayName: optionalString(profile.display_name) ?? optionalString(profile.displayName) ?? null,
   };
+}
+
+function readCanvaUserIdentity(accountPayload: Record<string, unknown>): CanvaUserIdentity {
+  const teamUser = optionalRecord(accountPayload.team_user) ?? optionalRecord(accountPayload.user) ?? {};
+  return {
+    userId:
+      optionalString(teamUser.user_id) ??
+      optionalString(teamUser.userId) ??
+      optionalString(teamUser.id) ??
+      optionalString(accountPayload.id),
+    teamId: optionalString(teamUser.team_id) ?? optionalString(teamUser.teamId),
+  };
+}
+
+function readCanvaGrantedScopes(value: unknown): string[] {
+  const scope = optionalString(value);
+  return scope ? [...new Set(scope.split(/[\s,]+/u).filter(Boolean))] : [];
 }
 
 function mapCanvaDesign(payload: Record<string, unknown>) {

--- a/src/providers/canva/executors.ts
+++ b/src/providers/canva/executors.ts
@@ -1,6 +1,5 @@
-import type { ProviderExecutors } from "../../core/types.ts";
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
-import type { OAuthProviderContext } from "../provider-runtime.ts";
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
@@ -19,6 +18,49 @@ export const canvaActionHandlers: ProviderActionHandlers<"canva", CanvaActionHan
   createCanvaActionHandlers(canvaApiBaseUrl);
 
 export const executors: ProviderExecutors = createCanvaExecutors(service, canvaApiBaseUrl);
+
+/** Build Canva credential validators for one regional OAuth API base URL. */
+export function createCanvaCredentialValidators(apiBaseUrl: string): CredentialValidators {
+  return {
+    async oauth2(input, { fetcher, signal }) {
+      const account = await canvaJsonRequest(
+        "GET",
+        "/v1/users/me",
+        {
+          accessToken: input.accessToken,
+          tokenType: input.tokenType,
+          fetcher,
+          signal,
+        },
+        apiBaseUrl,
+      );
+      const teamUser = optionalRecord(account.team_user) ?? optionalRecord(account.user) ?? {};
+      const userId =
+        optionalString(teamUser.user_id) ??
+        optionalString(teamUser.userId) ??
+        optionalString(teamUser.id) ??
+        optionalString(account.id);
+      if (!userId) {
+        throw new ProviderRequestError(502, "canva current user response is missing user id");
+      }
+      const teamId = optionalString(teamUser.team_id) ?? optionalString(teamUser.teamId);
+      return {
+        profile: {
+          accountId: userId,
+          displayName: userId,
+        },
+        metadata: compactObject({
+          apiBaseUrl,
+          validationEndpoint: "/v1/users/me",
+          userId,
+          teamId,
+        }),
+      };
+    },
+  };
+}
+
+export const credentialValidators: CredentialValidators = createCanvaCredentialValidators(canvaApiBaseUrl);
 
 function createCanvaActionHandlers(apiBaseUrl: string): ProviderActionHandlers<"canva", CanvaActionHandler> {
   return {

--- a/src/providers/canva_cn/executors.ts
+++ b/src/providers/canva_cn/executors.ts
@@ -1,5 +1,7 @@
-import type { ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 
-import { createCanvaExecutors } from "../canva/executors.ts";
+import { createCanvaCredentialValidators, createCanvaExecutors } from "../canva/executors.ts";
 
 export const executors: ProviderExecutors = createCanvaExecutors("canva_cn", "https://api.canva.cn/rest");
+
+export const credentialValidators: CredentialValidators = createCanvaCredentialValidators("https://api.canva.cn/rest");

--- a/src/providers/canva_cn/executors.ts
+++ b/src/providers/canva_cn/executors.ts
@@ -2,6 +2,8 @@ import type { CredentialValidators, ProviderExecutors } from "../../core/types.t
 
 import { createCanvaCredentialValidators, createCanvaExecutors } from "../canva/executors.ts";
 
-export const executors: ProviderExecutors = createCanvaExecutors("canva_cn", "https://api.canva.cn/rest");
+const canvaCnApiBaseUrl = "https://api.canva.cn/rest";
 
-export const credentialValidators: CredentialValidators = createCanvaCredentialValidators("https://api.canva.cn/rest");
+export const executors: ProviderExecutors = createCanvaExecutors("canva_cn", canvaCnApiBaseUrl);
+
+export const credentialValidators: CredentialValidators = createCanvaCredentialValidators(canvaCnApiBaseUrl);

--- a/src/providers/clickup/runtime.ts
+++ b/src/providers/clickup/runtime.ts
@@ -81,22 +81,11 @@ export async function fetchClickupCurrentAccount(
     signal,
     mode,
   });
-  const workspacePayload = await requestClickupJson({
-    path: "/team",
-    authorizationHeader,
-    fetcher,
-    signal,
-    mode,
-  });
 
   const user = readObjectField(userPayload, "user");
-  const workspaces = readArrayField(workspacePayload, "teams");
   const userId = asStringId(user.id);
   const username = optionalString(user.username);
   const email = optionalString(user.email);
-  const workspaceNames = workspaces
-    .map((workspace) => optionalString(optionalRecord(workspace)?.name))
-    .filter((value): value is string => Boolean(value));
 
   return {
     accountId: userId ? `clickup:user:${userId}` : "clickup",
@@ -104,12 +93,9 @@ export async function fetchClickupCurrentAccount(
     metadata: compactObject({
       apiBaseUrl: clickupApiV2BaseUrl,
       validationUserEndpoint: "/user",
-      validationWorkspaceEndpoint: "/team",
       userId,
       username,
       email,
-      workspaceCount: workspaces.length,
-      workspaceNames,
     }),
   };
 }

--- a/src/providers/cloudflare-current-user.test.ts
+++ b/src/providers/cloudflare-current-user.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { cloudflareCurrentUserDisplayName, readCloudflareCurrentUser } from "./cloudflare-current-user.ts";
+import { ProviderRequestError } from "./provider-runtime.ts";
+
+describe("Cloudflare current-user parsing", () => {
+  it("normalizes a Cloudflare user and display name", () => {
+    const user = readCloudflareCurrentUser({
+      id: "user-1",
+      email: "ada@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      username: "ada",
+    });
+
+    expect(user).toEqual({
+      userId: "user-1",
+      email: "ada@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      username: "ada",
+    });
+    expect(cloudflareCurrentUserDisplayName(user, "Cloudflare")).toBe("Ada Lovelace");
+  });
+
+  it("rejects a user response without an id", () => {
+    expect(() => readCloudflareCurrentUser({ email: "ada@example.com" })).toThrow(
+      new ProviderRequestError(502, "cloudflare user response is missing id"),
+    );
+  });
+});

--- a/src/providers/cloudflare-current-user.ts
+++ b/src/providers/cloudflare-current-user.ts
@@ -1,0 +1,32 @@
+import { optionalRecord, optionalString } from "../core/cast.ts";
+import { ProviderRequestError } from "./provider-runtime.ts";
+
+export interface CloudflareCurrentUser {
+  userId: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  username?: string;
+}
+
+export function readCloudflareCurrentUser(value: unknown): CloudflareCurrentUser {
+  const user = optionalRecord(value);
+  if (!user) {
+    throw new ProviderRequestError(502, "cloudflare user response is invalid");
+  }
+  const userId = optionalString(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "cloudflare user response is missing id");
+  }
+  return {
+    userId,
+    email: optionalString(user.email),
+    firstName: optionalString(user.first_name),
+    lastName: optionalString(user.last_name),
+    username: optionalString(user.username),
+  };
+}
+
+export function cloudflareCurrentUserDisplayName(user: CloudflareCurrentUser, fallback: string): string {
+  return [user.firstName, user.lastName].filter(Boolean).join(" ").trim() || user.username || user.email || fallback;
+}

--- a/src/providers/cloudflare_browser_rendering/executors.test.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.test.ts
@@ -28,58 +28,31 @@ afterEach(() => {
 });
 
 describe("Cloudflare Browser Run OAuth", () => {
-  it("validates OAuth by resolving the one accessible Cloudflare account", async () => {
+  it("validates OAuth with the current Cloudflare user", async () => {
     const fetch = vi.fn(async () =>
       Response.json({
         success: true,
-        result: [
-          {
-            id: "membership-1",
-            account: { id: "account-1", name: "Amplift", type: "standard" },
-            status: "accepted",
-          },
-        ],
-        result_info: { page: 1, per_page: 50, count: 1, total_count: 1, total_pages: 1 },
+        result: {
+          id: "user-1",
+          email: "ada@example.com",
+          first_name: "Ada",
+          last_name: "Lovelace",
+          username: "ada",
+        },
       }),
     );
 
     const result = await credentialValidators.oauth2!(oauthCredential({}), { fetcher: fetch });
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.cloudflare.com/client/v4/memberships?page=1&per_page=50&status=accepted",
+      "https://api.cloudflare.com/client/v4/user",
       expect.objectContaining({ headers: expect.objectContaining({ authorization: "Bearer oauth-access-token" }) }),
     );
     expect(result).toMatchObject({
-      profile: { accountId: "account-1", displayName: "Amplift" },
-      metadata: { accountId: "account-1", accountName: "Amplift", accountType: "standard" },
+      profile: { accountId: "user-1", displayName: "Ada Lovelace" },
+      metadata: { userId: "user-1", email: "ada@example.com", validationEndpoint: "/user" },
     });
-  });
-
-  it("collects every memberships page before storing the OAuth account allowlist", async () => {
-    const fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const page = new URL(input.toString()).searchParams.get("page");
-      const accountId = page === "1" ? "account-1" : "account-2";
-      return Response.json({
-        success: true,
-        result: [
-          {
-            id: `membership-${page}`,
-            account: { id: accountId, name: `Account ${page}`, type: "standard" },
-            status: "accepted",
-          },
-        ],
-        result_info: { page: Number(page), per_page: 50, count: 1, total_count: 2, total_pages: 2 },
-      });
-    });
-
-    const result = await credentialValidators.oauth2!(oauthCredential({}), { fetcher: fetch });
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    if (!result) throw new Error("Expected OAuth credential validation result");
-    expect(result.metadata?.availableAccounts).toEqual([
-      { id: "account-1", name: "Account 1", type: "standard" },
-      { id: "account-2", name: "Account 2", type: "standard" },
-    ]);
+    expect(result?.metadata?.accountId).toBeUndefined();
   });
 
   it("lists OAuth accounts through Cloudflare memberships", async () => {

--- a/src/providers/cloudflare_browser_rendering/executors.test.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.test.ts
@@ -149,9 +149,24 @@ describe("Cloudflare Browser Run OAuth", () => {
 
     expect(missingAccount).toMatchObject({
       ok: false,
-      error: { message: expect.stringContaining("accountId is required") },
+      error: { message: expect.stringContaining("list_accounts") },
     });
     expect(selectedAccount).toEqual({ ok: true, output: { markdown: "# OpenMeld" } });
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("directs OAuth callers to list_accounts when no Cloudflare account is selected", async () => {
+    const result = await executors["cloudflare_browser_rendering.get_markdown"]!(
+      { url: "https://openmeld.ai" },
+      executionContext(oauthCredential({})),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        message:
+          "accountId is required for this Cloudflare Browser Run action. Use list_accounts to find an accessible Cloudflare account ID.",
+      },
+    });
   });
 });

--- a/src/providers/cloudflare_browser_rendering/executors.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.ts
@@ -12,6 +12,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
+import { cloudflareCurrentUserDisplayName, readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import {
   defineProviderExecutors,
   defineProviderProxy,
@@ -152,28 +153,19 @@ export const credentialValidators: CredentialValidators = {
       { fetcher, signal },
       "validate",
     );
-    const user = readObject(envelope.result, "cloudflare user");
-    const userId = optionalString(user.id);
-    if (!userId) {
-      throw new ProviderRequestError(502, "cloudflare user response is missing id");
-    }
-    const email = optionalString(user.email);
-    const displayName =
-      [optionalString(user.first_name), optionalString(user.last_name)].filter(Boolean).join(" ").trim() ||
-      optionalString(user.username) ||
-      email ||
-      "Cloudflare Browser Run";
+    const user = readCloudflareCurrentUser(envelope.result);
+    const displayName = cloudflareCurrentUserDisplayName(user, "Cloudflare Browser Run");
     return {
       profile: {
-        accountId: userId,
+        accountId: user.userId,
         displayName,
       },
       grantedScopes: input.profile.grantedScopes,
       metadata: compactObject({
         apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
         validationEndpoint: "/user",
-        userId,
-        email,
+        userId: user.userId,
+        email: user.email,
       }),
     };
   },

--- a/src/providers/cloudflare_browser_rendering/executors.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.ts
@@ -362,8 +362,8 @@ function resolveAccountId(input: Record<string, unknown>, context: CloudflareBro
   if (!accountId) {
     throw new ProviderRequestError(
       400,
-      Array.isArray(context.metadata.availableAccounts)
-        ? "accountId is required for this Cloudflare Browser Run action because the OAuth connection can access multiple accounts."
+      context.authType === "oauth2"
+        ? "accountId is required for this Cloudflare Browser Run action. Use list_accounts to find an accessible Cloudflare account ID."
         : "accountId is required in the connected Cloudflare Browser Run credential.",
     );
   }

--- a/src/providers/cloudflare_browser_rendering/executors.ts
+++ b/src/providers/cloudflare_browser_rendering/executors.ts
@@ -146,42 +146,35 @@ export const credentialValidators: CredentialValidators = {
     };
   },
   async oauth2(input, { fetcher, signal }) {
-    const accounts = await requestAllOAuthAccounts(input.accessToken, { fetcher, signal });
-    if (accounts.length === 0) {
-      throw new ProviderRequestError(400, "Cloudflare OAuth cannot access any accounts.");
+    const envelope = await cloudflareRequestEnvelope(
+      input.accessToken,
+      { path: "/user" },
+      { fetcher, signal },
+      "validate",
+    );
+    const user = readObject(envelope.result, "cloudflare user");
+    const userId = optionalString(user.id);
+    if (!userId) {
+      throw new ProviderRequestError(502, "cloudflare user response is missing id");
     }
-
-    if (accounts.length === 1) {
-      const account = accounts[0]!;
-      const accountId = readRequiredString(account, "id");
-      const accountName = readRequiredString(account, "name");
-      return {
-        profile: {
-          accountId,
-          displayName: accountName,
-        },
-        grantedScopes: input.profile.grantedScopes,
-        metadata: compactObject({
-          apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
-          validationEndpoint: "/memberships?page=1&per_page=50&status=accepted",
-          accountId,
-          accountName,
-          accountType: optionalString(account.type),
-        }),
-      };
-    }
-
+    const email = optionalString(user.email);
+    const displayName =
+      [optionalString(user.first_name), optionalString(user.last_name)].filter(Boolean).join(" ").trim() ||
+      optionalString(user.username) ||
+      email ||
+      "Cloudflare Browser Run";
     return {
       profile: {
-        accountId: input.profile.accountId,
-        displayName: "Cloudflare Browser Run",
+        accountId: userId,
+        displayName,
       },
       grantedScopes: input.profile.grantedScopes,
-      metadata: {
+      metadata: compactObject({
         apiBaseUrl: cloudflareBrowserRenderingApiBaseUrl,
-        validationEndpoint: "/memberships?page=1&per_page=50&status=accepted",
-        availableAccounts: accounts,
-      },
+        validationEndpoint: "/user",
+        userId,
+        email,
+      }),
     };
   },
 };
@@ -223,24 +216,6 @@ async function requestOAuthAccounts(
     accounts: normalizeMembershipAccountList(envelope.result),
     resultInfo: normalizeResultInfo(envelope.result_info),
   };
-}
-
-async function requestAllOAuthAccounts(
-  accessToken: string,
-  context: Pick<CloudflareBrowserRenderingContext, "fetcher" | "signal">,
-): Promise<Array<Record<string, unknown>>> {
-  const firstPage = await requestOAuthAccounts(accessToken, context, { page: 1, perPage: 50 }, "validate");
-  const totalPages = optionalInteger(firstPage.resultInfo.totalPages);
-  if (totalPages === undefined || totalPages < 1) {
-    throw new ProviderRequestError(502, "malformed cloudflare memberships pagination");
-  }
-
-  const accounts = [...firstPage.accounts];
-  for (let page = 2; page <= totalPages; page += 1) {
-    const result = await requestOAuthAccounts(accessToken, context, { page, perPage: 50 }, "validate");
-    accounts.push(...result.accounts);
-  }
-  return accounts;
 }
 
 async function requestAccounts(

--- a/src/providers/cloudflare_dns/executors.ts
+++ b/src/providers/cloudflare_dns/executors.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 
 import { compactObject } from "../../core/cast.ts";
+import { cloudflareCurrentUserDisplayName } from "../cloudflare-current-user.ts";
 import { defineBearerProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 import { cloudflareDnsActionHandlers, requestCloudflareCurrentUser, validateCloudflareDnsToken } from "./runtime.ts";
 
@@ -14,11 +15,7 @@ export const credentialValidators: CredentialValidators = {
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
     const user = await requestCloudflareCurrentUser(input.accessToken, fetcher, signal);
-    const displayName =
-      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
-      user.username ||
-      user.email ||
-      "Cloudflare DNS";
+    const displayName = cloudflareCurrentUserDisplayName(user, "Cloudflare DNS");
     return {
       profile: {
         accountId: user.userId,

--- a/src/providers/cloudflare_dns/executors.ts
+++ b/src/providers/cloudflare_dns/executors.ts
@@ -1,7 +1,8 @@
 import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 
+import { compactObject } from "../../core/cast.ts";
 import { defineBearerProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
-import { cloudflareDnsActionHandlers, requestCloudflareAccounts, validateCloudflareDnsToken } from "./runtime.ts";
+import { cloudflareDnsActionHandlers, requestCloudflareCurrentUser, validateCloudflareDnsToken } from "./runtime.ts";
 
 const service = "cloudflare_dns";
 
@@ -12,19 +13,23 @@ export const credentialValidators: CredentialValidators = {
     return validateCloudflareDnsToken(input.apiKey, fetcher, signal);
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    const result = await requestCloudflareAccounts(input.accessToken, fetcher, signal, { page: 1, perPage: 1 });
-    const firstAccount = result.accounts[0];
+    const user = await requestCloudflareCurrentUser(input.accessToken, fetcher, signal);
+    const displayName =
+      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+      user.username ||
+      user.email ||
+      "Cloudflare DNS";
     return {
       profile: {
-        accountId: firstAccount?.id ?? input.profile.accountId,
-        displayName: firstAccount?.name ?? input.profile.displayName,
+        accountId: user.userId,
+        displayName,
       },
       grantedScopes: input.profile.grantedScopes,
-      metadata: {
-        accountId: firstAccount?.id,
-        accountName: firstAccount?.name,
-        validationEndpoint: "/accounts?page=1&per_page=1",
-      },
+      metadata: compactObject({
+        userId: user.userId,
+        email: user.email,
+        validationEndpoint: "/user",
+      }),
     };
   },
 };

--- a/src/providers/cloudflare_dns/runtime.ts
+++ b/src/providers/cloudflare_dns/runtime.ts
@@ -138,6 +138,26 @@ export async function requestCloudflareAccounts(
   };
 }
 
+export async function requestCloudflareCurrentUser(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+  const envelope = await cloudflareRequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
+  const user = readObject(envelope.result, "cloudflare user");
+  const userId = optionalString(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "cloudflare user response is missing id");
+  }
+  return {
+    userId,
+    email: optionalString(user.email),
+    firstName: optionalString(user.first_name),
+    lastName: optionalString(user.last_name),
+    username: optionalString(user.username),
+  };
+}
+
 async function probeCloudflareDnsZones(
   apiToken: string,
   fetcher: typeof fetch,

--- a/src/providers/cloudflare_dns/runtime.ts
+++ b/src/providers/cloudflare_dns/runtime.ts
@@ -1,9 +1,11 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
+import type { CloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { BearerProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
+import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 interface CloudflareEnvelope {
@@ -142,20 +144,9 @@ export async function requestCloudflareCurrentUser(
   accessToken: string,
   fetcher: typeof fetch,
   signal?: AbortSignal,
-): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+): Promise<CloudflareCurrentUser> {
   const envelope = await cloudflareRequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
-  const user = readObject(envelope.result, "cloudflare user");
-  const userId = optionalString(user.id);
-  if (!userId) {
-    throw new ProviderRequestError(502, "cloudflare user response is missing id");
-  }
-  return {
-    userId,
-    email: optionalString(user.email),
-    firstName: optionalString(user.first_name),
-    lastName: optionalString(user.last_name),
-    username: optionalString(user.username),
-  };
+  return readCloudflareCurrentUser(envelope.result);
 }
 
 async function probeCloudflareDnsZones(

--- a/src/providers/cloudflare_mcp/executors.ts
+++ b/src/providers/cloudflare_mcp/executors.ts
@@ -13,7 +13,6 @@ import { defineBearerProviderExecutors, providerUserAgent, ProviderRequestError 
 const service = "cloudflare_mcp";
 const cloudflareMcpEndpoint = "https://mcp.cloudflare.com/mcp";
 const cloudflareMcpRequestTimeoutMs = 60_000;
-const expectedTools = ["docs", "execute", "search"];
 
 type CloudflareMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
@@ -48,14 +47,6 @@ export const credentialValidators: CredentialValidators = {
 async function validateCloudflareMcpCredential(accessToken: string, fetcher: typeof fetch, signal?: AbortSignal) {
   const tools = await listCloudflareMcpTools({ accessToken, fetcher, signal });
   const toolNames = tools.map((tool) => tool.name).sort();
-  const missingTools = expectedTools.filter((tool) => !toolNames.includes(tool));
-  if (missingTools.length > 0) {
-    throw new ProviderRequestError(
-      502,
-      `Cloudflare MCP did not advertise the expected tools: ${missingTools.join(", ")}`,
-    );
-  }
-
   const tokenHash = createHash("sha256").update(accessToken).digest("hex").slice(0, 16);
   return {
     profile: {

--- a/src/providers/cloudflare_mcp/executors.ts
+++ b/src/providers/cloudflare_mcp/executors.ts
@@ -13,6 +13,7 @@ import { defineBearerProviderExecutors, providerUserAgent, ProviderRequestError 
 const service = "cloudflare_mcp";
 const cloudflareMcpEndpoint = "https://mcp.cloudflare.com/mcp";
 const cloudflareMcpRequestTimeoutMs = 60_000;
+const supportedToolNames = new Set(["docs", "search", "execute"]);
 
 type CloudflareMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
@@ -46,7 +47,9 @@ export const credentialValidators: CredentialValidators = {
 
 async function validateCloudflareMcpCredential(accessToken: string, fetcher: typeof fetch, signal?: AbortSignal) {
   const tools = await listCloudflareMcpTools({ accessToken, fetcher, signal });
-  const toolNames = tools.map((tool) => tool.name).sort();
+  if (!tools.some((tool) => supportedToolNames.has(tool.name))) {
+    throw new ProviderRequestError(502, "Cloudflare MCP did not advertise any supported tools");
+  }
   const tokenHash = createHash("sha256").update(accessToken).digest("hex").slice(0, 16);
   return {
     profile: {
@@ -55,7 +58,6 @@ async function validateCloudflareMcpCredential(accessToken: string, fetcher: typ
     },
     metadata: {
       mcpEndpoint: cloudflareMcpEndpoint,
-      mcpTools: toolNames,
     },
   };
 }

--- a/src/providers/cloudflare_r2/executors.ts
+++ b/src/providers/cloudflare_r2/executors.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../core/types.ts";
 import type { CloudflareR2Context } from "./runtime.ts";
 
-import { optionalString, requiredString } from "../../core/cast.ts";
+import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -22,7 +22,7 @@ import {
 import {
   cloudflareR2ActionHandlers,
   cloudflareR2ApiBaseUrl,
-  requestCloudflareR2Accounts,
+  requestCloudflareR2CurrentUser,
   validateCloudflareR2Credential,
 } from "./runtime.ts";
 
@@ -118,33 +118,23 @@ export const credentialValidators: CredentialValidators = {
     return validateCloudflareR2Credential(input.values, fetcher, signal);
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    const result = await requestCloudflareR2Accounts(input.accessToken, fetcher, signal, { page: 1, perPage: 50 });
-    if (result.accounts.length === 1) {
-      const account = result.accounts[0]!;
-      return {
-        profile: {
-          accountId: account.id,
-          displayName: account.name ?? "Cloudflare R2",
-        },
-        grantedScopes: input.profile.grantedScopes,
-        metadata: {
-          accountId: account.id,
-          accountName: account.name,
-          accountType: account.type,
-          validationEndpoint: "/accounts?page=1&per_page=50",
-        },
-      };
-    }
+    const user = await requestCloudflareR2CurrentUser(input.accessToken, fetcher, signal);
+    const displayName =
+      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+      user.username ||
+      user.email ||
+      "Cloudflare R2";
     return {
       profile: {
-        accountId: input.profile.accountId,
-        displayName: "Cloudflare R2",
+        accountId: user.userId,
+        displayName,
       },
       grantedScopes: input.profile.grantedScopes,
-      metadata: {
-        availableAccounts: result.accounts,
-        validationEndpoint: "/accounts?page=1&per_page=50",
-      },
+      metadata: compactObject({
+        userId: user.userId,
+        email: user.email,
+        validationEndpoint: "/user",
+      }),
     };
   },
 };

--- a/src/providers/cloudflare_r2/executors.ts
+++ b/src/providers/cloudflare_r2/executors.ts
@@ -8,6 +8,7 @@ import type {
 import type { CloudflareR2Context } from "./runtime.ts";
 
 import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
+import { cloudflareCurrentUserDisplayName } from "../cloudflare-current-user.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -119,11 +120,7 @@ export const credentialValidators: CredentialValidators = {
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
     const user = await requestCloudflareR2CurrentUser(input.accessToken, fetcher, signal);
-    const displayName =
-      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
-      user.username ||
-      user.email ||
-      "Cloudflare R2";
+    const displayName = cloudflareCurrentUserDisplayName(user, "Cloudflare R2");
     return {
       profile: {
         accountId: user.userId,

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -388,8 +388,8 @@ function resolveAccountId(input: Record<string, unknown>, context: CloudflareR2C
   if (!accountId) {
     throw new ProviderRequestError(
       400,
-      Array.isArray(context.metadata.availableAccounts)
-        ? "accountId is required for this Cloudflare R2 action because the OAuth credential can access multiple accounts"
+      context.authType === "oauth2"
+        ? "accountId is required for this Cloudflare R2 action. Use list_accounts to find an accessible Cloudflare account ID."
         : "accountId is required in the connected credential",
     );
   }

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -1,4 +1,5 @@
 import type { CredentialValidationResult, TransitFileWriter } from "../../core/types.ts";
+import type { CloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
@@ -11,6 +12,7 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { queryParams, readBoundedResponseBytes } from "../../core/request.ts";
+import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface CloudflareR2Context {
@@ -147,20 +149,9 @@ export async function requestCloudflareR2CurrentUser(
   accessToken: string,
   fetcher: typeof fetch,
   signal?: AbortSignal,
-): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+): Promise<CloudflareCurrentUser> {
   const envelope = await cloudflareR2RequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
-  const user = readObject(envelope.result, "cloudflare user");
-  const userId = optionalString(user.id);
-  if (!userId) {
-    throw new ProviderRequestError(502, "cloudflare user response is missing id");
-  }
-  return {
-    userId,
-    email: optionalString(user.email),
-    firstName: optionalString(user.first_name),
-    lastName: optionalString(user.last_name),
-    username: optionalString(user.username),
-  };
+  return readCloudflareCurrentUser(envelope.result);
 }
 
 async function listAccounts(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -143,6 +143,26 @@ export async function requestCloudflareR2Accounts(
   };
 }
 
+export async function requestCloudflareR2CurrentUser(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+  const envelope = await cloudflareR2RequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
+  const user = readObject(envelope.result, "cloudflare user");
+  const userId = optionalString(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "cloudflare user response is missing id");
+  }
+  return {
+    userId,
+    email: optionalString(user.email),
+    firstName: optionalString(user.first_name),
+    lastName: optionalString(user.last_name),
+    username: optionalString(user.username),
+  };
+}
+
 async function listAccounts(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {
   return requestCloudflareR2Accounts(context.accessToken, context.fetcher, context.signal, {
     page: optionalInteger(input.page),

--- a/src/providers/cloudflare_worker/executors.ts
+++ b/src/providers/cloudflare_worker/executors.ts
@@ -7,6 +7,7 @@ import type {
 import type { CloudflareWorkerContext } from "./runtime.ts";
 
 import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
+import { cloudflareCurrentUserDisplayName } from "../cloudflare-current-user.ts";
 import { defineProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 import {
   cloudflareWorkerActionHandlers,
@@ -59,11 +60,7 @@ export const credentialValidators: CredentialValidators = {
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
     const user = await requestCloudflareWorkerCurrentUser(input.accessToken, fetcher, signal);
-    const displayName =
-      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
-      user.username ||
-      user.email ||
-      "Cloudflare Worker";
+    const displayName = cloudflareCurrentUserDisplayName(user, "Cloudflare Worker");
     return {
       profile: {
         accountId: user.userId,

--- a/src/providers/cloudflare_worker/executors.ts
+++ b/src/providers/cloudflare_worker/executors.ts
@@ -6,11 +6,11 @@ import type {
 } from "../../core/types.ts";
 import type { CloudflareWorkerContext } from "./runtime.ts";
 
-import { optionalInteger, optionalString, requiredString } from "../../core/cast.ts";
+import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
 import { defineProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 import {
   cloudflareWorkerActionHandlers,
-  requestCloudflareWorkerAccounts,
+  requestCloudflareWorkerCurrentUser,
   validateCloudflareWorkerCredential,
 } from "./runtime.ts";
 
@@ -58,37 +58,23 @@ export const credentialValidators: CredentialValidators = {
     return validateCloudflareWorkerCredential(input.values, fetcher, signal);
   },
   async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    const result = await requestCloudflareWorkerAccounts(input.accessToken, fetcher, signal, { page: 1, perPage: 50 });
-    if (result.accounts.length === 0) {
-      throw new ProviderRequestError(400, "Cloudflare OAuth credential cannot access any accounts");
-    }
-    const totalCount = optionalInteger(result.resultInfo?.totalCount);
-    if (result.accounts.length === 1 && totalCount === 1) {
-      const account = result.accounts[0]!;
-      return {
-        profile: {
-          accountId: account.id,
-          displayName: account.name ?? "Cloudflare Worker",
-        },
-        grantedScopes: input.profile.grantedScopes,
-        metadata: {
-          accountId: account.id,
-          accountName: account.name,
-          accountType: account.type,
-          validationEndpoint: "/accounts?page=1&per_page=50",
-        },
-      };
-    }
+    const user = await requestCloudflareWorkerCurrentUser(input.accessToken, fetcher, signal);
+    const displayName =
+      [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+      user.username ||
+      user.email ||
+      "Cloudflare Worker";
     return {
       profile: {
-        accountId: input.profile.accountId,
-        displayName: "Cloudflare Worker",
+        accountId: user.userId,
+        displayName,
       },
       grantedScopes: input.profile.grantedScopes,
-      metadata: {
-        requiresAccountSelection: true,
-        validationEndpoint: "/accounts?page=1&per_page=50",
-      },
+      metadata: compactObject({
+        userId: user.userId,
+        email: user.email,
+        validationEndpoint: "/user",
+      }),
     };
   },
 };

--- a/src/providers/cloudflare_worker/runtime.ts
+++ b/src/providers/cloudflare_worker/runtime.ts
@@ -732,8 +732,8 @@ function resolveAccountId(input: Record<string, unknown>, context: CloudflareWor
   if (!accountId) {
     throw new ProviderRequestError(
       400,
-      context.metadata.requiresAccountSelection === true || Array.isArray(context.metadata.availableAccounts)
-        ? "accountId is required for this Cloudflare Worker action because the OAuth credential can access multiple accounts"
+      context.authType === "oauth2"
+        ? "accountId is required for this Cloudflare Worker action. Use list_accounts to find an accessible Cloudflare account ID."
         : "accountId is required in the connected credential",
     );
   }

--- a/src/providers/cloudflare_worker/runtime.ts
+++ b/src/providers/cloudflare_worker/runtime.ts
@@ -1,4 +1,5 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
+import type { CloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
@@ -11,6 +12,7 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
+import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface CloudflareWorkerContext {
@@ -228,20 +230,9 @@ export async function requestCloudflareWorkerCurrentUser(
   accessToken: string,
   fetcher: typeof fetch,
   signal?: AbortSignal,
-): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+): Promise<CloudflareCurrentUser> {
   const envelope = await cloudflareRequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
-  const user = readObject(envelope.result, "cloudflare user");
-  const userId = optionalString(user.id);
-  if (!userId) {
-    throw new ProviderRequestError(502, "cloudflare user response is missing id");
-  }
-  return {
-    userId,
-    email: optionalString(user.email),
-    firstName: optionalString(user.first_name),
-    lastName: optionalString(user.last_name),
-    username: optionalString(user.username),
-  };
+  return readCloudflareCurrentUser(envelope.result);
 }
 
 async function listAccounts(input: Record<string, unknown>, context: CloudflareWorkerContext): Promise<unknown> {

--- a/src/providers/cloudflare_worker/runtime.ts
+++ b/src/providers/cloudflare_worker/runtime.ts
@@ -224,6 +224,26 @@ export async function requestCloudflareWorkerAccounts(
   };
 }
 
+export async function requestCloudflareWorkerCurrentUser(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<{ userId: string; email?: string; firstName?: string; lastName?: string; username?: string }> {
+  const envelope = await cloudflareRequestEnvelope(accessToken, { path: "/user" }, { fetcher, signal }, "validate");
+  const user = readObject(envelope.result, "cloudflare user");
+  const userId = optionalString(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "cloudflare user response is missing id");
+  }
+  return {
+    userId,
+    email: optionalString(user.email),
+    firstName: optionalString(user.first_name),
+    lastName: optionalString(user.last_name),
+    username: optionalString(user.username),
+  };
+}
+
 async function listAccounts(input: Record<string, unknown>, context: CloudflareWorkerContext): Promise<unknown> {
   return requestCloudflareWorkerAccounts(context.accessToken, context.fetcher, context.signal, {
     page: optionalInteger(input.page),

--- a/src/providers/coinbase/executors.test.ts
+++ b/src/providers/coinbase/executors.test.ts
@@ -20,20 +20,19 @@ describe("Coinbase credentials", () => {
       },
       {
         fetcher: async (url, init) => {
-          expect(url.toString()).toBe("https://api.coinbase.com/api/v3/brokerage/accounts");
+          expect(url.toString()).toBe("https://api.coinbase.com/v2/user");
           expect(new Headers(init?.headers).get("authorization")).toBe("Bearer coinbase-oauth-token");
           return Response.json({
-            accounts: [{ uuid: "account-1", name: "Primary" }],
-            has_next: false,
+            data: { id: "user-1", name: "Ada Lovelace", username: "ada" },
           });
         },
       },
     );
 
     expect(result).toMatchObject({
-      profile: { accountId: "account-1", displayName: "Primary" },
+      profile: { accountId: "user-1", displayName: "Ada Lovelace" },
       grantedScopes: ["wallet:accounts:read", "offline_access"],
-      metadata: { accountCount: 1 },
+      metadata: { validationEndpoint: "/v2/user", userId: "user-1" },
     });
   });
 

--- a/src/providers/coinbase/executors.ts
+++ b/src/providers/coinbase/executors.ts
@@ -11,7 +11,14 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { createPrivateKey, createSign, randomBytes } from "node:crypto";
-import { optionalInteger, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
+import {
+  compactObject,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
 import {
   createProviderFetch,
@@ -29,6 +36,7 @@ import { readCoinbaseGrantedScopes } from "./scopes.ts";
 const service = "coinbase";
 const coinbaseApiBaseUrl = "https://api.coinbase.com";
 const accountsPath = "/api/v3/brokerage/accounts";
+const oauthUserPath = "/v2/user";
 const coinbaseFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CoinbaseRequestPhase = "validate" | "execute";
@@ -108,10 +116,9 @@ export const credentialValidators: CredentialValidators = {
     );
   },
   async oauth2(input, { fetcher, signal }) {
-    return validateCoinbaseCredential(
+    return validateCoinbaseOAuthCredential(
       createCoinbaseOAuthContext(input, fetcher, signal),
       readCoinbaseGrantedScopes(input.metadata.scope),
-      "Coinbase OAuth",
     );
   },
 };
@@ -197,6 +204,34 @@ function createCoinbaseOAuthContext(
     },
     fetcher,
     signal,
+  };
+}
+
+async function validateCoinbaseOAuthCredential(
+  context: CoinbaseActionContext,
+  grantedScopes: string[],
+): Promise<CredentialValidationResult> {
+  const payload = requiredRecord(
+    await coinbaseGetJson(oauthUserPath, {}, context, "validate"),
+    "coinbase user response",
+    providerResponseError,
+  );
+  const user = optionalRecord(payload.data) ?? payload;
+  const userId = optionalString(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "coinbase user response is missing id");
+  }
+  return {
+    profile: {
+      accountId: userId,
+      displayName: optionalString(user.name) ?? optionalString(user.username) ?? "Coinbase OAuth",
+    },
+    grantedScopes,
+    metadata: compactObject({
+      validationEndpoint: oauthUserPath,
+      apiBaseUrl: coinbaseApiBaseUrl,
+      userId,
+    }),
   };
 }
 

--- a/src/providers/confluence/executors.test.ts
+++ b/src/providers/confluence/executors.test.ts
@@ -21,31 +21,27 @@ afterEach(() => {
 });
 
 describe("Confluence OAuth credentials", () => {
-  it("discovers the authorized cloud site and validates its v2 API", async () => {
+  it("discovers the authorized cloud site", async () => {
     const requests: URL[] = [];
     const result = await credentialValidators.oauth2!(oauthCredential, {
       fetcher: async (input, init) => {
         const url = new URL(input.toString());
         requests.push(url);
         expect(new Headers(init?.headers).get("authorization")).toBe("Bearer confluence-oauth-token");
-        if (url.pathname === "/oauth/token/accessible-resources") {
-          return Response.json([
-            {
-              id: "cloud-123",
-              name: "Docs",
-              url: "https://docs.atlassian.net",
-              scopes: confluenceOAuthScopes,
-              avatarUrl: "https://docs.atlassian.net/avatar.png",
-            },
-          ]);
-        }
-        expect(url.pathname).toBe("/ex/confluence/cloud-123/wiki/api/v2/spaces");
-        expect(url.searchParams.get("limit")).toBe("1");
-        return Response.json({ results: [{ id: "space-1" }] });
+        expect(url.pathname).toBe("/oauth/token/accessible-resources");
+        return Response.json([
+          {
+            id: "cloud-123",
+            name: "Docs",
+            url: "https://docs.atlassian.net",
+            scopes: confluenceOAuthScopes,
+            avatarUrl: "https://docs.atlassian.net/avatar.png",
+          },
+        ]);
       },
     });
 
-    expect(requests).toHaveLength(2);
+    expect(requests).toHaveLength(1);
     expect(result).toMatchObject({
       profile: {
         accountId: "confluence:cloud-123",
@@ -58,8 +54,7 @@ describe("Confluence OAuth credentials", () => {
         siteUrl: "https://docs.atlassian.net",
         baseUrl: "https://api.atlassian.com/ex/confluence/cloud-123/wiki/api/v2",
         restApiBaseUrl: "https://api.atlassian.com/ex/confluence/cloud-123/wiki/rest/api",
-        validationEndpoint: "/spaces",
-        validationResultCount: 1,
+        validationEndpoint: "/oauth/token/accessible-resources",
       },
     });
   });

--- a/src/providers/confluence/executors.ts
+++ b/src/providers/confluence/executors.ts
@@ -23,8 +23,6 @@ import {
   buildConfluenceOAuthApiBaseUrls,
   confluenceActionHandlers,
   confluenceDefaultTimeoutMs,
-  confluenceValidationPath,
-  requestConfluenceJson,
   validateConfluenceCredential,
 } from "./runtime.ts";
 import {
@@ -159,23 +157,6 @@ async function validateConfluenceOAuthCredential(
   const siteAvatarUrl = optionalString(resource.avatarUrl);
   const resourceScopes = optionalStringArray(resource.scopes) ?? [];
   const { baseUrl, restApiBaseUrl } = buildConfluenceOAuthApiBaseUrls(cloudId);
-  const payload = await requestConfluenceJson({
-    baseUrl,
-    restApiBaseUrl,
-    auth: {
-      type: "oauth2",
-      accessToken: credential.accessToken,
-      tokenType: credential.tokenType,
-    },
-    fetcher,
-    signal,
-    method: "GET",
-    path: confluenceValidationPath,
-    phase: "validate",
-    query: { limit: 1 },
-  });
-  const payloadObject = optionalRecord(payload);
-  const validationResultCount = Array.isArray(payloadObject?.results) ? payloadObject.results.length : undefined;
 
   return {
     profile: {
@@ -193,8 +174,7 @@ async function validateConfluenceOAuthCredential(
       resourceCount: resources.length,
       baseUrl,
       restApiBaseUrl,
-      validationEndpoint: confluenceValidationPath,
-      validationResultCount,
+      validationEndpoint: "/oauth/token/accessible-resources",
     }),
   };
 }

--- a/src/providers/googlecalendar/executors.ts
+++ b/src/providers/googlecalendar/executors.ts
@@ -162,11 +162,7 @@ export const executors: ProviderExecutors = defineOAuthProviderExecutors(
 
 export const credentialValidators: CredentialValidators = {
   async oauth2(input, { fetcher, signal }) {
-    const profile: {
-      email?: string;
-      name?: string;
-      sub?: string;
-    } = await googlecalendarJsonRequest<{
+    const profile = await googlecalendarJsonRequest<{
       email?: string;
       name?: string;
       sub?: string;
@@ -174,20 +170,7 @@ export const credentialValidators: CredentialValidators = {
       accessToken: input.accessToken,
       fetcher,
       signal,
-    }).catch(
-      async (): Promise<{
-        email?: string;
-        name?: string;
-        sub?: string;
-      }> => {
-        await googlecalendarJsonRequest<Record<string, unknown>>(`${googlecalendarApiBaseUrl}/users/me/calendarList`, {
-          accessToken: input.accessToken,
-          fetcher,
-          signal,
-        });
-        return {};
-      },
-    );
+    });
 
     return {
       profile: {

--- a/src/providers/googlesheets/executors.ts
+++ b/src/providers/googlesheets/executors.ts
@@ -53,8 +53,6 @@ import {
 
 const service = "googlesheets";
 
-const sheetsApiBaseUrl = "https://sheets.googleapis.com/v4";
-
 type ActionContext = OAuthProviderContext;
 
 type ActionHandler = (input: Record<string, unknown>, context: ActionContext) => Promise<unknown>;
@@ -189,11 +187,7 @@ export const executors: ProviderExecutors = defineOAuthProviderExecutors(service
 
 export const credentialValidators: CredentialValidators = {
   async oauth2(input, { fetcher, signal }) {
-    const profile: {
-      email?: string;
-      name?: string;
-      sub?: string;
-    } = await googleJsonRequest<{
+    const profile = await googleJsonRequest<{
       email?: string;
       name?: string;
       sub?: string;
@@ -201,20 +195,7 @@ export const credentialValidators: CredentialValidators = {
       accessToken: input.accessToken,
       fetcher,
       signal,
-    }).catch(
-      async (): Promise<{
-        email?: string;
-        name?: string;
-        sub?: string;
-      }> => {
-        await googleJsonRequest<Record<string, unknown>>(`${sheetsApiBaseUrl}/spreadsheets`, {
-          accessToken: input.accessToken,
-          fetcher,
-          signal,
-        });
-        return {};
-      },
-    );
+    });
 
     return {
       profile: {

--- a/src/providers/harvest/executors.test.ts
+++ b/src/providers/harvest/executors.test.ts
@@ -1,0 +1,45 @@
+import type { ResolvedCredential } from "../../core/types.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { credentialValidators } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "harvest-access-token",
+  tokenType: "Bearer",
+  profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+  metadata: { scope: "all" },
+};
+
+describe("Harvest OAuth credential validation", () => {
+  it("rejects credentials without an executable Harvest account", async () => {
+    await expect(
+      credentialValidators.oauth2!(credential, {
+        fetcher: async () => Response.json({ user: { id: 42 }, accounts: [] }),
+      }),
+    ).rejects.toEqual(new ProviderRequestError(400, "harvest OAuth credential has no accessible Harvest account"));
+  });
+
+  it("selects the default Harvest account without a second API probe", async () => {
+    const calls: string[] = [];
+    const result = await credentialValidators.oauth2!(credential, {
+      fetcher: async (input) => {
+        calls.push(input.toString());
+        return Response.json({
+          user: { id: 42, first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" },
+          accounts: [
+            { id: 7, name: "Personal", product: "harvest", is_active: true },
+            { id: 9, name: "Work", product: "harvest", is_default: true },
+          ],
+        });
+      },
+    });
+
+    expect(calls).toEqual(["https://id.getharvest.com/api/v2/accounts"]);
+    expect(result).toMatchObject({
+      profile: { accountId: "42", displayName: "Ada Lovelace" },
+      metadata: { accountId: "9", defaultAccountId: "9" },
+    });
+  });
+});

--- a/src/providers/harvest/executors.ts
+++ b/src/providers/harvest/executors.ts
@@ -564,8 +564,11 @@ async function fetchHarvestCurrentAccount(
   const accountsResponse = requireObjectPayload(accountsPayload, "harvest accounts response");
   const accountUser = optionalRecord(accountsResponse.user);
   const accounts = readHarvestAccounts(accountsResponse);
-  const defaultAccount = accounts.length > 0 ? selectDefaultHarvestAccount(accounts) : undefined;
-  const accountId = defaultAccount ? requireHarvestResponseAccountId(defaultAccount.id) : undefined;
+  if (accounts.length === 0) {
+    throw new ProviderRequestError(400, "harvest OAuth credential has no accessible Harvest account");
+  }
+  const defaultAccount = selectDefaultHarvestAccount(accounts);
+  const accountId = requireHarvestResponseAccountId(defaultAccount.id);
   const userId = String(requireHarvestResponseId(accountUser?.id, "user.id"));
   const firstName = optionalString(accountUser?.first_name);
   const lastName = optionalString(accountUser?.last_name);

--- a/src/providers/harvest/executors.ts
+++ b/src/providers/harvest/executors.ts
@@ -562,24 +562,14 @@ async function fetchHarvestCurrentAccount(
 }> {
   const accountsPayload = await requestHarvestAccounts(credential.accessToken, fetcher, signal);
   const accountsResponse = requireObjectPayload(accountsPayload, "harvest accounts response");
-  const accounts = readHarvestAccounts(accountsResponse);
-  const defaultAccount = selectDefaultHarvestAccount(accounts);
-  const accountId = requireHarvestResponseAccountId(defaultAccount.id);
-  const payload = await requestHarvestJson<Record<string, unknown>>({
-    accountId,
-    accessToken: credential.accessToken,
-    path: harvestValidationPath,
-    fetcher,
-    signal,
-    mode: "validate",
-  });
-
-  const user = requireObjectPayload(payload, "harvest current user response");
   const accountUser = optionalRecord(accountsResponse.user);
-  const userId = String(requireHarvestResponseId(user.id ?? accountUser?.id, "user.id"));
-  const firstName = optionalString(user.first_name) ?? optionalString(accountUser?.first_name);
-  const lastName = optionalString(user.last_name) ?? optionalString(accountUser?.last_name);
-  const email = optionalString(user.email) ?? optionalString(accountUser?.email);
+  const accounts = readHarvestAccounts(accountsResponse);
+  const defaultAccount = accounts.length > 0 ? selectDefaultHarvestAccount(accounts) : undefined;
+  const accountId = defaultAccount ? requireHarvestResponseAccountId(defaultAccount.id) : undefined;
+  const userId = String(requireHarvestResponseId(accountUser?.id, "user.id"));
+  const firstName = optionalString(accountUser?.first_name);
+  const lastName = optionalString(accountUser?.last_name);
+  const email = optionalString(accountUser?.email);
   const accountLabel = [firstName, lastName].filter(Boolean).join(" ").trim() || email || "Harvest User";
 
   return {
@@ -589,12 +579,11 @@ async function fetchHarvestCurrentAccount(
       apiBaseUrl: harvestApiBaseUrl,
       accountId,
       defaultAccountId: accountId,
-      validationEndpoint: harvestValidationPath,
+      validationEndpoint: harvestAccountsUrl,
       userId: Number(userId),
       firstName,
       lastName,
       email,
-      timezone: optionalString(user.timezone),
       accounts: accounts.map((account) =>
         compactObject({
           id: requireHarvestResponseAccountId(account.id),
@@ -700,10 +689,6 @@ function readHarvestAccounts(payload: Record<string, unknown>): Array<Record<str
       const product = optionalString(item.product);
       return product == null || product === "harvest";
     });
-
-  if (accounts.length === 0) {
-    throw new ProviderRequestError(502, "harvest oauth account list is empty");
-  }
 
   return accounts;
 }

--- a/src/providers/helium10/runtime.ts
+++ b/src/providers/helium10/runtime.ts
@@ -97,11 +97,14 @@ export async function validateHelium10Credential(
   const result = await withClient({ accessToken, fetcher, signal }, (client) =>
     client.listTools({}, { timeout: requestTimeoutMs, signal }),
   );
+  if (!result.tools.some((tool) => readOnlyTools.has(tool.name))) {
+    throw new ProviderRequestError(502, "Helium 10 MCP did not expose any approved read-only tools");
+  }
   const tokenHash = createHash("sha256").update(accessToken).digest("hex").slice(0, 16);
   return {
     profile: { accountId: `helium10:mcp:${tokenHash}`, displayName: `Helium 10 MCP · ${tokenHash.slice(-6)}` },
     grantedScopes: ["mcp:tools"],
-    metadata: { mcpEndpoint: helium10McpEndpoint, availableTools: result.tools.map((tool) => tool.name) },
+    metadata: { mcpEndpoint: helium10McpEndpoint },
   };
 }
 

--- a/src/providers/helium10/runtime.ts
+++ b/src/providers/helium10/runtime.ts
@@ -94,13 +94,14 @@ export async function validateHelium10Credential(
   fetcher: typeof fetch,
   signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
-  const tools = await listTools({ accessToken, fetcher, signal });
-  if (tools.length === 0) throw new ProviderRequestError(502, "Helium 10 MCP did not expose any approved tools");
+  const result = await withClient({ accessToken, fetcher, signal }, (client) =>
+    client.listTools({}, { timeout: requestTimeoutMs, signal }),
+  );
   const tokenHash = createHash("sha256").update(accessToken).digest("hex").slice(0, 16);
   return {
     profile: { accountId: `helium10:mcp:${tokenHash}`, displayName: `Helium 10 MCP · ${tokenHash.slice(-6)}` },
     grantedScopes: ["mcp:tools"],
-    metadata: { mcpEndpoint: helium10McpEndpoint, availableTools: tools.map((tool) => tool.name) },
+    metadata: { mcpEndpoint: helium10McpEndpoint, availableTools: result.tools.map((tool) => tool.name) },
   };
 }
 

--- a/src/providers/hubspot/executors.ts
+++ b/src/providers/hubspot/executors.ts
@@ -168,8 +168,8 @@ export const hubspotActionHandlers: ProviderActionHandlers<"hubspot", HubspotAct
 export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, hubspotActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
-  async oauth2(input, { fetcher }): Promise<CredentialValidationResult> {
-    const profile = await fetchHubspotCurrentAccount(input.accessToken, fetcher);
+  async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const profile = await fetchHubspotCurrentAccount(input.accessToken, fetcher, signal);
     return {
       profile: {
         accountId: profile.providerAccountId,

--- a/src/providers/hubspot/executors.ts
+++ b/src/providers/hubspot/executors.ts
@@ -3,7 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
 import { defineOAuthProviderExecutors } from "../provider-runtime.ts";
-import { executeHubspotAction, fetchHubspotCurrentAccount, mapHubspotMcpDetailsToConnectorScopes } from "./runtime.ts";
+import { executeHubspotAction, fetchHubspotCurrentAccount } from "./runtime.ts";
 
 const service = "hubspot";
 
@@ -170,19 +170,13 @@ export const executors: ProviderExecutors = defineOAuthProviderExecutors(service
 export const credentialValidators: CredentialValidators = {
   async oauth2(input, { fetcher }): Promise<CredentialValidationResult> {
     const profile = await fetchHubspotCurrentAccount(input.accessToken, fetcher);
-    const userDetails = profile.providerMetadata.userDetails;
-    const grantedScopes = mapHubspotMcpDetailsToConnectorScopes(userDetails);
-
     return {
       profile: {
         accountId: profile.providerAccountId,
         displayName: profile.accountLabel,
       },
-      grantedScopes,
-      metadata: {
-        ...profile.providerMetadata,
-        connectorScopes: grantedScopes,
-      },
+      grantedScopes: ["mcp:tools"],
+      metadata: profile.providerMetadata,
     };
   },
 };

--- a/src/providers/hubspot/executors.ts
+++ b/src/providers/hubspot/executors.ts
@@ -168,8 +168,8 @@ export const hubspotActionHandlers: ProviderActionHandlers<"hubspot", HubspotAct
 export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, hubspotActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
-  async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
-    const profile = await fetchHubspotCurrentAccount(input.accessToken, fetcher, signal);
+  async oauth2(input, { fetcher }): Promise<CredentialValidationResult> {
+    const profile = await fetchHubspotCurrentAccount(input.accessToken, fetcher);
     return {
       profile: {
         accountId: profile.providerAccountId,

--- a/src/providers/hubspot/runtime.ts
+++ b/src/providers/hubspot/runtime.ts
@@ -161,9 +161,8 @@ export async function refreshHubspotAccessToken(
 export async function fetchHubspotCurrentAccount(
   accessToken: string,
   fetcher: typeof fetch,
-  signal?: AbortSignal,
 ): Promise<HubspotCurrentAccount> {
-  const tools = await listHubspotMcpTools({ accessToken, fetcher, signal });
+  await listHubspotMcpTools({ accessToken, fetcher });
   const tokenHash = hashHubspotToken(accessToken);
   const providerAccountId = `hubspot-mcp:${tokenHash}`;
   return {
@@ -171,8 +170,6 @@ export async function fetchHubspotCurrentAccount(
     accountLabel: `HubSpot MCP · ${tokenHash.slice(-6)}`,
     providerMetadata: {
       mcpEndpoint: hubspotMcpEndpoint,
-      mcpTools: tools.map((tool) => tool.name).sort(),
-      tokenHash,
     },
   };
 }
@@ -462,7 +459,7 @@ async function getHubspotProperty(input: Record<string, unknown>, context: Hubsp
   };
 }
 
-async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof fetch; signal?: AbortSignal }) {
+async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof fetch }): Promise<void> {
   const headers = new Headers();
   headers.set("authorization", `Bearer ${input.accessToken}`);
   headers.set("user-agent", providerUserAgent);
@@ -472,12 +469,13 @@ async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof
       transport: "streamable_http",
       fetcher: input.fetcher,
       headers,
-      signal: input.signal,
       mapError: (error) => mapHubspotMcpError("hubspot", error),
     },
     async (client) => {
-      const result = await client.listTools({}, { timeout: hubspotMcpRequestTimeoutMs, signal: input.signal });
-      return result.tools;
+      const result = await client.listTools({}, { timeout: hubspotMcpRequestTimeoutMs });
+      if (!result.tools.some((tool) => directMcpToolNames.has(tool.name) || tool.name === "get_user_details")) {
+        throw new ProviderRequestError(502, "hubspot MCP did not advertise any supported tools");
+      }
     },
   );
 }

--- a/src/providers/hubspot/runtime.ts
+++ b/src/providers/hubspot/runtime.ts
@@ -161,8 +161,9 @@ export async function refreshHubspotAccessToken(
 export async function fetchHubspotCurrentAccount(
   accessToken: string,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<HubspotCurrentAccount> {
-  const tools = await listHubspotMcpTools({ accessToken, fetcher });
+  const tools = await listHubspotMcpTools({ accessToken, fetcher, signal });
   const tokenHash = hashHubspotToken(accessToken);
   const providerAccountId = `hubspot-mcp:${tokenHash}`;
   return {
@@ -461,7 +462,7 @@ async function getHubspotProperty(input: Record<string, unknown>, context: Hubsp
   };
 }
 
-async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof fetch }) {
+async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof fetch; signal?: AbortSignal }) {
   const headers = new Headers();
   headers.set("authorization", `Bearer ${input.accessToken}`);
   headers.set("user-agent", providerUserAgent);
@@ -471,10 +472,11 @@ async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof
       transport: "streamable_http",
       fetcher: input.fetcher,
       headers,
+      signal: input.signal,
       mapError: (error) => mapHubspotMcpError("hubspot", error),
     },
     async (client) => {
-      const result = await client.listTools({}, { timeout: hubspotMcpRequestTimeoutMs });
+      const result = await client.listTools({}, { timeout: hubspotMcpRequestTimeoutMs, signal: input.signal });
       return result.tools;
     },
   );

--- a/src/providers/hubspot/runtime.ts
+++ b/src/providers/hubspot/runtime.ts
@@ -7,7 +7,6 @@ import { createHash } from "node:crypto";
 import { compactObject } from "../../core/cast.ts";
 import { withMcpClient } from "../mcp-client.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
-import { hubspotConnectorScopes } from "./actions.ts";
 
 interface OAuthClientConfig {
   clientId: string;
@@ -104,88 +103,6 @@ const directMcpToolNames = new Set([
   "submit_feedback",
 ]);
 
-interface HubspotObjectScopeMapping {
-  mcpObjectType: string;
-  read: string;
-  write?: string;
-  crmObject: boolean;
-}
-
-const objectScopeMappings: readonly HubspotObjectScopeMapping[] = [
-  {
-    mcpObjectType: "CONTACT",
-    read: hubspotConnectorScopes.contactsRead,
-    write: hubspotConnectorScopes.contactsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "COMPANY",
-    read: hubspotConnectorScopes.companiesRead,
-    write: hubspotConnectorScopes.companiesWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "DEAL",
-    read: hubspotConnectorScopes.dealsRead,
-    write: hubspotConnectorScopes.dealsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "TICKET",
-    read: hubspotConnectorScopes.ticketsRead,
-    write: hubspotConnectorScopes.ticketsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "LINE_ITEM",
-    read: hubspotConnectorScopes.lineItemsRead,
-    write: hubspotConnectorScopes.lineItemsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "PRODUCT",
-    read: hubspotConnectorScopes.productsRead,
-    write: hubspotConnectorScopes.productsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "CALL",
-    read: hubspotConnectorScopes.callsRead,
-    write: hubspotConnectorScopes.callsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "EMAIL",
-    read: hubspotConnectorScopes.emailsRead,
-    write: hubspotConnectorScopes.emailsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "MEETING_EVENT",
-    read: hubspotConnectorScopes.meetingsRead,
-    write: hubspotConnectorScopes.meetingsWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "NOTE",
-    read: hubspotConnectorScopes.notesRead,
-    write: hubspotConnectorScopes.notesWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "TASK",
-    read: hubspotConnectorScopes.tasksRead,
-    write: hubspotConnectorScopes.tasksWrite,
-    crmObject: true,
-  },
-  {
-    mcpObjectType: "CAMPAIGN",
-    read: hubspotConnectorScopes.campaignsRead,
-    write: hubspotConnectorScopes.campaignsWrite,
-    crmObject: false,
-  },
-];
-
 export async function exchangeHubspotCode(
   input: {
     code: string;
@@ -245,20 +162,16 @@ export async function fetchHubspotCurrentAccount(
   accessToken: string,
   fetcher: typeof fetch,
 ): Promise<HubspotCurrentAccount> {
-  const userDetails = await callHubspotMcpTool({
-    accessToken,
-    fetcher,
-    toolName: "get_user_details",
-    arguments: {},
-  });
-  const profile = buildHubspotAccountProfile(userDetails, accessToken);
-
+  const tools = await listHubspotMcpTools({ accessToken, fetcher });
+  const tokenHash = hashHubspotToken(accessToken);
+  const providerAccountId = `hubspot-mcp:${tokenHash}`;
   return {
-    ...profile,
+    providerAccountId,
+    accountLabel: `HubSpot MCP · ${tokenHash.slice(-6)}`,
     providerMetadata: {
-      ...profile.providerMetadata,
-      userDetails,
-      connectorScopes: mapHubspotMcpDetailsToConnectorScopes(userDetails),
+      mcpEndpoint: hubspotMcpEndpoint,
+      mcpTools: tools.map((tool) => tool.name).sort(),
+      tokenHash,
     },
   };
 }
@@ -309,67 +222,6 @@ export async function executeHubspotAction(input: ExecuteHubspotActionInput, fet
   }
 
   throw new HubspotRequestError("invalid_input", `unknown hubspot action: ${input.actionName}`, 400);
-}
-
-export function mapHubspotMcpDetailsToConnectorScopes(details: unknown): string[] {
-  const accessContainer = findHubspotAccessContainer(details);
-  if (!accessContainer) {
-    return [];
-  }
-
-  const scopes = new Set<string>();
-  for (const mapping of objectScopeMappings) {
-    addObjectScopes(scopes, accessContainer, mapping);
-  }
-
-  const hasCrmRead = objectScopeMappings.some((mapping) => mapping.crmObject && scopes.has(mapping.read));
-  const hasCrmWrite = objectScopeMappings.some(
-    (mapping) => mapping.crmObject && mapping.write && scopes.has(mapping.write),
-  );
-
-  if (hasCrmRead) {
-    scopes.add(hubspotConnectorScopes.crmRead);
-    scopes.add(hubspotConnectorScopes.ownersRead);
-    scopes.add(hubspotConnectorScopes.schemasRead);
-  }
-  if (hasCrmWrite) {
-    scopes.add(hubspotConnectorScopes.crmWrite);
-  }
-
-  return [...scopes];
-}
-
-function addObjectScopes(scopes: Set<string>, container: Record<string, unknown>, mapping: HubspotObjectScopeMapping) {
-  const objectAccess = asObject(container[mapping.mcpObjectType]);
-  if (!objectAccess) {
-    return;
-  }
-
-  if (hasAvailableAccess(objectAccess.read)) {
-    scopes.add(mapping.read);
-  }
-  if (mapping.write && hasAvailableAccess(objectAccess.write)) {
-    scopes.add(mapping.write);
-  }
-}
-
-function findHubspotAccessContainer(details: unknown) {
-  const body = asObject(details);
-  if (!body) {
-    return null;
-  }
-
-  const toolInformation = asObject(body.toolInformation);
-  const crmObjectTypeAvailability = asObject(toolInformation?.crmObjectTypeAvailability);
-  if (crmObjectTypeAvailability) {
-    return crmObjectTypeAvailability;
-  }
-
-  return null;
-}
-
-function hasAvailableAccess(value: unknown) {
-  return typeof value === "string" && value.trim().toUpperCase() === "AVAILABLE";
 }
 
 async function callDirectHubspotMcpTool(
@@ -609,6 +461,25 @@ async function getHubspotProperty(input: Record<string, unknown>, context: Hubsp
   };
 }
 
+async function listHubspotMcpTools(input: { accessToken: string; fetcher: typeof fetch }) {
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${input.accessToken}`);
+  headers.set("user-agent", providerUserAgent);
+  return withMcpClient(
+    {
+      endpoint: new URL(hubspotMcpEndpoint),
+      transport: "streamable_http",
+      fetcher: input.fetcher,
+      headers,
+      mapError: (error) => mapHubspotMcpError("hubspot", error),
+    },
+    async (client) => {
+      const result = await client.listTools({}, { timeout: hubspotMcpRequestTimeoutMs });
+      return result.tools;
+    },
+  );
+}
+
 async function callHubspotMcpTool(input: HubspotMcpToolCallInput) {
   try {
     const output = await callStreamableHttpMcpTool({
@@ -782,79 +653,6 @@ function parseHubspotProviderScopes(body: Record<string, unknown>) {
   }
 
   return [];
-}
-
-function buildHubspotAccountProfile(userDetails: unknown, accessToken: string) {
-  const body = asObject(userDetails) ?? {};
-  const user = asObject(body.user) ?? asObject(body.authenticatedUser) ?? body;
-  const userInformation = asObject(body.userInformation) ?? user;
-  const account = asObject(body.account) ?? asObject(body.portal) ?? asObject(body.hub) ?? body;
-  const hubId =
-    asString(account.hubId) ??
-    asString(account.hub_id) ??
-    asString(account.portalId) ??
-    asString(account.accountId) ??
-    asString(account.id) ??
-    asString(body.accountId) ??
-    asString(body.hubId) ??
-    asString(body.portalId);
-  const userId =
-    asString(user.userId) ??
-    asString(user.user_id) ??
-    asString(user.id) ??
-    asString(userInformation.userId) ??
-    asString(userInformation.ownerId) ??
-    asString(body.userId) ??
-    asString(body.user_id);
-  const userEmail =
-    asString(user.email) ??
-    asString(user.userEmail) ??
-    asString(user.user) ??
-    asString(userInformation.email) ??
-    asString(body.email) ??
-    asString(body.userEmail);
-  const hubDomain =
-    asString(account.domain) ??
-    asString(account.hubDomain) ??
-    asString(account.hub_domain) ??
-    asString(account.portalDomain) ??
-    asString(body.hubDomain) ??
-    asString(body.hub_domain);
-  const tokenHash = hashHubspotToken(accessToken);
-  const providerAccountId =
-    hubId && userId ? `${hubId}:${userId}` : hubId && userEmail ? `${hubId}:${userEmail}` : `hubspot-mcp:${tokenHash}`;
-
-  return {
-    providerAccountId,
-    accountLabel: buildHubspotAccountLabel({ hubId, hubDomain, userEmail }, providerAccountId),
-    providerMetadata: compactObject({
-      hubId,
-      hubDomain,
-      userId,
-      userEmail,
-      tokenHash,
-    }),
-  };
-}
-
-function buildHubspotAccountLabel(
-  payload: {
-    hubId?: string;
-    hubDomain?: string;
-    userEmail?: string;
-  },
-  providerAccountId: string,
-) {
-  if (payload.userEmail && payload.hubDomain) {
-    return `${payload.userEmail} (${payload.hubDomain})`;
-  }
-  if (payload.userEmail && payload.hubId) {
-    return `${payload.userEmail} (${payload.hubId})`;
-  }
-  if (payload.hubDomain) {
-    return payload.hubDomain;
-  }
-  return providerAccountId;
 }
 
 function normalizeSearchOutput(output: unknown) {

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -141,23 +141,10 @@ async function fetchJiraCurrentAccount(
   const siteAvatarUrl = asOptionalString(primaryResource.avatarUrl);
   const resourceScopes = readScopeArray(primaryResource.scopes);
 
-  const currentUser = await jiraJsonRequest<JiraCurrentUserPayload>({
-    accessToken,
-    fetcher,
-    providerMetadata: { cloudId },
-    path: jiraCurrentUserPath,
-    signal,
-  });
-
-  const accountId = requireNonEmptyString(currentUser.accountId, "jira accountId");
-  const displayName = asOptionalString(currentUser.displayName);
-  const emailAddress = asOptionalString(currentUser.emailAddress);
-  const accountLabel = displayName ?? emailAddress ?? accountId;
-
   return {
     profile: {
-      accountId: `jira:${cloudId}:${accountId}`,
-      displayName: `${accountLabel} (${siteName})`,
+      accountId: `jira:${cloudId}`,
+      displayName: siteName,
     },
     grantedScopes: mapJiraGrantedScopes(resourceScopes),
     metadata: compactObject({
@@ -168,13 +155,7 @@ async function fetchJiraCurrentAccount(
       resourceScopes,
       resourceCount: resources.length,
       apiBaseUrl: buildJiraApiBaseUrl(cloudId),
-      validationEndpoint: jiraCurrentUserPath,
-      accountId,
-      displayName,
-      emailAddress,
-      accountType: asOptionalString(currentUser.accountType),
-      active: optionalBoolean(currentUser.active),
-      timeZone: asOptionalString(currentUser.timeZone),
+      validationEndpoint: "/oauth/token/accessible-resources",
     }),
   };
 }

--- a/src/providers/orcid/executors.test.ts
+++ b/src/providers/orcid/executors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("ORCID credentials", () => {
+  it("validates OAuth with the OpenID userinfo endpoint", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "orcid-access-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: { scope: "openid" },
+      },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://orcid.org/oauth/userinfo");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer orcid-access-token");
+          return Response.json({
+            sub: "0000-0002-1825-0097",
+            name: "Josiah Carberry",
+            given_name: "Josiah",
+            family_name: "Carberry",
+          });
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "0000-0002-1825-0097", displayName: "Josiah Carberry" },
+      grantedScopes: ["openid"],
+      metadata: { validationEndpoint: "https://orcid.org/oauth/userinfo" },
+    });
+  });
+});

--- a/src/providers/orcid/executors.test.ts
+++ b/src/providers/orcid/executors.test.ts
@@ -31,4 +31,25 @@ describe("ORCID credentials", () => {
       metadata: { validationEndpoint: "https://orcid.org/oauth/userinfo" },
     });
   });
+
+  it("records granted OAuth scopes from credential metadata", async () => {
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "orcid-access-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: { scope: "openid /read-limited /activities/update" },
+      },
+      {
+        fetcher: async () =>
+          Response.json({
+            sub: "0000-0002-1825-0097",
+            name: "Josiah Carberry",
+          }),
+      },
+    );
+
+    expect(result?.grantedScopes).toEqual(["openid", "/read-limited", "/activities/update"]);
+  });
 });

--- a/src/providers/orcid/executors.ts
+++ b/src/providers/orcid/executors.ts
@@ -1,9 +1,11 @@
-import type { ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { OAuthProviderContext } from "../provider-runtime.ts";
 
+import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 const service = "orcid";
 const baseUrl = "https://pub.orcid.org/v3.0";
+const orcidUserInfoUrl = "https://orcid.org/oauth/userinfo";
 const handlers = {
   async search_records(input: Record<string, unknown>, context: OAuthProviderContext) {
     const start = integer(input.start, 0);
@@ -39,6 +41,61 @@ const handlers = {
 export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, handlers, {
   skipDnsValidation: true,
 });
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const response = await fetcher(orcidUserInfoUrl, {
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${input.accessToken}`,
+        "user-agent": providerUserAgent,
+      },
+      signal,
+    });
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new ProviderRequestError(502, "ORCID userinfo returned invalid JSON");
+    }
+    if (!response.ok) {
+      throw new ProviderRequestError(
+        response.status === 401 || response.status === 403
+          ? 401
+          : response.status === 429
+            ? 429
+            : response.status < 500
+              ? 400
+              : 502,
+        "ORCID userinfo request failed",
+        payload,
+      );
+    }
+    const user = optionalRecord(payload);
+    if (!user) {
+      throw new ProviderRequestError(502, "ORCID userinfo response is invalid");
+    }
+    const orcidId = optionalString(user.sub) ?? optionalString(user.orcid);
+    if (!orcidId) {
+      throw new ProviderRequestError(502, "ORCID userinfo response is missing sub");
+    }
+    const displayName = optionalString(user.name) ?? orcidId;
+    return {
+      profile: {
+        accountId: orcidId,
+        displayName,
+      },
+      grantedScopes: ["openid"],
+      metadata: compactObject({
+        validationEndpoint: orcidUserInfoUrl,
+        orcidId,
+        name: optionalString(user.name),
+        givenName: optionalString(user.given_name),
+        familyName: optionalString(user.family_name),
+      }),
+    };
+  },
+};
 async function request(url: URL, context: OAuthProviderContext): Promise<Record<string, unknown>> {
   const response = await context.fetcher(url, {
     headers: {

--- a/src/providers/orcid/executors.ts
+++ b/src/providers/orcid/executors.ts
@@ -85,7 +85,7 @@ export const credentialValidators: CredentialValidators = {
         accountId: orcidId,
         displayName,
       },
-      grantedScopes: ["openid"],
+      grantedScopes: readGrantedScopes(input.metadata.scope),
       metadata: compactObject({
         validationEndpoint: orcidUserInfoUrl,
         orcidId,
@@ -145,4 +145,7 @@ function objectOrEmpty(value: unknown): Record<string, unknown> {
 }
 function normalize(value: string): string {
   return value.toUpperCase().replace(/^HTTPS?:\/\/ORCID\.ORG\//, "");
+}
+function readGrantedScopes(scope: unknown): string[] {
+  return optionalString(scope)?.split(/\s+/u).filter(Boolean) ?? ["openid"];
 }

--- a/src/providers/orcid/executors.ts
+++ b/src/providers/orcid/executors.ts
@@ -6,6 +6,13 @@ import { defineOAuthProviderExecutors, ProviderRequestError, providerUserAgent }
 const service = "orcid";
 const baseUrl = "https://pub.orcid.org/v3.0";
 const orcidUserInfoUrl = "https://orcid.org/oauth/userinfo";
+
+interface OrcidResponseMessages {
+  invalidJson: string;
+  invalidPayload: string;
+  requestFailed: string;
+}
+
 const handlers = {
   async search_records(input: Record<string, unknown>, context: OAuthProviderContext) {
     const start = integer(input.start, 0);
@@ -52,29 +59,11 @@ export const credentialValidators: CredentialValidators = {
       },
       signal,
     });
-    let payload: unknown;
-    try {
-      payload = await response.json();
-    } catch {
-      throw new ProviderRequestError(502, "ORCID userinfo returned invalid JSON");
-    }
-    if (!response.ok) {
-      throw new ProviderRequestError(
-        response.status === 401 || response.status === 403
-          ? 401
-          : response.status === 429
-            ? 429
-            : response.status < 500
-              ? 400
-              : 502,
-        "ORCID userinfo request failed",
-        payload,
-      );
-    }
-    const user = optionalRecord(payload);
-    if (!user) {
-      throw new ProviderRequestError(502, "ORCID userinfo response is invalid");
-    }
+    const user = await readOrcidJsonResponse(response, {
+      invalidJson: "ORCID userinfo returned invalid JSON",
+      invalidPayload: "ORCID userinfo response is invalid",
+      requestFailed: "ORCID userinfo request failed",
+    });
     const orcidId = optionalString(user.sub) ?? optionalString(user.orcid);
     if (!orcidId) {
       throw new ProviderRequestError(502, "ORCID userinfo response is missing sub");
@@ -105,13 +94,23 @@ async function request(url: URL, context: OAuthProviderContext): Promise<Record<
     },
     signal: context.signal,
   });
+  return readOrcidJsonResponse(response, {
+    invalidJson: "ORCID returned invalid JSON",
+    invalidPayload: "ORCID response is invalid",
+    requestFailed: "ORCID request failed",
+  });
+}
+async function readOrcidJsonResponse(
+  response: Response,
+  messages: OrcidResponseMessages,
+): Promise<Record<string, unknown>> {
   let payload: unknown;
   try {
     payload = await response.json();
   } catch {
-    throw new ProviderRequestError(502, "ORCID returned invalid JSON");
+    throw new ProviderRequestError(502, messages.invalidJson);
   }
-  if (!response.ok)
+  if (!response.ok) {
     throw new ProviderRequestError(
       response.status === 401 || response.status === 403
         ? 401
@@ -120,12 +119,15 @@ async function request(url: URL, context: OAuthProviderContext): Promise<Record<
           : response.status < 500
             ? 400
             : 502,
-      "ORCID request failed",
+      messages.requestFailed,
       payload,
     );
-  if (!payload || typeof payload !== "object" || Array.isArray(payload))
-    throw new ProviderRequestError(502, "ORCID response is invalid");
-  return payload as Record<string, unknown>;
+  }
+  const record = optionalRecord(payload);
+  if (!record) {
+    throw new ProviderRequestError(502, messages.invalidPayload);
+  }
+  return record;
 }
 function string(value: unknown, name: string): string {
   if (typeof value !== "string" || !value.trim()) throw new ProviderRequestError(400, `${name} is required`);

--- a/src/providers/sentry/runtime.ts
+++ b/src/providers/sentry/runtime.ts
@@ -6,7 +6,7 @@ import { ProviderRequestError } from "../provider-runtime.ts";
 import { sentryProviderScopes } from "./scopes.ts";
 
 export const sentryApiBaseUrl: string = "https://sentry.io/api/0/";
-const sentryOrganizationsUrl = `${sentryApiBaseUrl}organizations/`;
+const sentryCurrentUserUrl = `${sentryApiBaseUrl}users/me/`;
 
 type SentryJsonResponse = {
   payload: unknown;
@@ -86,41 +86,29 @@ export async function validateSentryCredential(
   grantedScopes: string[];
   metadata: Record<string, unknown>;
 }> {
-  const { payload: organizations } = await requestSentryJson(
-    accessToken,
-    sentryOrganizationsUrl,
-    fetcher,
-    {},
-    "validate",
-  );
-  if (!Array.isArray(organizations) || organizations.length === 0) {
-    throw new ProviderRequestError(502, "sentry organizations response did not include an authorized organization");
+  const { payload } = await requestSentryJson(accessToken, sentryCurrentUserUrl, fetcher, {}, "validate");
+  const user = asRecord(payload);
+  if (!user) {
+    throw new ProviderRequestError(502, "sentry current user payload is invalid");
   }
-
-  const organization = asRecord(organizations[0]);
-  if (!organization) {
-    throw new ProviderRequestError(502, "sentry organization payload is invalid");
-  }
-  const links = asOptionalRecord(organization.links);
-  const organizationId = pickString(organization.id, organization.slug);
-  const organizationName = pickString(organization.name, organization.slug, organization.id);
-
-  if (!organizationId || !organizationName) {
-    throw new ProviderRequestError(502, "sentry organization payload is invalid");
+  const userId = pickString(user.id, user.username, user.email);
+  const displayName = pickString(user.name, user.username, user.email, user.id);
+  if (!userId || !displayName) {
+    throw new ProviderRequestError(502, "sentry current user payload is invalid");
   }
 
   return {
     profile: {
-      accountId: organizationId,
-      displayName: organizationName,
+      accountId: userId,
+      displayName,
     },
     grantedScopes: sentryProviderScopes,
     metadata: compactObject({
-      organizationId,
-      slug: optionalString(organization.slug),
-      name: optionalString(organization.name),
-      organizationUrl: optionalString(links?.organizationUrl),
-      regionUrl: optionalString(links?.regionUrl),
+      validationEndpoint: "/users/me/",
+      userId,
+      username: optionalString(user.username),
+      email: optionalString(user.email),
+      name: optionalString(user.name),
     }),
   };
 }

--- a/src/providers/shopify/executors.test.ts
+++ b/src/providers/shopify/executors.test.ts
@@ -22,17 +22,14 @@ function shopifyCredentialFetcher(expectedToken: string): typeof fetch {
     const requestUrl = new URL(url.toString());
     expect(requestUrl.origin).toBe("https://acme.myshopify.com");
     expect(new Headers(init?.headers).get("x-shopify-access-token")).toBe(expectedToken);
-    if (requestUrl.pathname.endsWith("/shop.json")) {
-      return Response.json({
-        shop: {
-          id: 123,
-          name: "Acme Store",
-          myshopify_domain: "acme.myshopify.com",
-        },
-      });
-    }
-    expect(requestUrl.pathname).toMatch(/\/blogs\/count\.json$/u);
-    return Response.json({ count: 1 });
+    expect(requestUrl.pathname.endsWith("/shop.json")).toBe(true);
+    return Response.json({
+      shop: {
+        id: 123,
+        name: "Acme Store",
+        myshopify_domain: "acme.myshopify.com",
+      },
+    });
   };
 }
 

--- a/src/providers/shopify/runtime.ts
+++ b/src/providers/shopify/runtime.ts
@@ -10,7 +10,6 @@ export const shopifyRestApiVersion = "2026-04";
 
 const credentialHelpUrl = "https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens";
 const shopPath = "/shop.json";
-const contentValidationPath = "/blogs/count.json";
 
 type ShopifyRequestPhase = "validate" | "execute";
 interface ShopifyPagination {
@@ -194,11 +193,6 @@ export async function validateShopifyCredential(
     phase: "validate",
   });
   const shop = requireRecord(requireRecord(shopResult.payload, "Shopify shop response").shop, "shop");
-  await requestShopifyRest({
-    context,
-    path: contentValidationPath,
-    phase: "validate",
-  });
 
   return {
     profile: {
@@ -212,7 +206,6 @@ export async function validateShopifyCredential(
       restApiVersion: shopifyRestApiVersion,
       credentialHelpUrl,
       validationEndpoint: shopPath,
-      contentScopeValidationEndpoint: contentValidationPath,
       shopId: optionalNumber(shop.id),
       myshopifyDomain: optionalString(shop.myshopify_domain),
     }),

--- a/src/providers/tiktok_business/executors.test.ts
+++ b/src/providers/tiktok_business/executors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("TikTok Business credentials", () => {
+  it("validates OAuth with user info and does not list advertisers", async () => {
+    const requestedUrls: string[] = [];
+    const result = await credentialValidators.oauth2!(
+      {
+        authType: "oauth2",
+        accessToken: "tiktok-access-token",
+        tokenType: "Bearer",
+        profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+        metadata: { scope: "advertiser.read" },
+      },
+      {
+        fetcher: async (url, init) => {
+          requestedUrls.push(url.toString());
+          expect(new Headers(init?.headers).get("access-token")).toBe("tiktok-access-token");
+          return Response.json({
+            code: 0,
+            data: {
+              core_user_id: "user-1",
+              display_name: "Ada",
+              email: "ada@example.com",
+            },
+          });
+        },
+      },
+    );
+
+    expect(requestedUrls).toEqual(["https://business-api.tiktok.com/open_api/v1.3/user/info/"]);
+    expect(result).toMatchObject({
+      profile: { accountId: "user-1", displayName: "Ada" },
+      grantedScopes: ["advertiser.read"],
+      metadata: { coreUserId: "user-1", email: "ada@example.com" },
+    });
+  });
+});

--- a/src/providers/tiktok_business/runtime.ts
+++ b/src/providers/tiktok_business/runtime.ts
@@ -6,6 +6,7 @@ import { compactObject, optionalRecord } from "../../core/cast.ts";
 import { ProviderRequestError } from "../provider-runtime.ts";
 
 const tiktokBusinessApiBaseUrl = "https://business-api.tiktok.com";
+const tiktokBusinessUserInfoUrl = `${tiktokBusinessApiBaseUrl}/open_api/v1.3/user/info/`;
 const tiktokBusinessAdvertiserUrl = `${tiktokBusinessApiBaseUrl}/open_api/v1.3/oauth2/advertiser/get/`;
 
 const tiktokBusinessPermissionScopeHint =
@@ -90,31 +91,36 @@ export async function validateTikTokBusinessCredential(
   fetcher: typeof fetch,
 ): Promise<CredentialValidationResult> {
   const envelope = await tiktokBusinessJsonEnvelopeRequest<{
-    list?: unknown[];
-    advertiser_list?: unknown[];
+    core_user_id?: unknown;
+    display_name?: unknown;
+    email?: unknown;
+    avatar_url?: unknown;
+    id?: unknown;
   }>({
-    url: tiktokBusinessAdvertiserUrl,
+    url: tiktokBusinessUserInfoUrl,
     fetcher,
     accessToken: input.accessToken,
   });
-  const advertisers = readTikTokBusinessAdvertisers(dataObject(envelope.data));
-  const firstAdvertiser = advertisers[0];
-  if (!firstAdvertiser) {
-    throw new ProviderRequestError(502, "tiktok business advertiser discovery returned no advertisers");
+  const user = dataObject(envelope.data);
+  const userId = stringOrUndefined(user.core_user_id) ?? stringOrUndefined(user.id);
+  if (!userId) {
+    throw new ProviderRequestError(502, "tiktok business user info is missing core_user_id");
   }
 
+  const displayName = stringOrUndefined(user.display_name) || userId;
   const grantedScopes = normalizeProviderScopes(input.metadata.scope);
   return {
     profile: {
-      accountId: firstAdvertiser.advertiserId,
-      displayName: firstAdvertiser.advertiserName || firstAdvertiser.advertiserId,
+      accountId: userId,
+      displayName,
       grantedScopes,
     },
     grantedScopes,
-    metadata: {
-      advertisers,
-      selectedAdvertiserId: firstAdvertiser.advertiserId,
-    },
+    metadata: compactObject({
+      coreUserId: userId,
+      email: stringOrUndefined(user.email),
+      avatarUrl: stringOrUndefined(user.avatar_url),
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Stop treating empty advertiser, workspace, organization, or tool lists as failed OAuth authentication.
- Probe current-user / userinfo (or site discovery for Atlassian) from each provider's `executors.ts` credential validator; leave account selection to later actions.
- Drop HubSpot runtime imports of action-catalog connector scopes; MCP-only providers still call `listTools` without requiring a fixed tool set.

## Test plan
- [ ] `npm run fix-check`
- [ ] Provider unit tests: Asana, Canva, Cloudflare Browser Run, Coinbase, Confluence, ORCID, Shopify, TikTok Business
- [ ] Confirm Canva CN validator hits `https://api.canva.cn/rest/v1/users/me`
- [ ] Note Jira profile `accountId` shape change (`jira:${cloudId}`) for existing connections


Made with [Cursor](https://cursor.com)