### PR TITLE
feat(runtime): propagate request cancellation through ActionRunner

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -182,8 +182,8 @@ export function createMcpServer(options: IMcpServerOptions): McpServer {
         connectionName: optionalConnectionNameSchema,
       },
     },
-    async ({ actionId, input, connectionName }) =>
-      toolResult(await executeAction(options, actionId, input, connectionName)),
+    async ({ actionId, input, connectionName }, extra) =>
+      toolResult(await executeAction(options, actionId, input, connectionName, extra.mcpReq.signal)),
   );
 
   return server;
@@ -318,6 +318,7 @@ async function executeAction(
   actionId: string,
   input: Record<string, unknown>,
   connectionName: string | undefined,
+  signal?: AbortSignal,
 ): Promise<ToolPayload> {
   const action = options.catalog.actionsById.get(actionId);
   if (!action) {
@@ -348,6 +349,7 @@ async function executeAction(
     connectionName,
     policy,
     runtimeTokenId: options.runtimeGrant?.tokenId,
+    signal,
   });
   if (!run) {
     return errorPayload("unknown_action", `Unknown action: ${actionId}`);

--- a/src/server/actions/action-runner.test.ts
+++ b/src/server/actions/action-runner.test.ts
@@ -257,6 +257,93 @@ describe("ActionRunner", () => {
     expect(denied?.result).toMatchObject({ ok: false, error: { code: "connection_not_allowed" } });
     expect(resolveConnection).toHaveBeenCalledTimes(2);
   });
+
+  it("propagates the caller abort signal into the executor context", async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    const runner = createRunner({
+      runs: new MemoryRunLogStore(),
+      logger: createTestLogger().logger,
+      providerLoader: new TestProviderLoader(async (_input, context) => {
+        seen = context.signal;
+        return { ok: true, output: {} };
+      }),
+    });
+
+    controller.abort();
+    const run = await runner.run({
+      actionId: "example.echo",
+      input: {},
+      caller: "http",
+      signal: controller.signal,
+    });
+
+    expect(run?.result).toEqual({ ok: true, output: {} });
+    expect(seen).toBe(controller.signal);
+    expect(seen?.aborted).toBe(true);
+  });
+
+  it("does not set context.signal when the caller omits one", async () => {
+    let seen: AbortSignal | undefined | "unset" = "unset";
+    const runner = createRunner({
+      runs: new MemoryRunLogStore(),
+      logger: createTestLogger().logger,
+      providerLoader: new TestProviderLoader(async (_input, context) => {
+        seen = context.signal;
+        return { ok: true, output: {} };
+      }),
+    });
+
+    await runner.run({ actionId: "example.echo", input: {}, caller: "http" });
+
+    expect(seen).toBeUndefined();
+  });
+
+  it("aborts a waiting executor when the caller signal aborts", async () => {
+    const controller = new AbortController();
+    let started!: () => void;
+    const startedPromise = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const runner = createRunner({
+      runs: new MemoryRunLogStore(),
+      logger: createTestLogger().logger,
+      providerLoader: new TestProviderLoader(async (_input, context) => {
+        await new Promise<void>((_resolve, reject) => {
+          const signal = context.signal;
+          if (!signal) {
+            reject(new Error("missing signal"));
+            return;
+          }
+          const abort = (): void => {
+            reject(signal.reason ?? new Error("aborted"));
+          };
+          if (signal.aborted) {
+            abort();
+            return;
+          }
+          signal.addEventListener("abort", abort, { once: true });
+          started();
+        });
+        return { ok: true, output: {} };
+      }),
+    });
+
+    const pending = runner.run({
+      actionId: "example.echo",
+      input: {},
+      caller: "http",
+      signal: controller.signal,
+    });
+    await startedPromise;
+    controller.abort();
+    const run = await pending;
+
+    expect(run?.result).toEqual({
+      ok: false,
+      error: { code: "internal_error", message: "Action execution failed unexpectedly." },
+    });
+  });
 });
 
 function createRunner(options: {

--- a/src/server/actions/action-runner.ts
+++ b/src/server/actions/action-runner.ts
@@ -27,6 +27,7 @@ export interface RunActionInput {
   connectionName?: string;
   policy?: ActionPolicySnapshot;
   runtimeTokenId?: string;
+  signal?: AbortSignal;
 }
 
 export interface ActionRunResult {
@@ -97,7 +98,7 @@ export class ActionRunner {
             action,
             executor,
             input.input,
-            this.createExecutionContext(connection.getCredential),
+            this.createExecutionContext(connection.getCredential, input.signal),
           );
         }
       } catch (error) {
@@ -176,12 +177,18 @@ export class ActionRunner {
     return this.options.runs.get(id);
   }
 
-  private createExecutionContext(getCredential: ExecutionConnection["getCredential"]): ExecutionContext {
+  private createExecutionContext(
+    getCredential: ExecutionConnection["getCredential"],
+    signal?: AbortSignal,
+  ): ExecutionContext {
     const context: ExecutionContext = {
       getCredential,
     };
     if (this.options.transitFiles) {
       context.transitFiles = this.options.transitFiles;
+    }
+    if (signal) {
+      context.signal = signal;
     }
     return context;
   }

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -474,7 +474,7 @@ export class ConnectServer {
     if (!policy.evaluate(action).allowed) {
       return writeRuntimeActionHttpResult(
         context,
-        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant),
+        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant, context.req.raw.signal),
       );
     }
     const idempotencyKey = readIdempotencyKey(context.req.header("idempotency-key"));
@@ -490,7 +490,7 @@ export class ConnectServer {
     if (!idempotencyKey.key) {
       return writeRuntimeActionHttpResult(
         context,
-        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant),
+        await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant, context.req.raw.signal),
       );
     }
 
@@ -544,7 +544,14 @@ export class ConnectServer {
       return writeRuntimeActionHttpResult(context, claim.response);
     }
 
-    const result = await this.executeRuntimeAction(actionId, input, connectionName, policy, runtimeGrant);
+    const result = await this.executeRuntimeAction(
+      actionId,
+      input,
+      connectionName,
+      policy,
+      runtimeGrant,
+      context.req.raw.signal,
+    );
     const completed = await this.options.idempotency.complete({
       keyHash,
       requestHash,
@@ -565,6 +572,7 @@ export class ConnectServer {
     connectionName: string | undefined,
     policy: ActionPolicySnapshot,
     runtimeGrant: RuntimeGrant | undefined,
+    signal?: AbortSignal,
   ): Promise<RuntimeActionHttpResult> {
     try {
       const run = await this.options.actions.run({
@@ -574,6 +582,7 @@ export class ConnectServer {
         connectionName,
         policy,
         runtimeTokenId: runtimeGrant?.tokenId,
+        signal,
       });
       if (!run) {
         return serializeRuntimeFailure(unknownActionFailure(actionId));


### PR DESCRIPTION
## Summary
- Thread the HTTP `Request` signal and MCP `extra.mcpReq.signal` into `ExecutionContext.signal`.
- Providers that already pass `context.signal` into guarded fetch can now stop when the caller disconnects.
- No runner-default deadline (hyrious on #371). Credential-validator abort is left for a follow-up.

Closes #380

## Test plan
- [x] `action-runner.test.ts`: omitted signal stays unset; aborted caller signal reaches the executor and fails the run as `internal_error`
- [x] `npm run fix-check`

Made with [Cursor](https://cursor.com)