### PR TITLE
feat(runtime): propagate request cancellation

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -445,6 +445,24 @@ describe("MCP server", () => {
     );
   });
 
+  it("propagates the MCP request cancellation signal to action execution", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await withMcpClient(
+      async (client) => {
+        const result = await client.callTool({
+          name: "execute_action",
+          arguments: { actionId: "example.echo", input: { message: "hello" } },
+        });
+        expect(result.structuredContent).toMatchObject({
+          ok: false,
+          error: { code: "execution_cancelled" },
+        });
+      },
+      { signal: controller.signal },
+    );
+  });
+
   it("applies token policy to MCP guides and execution", async () => {
     const policy = new ActionPolicyService().createSnapshot(emptyPolicyRules(), {
       allowedActions: ["example.*"],
@@ -608,6 +626,7 @@ async function withMcpClient(
       allowedProxies: string[];
       allowedConnections?: string[];
     };
+    signal?: AbortSignal;
   } = {},
 ): Promise<void> {
   const catalog = createCatalogStore([exampleProvider], {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -27,6 +27,7 @@ export interface IMcpServerOptions {
   actionSearch?: ActionSearchIndexProvider;
   getPolicySnapshot?(): Promise<ActionPolicySnapshot>;
   runtimeGrant?: RuntimeGrant;
+  signal?: AbortSignal;
 }
 
 /**
@@ -348,6 +349,7 @@ async function executeAction(
     connectionName,
     policy,
     runtimeTokenId: options.runtimeGrant?.tokenId,
+    signal: options.signal,
   });
   if (!run) {
     return errorPayload("unknown_action", `Unknown action: ${actionId}`);

--- a/src/server/actions/action-runner.test.ts
+++ b/src/server/actions/action-runner.test.ts
@@ -196,6 +196,41 @@ describe("ActionRunner", () => {
     expect(runs.items[0]).toMatchObject({ ok: false, errorCode: "execution_cancelled" });
   });
 
+  it("does not continue resource loading when cancelled during connection lookup", async () => {
+    const runs = new MemoryRunLogStore();
+    const providerLoader = new TestProviderLoader(async () => ({ ok: true, output: {} }));
+    const loadExecutor = vi.spyOn(providerLoader, "loadActionExecutor");
+    let finishLookup: (() => void) | undefined;
+    const lookupPending = new Promise<void>((resolve) => {
+      finishLookup = resolve;
+    });
+    const getConnectionSummary = vi
+      .spyOn(ConnectionService.prototype, "getConnectionSummary")
+      .mockImplementationOnce(async () => {
+        await lookupPending;
+        return undefined;
+      });
+    const resolveConnection = vi.spyOn(ConnectionService.prototype, "resolveForExecution");
+    const controller = new AbortController();
+    const runner = createRunner({ runs, logger: createTestLogger().logger, providerLoader });
+
+    const runPromise = runner.run({
+      actionId: "example.echo",
+      input: {},
+      caller: "http",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(getConnectionSummary).toHaveBeenCalledOnce());
+    controller.abort();
+    finishLookup?.();
+    const run = await runPromise;
+
+    expect(run?.result).toMatchObject({ ok: false, error: { code: "execution_cancelled" } });
+    expect(resolveConnection).not.toHaveBeenCalled();
+    expect(loadExecutor).not.toHaveBeenCalled();
+    expect(runs.items[0]).toMatchObject({ ok: false, errorCode: "execution_cancelled" });
+  });
+
   it("does not create a cancellation signal for callers that omit one", async () => {
     const runs = new MemoryRunLogStore();
     const runner = createRunner({

--- a/src/server/actions/action-runner.test.ts
+++ b/src/server/actions/action-runner.test.ts
@@ -129,6 +129,89 @@ describe("ActionRunner", () => {
     expect(JSON.stringify(entries)).not.toContain("secret-in-executor");
   });
 
+  it("propagates cancellation to the execution context and records it without a warning", async () => {
+    const runs = new MemoryRunLogStore();
+    const { entries, logger } = createTestLogger();
+    const controller = new AbortController();
+    let executionStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      executionStarted = resolve;
+    });
+    const runner = createRunner({
+      runs,
+      logger,
+      providerLoader: new TestProviderLoader(async (_input, context) => {
+        expect(context.signal).toBe(controller.signal);
+        executionStarted?.();
+        await new Promise<void>((_resolve, reject) => {
+          context.signal?.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+        }).catch(() => undefined);
+        return {
+          ok: false,
+          error: { code: "internal_error", message: "provider request failed" },
+        };
+      }),
+    });
+
+    const runPromise = runner.run({
+      actionId: "example.echo",
+      input: {},
+      caller: "http",
+      signal: controller.signal,
+    });
+    await started;
+    controller.abort();
+    const run = await runPromise;
+
+    expect(run?.result).toEqual({
+      ok: false,
+      error: { code: "execution_cancelled", message: "Action execution was cancelled." },
+    });
+    expect(runs.items[0]).toMatchObject({ ok: false, errorCode: "execution_cancelled" });
+    expect(entries).toContainEqual({
+      fields: expect.objectContaining({ ok: false, errorCode: "execution_cancelled" }),
+      message: "action run cancelled",
+    });
+  });
+
+  it("does not resolve a connection or load an executor for an already cancelled run", async () => {
+    const runs = new MemoryRunLogStore();
+    const providerLoader = new TestProviderLoader(async () => ({ ok: true, output: {} }));
+    const loadExecutor = vi.spyOn(providerLoader, "loadActionExecutor");
+    const resolveConnection = vi.spyOn(ConnectionService.prototype, "resolveForExecution");
+    const controller = new AbortController();
+    controller.abort();
+    const runner = createRunner({ runs, logger: createTestLogger().logger, providerLoader });
+
+    const run = await runner.run({
+      actionId: "example.echo",
+      input: {},
+      caller: "http",
+      signal: controller.signal,
+    });
+
+    expect(run?.result).toMatchObject({ ok: false, error: { code: "execution_cancelled" } });
+    expect(resolveConnection).not.toHaveBeenCalled();
+    expect(loadExecutor).not.toHaveBeenCalled();
+    expect(runs.items[0]).toMatchObject({ ok: false, errorCode: "execution_cancelled" });
+  });
+
+  it("does not create a cancellation signal for callers that omit one", async () => {
+    const runs = new MemoryRunLogStore();
+    const runner = createRunner({
+      runs,
+      logger: createTestLogger().logger,
+      providerLoader: new TestProviderLoader(async (_input, context) => {
+        expect(context.signal).toBeUndefined();
+        return { ok: true, output: {} };
+      }),
+    });
+
+    const run = await runner.run({ actionId: "example.echo", input: {}, caller: "web" });
+
+    expect(run?.result.ok).toBe(true);
+  });
+
   it("records policy denial before resolving a connection or loading an executor", async () => {
     const runs = new MemoryRunLogStore();
     const { logger } = createTestLogger();

--- a/src/server/actions/action-runner.ts
+++ b/src/server/actions/action-runner.ts
@@ -27,6 +27,7 @@ export interface RunActionInput {
   connectionName?: string;
   policy?: ActionPolicySnapshot;
   runtimeTokenId?: string;
+  signal?: AbortSignal;
 }
 
 export interface ActionRunResult {
@@ -76,6 +77,8 @@ export class ActionRunner {
     let result: ExecutionResult;
     if (!policy.allowed) {
       result = { ok: false, error: { code: policy.code, message: policy.message } };
+    } else if (input.signal?.aborted) {
+      result = cancelledExecutionResult();
     } else {
       try {
         const summary = await this.options.connections.getConnectionSummary(action.service, input.connectionName);
@@ -97,8 +100,11 @@ export class ActionRunner {
             action,
             executor,
             input.input,
-            this.createExecutionContext(connection.getCredential),
+            this.createExecutionContext(connection.getCredential, input.signal),
           );
+          if (input.signal?.aborted) {
+            result = cancelledExecutionResult();
+          }
         }
       } catch (error) {
         const missingConnectionPolicy =
@@ -108,6 +114,8 @@ export class ActionRunner {
         if (missingConnectionPolicy && !missingConnectionPolicy.allowed) {
           policy = missingConnectionPolicy;
           result = { ok: false, error: { code: policy.code, message: policy.message } };
+        } else if (input.signal?.aborted) {
+          result = cancelledExecutionResult();
         } else {
           result =
             error instanceof ConnectionError
@@ -161,6 +169,8 @@ export class ActionRunner {
     };
     if (result.ok) {
       this.options.logger?.info(completedLogContext, "action run completed");
+    } else if (result.error?.code === "execution_cancelled") {
+      this.options.logger?.info(completedLogContext, "action run cancelled");
     } else {
       this.options.logger?.warn(completedLogContext, "action run failed");
     }
@@ -176,9 +186,13 @@ export class ActionRunner {
     return this.options.runs.get(id);
   }
 
-  private createExecutionContext(getCredential: ExecutionConnection["getCredential"]): ExecutionContext {
+  private createExecutionContext(
+    getCredential: ExecutionConnection["getCredential"],
+    signal: AbortSignal | undefined,
+  ): ExecutionContext {
     const context: ExecutionContext = {
       getCredential,
+      signal,
     };
     if (this.options.transitFiles) {
       context.transitFiles = this.options.transitFiles;
@@ -194,4 +208,14 @@ export class ActionRunner {
       return "[unavailable]";
     }
   }
+}
+
+function cancelledExecutionResult(): ExecutionResult {
+  return {
+    ok: false,
+    error: {
+      code: "execution_cancelled",
+      message: "Action execution was cancelled.",
+    },
+  };
 }

--- a/src/server/actions/action-runner.ts
+++ b/src/server/actions/action-runner.ts
@@ -114,11 +114,11 @@ export class ActionRunner {
           error instanceof ConnectionError && error.code === "connection_not_found"
             ? snapshot?.evaluateConnection()
             : undefined;
-        if (missingConnectionPolicy && !missingConnectionPolicy.allowed) {
+        if (input.signal?.aborted) {
+          result = cancelledExecutionResult();
+        } else if (missingConnectionPolicy && !missingConnectionPolicy.allowed) {
           policy = missingConnectionPolicy;
           result = { ok: false, error: { code: policy.code, message: policy.message } };
-        } else if (input.signal?.aborted) {
-          result = cancelledExecutionResult();
         } else {
           result =
             error instanceof ConnectionError

--- a/src/server/actions/action-runner.ts
+++ b/src/server/actions/action-runner.ts
@@ -82,6 +82,7 @@ export class ActionRunner {
     } else {
       try {
         const summary = await this.options.connections.getConnectionSummary(action.service, input.connectionName);
+        input.signal?.throwIfAborted();
         const connectionPolicy =
           summary?.authType === "no_auth" ? undefined : snapshot?.evaluateConnection(summary?.id);
         if (connectionPolicy && !connectionPolicy.allowed) {
@@ -89,6 +90,7 @@ export class ActionRunner {
           result = { ok: false, error: { code: policy.code, message: policy.message } };
         } else {
           connection = await this.options.connections.resolveForExecution(action.service, input.connectionName);
+          input.signal?.throwIfAborted();
           const executor = action.execution.locallyExecutable
             ? await this.options.providerLoader.loadActionExecutor(
                 action.service,
@@ -96,6 +98,7 @@ export class ActionRunner {
                 this.options.catalog.providers.find((provider) => provider.service === action.service)?.displayName,
               )
             : undefined;
+          input.signal?.throwIfAborted();
           result = await executeProviderAction(
             action,
             executor,

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -941,6 +941,58 @@ describe("ConnectServer", () => {
     expect(logOutput).not.toContain("secret-token");
   });
 
+  it("propagates HTTP request cancellation to action execution", async () => {
+    const controller = new AbortController();
+    let executionStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      executionStarted = resolve;
+    });
+    let executionSignal: AbortSignal | undefined;
+    const providerLoader = new ActionProviderLoader(async (_input, context) => {
+      executionSignal = context.signal;
+      executionStarted?.();
+      await new Promise<void>((_resolve, reject) => {
+        if (!context.signal) {
+          reject(new Error("request signal missing"));
+          return;
+        }
+        context.signal.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+      });
+      return { ok: true, output: {} };
+    });
+    const runs = new MemoryRunLogStore();
+    const app = createTestServer([{ ...apiKeyProvider, actions: [echoAction] }], {
+      providerLoader,
+      runs,
+    }).createApp();
+    await app.request("/api/connections/example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authType: "api_key", values: { apiKey: "example-key" } }),
+    });
+    const request = new Request("http://localhost/v1/actions/example.echo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {} }),
+      signal: controller.signal,
+    });
+
+    const responsePromise = app.fetch(request);
+    await started;
+    controller.abort();
+    const response = await responsePromise;
+
+    expect(executionSignal?.aborted).toBe(true);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      errorCode: "execution_cancelled",
+    });
+    await expect(runs.list()).resolves.toMatchObject({
+      items: [expect.objectContaining({ caller: "http", ok: false, errorCode: "execution_cancelled" })],
+    });
+  });
+
   it("logs failed action runs with error codes", async () => {
     const { entries, logger } = createTestLogger();
     const app = createTestServer(

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -474,7 +474,7 @@ export class ConnectServer {
     if (!policy.evaluate(action).allowed) {
       return writeRuntimeActionHttpResult(
         context,
-        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant),
+        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant, context.req.raw.signal),
       );
     }
     const idempotencyKey = readIdempotencyKey(context.req.header("idempotency-key"));
@@ -490,7 +490,7 @@ export class ConnectServer {
     if (!idempotencyKey.key) {
       return writeRuntimeActionHttpResult(
         context,
-        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant),
+        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant, context.req.raw.signal),
       );
     }
 
@@ -544,7 +544,14 @@ export class ConnectServer {
       return writeRuntimeActionHttpResult(context, claim.response);
     }
 
-    const result = await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant);
+    const result = await this.executeRuntimeAction(
+      actionId,
+      input,
+      connectionName,
+      policy,
+      runtimeGrant,
+      context.req.raw.signal,
+    );
     const completed = await this.options.idempotency.complete({
       keyHash,
       requestHash,
@@ -565,6 +572,7 @@ export class ConnectServer {
     connectionName: string | undefined,
     policy: ActionPolicySnapshot,
     runtimeGrant: RuntimeGrant | undefined,
+    signal: AbortSignal | undefined,
   ): Promise<RuntimeActionHttpResult> {
     try {
       const run = await this.options.actions.run({
@@ -574,6 +582,7 @@ export class ConnectServer {
         connectionName,
         policy,
         runtimeTokenId: runtimeGrant?.tokenId,
+        signal,
       });
       if (!run) {
         return serializeRuntimeFailure(unknownActionFailure(actionId));
@@ -742,6 +751,7 @@ export class ConnectServer {
           actionSearch: this.actionSearch,
           getPolicySnapshot: () => this.getPolicySnapshot(context),
           runtimeGrant: readRuntimeGrant(context),
+          signal: context.req.raw.signal,
         }),
       { legacy: "stateless", responseMode: "json" },
     );


### PR DESCRIPTION
## Summary

- propagate inbound HTTP and MCP cancellation through `ActionRunner` to `ExecutionContext.signal`
- classify cancelled executions as `execution_cancelled` and keep cancellation out of warning/error noise
- avoid resolving connections or loading providers when a run is already cancelled
- cover runner, HTTP, and MCP cancellation behavior

No default execution deadline or provider-local timeout is introduced.

## Verification

- `npm test -- --run src/server/actions/action-runner.test.ts src/mcp.test.ts src/server/connect-server.test.ts` (116 tests passed)
- `npm run fix-check` passed, including lint fixes, formatting, generated registry checks, and typechecking `src`, `scripts-all`, and `examples`
- `git diff --check` passed

Closes #380