### PR TITLE
fix(ssrf): use shared assertPublicHttpUrl on self-hosted base URLs

### DIFF
--- a/src/providers/btcpay_server/runtime.test.ts
+++ b/src/providers/btcpay_server/runtime.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeBtcpayBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeBtcpayBaseUrl", () => {
+  it("allows a public host and strips the Greenfield API suffix", () => {
+    expect(normalizeBtcpayBaseUrl("https://btcpay.example.com/api/v1")).toBe("https://btcpay.example.com");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeBtcpayBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeBtcpayBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeBtcpayBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeBtcpayBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeBtcpayBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/btcpay_server/runtime.ts
+++ b/src/providers/btcpay_server/runtime.ts
@@ -10,6 +10,7 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const btcpayApiSegment = "api/v1";
@@ -82,22 +83,20 @@ export async function validateBtcpayServerCredential(
   };
 }
 
-export function normalizeBtcpayBaseUrl(value: string | undefined): string {
+export function normalizeBtcpayBaseUrl(
+  value: string | undefined,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const trimmed = optionalString(value);
   if (!trimmed) {
     throw new ProviderRequestError(400, "Base URL is required");
   }
 
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    throw new ProviderRequestError(400, "Base URL must be a valid absolute URL");
-  }
-
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new ProviderRequestError(400, "Base URL must use http or https");
-  }
+  const parsed = assertPublicHttpUrl(trimmed, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
 
   parsed.search = "";
   parsed.hash = "";

--- a/src/providers/clickhouse/runtime.test.ts
+++ b/src/providers/clickhouse/runtime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeClickhouseBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeClickhouseBaseUrl", () => {
+  it("allows a public host", () => {
+    expect(normalizeClickhouseBaseUrl("https://clickhouse.example.com:8443")).toBe(
+      "https://clickhouse.example.com:8443/",
+    );
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeClickhouseBaseUrl("https://10.0.0.5:8443")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeClickhouseBaseUrl("https://10.0.0.5:8443")).toBe("https://10.0.0.5:8443/");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeClickhouseBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeClickhouseBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeClickhouseBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/clickhouse/runtime.ts
+++ b/src/providers/clickhouse/runtime.ts
@@ -3,6 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalInteger, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -459,17 +460,16 @@ function createClickhouseError(
   return new ProviderRequestError(status || 500, message);
 }
 
-function normalizeClickhouseBaseUrl(value: unknown): string {
+export function normalizeClickhouseBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const raw = requireCredentialString(value, "baseUrl");
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    throw new ProviderRequestError(400, "baseUrl must be a valid URL");
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new ProviderRequestError(400, "baseUrl must use http or https");
-  }
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   url.hash = "";
   return url.toString();
 }

--- a/src/providers/home_assistant/runtime.test.ts
+++ b/src/providers/home_assistant/runtime.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { resolveHomeAssistantBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("resolveHomeAssistantBaseUrl", () => {
+  it("allows a public host", () => {
+    expect(resolveHomeAssistantBaseUrl({ values: { baseUrl: "https://ha.example.com" } })).toBe(
+      "https://ha.example.com",
+    );
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => resolveHomeAssistantBaseUrl({ values: { baseUrl: "https://10.0.0.5:8123" } })).toThrow(
+      "private or reserved IP addresses",
+    );
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(resolveHomeAssistantBaseUrl({ values: { baseUrl: "https://10.0.0.5:8123" } })).toBe("https://10.0.0.5:8123");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => resolveHomeAssistantBaseUrl({ values: { baseUrl: "https://169.254.169.254" } })).toThrow(
+      "private or reserved IP addresses",
+    );
+    expect(() => resolveHomeAssistantBaseUrl({ values: { baseUrl: "http://[::ffff:169.254.169.254]/" } })).toThrow(
+      "IPv6",
+    );
+    expect(() => resolveHomeAssistantBaseUrl({ values: { baseUrl: "https://metadata.google.internal" } })).toThrow(
+      "cloud metadata hosts",
+    );
+  });
+});

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -10,7 +10,7 @@ import {
   requiredString,
   requiredStringArray,
 } from "../../core/cast.ts";
-import { queryFlag, queryParams } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed, queryFlag, queryParams } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -395,20 +395,16 @@ function normalizeServiceCallResponse(payload: unknown): {
   };
 }
 
-function normalizeBaseUrl(value: unknown): string {
+function normalizeBaseUrl(value: unknown, allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed()): string {
   const raw = typeof value === "string" ? value.trim() : "";
   if (!raw) {
     throw new ProviderRequestError(400, "baseUrl is required");
   }
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    throw new ProviderRequestError(400, "baseUrl must be a valid http(s) URL");
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new ProviderRequestError(400, "baseUrl must be a valid http(s) URL");
-  }
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   if (url.username || url.password || url.search || url.hash) {
     throw new ProviderRequestError(400, "baseUrl must be a clean instance root URL");
   }


### PR DESCRIPTION
## Summary
- Home Assistant, ClickHouse, and BTCPay Server already opt into private instance access, but parsed `baseUrl` with `new URL()`.
- Normalize those instance URLs with `assertPublicHttpUrl(..., { allowPrivateNetwork })`, matching Dokploy.
- Cloud-metadata, loopback, and IPv6 literals stay blocked even when `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` is on.

Closes #381

## Test plan
- [x] Public host allowed; RFC1918 only with the opt-in; `169.254.169.254`, IPv6 metadata, and `metadata.google.internal` rejected with no fetch
- [x] `npm run fix-check`

Made with [Cursor](https://cursor.com)