### PR TITLE
feat(bluesky): add authenticated timeline action

### DIFF
--- a/src/providers/bluesky/actions.ts
+++ b/src/providers/bluesky/actions.ts
@@ -38,7 +38,7 @@ const postViewSchema = s.looseObject("The raw Bluesky post view returned by a fe
   cid: cidSchema,
   author: s.looseObject("The Bluesky author view for the post."),
   record: compactRecordSchema,
-  indexedAt: s.string("The server timestamp when the post was indexed."),
+  indexedAt: s.dateTime("The server timestamp when the post was indexed."),
 });
 
 const feedViewPostSchema = s.object(

--- a/src/providers/bluesky/actions.ts
+++ b/src/providers/bluesky/actions.ts
@@ -33,13 +33,24 @@ const profileSchema = s.looseObject("The detailed Bluesky profile object returne
   postsCount: s.integer("The number of posts by the actor."),
 });
 
-const postViewSchema = s.looseObject("The raw Bluesky post view returned by search.", {
+const postViewSchema = s.looseObject("The raw Bluesky post view returned by a feed or search.", {
   uri: postUriSchema,
   cid: cidSchema,
   author: s.looseObject("The Bluesky author view for the post."),
   record: compactRecordSchema,
   indexedAt: s.string("The server timestamp when the post was indexed."),
 });
+
+const feedViewPostSchema = s.object(
+  "A Bluesky timeline feed item containing a post and optional reply or repost context.",
+  {
+    post: postViewSchema,
+    reply: compactRecordSchema,
+    reason: compactRecordSchema,
+    feedContext: s.string("Opaque feed-specific context returned by Bluesky."),
+  },
+  { required: ["post"], optional: ["reply", "reason", "feedContext"] },
+);
 
 const strongRefSchema = s.object("A Bluesky strong reference to a post.", {
   uri: postUriSchema,
@@ -92,6 +103,24 @@ export const blueskyActions: ProviderActionDefinition[] = [
       posts: s.array("Posts returned by Bluesky.", postViewSchema),
       cursor: s.nullable(cursorSchema),
       hitsTotal: s.nullable(s.integer("The total hit count when returned by Bluesky.")),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_timeline",
+    description: "Get the authenticated account's home timeline with cursor pagination.",
+    requiredScopes: [],
+    inputSchema: s.object(
+      "Parameters for retrieving the authenticated Bluesky timeline.",
+      {
+        algorithm: s.string("Optional Bluesky feed algorithm identifier.", { minLength: 1 }),
+        limit: s.integer("The maximum number of posts to return.", { minimum: 1, maximum: 100 }),
+        cursor: cursorSchema,
+      },
+      { optional: ["algorithm", "limit", "cursor"] },
+    ),
+    outputSchema: s.object("The authenticated Bluesky timeline response.", {
+      feed: s.array("Timeline feed items returned by Bluesky.", feedViewPostSchema),
+      cursor: s.nullable(cursorSchema),
     }),
   }),
   defineProviderAction(service, {

--- a/src/providers/bluesky/runtime.ts
+++ b/src/providers/bluesky/runtime.ts
@@ -85,6 +85,33 @@ export const blueskyActionHandlers: ProviderActionHandlers<"bluesky", BlueskyAct
       hitsTotal: optionalInteger(record.hitsTotal) ?? null,
     };
   },
+  async get_timeline(input, context) {
+    const session = await createBlueskySession({
+      identifier: context.handle,
+      appPassword: context.apiKey,
+      fetcher: context.fetcher,
+      signal: context.signal,
+      phase: "execute",
+    });
+    const payload = await requestBlueskyJson({
+      path: "/xrpc/app.bsky.feed.getTimeline",
+      method: "GET",
+      query: compactObject({
+        algorithm: optionalString(input.algorithm),
+        limit: optionalInteger(input.limit),
+        cursor: optionalString(input.cursor),
+      }),
+      accessJwt: session.accessJwt,
+      fetcher: context.fetcher,
+      signal: context.signal,
+      phase: "execute",
+    });
+    const record = requireRecord(payload, "Bluesky timeline response");
+    return {
+      feed: requireArray(record.feed, "feed").map((item) => requireRecord(item, "Bluesky timeline item")),
+      cursor: optionalString(record.cursor) ?? null,
+    };
+  },
   async create_text_post(input, context) {
     const session = await createBlueskySession({
       identifier: context.handle,


### PR DESCRIPTION
## Summary

- Add a locally executable Bluesky get_timeline action for the authenticated home timeline.
- Support the official algorithm, limit, and cursor pagination parameters.
- Add schema coverage for Bluesky feed items.

## Validation

- npm run generate:catalog
- npm run fix-check (passed)
- npm test: 1254 tests passed; 2 PostgreSQL suites could not load because the local environment does not include pg, @electric-sql/pglite, and related optional database packages.

The branch was rebased onto the latest origin/main before opening this PR.