### PR TITLE
fix(harvest): treat empty account lists as a valid OAuth identity

### DIFF
--- a/src/providers/harvest/executors.test.ts
+++ b/src/providers/harvest/executors.test.ts
@@ -1,7 +1,6 @@
 import type { ResolvedCredential } from "../../core/types.ts";
 
 import { describe, expect, it } from "vitest";
-import { ProviderRequestError } from "../provider-runtime.ts";
 import { credentialValidators } from "./executors.ts";
 
 const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
@@ -13,12 +12,28 @@ const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
 };
 
 describe("Harvest OAuth credential validation", () => {
-  it("rejects credentials without an executable Harvest account", async () => {
-    await expect(
-      credentialValidators.oauth2!(credential, {
-        fetcher: async () => Response.json({ user: { id: 42 }, accounts: [] }),
-      }),
-    ).rejects.toEqual(new ProviderRequestError(400, "harvest OAuth credential has no accessible Harvest account"));
+  it("accepts a valid identity when Harvest has not provisioned an account yet", async () => {
+    const result = await credentialValidators.oauth2!(credential, {
+      fetcher: async () =>
+        Response.json({
+          user: { id: 42, first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" },
+          accounts: [],
+        }),
+    });
+
+    expect(result).toEqual({
+      profile: { accountId: "42", displayName: "Ada Lovelace" },
+      grantedScopes: ["harvest.read", "harvest.write"],
+      metadata: {
+        apiBaseUrl: "https://api.harvestapp.com",
+        validationEndpoint: "https://id.getharvest.com/api/v2/accounts",
+        userId: 42,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.com",
+        accounts: [],
+      },
+    });
   });
 
   it("selects the default Harvest account without a second API probe", async () => {

--- a/src/providers/harvest/executors.ts
+++ b/src/providers/harvest/executors.ts
@@ -564,11 +564,8 @@ async function fetchHarvestCurrentAccount(
   const accountsResponse = requireObjectPayload(accountsPayload, "harvest accounts response");
   const accountUser = optionalRecord(accountsResponse.user);
   const accounts = readHarvestAccounts(accountsResponse);
-  if (accounts.length === 0) {
-    throw new ProviderRequestError(400, "harvest OAuth credential has no accessible Harvest account");
-  }
-  const defaultAccount = selectDefaultHarvestAccount(accounts);
-  const accountId = requireHarvestResponseAccountId(defaultAccount.id);
+  const defaultAccount = accounts.length > 0 ? selectDefaultHarvestAccount(accounts) : undefined;
+  const accountId = defaultAccount ? requireHarvestResponseAccountId(defaultAccount.id) : undefined;
   const userId = String(requireHarvestResponseId(accountUser?.id, "user.id"));
   const firstName = optionalString(accountUser?.first_name);
   const lastName = optionalString(accountUser?.last_name);


### PR DESCRIPTION
## Summary
- Harvest identity already comes from `id.getharvest.com/api/v2/accounts` (`user` + `accounts`).
- An empty `accounts` array is a provisioning state, not a bad token; stop throwing `credential_verification_failed`.
- Profile still uses the user id/name. `accountId` is omitted until an account exists (actions that need Harvest-Account-Id still fail later, which is correct).

Closes #382

## Test plan
- [x] Empty accounts: valid profile, no `metadata.accountId`
- [x] Default account still selected in one request when accounts exist
- [x] `npm run fix-check`

Made with [Cursor](https://cursor.com)