### PR TITLE
feat(storage): add download_object transit actions for aliyun_oss and aws_s3

### DIFF
--- a/src/providers/aliyun_oss/actions.ts
+++ b/src/providers/aliyun_oss/actions.ts
@@ -36,6 +36,20 @@ const objectSchema = s.object("An OSS object summary.", {
   owner: s.nullable(ownerSchema),
 });
 
+const downloadedObjectSchema = s.requiredObject("A downloaded OSS object stored in local transit storage.", {
+  fileId: s.nonEmptyString("The OSS object key."),
+  name: s.nonEmptyString("The filename used for the local transit file."),
+  mimeType: s.nonEmptyString("The downloaded object MIME type."),
+  sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),
+  file: s.requiredObject("The downloaded object in local transit file storage.", {
+    fileId: s.nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored object."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: s.nonEmptyString("The stored transit file name."),
+    mimeType: s.nonEmptyString("The stored transit file MIME type."),
+  }),
+});
+
 const objectMetadataSchema = s.object("Structured OSS object metadata.", {
   bucket: s.string("The bucket that stores the object."),
   objectKey: s.string("The object key."),
@@ -123,6 +137,22 @@ export const aliyunOssActions: ActionDefinition[] = [
     outputSchema: s.object("The output payload for this action.", {
       object: { ...objectMetadataSchema, description: "The normalized OSS object metadata." },
     }),
+  }),
+  defineProviderAction(service, {
+    name: "download_object",
+    description: "Download one OSS object into local transit file storage.",
+    inputSchema: s.object(
+      "The input payload for downloading one OSS object.",
+      {
+        bucket: bucketNameSchema,
+        objectKey: s.nonEmptyString("The complete OSS object key. Slashes are preserved as key delimiters."),
+        endpoint: endpointSchema,
+        versionId: s.string("The optional object version ID."),
+        fileName: s.nonEmptyString("An optional filename override for the local transit file."),
+      },
+      { optional: ["bucket", "endpoint", "versionId", "fileName"] },
+    ),
+    outputSchema: downloadedObjectSchema,
   }),
   defineProviderAction(service, {
     name: "put_object",

--- a/src/providers/aliyun_oss/actions.ts
+++ b/src/providers/aliyun_oss/actions.ts
@@ -37,7 +37,7 @@ const objectSchema = s.object("An OSS object summary.", {
 });
 
 const downloadedObjectSchema = s.requiredObject("A downloaded OSS object stored in local transit storage.", {
-  fileId: s.nonEmptyString("The OSS object key."),
+  objectKey: objectKeySchema,
   name: s.nonEmptyString("The filename used for the local transit file."),
   mimeType: s.nonEmptyString("The downloaded object MIME type."),
   sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -1,0 +1,196 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+}
+
+const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    accessKeyId: "LTAIEXAMPLE",
+    accessKeySecret: "secretAccessKeyExample",
+    endpoint: "oss-cn-hangzhou.aliyuncs.com",
+    bucket: "documents",
+  },
+  profile: { accountId: "LTAIEXAMPLE", displayName: "Alibaba Cloud OSS test", grantedScopes: [] },
+  metadata: { endpoint: "https://oss-cn-hangzhou.aliyuncs.com", bucket: "documents" },
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("Alibaba Cloud OSS download_object", () => {
+  it("downloads an object byte-for-byte into transit storage", async () => {
+    const content = new Uint8Array([79, 83, 83, 0, 255]);
+    const requests = stubResponses([
+      new Response(content, {
+        headers: {
+          "content-type": "application/pdf",
+          etag: '"etag-1"',
+        },
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "reports/annual report #1.pdf" }, store);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "reports/annual report #1.pdf",
+        name: "annual report #1.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "annual report #1.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.hostname).toBe("documents.oss-cn-hangzhou.aliyuncs.com");
+    expect(requests[0]?.url.pathname).toBe("/reports/annual%20report%20%231.pdf");
+    expect(requests[0]?.authorization).toMatch(/^OSS LTAIEXAMPLE:/);
+    expect(create).toHaveBeenCalledOnce();
+    expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
+  });
+
+  it("preserves boundary whitespace and strictly encodes reserved key characters", async () => {
+    const objectKey = " reports/file!'()*.txt ";
+    const requests = stubResponses([new Response("ok")]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey, fileName: "report.txt" }, store);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: objectKey,
+        name: "report.txt",
+        file: { name: "report.txt" },
+      },
+    });
+    expect(requests[0]?.url.pathname).toBe("/%20reports/file%21%27%28%29%2A.txt%20");
+  });
+
+  it("rejects dot segments instead of normalizing the object key", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "a/../secret" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectKey must not contain . or .. path segments",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("honors the transit size limit without storing a partial object", async () => {
+    const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "large.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "Alibaba Cloud OSS download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when transit file storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "report.pdf" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "aliyun_oss download_object requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected Alibaba Cloud OSS request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("aliyun_oss");
+      return credential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executors["aliyun_oss.download_object"]!(input, context);
+}

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -1,5 +1,6 @@
 import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
+import AliOss from "ali-oss";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { executors } from "./executors.ts";
@@ -7,6 +8,16 @@ import { executors } from "./executors.ts";
 interface CapturedRequest {
   url: URL;
   authorization: string | null;
+  headers: Record<string, string>;
+}
+
+interface AliyunOssSigner {
+  authorization(
+    method: string,
+    resource: string,
+    subres: Record<string, string>,
+    headers: Record<string, string>,
+  ): string;
 }
 
 const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
@@ -48,7 +59,7 @@ describe("Alibaba Cloud OSS download_object", () => {
     expect(result).toEqual({
       ok: true,
       output: {
-        fileId: "reports/annual report #1.pdf",
+        objectKey: "reports/annual report #1.pdf",
         name: "annual report #1.pdf",
         mimeType: "application/pdf",
         sizeBytes: content.length,
@@ -79,12 +90,37 @@ describe("Alibaba Cloud OSS download_object", () => {
     expect(result).toMatchObject({
       ok: true,
       output: {
-        fileId: objectKey,
+        objectKey,
         name: "report.txt",
         file: { name: "report.txt" },
       },
     });
     expect(requests[0]?.url.pathname).toBe("/%20reports/file%21%27%28%29%2A.txt%20");
+  });
+
+  it("signs the raw object key while sending the encoded request path", async () => {
+    const objectKey = "reports/annual report #1.pdf";
+    const requests = stubResponses([new Response("ok")]);
+    const { store } = createTransitFileStore(1024);
+
+    await executeDownload({ bucket: "documents", objectKey }, store);
+
+    const request = requests[0]!;
+    expect(request.url.pathname).toBe("/reports/annual%20report%20%231.pdf");
+
+    const signedHeaders = { ...request.headers };
+    delete signedHeaders.authorization;
+    const client = new AliOss({
+      accessKeyId: credential.values.accessKeyId,
+      accessKeySecret: credential.values.accessKeySecret,
+      endpoint: "oss-cn-hangzhou.aliyuncs.com",
+      bucket: "documents",
+      secure: true,
+    }) as unknown as AliyunOssSigner;
+    expect(request.authorization).toBe(client.authorization("GET", `/documents/${objectKey}`, {}, signedHeaders));
+    expect(request.authorization).not.toBe(
+      client.authorization("GET", `/documents${request.url.pathname}`, {}, signedHeaders),
+    );
   });
 
   it("rejects dot segments instead of normalizing the object key", async () => {
@@ -139,6 +175,28 @@ describe("Alibaba Cloud OSS download_object", () => {
   });
 });
 
+describe("Alibaba Cloud OSS put_object sourceUrl", () => {
+  it("rejects a cloud-metadata sourceUrl before any outbound fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucket: "documents",
+      objectKey: "reports/source.bin",
+      sourceUrl: "https://169.254.169.254/latest/meta-data/",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "sourceUrl must not target private or reserved IP addresses",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
 function stubResponses(responses: Response[]): CapturedRequest[] {
   const requests: CapturedRequest[] = [];
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -146,6 +204,7 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
     requests.push({
       url: new URL(request.url),
       authorization: request.headers.get("authorization"),
+      headers: Object.fromEntries(request.headers.entries()),
     });
     const response = responses.shift();
     if (!response) {
@@ -183,6 +242,18 @@ function createTransitFileStore(maxBytes: number): {
 }
 
 async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  return executeAction("aliyun_oss.download_object", input, transitFiles);
+}
+
+async function executePut(input: Record<string, unknown>) {
+  return executeAction("aliyun_oss.put_object", input);
+}
+
+async function executeAction(
+  action: "aliyun_oss.download_object" | "aliyun_oss.put_object",
+  input: Record<string, unknown>,
+  transitFiles?: TransitFileStore,
+) {
   const context: ExecutionContext = {
     getCredential: async (service) => {
       expect(service).toBe("aliyun_oss");
@@ -192,5 +263,5 @@ async function executeDownload(input: Record<string, unknown>, transitFiles?: Tr
   if (transitFiles) {
     context.transitFiles = transitFiles;
   }
-  return executors["aliyun_oss.download_object"]!(input, context);
+  return executors[action]!(input, context);
 }

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -175,12 +175,13 @@ describe("Alibaba Cloud OSS download_object", () => {
   });
 
   it("returns 504 when the download request times out", async () => {
+    const timeoutReason = new DOMException("The operation was aborted due to timeout", "TimeoutError");
     const timeoutController = new AbortController();
-    timeoutController.abort();
+    timeoutController.abort(timeoutReason);
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
     vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
+        throw timeoutReason;
       }
       throw new Error("expected download fetch to use an aborted timeout signal");
     });

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -140,6 +140,23 @@ describe("Alibaba Cloud OSS download_object", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects bucket values that alter the provider origin", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "attacker.example#", objectKey: "report.pdf" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "bucket must not alter the Alibaba Cloud OSS endpoint",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
     const { store, create } = createTransitFileStore(2);

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -173,6 +173,34 @@ describe("Alibaba Cloud OSS download_object", () => {
     });
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it("returns 504 when the download request times out", async () => {
+    const timeoutController = new AbortController();
+    timeoutController.abort();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+    vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      throw new Error("expected download fetch to use an aborted timeout signal");
+    });
+    const { store } = createTransitFileStore(1024);
+
+    try {
+      const result = await executeDownload({ bucket: "documents", objectKey: "slow.bin" }, store);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "provider_error",
+          message: "aliyun_oss download timed out",
+          details: { status: 504 },
+        },
+      });
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("Alibaba Cloud OSS put_object sourceUrl", () => {

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -173,35 +173,6 @@ describe("Alibaba Cloud OSS download_object", () => {
     });
     expect(fetch).not.toHaveBeenCalled();
   });
-
-  it("returns 504 when the download request times out", async () => {
-    const timeoutReason = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    const timeoutController = new AbortController();
-    timeoutController.abort(timeoutReason);
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.signal?.aborted) {
-        throw timeoutReason;
-      }
-      throw new Error("expected download fetch to use an aborted timeout signal");
-    });
-    const { store } = createTransitFileStore(1024);
-
-    try {
-      const result = await executeDownload({ bucket: "documents", objectKey: "slow.bin" }, store);
-
-      expect(result).toMatchObject({
-        ok: false,
-        error: {
-          code: "provider_error",
-          message: "aliyun_oss download timed out",
-          details: { status: 504 },
-        },
-      });
-    } finally {
-      timeoutSpy.mockRestore();
-    }
-  });
 });
 
 describe("Alibaba Cloud OSS put_object sourceUrl", () => {

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -4,13 +4,14 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
+  TransitFileWriter,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import AliOss from "ali-oss";
-import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { compactObject, optionalInteger, optionalRecord, optionalString, requiredRawString } from "../../core/cast.ts";
 import { assertGuardedEgressUrl } from "../../core/guarded-fetch.ts";
-import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -118,6 +119,7 @@ interface AliyunOssContext {
   values: Record<string, string>;
   metadata: Record<string, unknown>;
   fetcher: typeof fetch;
+  transitFiles?: TransitFileWriter;
   signal?: AbortSignal;
 }
 
@@ -191,6 +193,9 @@ export const aliyunOssActionHandlers: ProviderActionHandlers<"aliyun_oss", Aliyu
   head_object(input, context) {
     return aliyunHeadObject(input, context);
   },
+  download_object(input, context) {
+    return aliyunDownloadObject(input, context);
+  },
   put_object(input, context) {
     return aliyunPutObject(input, context);
   },
@@ -205,6 +210,7 @@ export const aliyunOssActionHandlers: ProviderActionHandlers<"aliyun_oss", Aliyu
 export const executors: ProviderExecutors = defineProviderExecutors<AliyunOssContext>({
   service,
   handlers: aliyunOssActionHandlers,
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AliyunOssContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {
@@ -214,6 +220,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<AliyunOssCon
       values: credential.values,
       metadata: credential.metadata,
       fetcher,
+      transitFiles: context.transitFiles,
       signal: context.signal,
     };
   },
@@ -358,6 +365,39 @@ function buildAliyunOssProxySubres(url: URL): Record<string, string> {
   return subres;
 }
 
+function encodeOssObjectKey(value: string): string {
+  return value
+    .split("/")
+    .map((segment) =>
+      encodeURIComponent(segment)
+        .replaceAll("!", "%21")
+        .replaceAll("'", "%27")
+        .replaceAll("(", "%28")
+        .replaceAll(")", "%29")
+        .replaceAll("*", "%2A"),
+    )
+    .join("/");
+}
+
+function readObjectKey(input: Record<string, unknown>): string {
+  const objectKey = requiredRawString(
+    input.objectKey,
+    "objectKey",
+    (message) => new ProviderRequestError(400, message),
+  );
+  if (objectKey.length === 0) {
+    throw new ProviderRequestError(400, "objectKey must not be empty");
+  }
+  if (objectKey.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new ProviderRequestError(400, "objectKey must not contain . or .. path segments");
+  }
+  return objectKey;
+}
+
+function defaultObjectFileName(objectKey: string): string {
+  return objectKey.split("/").findLast((segment) => segment.length > 0) ?? "oss-object";
+}
+
 async function aliyunListBuckets(input: Record<string, unknown>, context: AliyunOssContext): Promise<unknown> {
   const client = await createClientForAction(input, context);
   const result = await client.listBuckets(
@@ -429,6 +469,73 @@ async function aliyunHeadObject(input: Record<string, unknown>, context: AliyunO
       headers,
     },
   };
+}
+
+async function aliyunDownloadObject(input: Record<string, unknown>, context: AliyunOssContext): Promise<unknown> {
+  try {
+    if (!context.transitFiles) {
+      throw new ProviderRequestError(400, "aliyun_oss download_object requires local transit file storage");
+    }
+
+    const bucket = resolveBucket(input, context);
+    const objectKey = readObjectKey(input);
+    const endpoint = resolveEndpoint(input, context);
+    const client = await createClientForAction(input, context, bucket);
+    const versionId = optionalString(input.versionId);
+    const url = createProviderProxyUrl(
+      buildAliyunOssProxyBaseUrl(endpoint, bucket),
+      `/${encodeOssObjectKey(objectKey)}`,
+      versionId ? { versionId } : undefined,
+    );
+    const headers = new Headers();
+    headers.set("accept", "*/*");
+    headers.set("user-agent", providerUserAgent);
+    headers.set("x-oss-date", new Date().toUTCString());
+    const securityToken = optionalString(context.values.securityToken);
+    if (securityToken) {
+      headers.set("x-oss-security-token", securityToken);
+    }
+    headers.set(
+      "authorization",
+      client.authorization(
+        "GET",
+        buildAliyunOssProxyResource(url, bucket),
+        buildAliyunOssProxySubres(url),
+        Object.fromEntries(headers.entries()),
+      ),
+    );
+
+    const response = await context.fetcher(url, {
+      method: "GET",
+      headers,
+      signal: context.signal,
+    });
+    if (!response.ok) {
+      throw new ProviderRequestError(
+        response.status,
+        await readProviderProxyErrorMessage(response, `Alibaba Cloud OSS download failed with HTTP ${response.status}`),
+      );
+    }
+
+    const name = optionalString(input.fileName) ?? defaultObjectFileName(objectKey);
+    const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "Alibaba Cloud OSS download",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+
+    return {
+      fileId: objectKey,
+      name,
+      mimeType,
+      sizeBytes: file.sizeBytes,
+      file,
+    };
+  } catch (error) {
+    throw normalizeAliyunError(error, "execute");
+  }
 }
 
 async function aliyunPutObject(input: Record<string, unknown>, context: AliyunOssContext): Promise<unknown> {

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -539,7 +539,11 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
       file,
     };
   } catch (error) {
-    if (timeoutSignal?.aborted && !context.signal?.aborted && isAbortLikeError(error)) {
+    if (
+      timeoutSignal?.aborted &&
+      !context.signal?.aborted &&
+      (isAbortLikeError(error) || error === timeoutSignal.reason)
+    ) {
       throw new ProviderRequestError(504, "aliyun_oss download timed out", error);
     }
     throw normalizeAliyunError(error, "execute");

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -16,7 +16,6 @@ import {
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -473,13 +472,10 @@ async function aliyunHeadObject(input: Record<string, unknown>, context: AliyunO
 }
 
 async function aliyunDownloadObject(input: Record<string, unknown>, context: AliyunOssContext): Promise<unknown> {
-  let timeoutSignal: AbortSignal | undefined;
   try {
     if (!context.transitFiles) {
       throw new ProviderRequestError(400, "aliyun_oss download_object requires local transit file storage");
     }
-
-    timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
 
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
@@ -513,7 +509,7 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
     const response = await context.fetcher(url, {
       method: "GET",
       headers,
-      signal: context.signal ? AbortSignal.any([context.signal, timeoutSignal]) : timeoutSignal,
+      signal: context.signal,
     });
     if (!response.ok) {
       throw new ProviderRequestError(
@@ -539,13 +535,6 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
       file,
     };
   } catch (error) {
-    if (
-      timeoutSignal?.aborted &&
-      !context.signal?.aborted &&
-      (isAbortLikeError(error) || error === timeoutSignal.reason)
-    ) {
-      throw new ProviderRequestError(504, "aliyun_oss download timed out", error);
-    }
     throw normalizeAliyunError(error, "execute");
   }
 }

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -499,16 +499,18 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
       "authorization",
       client.authorization(
         "GET",
-        buildAliyunOssProxyResource(url, bucket),
+        // ali-oss signs the raw object key; the request URL stays percent-encoded.
+        `/${bucket}/${objectKey}`,
         buildAliyunOssProxySubres(url),
         Object.fromEntries(headers.entries()),
       ),
     );
 
+    const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
     const response = await context.fetcher(url, {
       method: "GET",
       headers,
-      signal: context.signal,
+      signal: context.signal ? AbortSignal.any([context.signal, timeoutSignal]) : timeoutSignal,
     });
     if (!response.ok) {
       throw new ProviderRequestError(
@@ -527,7 +529,7 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
     const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
     return {
-      fileId: objectKey,
+      objectKey,
       name,
       mimeType,
       sizeBytes: file.sizeBytes,

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -348,7 +348,28 @@ async function createAliyunOssClient(input: AliyunClientOptions): Promise<Aliyun
 
 function buildAliyunOssProxyBaseUrl(endpoint: string, bucket: string | undefined): string {
   const endpointUrl = new URL(normalizeEndpoint(endpoint));
-  return bucket ? `https://${bucket}.${endpointUrl.host}` : endpointUrl.toString();
+  if (!bucket) {
+    return endpointUrl.toString();
+  }
+
+  const expectedHost = `${bucket}.${endpointUrl.host}`;
+  let url: URL;
+  try {
+    url = new URL(`https://${expectedHost}`);
+  } catch {
+    throw new ProviderRequestError(400, "bucket must not alter the Alibaba Cloud OSS endpoint");
+  }
+  if (
+    url.host !== expectedHost.toLowerCase() ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new ProviderRequestError(400, "bucket must not alter the Alibaba Cloud OSS endpoint");
+  }
+  return url.toString();
 }
 
 function buildAliyunOssProxyResource(url: URL, bucket: string | undefined): string {
@@ -480,13 +501,13 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
     const endpoint = resolveEndpoint(input, context);
-    const client = await createClientForAction(input, context, bucket);
     const versionId = optionalString(input.versionId);
     const url = createProviderProxyUrl(
       buildAliyunOssProxyBaseUrl(endpoint, bucket),
       `/${encodeOssObjectKey(objectKey)}`,
       versionId ? { versionId } : undefined,
     );
+    const client = await createClientForAction(input, context, bucket);
     const headers = new Headers();
     headers.set("accept", "*/*");
     headers.set("user-agent", providerUserAgent);

--- a/src/providers/aliyun_oss/executors.ts
+++ b/src/providers/aliyun_oss/executors.ts
@@ -16,6 +16,7 @@ import {
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -472,10 +473,13 @@ async function aliyunHeadObject(input: Record<string, unknown>, context: AliyunO
 }
 
 async function aliyunDownloadObject(input: Record<string, unknown>, context: AliyunOssContext): Promise<unknown> {
+  let timeoutSignal: AbortSignal | undefined;
   try {
     if (!context.transitFiles) {
       throw new ProviderRequestError(400, "aliyun_oss download_object requires local transit file storage");
     }
+
+    timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
 
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
@@ -506,7 +510,6 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
       ),
     );
 
-    const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
     const response = await context.fetcher(url, {
       method: "GET",
       headers,
@@ -536,6 +539,9 @@ async function aliyunDownloadObject(input: Record<string, unknown>, context: Ali
       file,
     };
   } catch (error) {
+    if (timeoutSignal?.aborted && !context.signal?.aborted && isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, "aliyun_oss download timed out", error);
+    }
     throw normalizeAliyunError(error, "execute");
   }
 }

--- a/src/providers/aws_s3/actions.ts
+++ b/src/providers/aws_s3/actions.ts
@@ -36,6 +36,20 @@ const objectSchema = s.object("An S3 object summary.", {
   owner: s.nullable(ownerSchema),
 });
 
+const downloadedObjectSchema = s.requiredObject("A downloaded S3 object stored in local transit storage.", {
+  fileId: s.nonEmptyString("The S3 object key."),
+  name: s.nonEmptyString("The filename used for the local transit file."),
+  mimeType: s.nonEmptyString("The downloaded object MIME type."),
+  sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),
+  file: s.requiredObject("The downloaded object in local transit file storage.", {
+    fileId: s.nonEmptyString("The local transit file identifier."),
+    downloadUrl: s.url("The local transit URL for downloading the stored object."),
+    sizeBytes: s.nonNegativeInteger("The stored transit file size in bytes."),
+    name: s.nonEmptyString("The stored transit file name."),
+    mimeType: s.nonEmptyString("The stored transit file MIME type."),
+  }),
+});
+
 const objectMetadataSchema = s.object("Structured S3 object metadata.", {
   bucket: s.string("The bucket that stores the object."),
   objectKey: s.string("The object key."),
@@ -159,6 +173,22 @@ export const awsActions: ActionDefinition[] = [
     outputSchema: s.object("The output payload for this action.", {
       object: objectMetadataSchema,
     }),
+  }),
+  defineProviderAction(service, {
+    name: "download_object",
+    description: "Download one S3 object into local transit file storage.",
+    inputSchema: s.object(
+      "The input payload for downloading one S3 object.",
+      {
+        bucket: bucketNameField,
+        objectKey: s.nonEmptyString("The complete S3 object key. Slashes are preserved as key delimiters."),
+        region: regionField,
+        versionId: s.string("The optional object version ID."),
+        fileName: s.nonEmptyString("An optional filename override for the local transit file."),
+      },
+      { optional: ["bucket", "region", "versionId", "fileName"] },
+    ),
+    outputSchema: downloadedObjectSchema,
   }),
   defineProviderAction(service, {
     name: "put_object",

--- a/src/providers/aws_s3/actions.ts
+++ b/src/providers/aws_s3/actions.ts
@@ -37,7 +37,7 @@ const objectSchema = s.object("An S3 object summary.", {
 });
 
 const downloadedObjectSchema = s.requiredObject("A downloaded S3 object stored in local transit storage.", {
-  fileId: s.nonEmptyString("The S3 object key."),
+  objectKey: objectKeyField,
   name: s.nonEmptyString("The filename used for the local transit file."),
   mimeType: s.nonEmptyString("The downloaded object MIME type."),
   sizeBytes: s.nonNegativeInteger("The downloaded object size in bytes."),

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -139,35 +139,6 @@ describe("AWS S3 download_object", () => {
     });
     expect(fetch).not.toHaveBeenCalled();
   });
-
-  it("returns 504 when the download request times out", async () => {
-    const timeoutReason = new DOMException("The operation was aborted due to timeout", "TimeoutError");
-    const timeoutController = new AbortController();
-    timeoutController.abort(timeoutReason);
-    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
-    vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.signal?.aborted) {
-        throw timeoutReason;
-      }
-      throw new Error("expected download fetch to use an aborted timeout signal");
-    });
-    const { store } = createTransitFileStore(1024);
-
-    try {
-      const result = await executeDownload({ bucket: "documents", objectKey: "slow.bin" }, store);
-
-      expect(result).toMatchObject({
-        ok: false,
-        error: {
-          code: "provider_error",
-          message: "aws_s3 download timed out",
-          details: { status: 504 },
-        },
-      });
-    } finally {
-      timeoutSpy.mockRestore();
-    }
-  });
 });
 
 describe("AWS S3 put_object sourceUrl", () => {

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -49,7 +49,7 @@ describe("AWS S3 download_object", () => {
     expect(result).toEqual({
       ok: true,
       output: {
-        fileId: "reports/annual report #1.pdf",
+        objectKey: "reports/annual report #1.pdf",
         name: "annual report #1.pdf",
         mimeType: "application/pdf",
         sizeBytes: content.length,
@@ -81,7 +81,7 @@ describe("AWS S3 download_object", () => {
     expect(result).toMatchObject({
       ok: true,
       output: {
-        fileId: objectKey,
+        objectKey,
         name: "report.txt",
         file: { name: "report.txt" },
       },
@@ -141,6 +141,28 @@ describe("AWS S3 download_object", () => {
   });
 });
 
+describe("AWS S3 put_object sourceUrl", () => {
+  it("rejects a cloud-metadata sourceUrl before any outbound fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucket: "documents",
+      objectKey: "reports/source.bin",
+      sourceUrl: "https://169.254.169.254/latest/meta-data/",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "sourceUrl must not target private or reserved IP addresses",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
 function stubResponses(responses: Response[]): CapturedRequest[] {
   const requests: CapturedRequest[] = [];
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -186,6 +208,18 @@ function createTransitFileStore(maxBytes: number): {
 }
 
 async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  return executeAction("aws_s3.download_object", input, transitFiles);
+}
+
+async function executePut(input: Record<string, unknown>) {
+  return executeAction("aws_s3.put_object", input);
+}
+
+async function executeAction(
+  action: "aws_s3.download_object" | "aws_s3.put_object",
+  input: Record<string, unknown>,
+  transitFiles?: TransitFileStore,
+) {
   const context: ExecutionContext = {
     getCredential: async (service) => {
       expect(service).toBe("aws_s3");
@@ -195,5 +229,5 @@ async function executeDownload(input: Record<string, unknown>, transitFiles?: Tr
   if (transitFiles) {
     context.transitFiles = transitFiles;
   }
-  return executors["aws_s3.download_object"]!(input, context);
+  return executors[action]!(input, context);
 }

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -106,6 +106,34 @@ describe("AWS S3 download_object", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects bucket and region values that alter the provider origin", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const invalidBucket = await executeDownload({ bucket: "attacker.example#", objectKey: "report.pdf" }, store);
+    const invalidRegion = await executeDownload(
+      { bucket: "documents", region: "us-east-1.attacker.example#", objectKey: "report.pdf" },
+      store,
+    );
+
+    expect(invalidBucket).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "bucket and region must form a valid AWS S3 endpoint",
+      },
+    });
+    expect(invalidRegion).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "bucket and region must form a valid AWS S3 endpoint",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
     const { store, create } = createTransitFileStore(2);

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -139,6 +139,34 @@ describe("AWS S3 download_object", () => {
     });
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it("returns 504 when the download request times out", async () => {
+    const timeoutController = new AbortController();
+    timeoutController.abort();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+    vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      throw new Error("expected download fetch to use an aborted timeout signal");
+    });
+    const { store } = createTransitFileStore(1024);
+
+    try {
+      const result = await executeDownload({ bucket: "documents", objectKey: "slow.bin" }, store);
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "provider_error",
+          message: "aws_s3 download timed out",
+          details: { status: 504 },
+        },
+      });
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("AWS S3 put_object sourceUrl", () => {

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -141,12 +141,13 @@ describe("AWS S3 download_object", () => {
   });
 
   it("returns 504 when the download request times out", async () => {
+    const timeoutReason = new DOMException("The operation was aborted due to timeout", "TimeoutError");
     const timeoutController = new AbortController();
-    timeoutController.abort();
+    timeoutController.abort(timeoutReason);
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
     vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.signal?.aborted) {
-        throw new DOMException("Aborted", "AbortError");
+        throw timeoutReason;
       }
       throw new Error("expected download fetch to use an aborted timeout signal");
     });

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -1,0 +1,199 @@
+import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+interface CapturedRequest {
+  url: URL;
+  authorization: string | null;
+  amzContentSha256: string | null;
+}
+
+const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    accessKeyId: "AKIAEXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    region: "us-east-1",
+    bucket: "documents",
+  },
+  profile: { accountId: "AKIAEXAMPLE", displayName: "AWS S3 test", grantedScopes: [] },
+  metadata: { region: "us-east-1", bucket: "documents" },
+};
+
+beforeEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe("AWS S3 download_object", () => {
+  it("downloads an object byte-for-byte into transit storage", async () => {
+    const content = new Uint8Array([83, 51, 0, 255]);
+    const requests = stubResponses([
+      new Response(content, {
+        headers: {
+          "content-type": "application/pdf",
+          etag: '"etag-1"',
+        },
+      }),
+    ]);
+    const { store, create } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "reports/annual report #1.pdf" }, store);
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        fileId: "reports/annual report #1.pdf",
+        name: "annual report #1.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: content.length,
+        file: {
+          fileId: "transit-file-1",
+          downloadUrl: "http://localhost/api/files/transit-file-1",
+          sizeBytes: content.length,
+          name: "annual report #1.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.hostname).toBe("documents.s3.us-east-1.amazonaws.com");
+    expect(requests[0]?.url.pathname).toBe("/reports/annual%20report%20%231.pdf");
+    expect(requests[0]?.authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE\//);
+    expect(requests[0]?.amzContentSha256).toBe("UNSIGNED-PAYLOAD");
+    expect(create).toHaveBeenCalledOnce();
+    expect(new Uint8Array(await create.mock.calls[0]![0].arrayBuffer())).toEqual(content);
+  });
+
+  it("preserves boundary whitespace and strictly encodes reserved key characters", async () => {
+    const objectKey = " reports/file!'()*.txt ";
+    const requests = stubResponses([new Response("ok")]);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey, fileName: "report.txt" }, store);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        fileId: objectKey,
+        name: "report.txt",
+        file: { name: "report.txt" },
+      },
+    });
+    expect(requests[0]?.url.pathname).toBe("/%20reports/file%21%27%28%29%2A.txt%20");
+  });
+
+  it("rejects dot segments instead of normalizing the object key", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "a/../secret" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectKey must not contain . or .. path segments",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("honors the transit size limit without storing a partial object", async () => {
+    const requests = stubResponses([new Response(new Uint8Array([1, 2, 3]))]);
+    const { store, create } = createTransitFileStore(2);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "large.bin" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "AWS S3 download exceeds 2 bytes",
+        details: { status: 413 },
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when transit file storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeDownload({ bucket: "documents", objectKey: "report.pdf" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "aws_s3 download_object requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function stubResponses(responses: Response[]): CapturedRequest[] {
+  const requests: CapturedRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      authorization: request.headers.get("authorization"),
+      amzContentSha256: request.headers.get("x-amz-content-sha256"),
+    });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected AWS S3 request to ${request.url}`);
+    }
+    return response;
+  });
+  return requests;
+}
+
+function createTransitFileStore(maxBytes: number): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (file) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: file.size,
+    name: file.name,
+    mimeType: file.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        throw new Error("read is not expected in this test");
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
+async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("aws_s3");
+      return credential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executors["aws_s3.download_object"]!(input, context);
+}

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -15,6 +15,7 @@ import {
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -346,14 +347,16 @@ async function awsHeadObject(input: Record<string, unknown>, context: AwsActionC
 }
 
 async function awsDownloadObject(input: Record<string, unknown>, context: AwsActionContext) {
+  let timeoutSignal: AbortSignal | undefined;
   try {
     if (!context.transitFiles) {
       throw new ProviderRequestError(400, "aws_s3 download_object requires local transit file storage");
     }
 
+    timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
+
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
-    const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
     const response = await awsS3Request(createClientForAction(input, context), {
       method: "GET",
       bucket,
@@ -381,6 +384,9 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
       file,
     };
   } catch (error) {
+    if (timeoutSignal?.aborted && !context.signal?.aborted && isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, "aws_s3 download timed out", error);
+    }
     throw normalizeAwsError(error, "execute");
   }
 }

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -15,7 +15,6 @@ import {
   createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -347,13 +346,10 @@ async function awsHeadObject(input: Record<string, unknown>, context: AwsActionC
 }
 
 async function awsDownloadObject(input: Record<string, unknown>, context: AwsActionContext) {
-  let timeoutSignal: AbortSignal | undefined;
   try {
     if (!context.transitFiles) {
       throw new ProviderRequestError(400, "aws_s3 download_object requires local transit file storage");
     }
-
-    timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
 
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
@@ -364,7 +360,7 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
       query: compactObject({
         versionId: optionalString(input.versionId),
       }),
-      signal: context.signal ? AbortSignal.any([context.signal, timeoutSignal]) : timeoutSignal,
+      signal: context.signal,
     });
 
     const name = optionalString(input.fileName) ?? defaultObjectFileName(objectKey);
@@ -384,13 +380,6 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
       file,
     };
   } catch (error) {
-    if (
-      timeoutSignal?.aborted &&
-      !context.signal?.aborted &&
-      (isAbortLikeError(error) || error === timeoutSignal.reason)
-    ) {
-      throw new ProviderRequestError(504, "aws_s3 download timed out", error);
-    }
     throw normalizeAwsError(error, "execute");
   }
 }

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -384,7 +384,11 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
       file,
     };
   } catch (error) {
-    if (timeoutSignal?.aborted && !context.signal?.aborted && isAbortLikeError(error)) {
+    if (
+      timeoutSignal?.aborted &&
+      !context.signal?.aborted &&
+      (isAbortLikeError(error) || error === timeoutSignal.reason)
+    ) {
       throw new ProviderRequestError(504, "aws_s3 download timed out", error);
     }
     throw normalizeAwsError(error, "execute");

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -353,6 +353,7 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
 
     const bucket = resolveBucket(input, context);
     const objectKey = readObjectKey(input);
+    const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
     const response = await awsS3Request(createClientForAction(input, context), {
       method: "GET",
       bucket,
@@ -360,7 +361,7 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
       query: compactObject({
         versionId: optionalString(input.versionId),
       }),
-      signal: context.signal,
+      signal: context.signal ? AbortSignal.any([context.signal, timeoutSignal]) : timeoutSignal,
     });
 
     const name = optionalString(input.fileName) ?? defaultObjectFileName(objectKey);
@@ -373,7 +374,7 @@ async function awsDownloadObject(input: Record<string, unknown>, context: AwsAct
     const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
 
     return {
-      fileId: objectKey,
+      objectKey,
       name,
       mimeType,
       sizeBytes: file.sizeBytes,

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -4,12 +4,13 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
+  TransitFileWriter,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { createHash, createHmac } from "node:crypto";
-import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl } from "../../core/request.ts";
+import { compactObject, optionalRecord, optionalString, requiredRawString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   createProviderProxyUrl,
   createProviderTimeout,
@@ -26,6 +27,7 @@ type AwsActionContext = {
   values: Record<string, string>;
   metadata: Record<string, unknown>;
   fetcher: typeof fetch;
+  transitFiles?: TransitFileWriter;
   signal?: AbortSignal;
 };
 
@@ -98,6 +100,9 @@ export const awsActionHandlers: ProviderActionHandlers<"aws_s3", AwsActionHandle
   head_object(input, context) {
     return awsHeadObject(input, context);
   },
+  download_object(input, context) {
+    return awsDownloadObject(input, context);
+  },
   put_object(input, context) {
     return awsPutObject(input, context);
   },
@@ -121,6 +126,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<AwsActionCon
       values: credential.values,
       metadata: credential.metadata,
       fetcher,
+      transitFiles: context.transitFiles,
       signal: context.signal,
     };
   },
@@ -337,6 +343,45 @@ async function awsHeadObject(input: Record<string, unknown>, context: AwsActionC
       headers,
     },
   };
+}
+
+async function awsDownloadObject(input: Record<string, unknown>, context: AwsActionContext) {
+  try {
+    if (!context.transitFiles) {
+      throw new ProviderRequestError(400, "aws_s3 download_object requires local transit file storage");
+    }
+
+    const bucket = resolveBucket(input, context);
+    const objectKey = readObjectKey(input);
+    const response = await awsS3Request(createClientForAction(input, context), {
+      method: "GET",
+      bucket,
+      objectKey,
+      query: compactObject({
+        versionId: optionalString(input.versionId),
+      }),
+      signal: context.signal,
+    });
+
+    const name = optionalString(input.fileName) ?? defaultObjectFileName(objectKey);
+    const mimeType = optionalString(response.headers.get("content-type")) ?? "application/octet-stream";
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: context.transitFiles.maxBytes,
+      fieldName: "AWS S3 download",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+
+    return {
+      fileId: objectKey,
+      name,
+      mimeType,
+      sizeBytes: file.sizeBytes,
+      file,
+    };
+  } catch (error) {
+    throw normalizeAwsError(error, "execute");
+  }
 }
 
 async function awsPutObject(input: Record<string, unknown>, context: AwsActionContext) {
@@ -663,6 +708,25 @@ function encodeS3Key(value: string) {
     .split("/")
     .map((segment) => encodeRfc3986(segment))
     .join("/");
+}
+
+function readObjectKey(input: Record<string, unknown>): string {
+  const objectKey = requiredRawString(
+    input.objectKey,
+    "objectKey",
+    (message) => new ProviderRequestError(400, message),
+  );
+  if (objectKey.length === 0) {
+    throw new ProviderRequestError(400, "objectKey must not be empty");
+  }
+  if (objectKey.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new ProviderRequestError(400, "objectKey must not contain . or .. path segments");
+  }
+  return objectKey;
+}
+
+function defaultObjectFileName(objectKey: string): string {
+  return objectKey.split("/").findLast((segment) => segment.length > 0) ?? "s3-object";
 }
 
 function encodeRfc3986(value: string) {

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -475,7 +475,7 @@ function normalizeAwsS3ProxyMethod(method: string): "GET" | "PUT" | "HEAD" | "DE
 }
 
 function buildAwsS3ProxyBaseUrl(region: string, bucket: string | undefined): string {
-  return bucket ? `https://${bucket}.s3.${region}.amazonaws.com` : `https://s3.${region}.amazonaws.com`;
+  return createAwsS3BaseUrl(region, bucket).origin;
 }
 
 function normalizeAwsS3ProxyBody(body: unknown): string | undefined {
@@ -651,8 +651,7 @@ function buildRequestTarget(input: {
   objectKey?: string;
   query?: Record<string, string | number | boolean | undefined>;
 }) {
-  const host = input.bucket ? `${input.bucket}.s3.${input.region}.amazonaws.com` : `s3.${input.region}.amazonaws.com`;
-  const url = new URL(`https://${host}`);
+  const url = createAwsS3BaseUrl(input.region, input.bucket);
   url.pathname = input.objectKey ? `/${encodeS3Key(input.objectKey)}` : "/";
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value == null) {
@@ -664,6 +663,27 @@ function buildRequestTarget(input: {
   return {
     url,
   };
+}
+
+function createAwsS3BaseUrl(region: string, bucket: string | undefined): URL {
+  const expectedHost = bucket ? `${bucket}.s3.${region}.amazonaws.com` : `s3.${region}.amazonaws.com`;
+  let url: URL;
+  try {
+    url = new URL(`https://${expectedHost}`);
+  } catch {
+    throw new ProviderRequestError(400, "bucket and region must form a valid AWS S3 endpoint");
+  }
+  if (
+    url.host !== expectedHost.toLowerCase() ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new ProviderRequestError(400, "bucket and region must form a valid AWS S3 endpoint");
+  }
+  return url;
 }
 
 function buildObjectUrl(region: string, bucket: string, objectKey: string) {


### PR DESCRIPTION
## Summary
- Add `download_object` for `aliyun_oss` and `aws_s3` so objects can be fetched into local transit file storage with bounded reads and safe object-key handling.
- Harden `put_object` `sourceUrl` downloads to use shared `assertPublicHttpUrl` plus public-only `providerFetch` (never private-network opt-in).
- Cover success and rejection paths with provider-local executor tests.

## Test plan
- [x] `npm run fix-check`
- [ ] Review that `sourceUrl` uses public-only validation/fetch; `download_object` only talks to the configured OSS/S3 endpoint
- [ ] Spot-check key encoding / `..` rejection tests in `aliyun_oss` and `aws_s3` executor tests

Made with [Cursor](https://cursor.com)