### PR TITLE
fix(outlook): accept Graph's parenthesized folder-scoped nextLink

### DIFF
--- a/src/providers/outlook/executors.test.ts
+++ b/src/providers/outlook/executors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { outlookJsonRequest } from "./executors.ts";
+
+// The allowlist runs before any fetch, so whether the fetcher was
+// called tells which side of it a URL landed on.
+function recordingFetcher(calls: string[]): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    calls.push(String(input));
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+}
+
+describe("outlook nextLink path allowlist", () => {
+  it("accepts Graph's parenthesized folder-scoped continuation URL", async () => {
+    // Real wire shape, id elided.
+    const calls: string[] = [];
+    await outlookJsonRequest(
+      "https://graph.microsoft.com/v1.0/me/mailFolders('AQMkADAwATM3ZmYtRFRM')/messages?%24select=id&%24top=2&%24skiptoken=RFRM9",
+      { accessToken: "test-token", fetcher: recordingFetcher(calls) },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/v1.0/me/mailFolders('AQMkADAwATM3ZmYtRFRM')/messages");
+  });
+
+  it("accepts the unscoped messages URL and the slash-form folder URL", async () => {
+    for (const url of [
+      "https://graph.microsoft.com/v1.0/me/messages?%24top=2&%24skiptoken=RFRM9",
+      "https://graph.microsoft.com/v1.0/me/mailFolders/AQMkADAwATM3ZmYtRFRM/messages?%24top=2",
+    ]) {
+      const calls: string[] = [];
+      await outlookJsonRequest(url, { accessToken: "test-token", fetcher: recordingFetcher(calls) });
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  it("rejects foreign hosts, non-mail Graph paths, http downgrades, and an empty parenthesized id", async () => {
+    for (const url of [
+      "https://evil.example.com/v1.0/me/messages",
+      "https://graph.microsoft.com/v1.0/me/events",
+      "http://graph.microsoft.com/v1.0/me/messages",
+      "https://graph.microsoft.com/v1.0/me/mailFolders('')/messages",
+    ]) {
+      const calls: string[] = [];
+      await expect(
+        outlookJsonRequest(url, { accessToken: "test-token", fetcher: recordingFetcher(calls) }),
+      ).rejects.toThrow();
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  it("accepts the mail-folder listing URL under the mailFolders policy", async () => {
+    const calls: string[] = [];
+    await outlookJsonRequest("https://graph.microsoft.com/v1.0/me/mailFolders?%24top=10&%24skiptoken=RFRM9", {
+      accessToken: "test-token",
+      fetcher: recordingFetcher(calls),
+      absoluteUrlPolicy: "mailFolders",
+    });
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/providers/outlook/executors.ts
+++ b/src/providers/outlook/executors.ts
@@ -196,9 +196,7 @@ function isAllowedOutlookMessageNextLinkPath(pathname: string) {
 // Graph's @odata.nextLink uses the OData parenthesized-key form for
 // folder-scoped listings: /v1.0/me/mailFolders('{id}')/messages.
 function isParenthesizedMailFoldersSegment(segment: string) {
-  return (
-    segment.startsWith("mailFolders('") && segment.endsWith("')") && segment.length > "mailFolders('')".length
-  );
+  return segment.startsWith("mailFolders('") && segment.endsWith("')") && segment.length > "mailFolders('')".length;
 }
 
 function isAllowedOutlookMailFolderNextLinkPath(pathname: string) {

--- a/src/providers/outlook/executors.ts
+++ b/src/providers/outlook/executors.ts
@@ -187,7 +187,18 @@ function isAllowedOutlookMessageNextLinkPath(pathname: string) {
   if (segments.length === 3 && segments[2] === "messages") {
     return true;
   }
+  if (segments.length === 4 && isParenthesizedMailFoldersSegment(segments[2]) && segments[3] === "messages") {
+    return true;
+  }
   return segments.length === 5 && segments[2] === "mailFolders" && segments[3] !== "" && segments[4] === "messages";
+}
+
+// Graph's @odata.nextLink uses the OData parenthesized-key form for
+// folder-scoped listings: /v1.0/me/mailFolders('{id}')/messages.
+function isParenthesizedMailFoldersSegment(segment: string) {
+  return (
+    segment.startsWith("mailFolders('") && segment.endsWith("')") && segment.length > "mailFolders('')".length
+  );
 }
 
 function isAllowedOutlookMailFolderNextLinkPath(pathname: string) {


### PR DESCRIPTION
## Problem

`outlook.list_messages` with a `mailFolderId` returns a `nextLink` that the same action then refuses to consume: any folder-scoped listing that spans more than one page fails with HTTP 400 on the second request.

Graph's `@odata.nextLink` for a folder-scoped listing addresses the folder in the **OData parenthesized-key form** (real capture, id elided):

```
https://graph.microsoft.com/v1.0/me/mailFolders('AQMkA…')/messages?%24select=…&%24skiptoken=…
```

but `isAllowedOutlookMessageNextLinkPath` (src/providers/outlook/executors.ts) only accepted the five-segment slash form `/v1.0/me/mailFolders/<id>/messages`. The parenthesized path splits into four segments, so the check fails and the executor throws:

```json
{"success":false,"message":"nextLink must target Outlook message pagination endpoints","data":{"status":400},"errorCode":"invalid_input"}
```

The failure is unavoidable for the caller — the rejected URL is the one the previous response produced. The unscoped `/v1.0/me/messages` form is unaffected.

## Fix

Accept the parenthesized segment (`mailFolders('<non-empty id>')`) alongside the existing forms. Host pinning, the https requirement, and every other rejection are unchanged.

Also adds the first tests for this allowlist (`executors.test.ts`, through the exported `outlookJsonRequest` with an injected fetcher): the parenthesized form is accepted, the previously-accepted forms stay accepted, and foreign hosts / non-mail Graph paths / http downgrades / an empty parenthesized id all stay refused before any fetch.

## Verification

Reproduced and verified against a live personal (MSA) mailbox through gateway v1.3.4:

- **Before**: `top=2` folder-scoped walk — page 1 returns rows + `nextLink`; feeding that `nextLink` back → 400 `invalid_input`.
- **After**: the same walk paginates 3 pages (2+2+1 rows, all in the scoped folder) to a genuinely-null terminal `nextLink`; the negative cases above still 400.
- `npx vitest run src/providers/outlook/executors.test.ts` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
