### PR TITLE
feat(runtime): align unknown_action errors with OpenAPI and runtime docs

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -173,8 +173,7 @@ curl -s -X POST "http://localhost:3000/v1/actions/github.get_current_user?alias=
 ```
 
 `alias` is the `/v1` name for a named connection. MCP tools use `connectionName` for the same
-fact, and HTTP also accepts `connectionName` in the query or JSON body, plus the
-`x-oo-connector-alias` and legacy `x-oomol-connector-alias` headers. The default connection is
+fact, and HTTP also accepts `connectionName` in the query or JSON body. The default connection is
 `default`.
 
 Persistent tokens with a non-empty `allowedConnections` list must be granted the selected stable

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -172,10 +172,18 @@ curl -s -X POST "http://localhost:3000/v1/actions/github.get_current_user?alias=
   -d '{"input":{}}'
 ```
 
+`alias` is the `/v1` name for a named connection. MCP tools use `connectionName` for the same
+fact, and HTTP also accepts `connectionName` in the query or JSON body, plus the
+`x-oo-connector-alias` and legacy `x-oomol-connector-alias` headers. The default connection is
+`default`.
+
 Persistent tokens with a non-empty `allowedConnections` list must be granted the selected stable
 connection ID. Omitting the alias selects the target provider's default connection and is denied
 unless that connection's ID is listed. The denial is HTTP `403` with `connection_not_allowed` and happens before
 credential lookup. `/v1/apps` discovery for that token is filtered to granted credential connections.
+
+Unknown Action ids return `404 unknown_action` on both `/v1` and MCP `execute_action` /
+`get_action_guide`. Schema and idempotency-key failures stay `400 invalid_input`.
 
 ### Idempotent Action Retries
 

--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -265,6 +265,9 @@ by age.
 - `GET /v1/apps/authenticated`
 - `POST /v1/proxy/:service`
 
+`GET /v1/apps/authenticated` checks the repeated `service` query values and returns the authenticated
+service IDs from that candidate set. It returns an empty list when no candidates are supplied.
+
 `POST /v1/proxy/:service` proxies one provider API request when that provider has a registered or
 provider-specific local proxy executor. Providers without a proxy executor return `proxy_not_supported`.
 

--- a/src/server/actions/action-runner.ts
+++ b/src/server/actions/action-runner.ts
@@ -53,7 +53,7 @@ export class ActionRunner {
         {
           actionId: input.actionId,
           caller: input.caller,
-          errorCode: "invalid_input",
+          errorCode: "unknown_action",
         },
         "action run rejected",
       );

--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -60,6 +60,14 @@ describe("action execution OpenAPI", () => {
         description:
           "Optional runtime-wide key for deduplicating retries of the same action request. Leading and trailing whitespace is trimmed; the remaining value must be non-empty and must not exceed 255 UTF-8 bytes. Reuse a key only for retries with the same action, input, effective connection, and stored runtime token. When this header is present, the action input must not exceed an object/array nesting depth of 100 levels.",
       });
+      expect(path.post.parameters).toContainEqual({
+        name: "connectionName",
+        in: "query",
+        required: false,
+        schema: { type: "string" },
+        description:
+          "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, and x-oo-connector-alias are equivalent. Defaults to default.",
+      });
       expect(path.post.responses["409"]?.description).toBe(
         "For idempotency, idempotency_request_in_progress means the original request is still running or its outcome is uncertain, while idempotency_key_conflict means the key was reused for a different action, input, effective connection, or stored runtime token. Other runtime conflicts may return their own error code with the same status.",
       );
@@ -81,6 +89,9 @@ describe("action execution OpenAPI", () => {
       };
     };
     const actionPath = document.paths["/v1/actions/{actionId}"] as { get?: unknown; post?: unknown };
