### PR TITLE
fix(ssrf): keep DNS validation on region- and credential-resolved hosts

### DIFF
--- a/src/providers/amplitude/executors.ts
+++ b/src/providers/amplitude/executors.ts
@@ -21,7 +21,6 @@ const service = "amplitude";
 export const executors: ProviderExecutors = defineProviderExecutors<AmplitudeActionContext>({
   service,
   handlers: amplitudeActionHandlers,
-  skipDnsValidation: true,
   async createContext(context, fetcher): Promise<AmplitudeActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =
@@ -44,7 +43,6 @@ export const credentialValidators: CredentialValidators = {
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  skipDnsValidation: true,
   baseUrl: async (context) => {
     const credential = await requireApiKeyCredential(context, service);
     const dataResidency =

--- a/src/providers/appcues/executors.ts
+++ b/src/providers/appcues/executors.ts
@@ -47,7 +47,6 @@ const handlers: ProviderActionHandlers<"appcues", ProviderRuntimeHandler<Context
 
 export const executors: ProviderExecutors = defineProviderExecutors<Context>({
   service: "appcues",
-  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireApiKeyCredential(context, "appcues");
     const apiSecret = credential.values.apiSecret;
@@ -121,5 +120,4 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     if (!headers.has("accept")) headers.set("accept", "application/json");
     if (!headers.has("user-agent")) headers.set("user-agent", providerUserAgent);
   },
-  skipDnsValidation: true,
 });

--- a/src/providers/aws_sts/executors.test.ts
+++ b/src/providers/aws_sts/executors.test.ts
@@ -1,0 +1,43 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    accessKeyId: "AKIATEST",
+    secretAccessKey: "secret",
+  },
+  profile: { accountId: "AKIATEST", displayName: "AWS STS", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("AWS STS region resolver DNS", () => {
+  it("rejects a region host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["aws_sts.assume_role"]!(
+      { roleArn: "arn:aws:iam::123456789012:role/demo", region: "ap-southeast-1" },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/aws_sts/executors.ts
+++ b/src/providers/aws_sts/executors.ts
@@ -31,7 +31,7 @@ const stsApiVersion = "2011-06-15";
 const awsServiceName = "sts";
 const defaultRegion = "ap-southeast-1";
 const defaultRoleSessionName = "oomol-connect";
-const awsStsFetch = createProviderFetch({ skipDnsValidation: true });
+const awsStsFetch = createProviderFetch();
 
 interface AwsStsContext {
   values: Record<string, string>;
@@ -88,7 +88,6 @@ export const awsStsActionHandlers: ProviderActionHandlers<"aws_sts", AwsStsActio
 export const executors: ProviderExecutors = defineProviderExecutors<AwsStsContext>({
   service,
   handlers: awsStsActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AwsStsContext> {
     const credential = await context.getCredential(service);
     if (credential?.authType !== "custom_credential") {

--- a/src/providers/saucelabs/executors.ts
+++ b/src/providers/saucelabs/executors.ts
@@ -36,7 +36,6 @@ const handlers: ProviderActionHandlers<
 export const executors: ProviderExecutors = defineProviderExecutors({
   service: "saucelabs",
   handlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<SaucelabsContext> {
     const credential = await requireApiKeyCredential(context, "saucelabs");
     return { credential: resolveSaucelabsCredential({ apiKey: credential.apiKey, ...credential.values }), fetcher };
@@ -57,7 +56,6 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     if (!headers.has("accept")) headers.set("accept", "application/json");
     if (!headers.has("user-agent")) headers.set("user-agent", providerUserAgent);
   },
-  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {

--- a/src/providers/sonarcloud/executors.test.ts
+++ b/src/providers/sonarcloud/executors.test.ts
@@ -1,0 +1,38 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "api_key" }> = {
+  authType: "api_key",
+  apiKey: "sonar-token",
+  values: { apiBaseUrl: "https://sonarcloud.io/api" },
+  profile: { accountId: "sonarcloud", displayName: "SonarQube Cloud", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("SonarQube Cloud resolver DNS", () => {
+  it("rejects an allowlisted API host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["sonarcloud.list_projects"]!({ organization: "example" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/sonarcloud/executors.ts
+++ b/src/providers/sonarcloud/executors.ts
@@ -14,7 +14,6 @@ const service = "sonarcloud";
 export const executors: ProviderExecutors = defineProviderExecutors<SonarCloudActionContext>({
   service,
   handlers: sonarCloudActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<SonarCloudActionContext> {
     const credential = await requireApiKeyCredential(context, service);
     return {
@@ -34,7 +33,6 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     return resolveSonarCloudApiBaseUrl(credential.metadata.apiBaseUrl ?? credential.values.apiBaseUrl);
   },
   auth: { type: "bearer" },
-  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {


### PR DESCRIPTION
## Summary
- Remove `skipDnsValidation` from Amplitude, AWS STS, Appcues, Sauce Labs, and SonarQube Cloud.
- Those hosts come from region/data-residency/credential input, so the DNS resolved-address check is the SSRF defense.
- Left `aliyun_sts` alone: it still uses the hardcoded `https://sts.aliyuncs.com/` literal.

Closes #383

## Test plan
- [x] AWS STS `assume_role` and SonarQube Cloud `list_projects` reject a metadata-resolving host before fetch
- [x] `npm run fix-check`

Made with [Cursor](https://cursor.com)