+    const authenticatedApps = document.paths["/v1/apps/authenticated"] as {
+      get: { summary: string; parameters: Array<{ name: string; description: string }> };
+    };
     const connectedApp = document.components.schemas.RuntimeConnectedApp as {
       required: string[];
       properties: { alias?: { description?: string } };
@@ -127,6 +138,15 @@ describe("action execution OpenAPI", () => {
     expect(connectedApp.required).toEqual(expect.arrayContaining(["alias", "isDefault"]));
     expect(connectedApp.properties.alias?.description).toContain("connectionName");
     expect(connectedApp.properties.alias?.description).not.toContain("x-oomol-connector-alias");
+    expect(authenticatedApps.get.summary).toBe(
+      "Return authenticated provider service IDs from the supplied candidates.",
+    );
+    expect(authenticatedApps.get.parameters).toContainEqual(
+      expect.objectContaining({
+        name: "service",
+        description: "Candidate service id to check. Repeat to check multiple services.",
+      }),
+    );
   });
 
   it("documents Runtime and token policy management and run audit metadata", () => {

--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -86,12 +86,24 @@ describe("action execution OpenAPI", () => {
       properties: { alias?: { description?: string } };
     };
 
+    const health = document.paths["/health"] as {
+      get: {
+        responses: Record<
+          string,
+          { content?: { "application/json"?: { schema?: { type?: string; required?: string[] } } } }
+        >;
+      };
+    };
+    const healthSchema = health.get.responses["200"]?.content?.["application/json"]?.schema;
+
     expect(document.paths["/v1/health"]).toBeDefined();
     expect(document.paths["/v1/providers"]).toBeDefined();
     expect(document.paths["/v1/actions"]).toBeDefined();
     expect(document.paths["/v1/apps"]).toBeDefined();
     expect(actionPath.get).toBeDefined();
     expect(actionPath.post).toBeDefined();
+    expect(healthSchema?.type).toBe("object");
+    expect(healthSchema?.required).toEqual(expect.arrayContaining(["ok"]));
     expect(document.components.schemas.ActionSearchRuntimeResult).toEqual({
       $ref: "#/components/schemas/ActionSearchResult",
     });
@@ -101,6 +113,7 @@ describe("action execution OpenAPI", () => {
     expect(search.get.responses["404"]).toBeUndefined();
     expect(connectedApp.required).toEqual(expect.arrayContaining(["alias", "isDefault"]));
     expect(connectedApp.properties.alias?.description).toContain("connectionName");
+    expect(connectedApp.properties.alias?.description).toContain("x-oomol-connector-alias");
   });
 
   it("documents Runtime and token policy management and run audit metadata", () => {

--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -86,15 +86,26 @@ describe("action execution OpenAPI", () => {
       properties: { alias?: { description?: string } };
     };
 
-    const health = document.paths["/health"] as {
+    const health = document.paths["/v1/health"] as {
       get: {
         responses: Record<
           string,
-          { content?: { "application/json"?: { schema?: { type?: string; required?: string[] } } } }
+          {
+            content?: {
+              "application/json"?: {
+                schema?: {
+                  type?: string;
+                  required?: string[];
+                  properties?: { data?: { type?: string; required?: string[] } };
+                };
+              };
+            };
+          }
         >;
       };
     };
     const healthSchema = health.get.responses["200"]?.content?.["application/json"]?.schema;
+    const healthDataSchema = healthSchema?.properties?.data;
 
     expect(document.paths["/v1/health"]).toBeDefined();
     expect(document.paths["/v1/providers"]).toBeDefined();
@@ -103,7 +114,9 @@ describe("action execution OpenAPI", () => {
     expect(actionPath.get).toBeDefined();
     expect(actionPath.post).toBeDefined();
     expect(healthSchema?.type).toBe("object");
-    expect(healthSchema?.required).toEqual(expect.arrayContaining(["ok"]));
+    expect(healthSchema?.required).toEqual(expect.arrayContaining(["success", "message", "data", "meta"]));
+    expect(healthDataSchema?.type).toBe("object");
+    expect(healthDataSchema?.required).toEqual(expect.arrayContaining(["ok", "runtime"]));
     expect(document.components.schemas.ActionSearchRuntimeResult).toEqual({
       $ref: "#/components/schemas/ActionSearchResult",
     });

--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -113,7 +113,7 @@ describe("action execution OpenAPI", () => {
     expect(search.get.responses["404"]).toBeUndefined();
     expect(connectedApp.required).toEqual(expect.arrayContaining(["alias", "isDefault"]));
     expect(connectedApp.properties.alias?.description).toContain("connectionName");
-    expect(connectedApp.properties.alias?.description).toContain("x-oomol-connector-alias");
+    expect(connectedApp.properties.alias?.description).not.toContain("x-oomol-connector-alias");
   });
 
   it("documents Runtime and token policy management and run audit metadata", () => {

--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -73,6 +73,36 @@ describe("action execution OpenAPI", () => {
     },
   );
 
+  it("documents public /v1 catalog routes with the runtime envelope", () => {
+    const document = createOpenApiDocument([provider]);
+    const search = document.paths["/v1/actions/search"] as {
+      get: {
+        responses: Record<string, { content?: { "application/json"?: { schema?: { required?: string[] } } } }>;
+      };
+    };
+    const actionPath = document.paths["/v1/actions/{actionId}"] as { get?: unknown; post?: unknown };
+    const connectedApp = document.components.schemas.RuntimeConnectedApp as {
+      required: string[];
+      properties: { alias?: { description?: string } };
+    };
+
+    expect(document.paths["/v1/health"]).toBeDefined();
+    expect(document.paths["/v1/providers"]).toBeDefined();
+    expect(document.paths["/v1/actions"]).toBeDefined();
+    expect(document.paths["/v1/apps"]).toBeDefined();
+    expect(actionPath.get).toBeDefined();
+    expect(actionPath.post).toBeDefined();
+    expect(document.components.schemas.ActionSearchRuntimeResult).toEqual({
+      $ref: "#/components/schemas/ActionSearchResult",
+    });
+    expect(search.get.responses["400"]?.content?.["application/json"]?.schema?.required).toEqual(
+      expect.arrayContaining(["success", "errorCode"]),
+    );
+    expect(search.get.responses["404"]).toBeUndefined();
+    expect(connectedApp.required).toEqual(expect.arrayContaining(["alias", "isDefault"]));
+    expect(connectedApp.properties.alias?.description).toContain("connectionName");
+  });
+
   it("documents Runtime and token policy management and run audit metadata", () => {
     const document = createOpenApiDocument([provider]);
     const runtimePolicyPath = document.paths["/api/runtime-policy"] as {

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -131,6 +131,13 @@ const namedConnectionParameters = [
     description: namedConnectionDescription,
   },
   {
+    name: "connectionName",
+    in: "query",
+    required: false,
+    schema: jsonSchema.string(),
+    description: namedConnectionDescription,
+  },
+  {
     name: "alias",
     in: "query",
     required: false,
@@ -260,15 +267,21 @@ export function createOpenApiDocument(
         "RuntimeConnectedApp rows, not the provider catalog. Use GET /v1/providers or MCP list_apps for providers.",
       data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeConnectedApp" }),
     }),
-    "/v1/apps/authenticated": runtimeGetOperation("Connections", "List authenticated provider service ids.", {
-      parameters: [
-        queryParameter("service", "Optional service id filter. Repeat to include multiple services.", {
-          type: "array",
-          items: jsonSchema.string(),
+    "/v1/apps/authenticated": runtimeGetOperation(
+      "Connections",
+      "Return authenticated provider service IDs from the supplied candidates.",
+      {
+        parameters: [
+          queryParameter("service", "Candidate service id to check. Repeat to check multiple services.", {
+            type: "array",
+            items: jsonSchema.string(),
+          }),
+        ],
+        data: jsonSchema.array(jsonSchema.string(), {
+          description: "Authenticated service IDs from the supplied candidates.",
         }),
-      ],
-      data: jsonSchema.array(jsonSchema.string(), { description: "Authenticated provider service ids." }),
-    }),
+      },
+    ),
     "/v1/apps/services/{service}": runtimeGetOperation("Connections", "List connected accounts for one provider.", {
       parameters: [
         {

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -119,6 +119,31 @@ const actionIdParameter = {
   schema: jsonSchema.string({ description: "Action id, usually <service>.<name>." }),
 };
 
+const namedConnectionDescription =
+  "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, and x-oo-connector-alias are equivalent. Defaults to default.";
+
+const namedConnectionParameters = [
+  {
+    name: "x-oo-connector-alias",
+    in: "header",
+    required: false,
+    schema: jsonSchema.string(),
+    description: namedConnectionDescription,
+  },
+  {
+    name: "alias",
+    in: "query",
+    required: false,
+    schema: jsonSchema.string(),
+    description: namedConnectionDescription,
+  },
+];
+
+const namedConnectionProperties = {
+  connectionName: jsonSchema.string({ description: namedConnectionDescription }),
+  alias: jsonSchema.string({ description: namedConnectionDescription }),
+};
+
 const idempotencyKeyParameter = {
   name: "Idempotency-Key",
   in: "header",
@@ -150,7 +175,16 @@ export function createOpenApiDocument(
   }
 
   const paths: Record<string, unknown> = {
-    "/health": getOperation("System", "Runtime health check.", { ok: jsonSchema.boolean() }),
+    "/health": getOperation("System", "Unauthenticated process health check.", { ok: jsonSchema.boolean() }),
+    "/v1/health": runtimeGetOperation("System", "Runtime health check.", {
+      data: jsonSchema.object(
+        {
+          ok: jsonSchema.boolean(),
+          runtime: jsonSchema.string({ description: "Runtime identifier." }),
+        },
+        { required: ["ok", "runtime"], description: "Runtime health payload." },
+      ),
+    }),
     "/api/auth/session": getOperation("System", "Read local admin auth session state.", {
       $ref: "#/components/schemas/LocalAuthSession",
     }),
@@ -183,15 +217,56 @@ export function createOpenApiDocument(
       type: "array",
       items: { $ref: "#/components/schemas/ActionSearchResult" },
     }),
-    "/v1/actions/search": getOperation("Catalog", "Fuzzy keyword search over the action catalog.", {
-      type: "object",
-      properties: {
-        success: { type: "boolean" },
-        message: { type: "string" },
-        data: { type: "array", items: { $ref: "#/components/schemas/ActionSearchRuntimeResult" } },
-        meta: { type: "object", additionalProperties: true },
-      },
-      required: ["success", "message", "data", "meta"],
+    "/v1/providers": runtimeGetOperation("Catalog", "List public provider catalog entries.", {
+      description: "Closest HTTP analog of MCP list_apps. Categories are objects; MCP list_apps returns strings.",
+      parameters: [
+        queryParameter("q", "Optional case-insensitive filter over service, display name, category, or auth type."),
+        queryParameter("service", "Optional provider service id. Repeat to include multiple providers."),
+      ],
+      data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeProviderMetadata" }),
+    }),
+    "/v1/actions": runtimeGetOperation("Catalog", "List action services, or actions for one service.", {
+      description: "Without service, data is [{service}]. With service, data is RuntimeActionMetadata.",
+      parameters: [queryParameter("service", "Provider service id. Omit to list services instead of actions.")],
+      data: jsonSchema.anyOf("Runtime action index payload.", [
+        jsonSchema.array({ $ref: "#/components/schemas/RuntimeActionService" }),
+        jsonSchema.array({ $ref: "#/components/schemas/RuntimeActionMetadata" }),
+      ]),
+    }),
+    "/v1/actions/search": runtimeGetOperation("Catalog", "Fuzzy keyword search over the action catalog.", {
+      parameters: [
+        queryParameter("q", "Required search text. query is accepted as an alias."),
+        queryParameter("service", "Optional provider service id."),
+        queryParameter("limit", "Maximum actions to return. Defaults to 10. Maximum 50.", {
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
+          default: 10,
+        }),
+      ],
+      data: jsonSchema.array({ $ref: "#/components/schemas/ActionSearchResult" }),
+      errorStatuses: [400],
+    }),
+    "/v1/apps": runtimeGetOperation("Connections", "List connected accounts.", {
+      description:
+        "RuntimeConnectedApp rows, not the provider catalog. Use GET /v1/providers or MCP list_apps for providers.",
+      data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeConnectedApp" }),
+    }),
+    "/v1/apps/authenticated": runtimeGetOperation("Connections", "List authenticated provider service ids.", {
+      parameters: [queryParameter("service", "Optional service id filter. Repeat to include multiple services.")],
+      data: jsonSchema.array(jsonSchema.string(), { description: "Authenticated provider service ids." }),
+    }),
+    "/v1/apps/services/{service}": runtimeGetOperation("Connections", "List connected accounts for one provider.", {
+      parameters: [
+        {
+          name: "service",
+          in: "path",
+          required: true,
+          schema: jsonSchema.string({ description: "Provider service identifier." }),
+        },
+      ],
+      data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeConnectedApp" }),
+      errorStatuses: [400, 404],
     }),
     "/api/actions/{actionId}": getOperation("Catalog", "Get one catalog action.", {
       $ref: "#/components/schemas/ActionDefinition",
@@ -282,20 +357,123 @@ export function createOpenApiDocument(
             description: "A single action returned by fuzzy keyword search.",
           },
         ),
-        ActionSearchRuntimeResult: jsonSchema.object(
+        ActionSearchRuntimeResult: { $ref: "#/components/schemas/ActionSearchResult" },
+        RuntimeProviderMetadata: jsonSchema.object(
           {
-            service: jsonSchema.string({ description: "The provider service that owns the action." }),
-            name: jsonSchema.string({ description: "The provider-scoped action name." }),
-            description: jsonSchema.string({ description: "The action description." }),
-            authenticated: jsonSchema.boolean({
-              description: "Whether the provider service has an authenticated local connection.",
-            }),
-            inputSchema: jsonSchema.unknownObject("The normalized JSON Schema for the action input."),
-            outputSchema: jsonSchema.unknownObject("The normalized JSON Schema for the action output."),
+            service: jsonSchema.string({ description: "Provider service identifier." }),
+            displayName: jsonSchema.string({ description: "Human-readable provider name." }),
+            iconUrl: jsonSchema.nullable(jsonSchema.string({ description: "Provider icon URL." })),
+            homepageUrl: jsonSchema.nullable(jsonSchema.string({ description: "Provider homepage URL." })),
+            categories: jsonSchema.array(
+              jsonSchema.object(
+                {
+                  id: jsonSchema.string(),
+                  displayName: jsonSchema.string(),
+                },
+                { required: ["id", "displayName"], description: "Catalog category." },
+              ),
+            ),
+            authTypes: jsonSchema.array(jsonSchema.string(), { description: "Supported authentication types." }),
           },
           {
-            required: ["service", "name", "description", "authenticated", "inputSchema", "outputSchema"],
-            description: "A single action returned by the /v1 keyword search endpoint.",
+            required: ["service", "displayName", "iconUrl", "homepageUrl", "categories", "authTypes"],
+            description: "Public provider catalog row from GET /v1/providers.",
+          },
+        ),
+        RuntimeActionService: jsonSchema.object(
+          {
+            service: jsonSchema.string({ description: "Provider service identifier." }),
+          },
+          {
+            required: ["service"],
+            description: "Service index row from GET /v1/actions when service is omitted.",
+          },
+        ),
+        RuntimeActionMetadata: jsonSchema.object(
+          {
+            id: jsonSchema.string({ description: "Full action id, usually <service>.<name>." }),
+            service: jsonSchema.string({ description: "Provider service that owns the action." }),
+            name: jsonSchema.string({ description: "Provider-scoped action name." }),
+            description: jsonSchema.string({ description: "Action description." }),
+            requiredScopes: jsonSchema.array(jsonSchema.string()),
+            providerPermissions: jsonSchema.array(jsonSchema.string()),
+            inputSchema: jsonSchema.unknownObject("Normalized JSON Schema for the action input."),
+            outputSchema: jsonSchema.unknownObject("Normalized JSON Schema for the action output."),
+            followUpActions: jsonSchema.array(
+              jsonSchema.object(
+                { actionId: jsonSchema.string() },
+                { required: ["actionId"], description: "Follow-up action." },
+              ),
+            ),
+            asyncLifecycle: jsonSchema.nullable(jsonSchema.unknownObject("Start/status/cancel action ids.")),
+            execution: jsonSchema.object(
+              {
+                locallyExecutable: jsonSchema.boolean(),
+                catalogOnly: jsonSchema.boolean(),
+                requiredAuthTypes: jsonSchema.array(jsonSchema.string()),
+                noAuthRunnable: jsonSchema.boolean(),
+                needsCredential: jsonSchema.boolean(),
+              },
+              {
+                required: [
+                  "locallyExecutable",
+                  "catalogOnly",
+                  "requiredAuthTypes",
+                  "noAuthRunnable",
+                  "needsCredential",
+                ],
+                description: "Runtime execution status.",
+              },
+            ),
+          },
+          {
+            required: [
+              "id",
+              "service",
+              "name",
+              "description",
+              "requiredScopes",
+              "providerPermissions",
+              "inputSchema",
+              "outputSchema",
+              "followUpActions",
+              "asyncLifecycle",
+              "execution",
+            ],
+            description: "Public runtime action metadata.",
+          },
+        ),
+        RuntimeConnectedApp: jsonSchema.object(
+          {
+            id: jsonSchema.string({ description: "Stable local connection identifier." }),
+            service: jsonSchema.string({ description: "Provider service identifier." }),
+            status: { type: "string", enum: ["active", "disconnected"] },
+            alias: jsonSchema.string({ description: namedConnectionDescription }),
+            authType: jsonSchema.string({ description: "Connection authentication type." }),
+            displayName: jsonSchema.string({ description: "Human-readable account label." }),
+            accountLabel: jsonSchema.string({
+              description: "Same value as displayName. Kept for existing /v1 clients.",
+            }),
+            isDefault: jsonSchema.boolean({
+              description: "Whether this is the default connection. Same fact as MCP default.",
+            }),
+            scopes: jsonSchema.array(jsonSchema.string(), {
+              description: "Granted scopes. Same fact as MCP profile.grantedScopes.",
+            }),
+          },
+          {
+            required: [
+              "id",
+              "service",
+              "status",
+              "alias",
+              "authType",
+              "displayName",
+              "accountLabel",
+              "isDefault",
+              "scopes",
+            ],
+            description: "Connected account from GET /v1/apps.",
           },
         ),
         ConnectionSummary: jsonSchema.object(
@@ -894,43 +1072,27 @@ function createRunDetailPath(): Record<string, unknown> {
 
 function createRunPath(): Record<string, unknown> {
   return {
+    get: {
+      tags: ["Catalog"],
+      summary: "Get one runtime action.",
+      parameters: [actionIdParameter],
+      responses: {
+        200: jsonResponse(runtimeSuccessSchema({ $ref: "#/components/schemas/RuntimeActionMetadata" })),
+        404: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema), "unknown_action."),
+      },
+    },
     post: {
       tags: ["Runs"],
       summary: "Execute a runtime action.",
       description:
         "Use the action catalog to discover provider-specific input and output schemas. For a compact strongly typed OpenAPI document for one action, request /openapi.json?actionId=<actionId>. " +
         actionIdempotencyDescription,
-      parameters: [actionIdParameter, idempotencyKeyParameter],
-      requestBody: {
-        required: true,
-        content: {
-          "application/json": {
-            schema: jsonSchema.object(
-              {
-                input: jsonSchema.unknownObject("Action input matching the catalog schema."),
-              },
-              {
-                required: ["input"],
-                description: "Generic action run creation request.",
-              },
-            ),
-          },
-        },
-      },
-      responses: {
-        200: jsonResponse(
-          runtimeSuccessSchema(
-            jsonSchema.unknown("Action output matching the catalog schema."),
-            actionResultMetaSchema,
-          ),
-        ),
-        400: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-        403: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-        404: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-        409: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema), idempotencyConflictDescription),
-        429: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-        500: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-      },
+      parameters: [actionIdParameter, idempotencyKeyParameter, ...namedConnectionParameters],
+      requestBody: actionRunBody(
+        jsonSchema.unknownObject("Action input matching the catalog schema. Omitted input is treated as {}."),
+        "Generic action run creation request.",
+      ),
+      responses: actionRunResponses(jsonSchema.unknown("Action output matching the catalog schema.")),
     },
   };
 }
@@ -949,6 +1111,7 @@ function createProxyPath(): Record<string, unknown> {
           required: true,
           schema: jsonSchema.string({ description: "Provider service identifier." }),
         },
+        ...namedConnectionParameters,
       ],
       requestBody: {
         required: true,
@@ -971,9 +1134,7 @@ function createProxyPath(): Record<string, unknown> {
                   description: "Provider request headers. Hop-by-hop and auth headers are not forwarded.",
                 },
                 body: jsonSchema.unknown("Provider request body."),
-                connectionName: jsonSchema.string({
-                  description: "Optional local connection name. Defaults to default.",
-                }),
+                ...namedConnectionProperties,
               },
               {
                 required: ["endpoint", "method"],
@@ -1186,6 +1347,73 @@ function getOperation(tag: string, summary: string, schema: JsonSchema): Record<
   };
 }
 
+function runtimeGetOperation(
+  tag: string,
+  summary: string,
+  options: {
+    data: JsonSchema;
+    description?: string;
+    parameters?: unknown[];
+    errorStatuses?: Array<400 | 404>;
+  },
+): Record<string, unknown> {
+  const responses: Record<string, unknown> = {
+    200: jsonResponse(runtimeSuccessSchema(options.data)),
+  };
+  for (const status of options.errorStatuses ?? []) {
+    responses[String(status)] = jsonResponse(runtimeFailureSchema());
+  }
+  return {
+    get: {
+      tags: [tag],
+      summary,
+      description: options.description,
+      parameters: options.parameters,
+      responses,
+    },
+  };
+}
+
+function queryParameter(name: string, description: string, schema: JsonSchema = jsonSchema.string()): unknown {
+  return {
+    name,
+    in: "query",
+    required: false,
+    schema,
+    description,
+  };
+}
+
+function actionRunBody(input: JsonSchema, description: string): Record<string, unknown> {
+  return {
+    required: true,
+    content: {
+      "application/json": {
+        schema: jsonSchema.object(
+          {
+            input,
+            ...namedConnectionProperties,
+          },
+          { description },
+        ),
+      },
+    },
+  };
+}
+
+function actionRunResponses(output: JsonSchema): Record<string, unknown> {
+  const failure = runtimeFailureSchema(actionFailureMetaSchema);
+  return {
+    200: jsonResponse(runtimeSuccessSchema(output, actionResultMetaSchema)),
+    400: jsonResponse(failure, "invalid_input, action_blocked, or action_not_allowed."),
+    403: jsonResponse(failure, "authorization_failed."),
+    404: jsonResponse(failure, "unknown_action or connection_not_found."),
+    409: jsonResponse(failure, idempotencyConflictDescription),
+    429: jsonResponse(failure),
+    500: jsonResponse(failure),
+  };
+}
+
 function createConnectionUpsertRequestSchema(): JsonSchema {
   return jsonSchema.object(
     {
@@ -1213,32 +1441,12 @@ function createConcreteRunOperation(action: ActionDefinition): Record<string, un
     tags: ["Runs"],
     summary: `Execute ${action.id}.`,
     description: `${action.description} ${actionIdempotencyDescription}`,
-    parameters: [actionIdParameter, idempotencyKeyParameter],
-    requestBody: {
-      required: true,
-      content: {
-        "application/json": {
-          schema: jsonSchema.object(
-            {
-              input: action.inputSchema,
-            },
-            {
-              required: ["input"],
-              description: `Run creation request for ${action.id}.`,
-            },
-          ),
-        },
-      },
-    },
-    responses: {
-      200: jsonResponse(runtimeSuccessSchema(action.outputSchema, actionResultMetaSchema)),
-      400: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-      403: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-      404: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-      409: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema), idempotencyConflictDescription),
-      429: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-      500: jsonResponse(runtimeFailureSchema(actionFailureMetaSchema)),
-    },
+    parameters: [actionIdParameter, idempotencyKeyParameter, ...namedConnectionParameters],
+    requestBody: actionRunBody(
+      action.inputSchema,
+      `Run creation request for ${action.id}. Omitted input is treated as {}.`,
+    ),
+    responses: actionRunResponses(action.outputSchema),
   };
 }
 

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -120,18 +120,11 @@ const actionIdParameter = {
 };
 
 const namedConnectionDescription =
-  "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, x-oo-connector-alias, and legacy x-oomol-connector-alias are equivalent. Defaults to default.";
+  "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, and x-oo-connector-alias are equivalent. Defaults to default.";
 
 const namedConnectionParameters = [
   {
     name: "x-oo-connector-alias",
-    in: "header",
-    required: false,
-    schema: jsonSchema.string(),
-    description: namedConnectionDescription,
-  },
-  {
-    name: "x-oomol-connector-alias",
     in: "header",
     required: false,
     schema: jsonSchema.string(),

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -120,11 +120,18 @@ const actionIdParameter = {
 };
 
 const namedConnectionDescription =
-  "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, and x-oo-connector-alias are equivalent. Defaults to default.";
+  "Named connection. Same fact as MCP connectionName; HTTP alias, connectionName, x-oo-connector-alias, and legacy x-oomol-connector-alias are equivalent. Defaults to default.";
 
 const namedConnectionParameters = [
   {
     name: "x-oo-connector-alias",
+    in: "header",
+    required: false,
+    schema: jsonSchema.string(),
+    description: namedConnectionDescription,
+  },
+  {
+    name: "x-oomol-connector-alias",
     in: "header",
     required: false,
     schema: jsonSchema.string(),
@@ -175,7 +182,11 @@ export function createOpenApiDocument(
   }
 
   const paths: Record<string, unknown> = {
-    "/health": getOperation("System", "Unauthenticated process health check.", { ok: jsonSchema.boolean() }),
+    "/health": getOperation(
+      "System",
+      "Unauthenticated process health check.",
+      jsonSchema.object({ ok: jsonSchema.boolean() }, { required: ["ok"], description: "Process health payload." }),
+    ),
     "/v1/health": runtimeGetOperation("System", "Runtime health check.", {
       data: jsonSchema.object(
         {
@@ -1347,15 +1358,17 @@ function getOperation(tag: string, summary: string, schema: JsonSchema): Record<
   };
 }
 
+interface RuntimeGetOperationOptions {
+  data: JsonSchema;
+  description?: string;
+  parameters?: unknown[];
+  errorStatuses?: Array<400 | 404>;
+}
+
 function runtimeGetOperation(
   tag: string,
   summary: string,
-  options: {
-    data: JsonSchema;
-    description?: string;
-    parameters?: unknown[];
-    errorStatuses?: Array<400 | 404>;
-  },
+  options: RuntimeGetOperationOptions,
 ): Record<string, unknown> {
   const responses: Record<string, unknown> = {
     200: jsonResponse(runtimeSuccessSchema(options.data)),

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -225,7 +225,10 @@ export function createOpenApiDocument(
       description: "Closest HTTP analog of MCP list_apps. Categories are objects; MCP list_apps returns strings.",
       parameters: [
         queryParameter("q", "Optional case-insensitive filter over service, display name, category, or auth type."),
-        queryParameter("service", "Optional provider service id. Repeat to include multiple providers."),
+        queryParameter("service", "Optional provider service id. Repeat to include multiple providers.", {
+          type: "array",
+          items: jsonSchema.string(),
+        }),
       ],
       data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeProviderMetadata" }),
     }),
@@ -239,7 +242,8 @@ export function createOpenApiDocument(
     }),
     "/v1/actions/search": runtimeGetOperation("Catalog", "Fuzzy keyword search over the action catalog.", {
       parameters: [
-        queryParameter("q", "Required search text. query is accepted as an alias."),
+        queryParameter("q", "Search text. Provide either q or query."),
+        queryParameter("query", "Alias for q. Provide either q or query."),
         queryParameter("service", "Optional provider service id."),
         queryParameter("limit", "Maximum actions to return. Defaults to 10. Maximum 50.", {
           type: "integer",
@@ -257,7 +261,12 @@ export function createOpenApiDocument(
       data: jsonSchema.array({ $ref: "#/components/schemas/RuntimeConnectedApp" }),
     }),
     "/v1/apps/authenticated": runtimeGetOperation("Connections", "List authenticated provider service ids.", {
-      parameters: [queryParameter("service", "Optional service id filter. Repeat to include multiple services.")],
+      parameters: [
+        queryParameter("service", "Optional service id filter. Repeat to include multiple services.", {
+          type: "array",
+          items: jsonSchema.string(),
+        }),
+      ],
       data: jsonSchema.array(jsonSchema.string(), { description: "Authenticated provider service ids." }),
     }),
     "/v1/apps/services/{service}": runtimeGetOperation("Connections", "List connected accounts for one provider.", {

--- a/src/server/api/runtime-api.test.ts
+++ b/src/server/api/runtime-api.test.ts
@@ -7,6 +7,7 @@ import {
   serializeRuntimeAction,
   serializeRuntimeActionResult,
   serializeRuntimeFailure,
+  unknownActionFailure,
   writeRuntimeActionHttpResult,
 } from "./runtime-api.ts";
 
@@ -70,6 +71,7 @@ describe("runtime action HTTP results", () => {
     ["authorization_failed", 403],
     ["connection_not_allowed", 403],
     ["connection_not_found", 404],
+    ["unknown_action", 404],
     ["rate_limited", 429],
     ["provider_error", 500],
     ["internal_error", 500],
@@ -141,6 +143,19 @@ describe("runtime action HTTP results", () => {
     });
 
     expect(parseRuntimeActionHttpResult(result)).toEqual(result);
+  });
+
+  it("serializes a catalog miss as unknown_action", () => {
+    expect(serializeRuntimeFailure(unknownActionFailure("example.missing"))).toEqual({
+      status: 404,
+      body: {
+        success: false,
+        message: "Unknown action: example.missing",
+        data: null,
+        errorCode: "unknown_action",
+        meta: { actionId: "example.missing" },
+      },
+    });
   });
 
   it("writes a previously serialized result", async () => {

--- a/src/server/api/runtime-api.ts
+++ b/src/server/api/runtime-api.ts
@@ -157,6 +157,16 @@ export function writeRuntimeFailure(context: Context, input: RuntimeFailureInput
   return writeRuntimeActionHttpResult(context, serializeRuntimeFailure(input));
 }
 
+/** Public 404 used when an action id is missing from the catalog. */
+export function unknownActionFailure(actionId: string): RuntimeFailureInput {
+  return {
+    status: 404,
+    errorCode: "unknown_action",
+    message: `Unknown action: ${actionId}`,
+    meta: { actionId },
+  };
+}
+
 /** Build a runtime failure response without writing it to the HTTP context. */
 export function serializeRuntimeFailure(input: RuntimeFailureInput): RuntimeActionHttpResult {
   const body: RuntimeFailureEnvelope = {
@@ -239,7 +249,7 @@ function mapExecutionErrorStatus(code: string | undefined): RuntimeStatus {
   if (code === "oauth_token_expired" || code === "oauth_refresh_unavailable") {
     return 409;
   }
-  if (code === "connection_not_found" || code === "unknown_service") {
+  if (code === "connection_not_found" || code === "unknown_service" || code === "unknown_action") {
     return 404;
   }
   if (code === "authorization_failed" || code === "connection_not_allowed") {

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -502,7 +502,7 @@ describe("ConnectServer", () => {
       message: "Request body must be valid JSON.",
       data: null,
       errorCode: "invalid_json",
-      meta: {},
+      meta: { service: "example" },
     });
   });
 

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -484,10 +484,11 @@ describe("ConnectServer", () => {
     });
     expect(action.status).toBe(400);
     await expect(action.json()).resolves.toEqual({
-      error: {
-        code: "invalid_json",
-        message: "Request body must be valid JSON.",
-      },
+      success: false,
+      message: "Request body must be valid JSON.",
+      data: null,
+      errorCode: "invalid_json",
+      meta: {},
     });
   });
 
@@ -508,10 +509,11 @@ describe("ConnectServer", () => {
 
       expect(response.status).toBe(400);
       await expect(response.json()).resolves.toEqual({
-        error: {
-          code: "invalid_json",
-          message: "Request body must be a JSON object.",
-        },
+        success: false,
+        message: "Request body must be a JSON object.",
+        data: null,
+        errorCode: "invalid_json",
+        meta: {},
       });
     }
   });
@@ -3042,7 +3044,7 @@ describe("ConnectServer", () => {
     expect(unknown.status).toBe(404);
     await expect(unknown.json()).resolves.toMatchObject({
       success: false,
-      errorCode: "invalid_input",
+      errorCode: "unknown_action",
       meta: { actionId: "example.missing" },
     });
 

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -490,6 +490,20 @@ describe("ConnectServer", () => {
       errorCode: "invalid_json",
       meta: {},
     });
+
+    const proxy = await app.request("/v1/proxy/example", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(proxy.status).toBe(400);
+    await expect(proxy.json()).resolves.toEqual({
+      success: false,
+      message: "Request body must be valid JSON.",
+      data: null,
+      errorCode: "invalid_json",
+      meta: {},
+    });
   });
 
   it("rejects JSON request bodies that are not objects", async () => {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -600,7 +600,21 @@ export class ConnectServer {
   }
 
   private async createRuntimeProxyRequest(context: Context, service: string): Promise<Response> {
-    const body = await readJsonBody(context);
+    let body: Record<string, unknown>;
+    try {
+      body = await readJsonBody(context);
+    } catch (error) {
+      if (error instanceof HttpRequestError) {
+        return writeRuntimeFailure(context, {
+          status: error.status,
+          errorCode: error.code,
+          message: error.message,
+          meta: { service },
+        });
+      }
+
+      throw error;
+    }
 
     let policy: ActionPolicySnapshot;
     try {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -600,21 +600,7 @@ export class ConnectServer {
   }
 
   private async createRuntimeProxyRequest(context: Context, service: string): Promise<Response> {
-    let body: Record<string, unknown>;
-    try {
-      body = await readJsonBody(context);
-    } catch (error) {
-      if (error instanceof HttpRequestError) {
-        return writeRuntimeFailure(context, {
-          status: 400,
-          errorCode: "invalid_input",
-          message: error.message,
-          meta: { service },
-        });
-      }
-
-      throw error;
-    }
+    const body = await readJsonBody(context);
 
     let policy: ActionPolicySnapshot;
     try {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -48,6 +48,7 @@ import {
   serializeRuntimeConnectedApp,
   serializeRuntimeFailure,
   serializeRuntimeProvider,
+  unknownActionFailure,
   writeRuntimeActionHttpResult,
   writeRuntimeFailure,
   writeRuntimeSuccess,
@@ -217,6 +218,13 @@ export class ConnectServer {
     this.options.registerStaticRoutes?.(app);
     app.onError((error, context) => {
       if (error instanceof HttpRequestError) {
+        if (context.req.path.startsWith("/v1/")) {
+          return writeRuntimeFailure(context, {
+            status: error.status,
+            errorCode: error.code,
+            message: error.message,
+          });
+        }
         return jsonError(context, error.status, error.code, error.message);
       }
       this.options.logger?.error(
@@ -436,12 +444,7 @@ export class ConnectServer {
   private getRuntimeAction(context: Context, actionId: string): Response {
     const action = this.options.catalog.actionsById.get(actionId);
     if (!action) {
-      return writeRuntimeFailure(context, {
-        status: 404,
-        errorCode: "invalid_input",
-        message: `unknown action: ${actionId}`,
-        meta: { actionId },
-      });
+      return writeRuntimeFailure(context, unknownActionFailure(actionId));
     }
 
     return writeRuntimeSuccess(context, serializeRuntimeAction(action));
@@ -450,12 +453,7 @@ export class ConnectServer {
   private async createRuntimeActionRun(context: Context, actionId: string): Promise<Response> {
     const action = this.options.catalog.actionsById.get(actionId);
     if (!action) {
-      return writeRuntimeFailure(context, {
-        status: 404,
-        errorCode: "invalid_input",
-        message: `unknown action: ${actionId}`,
-        meta: { actionId },
-      });
+      return writeRuntimeFailure(context, unknownActionFailure(actionId));
     }
 
     const body = await readJsonBody(context);
@@ -578,12 +576,7 @@ export class ConnectServer {
         runtimeTokenId: runtimeGrant?.tokenId,
       });
       if (!run) {
-        return serializeRuntimeFailure({
-          status: 404,
-          errorCode: "invalid_input",
-          message: `unknown action: ${actionId}`,
-          meta: { actionId },
-        });
+        return serializeRuntimeFailure(unknownActionFailure(actionId));
       }
 
       return serializeRuntimeActionResult({


### PR DESCRIPTION
## Summary
- Map catalog misses to `404 unknown_action` (was `invalid_input` at 404) via `unknownActionFailure` in `runtime-api.ts`, shared by `/v1` routes and MCP action execution.
- Shape `/v1` `HttpRequestError` responses with the runtime failure envelope instead of the legacy `{ error: { code, message } }` object.
- Expand OpenAPI coverage for public `/v1` catalog/health/apps routes and document that HTTP `alias` and MCP `connectionName` name the same connection fact.

## Compatibility
- **Breaking for error-code consumers:** unknown action `errorCode` is now `unknown_action`; message casing/prefix is `Unknown action: …`.
- **Breaking for `/v1` JSON-parse failures:** clients must read `errorCode` on the runtime envelope, not `error.code`.
- HTTP status for unknown actions remains 404. Schema/idempotency failures stay `400 invalid_input`.
- No new placeholder public fields; serializers remain the single owner of `/v1` response shapes.

## Test plan
- [x] `npm run fix-check`
- [ ] Confirm `GET/POST /v1/actions/<missing>` returns `404` + `errorCode: "unknown_action"`
- [ ] Confirm invalid JSON on a `/v1` route returns the runtime failure envelope
- [ ] Spot-check generated OpenAPI includes `/v1/health`, `/v1/providers`, `/v1/actions`, `/v1/apps`


Made with [Cursor](https://cursor.com)