### PR TITLE
feat(oura): add Oura Ring provider

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -59,11 +59,7 @@ export type OAuthClientConfigFieldDefinition = CredentialDefinition & {
 export type OAuthClientSetupDefinition = {
   /** Provider page where users register the OAuth app. */
   docsUrl?: string;
-  /**
-   * Ordered setup steps, each a single self-contained sentence. Wrap literal
-   * values such as scope names in backticks; the console renders those spans
-   * as code and everything else as plain text. No other markup is supported.
-   */
+  /** Ordered setup steps, each a single self-contained sentence of plain text. */
   steps: string[];
 };
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,6 +49,25 @@ export type OAuthClientConfigFieldDefinition = CredentialDefinition & {
 };
 
 /**
+ * Instructions for registering the OAuth app this provider needs.
+ *
+ * The local console shows these where users paste the client id and secret,
+ * because that is the moment they need them. Steps describe the provider's
+ * flow in this project's own words and link to the provider's own
+ * documentation; they never reproduce provider documentation or screenshots.
+ */
+export type OAuthClientSetupDefinition = {
+  /** Provider page where users register the OAuth app. */
+  docsUrl?: string;
+  /**
+   * Ordered setup steps, each a single self-contained sentence. Wrap literal
+   * values such as scope names in backticks; the console renders those spans
+   * as code and everything else as plain text. No other markup is supported.
+   */
+  steps: string[];
+};
+
+/**
  * API key connection configuration shown by the local console.
  */
 export type ApiKeyAuthDefinition = {
@@ -145,6 +164,8 @@ export type OAuth2AuthDefinition = {
   };
   /** Extra local OAuth app fields required before starting authorization. */
   clientConfigFields?: OAuthClientConfigFieldDefinition[];
+  /** How to register the provider OAuth app that supplies the client id and secret. */
+  clientSetup?: OAuthClientSetupDefinition;
 };
 
 /**

--- a/src/providers/oura/actions.ts
+++ b/src/providers/oura/actions.ts
@@ -1,0 +1,112 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+import type { OuraDocumentCollection } from "./collections.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { ouraDocumentCollections } from "./collections.ts";
+
+const service = "oura";
+
+const documentSchema = s.looseObject("One Oura document. Fields differ per collection; `id` is always present.", {
+  id: s.nonEmptyString("The Oura document identifier."),
+});
+
+const nextTokenSchema = s.nullableString(
+  "Pagination token for the next page, or null when the last page has been returned.",
+);
+
+const fieldsSchema = s.stringArray(
+  "Extra document fields to include in the response, in addition to the fields Oura always returns. Defaults to all fields.",
+  { itemDescription: "One Oura document field name." },
+);
+
+const documentIdInputSchema = s.object(
+  "The Oura document lookup input.",
+  { documentId: s.nonEmptyString("The Oura document identifier.") },
+  { required: ["documentId"] },
+);
+
+const personalInfoSchema = s.looseObject("The personal information stored on the authenticated Oura account.", {
+  id: s.nonEmptyString("The Oura user identifier."),
+  age: s.nullableInteger("The user age in years."),
+  weight: s.nullableNumber("The user weight in kilograms."),
+  height: s.nullableNumber("The user height in meters."),
+  biological_sex: s.nullableString("The biological sex recorded on the Oura account."),
+  email: s.nullableString("The email address of the Oura account. Requires the `email` scope."),
+});
+
+/**
+ * Public Oura action catalog: one `list_*` action per user data collection,
+ * one `get_*` action per collection that Oura serves by document ID, plus the
+ * account personal information document.
+ */
+export const ouraActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_personal_info",
+    description: "Get personal information for the authenticated Oura account.",
+    requiredScopes: ["personal"],
+    inputSchema: s.object("No input parameters are required for this action.", {}),
+    outputSchema: s.object("The personal information response returned by Oura.", {
+      personalInfo: personalInfoSchema,
+    }),
+  }),
+  ...ouraDocumentCollections.flatMap(collectionActions),
+];
+
+function collectionActions(collection: OuraDocumentCollection): ActionDefinition[] {
+  const actions: ActionDefinition[] = [
+    defineProviderAction(service, {
+      name: `list_${collection.name}`,
+      description: describe(collection, `List ${collection.label} documents from Oura.`),
+      requiredScopes: [collection.scope],
+      inputSchema: listInputSchema(collection),
+      outputSchema: s.object(`The paginated ${collection.label} list returned by Oura.`, {
+        documents: s.array(`The ${collection.label} documents returned for this page.`, documentSchema),
+        nextToken: nextTokenSchema,
+      }),
+    }),
+  ];
+
+  if (collection.hasDocumentEndpoint) {
+    actions.push(
+      defineProviderAction(service, {
+        name: `get_${collection.name}`,
+        description: describe(collection, `Get one ${collection.label} document from Oura by document ID.`),
+        requiredScopes: [collection.scope],
+        inputSchema: documentIdInputSchema,
+        outputSchema: s.object(`The single ${collection.label} document returned by Oura.`, {
+          document: documentSchema,
+        }),
+      }),
+    );
+  }
+
+  return actions;
+}
+
+function listInputSchema(collection: OuraDocumentCollection): JsonSchema {
+  const properties: Record<string, JsonSchema> = {};
+
+  if (collection.window === "date") {
+    properties.startDate = s.date(`The earliest day to return ${collection.label} documents for, as YYYY-MM-DD.`);
+    properties.endDate = s.date(`The latest day to return ${collection.label} documents for, as YYYY-MM-DD.`);
+  }
+  if (collection.window === "datetime") {
+    properties.startDatetime = s.dateTime(
+      `The earliest ISO 8601 timestamp to return ${collection.label} documents for.`,
+    );
+    properties.endDatetime = s.dateTime(`The latest ISO 8601 timestamp to return ${collection.label} documents for.`);
+  }
+  if (collection.supportsLatest) {
+    properties.latest = s.boolean(`Return only the most recent ${collection.label} instead of a full page.`);
+  }
+
+  properties.nextToken = s.nonEmptyString("The pagination token returned by a previous call as `nextToken`.");
+  properties.fields = fieldsSchema;
+
+  return s.object(`The ${collection.label} list query.`, properties);
+}
+
+function describe(collection: OuraDocumentCollection, sentence: string): string {
+  return collection.note ? `${sentence} ${collection.note}` : sentence;
+}

--- a/src/providers/oura/actions.ts
+++ b/src/providers/oura/actions.ts
@@ -11,6 +11,14 @@ const documentSchema = s.looseObject("One Oura document. Fields differ per colle
   id: s.nonEmptyString("The Oura document identifier."),
 });
 
+/**
+ * Time series collections return bare samples: Oura assigns them no document
+ * id, and exposes no single-document endpoint one could be used on.
+ */
+const sampleSchema = s.unknownObject(
+  "One Oura time series sample. Fields differ per collection, and samples carry no document identifier.",
+);
+
 const nextTokenSchema = s.nullableString(
   "Pagination token for the next page, or null when the last page has been returned.",
 );
@@ -61,7 +69,10 @@ function collectionActions(collection: OuraDocumentCollection): ActionDefinition
       requiredScopes: [collection.scope],
       inputSchema: listInputSchema(collection),
       outputSchema: s.object(`The paginated ${collection.label} list returned by Oura.`, {
-        documents: s.array(`The ${collection.label} documents returned for this page.`, documentSchema),
+        documents: s.array(
+          `The ${collection.label} documents returned for this page.`,
+          collection.hasDocumentEndpoint ? documentSchema : sampleSchema,
+        ),
         nextToken: nextTokenSchema,
       }),
     }),

--- a/src/providers/oura/collections.ts
+++ b/src/providers/oura/collections.ts
@@ -7,8 +7,14 @@ export const ouraApiBaseUrl = "https://api.ouraring.com";
 export const ouraUserCollectionPath = "/v2/usercollection";
 
 /**
- * Official Oura OAuth2 scopes, taken from the `OAuth2` security scheme in the
- * Oura API v2 OpenAPI document.
+ * Official Oura OAuth2 scopes.
+ *
+ * `email` through `session` come from the `OAuth2` security scheme in the Oura
+ * API v2 OpenAPI document. That scheme is stale: it omits `heart_health`,
+ * `stress`, and `ring_configuration`, and names the SpO2 scope `spo2Daily`
+ * where the API enforces `spo2`. The names below are the ones the live API
+ * reports in its 401 responses, so they are what an authorization request has
+ * to ask for.
  */
 export const ouraOauthScopes: string[] = [
   "email",
@@ -18,7 +24,10 @@ export const ouraOauthScopes: string[] = [
   "workout",
   "tag",
   "session",
-  "spo2Daily",
+  "spo2",
+  "heart_health",
+  "stress",
+  "ring_configuration",
 ];
 
 /**
@@ -64,7 +73,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
   collection({
     name: "daily_cardiovascular_age",
     label: "daily cardiovascular age",
-    scope: "daily",
+    scope: "heart_health",
   }),
   collection({
     name: "daily_readiness",
@@ -74,7 +83,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
   collection({
     name: "daily_resilience",
     label: "daily resilience summary",
-    scope: "daily",
+    scope: "stress",
   }),
   collection({
     name: "daily_sleep",
@@ -84,7 +93,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
   collection({
     name: "daily_spo2",
     label: "daily SpO2 summary",
-    scope: "spo2Daily",
+    scope: "spo2",
   }),
   collection({
     name: "daily_stress",
@@ -112,7 +121,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
   collection({
     name: "ring_battery_level",
     label: "ring battery level sample",
-    scope: "daily",
+    scope: "ring_configuration",
     window: "datetime",
     hasDocumentEndpoint: false,
     supportsLatest: true,
@@ -120,7 +129,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
   collection({
     name: "ring_configuration",
     label: "ring configuration",
-    scope: "daily",
+    scope: "ring_configuration",
     window: "none",
   }),
   collection({
@@ -148,7 +157,7 @@ export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
     name: "vo2_max",
     path: "vO2_max",
     label: "VO2 max measurement",
-    scope: "daily",
+    scope: "heart_health",
   }),
   collection({
     name: "workout",

--- a/src/providers/oura/collections.ts
+++ b/src/providers/oura/collections.ts
@@ -7,6 +7,12 @@ export const ouraApiBaseUrl = "https://api.ouraring.com";
 export const ouraUserCollectionPath = "/v2/usercollection";
 
 /**
+ * Prefix Oura puts on the scopes it grants. An authorization request asks for
+ * `daily`, and the issued token reports `extapi:daily` for the same scope.
+ */
+export const ouraGrantedScopePrefix = "extapi:";
+
+/**
  * Official Oura OAuth2 scopes.
  *
  * `email` through `session` come from the `OAuth2` security scheme in the Oura

--- a/src/providers/oura/collections.ts
+++ b/src/providers/oura/collections.ts
@@ -1,0 +1,183 @@
+/**
+ * Oura API v2 base URL. Documented at https://cloud.ouraring.com/v2/docs.
+ */
+export const ouraApiBaseUrl = "https://api.ouraring.com";
+
+/** Path prefix shared by every Oura user data collection. */
+export const ouraUserCollectionPath = "/v2/usercollection";
+
+/**
+ * Official Oura OAuth2 scopes, taken from the `OAuth2` security scheme in the
+ * Oura API v2 OpenAPI document.
+ */
+export const ouraOauthScopes: string[] = [
+  "email",
+  "personal",
+  "daily",
+  "heartrate",
+  "workout",
+  "tag",
+  "session",
+  "spo2Daily",
+];
+
+/**
+ * Query window accepted by one Oura collection list endpoint. Daily summaries
+ * are filtered by calendar day, time series by timestamp, and a few
+ * collections accept no window at all.
+ */
+export type OuraCollectionWindow = "date" | "datetime" | "none";
+
+/**
+ * One Oura user data collection exposed as a `list_*` (and usually `get_*`)
+ * action pair.
+ */
+export interface OuraDocumentCollection {
+  /** Action name suffix, such as `daily_sleep` in `oura.list_daily_sleep`. */
+  name: string;
+  /** Path segment under {@link ouraUserCollectionPath}; differs from `name` where Oura uses mixed case. */
+  path: string;
+  /** Human-readable collection name used in action descriptions. */
+  label: string;
+  /** Oura OAuth scope that grants access to this collection. */
+  scope: string;
+  /** Query window accepted by the list endpoint. */
+  window: OuraCollectionWindow;
+  /** Whether Oura exposes a single-document endpoint for this collection. */
+  hasDocumentEndpoint: boolean;
+  /** Whether the list endpoint accepts `latest` to return only the newest sample. */
+  supportsLatest: boolean;
+  /** Extra sentence appended to the generated action descriptions. */
+  note?: string;
+}
+
+/**
+ * Every user data collection served by the Oura API v2, in the order actions
+ * are published to the catalog.
+ */
+export const ouraDocumentCollections: readonly OuraDocumentCollection[] = [
+  collection({
+    name: "daily_activity",
+    label: "daily activity summary",
+    scope: "daily",
+  }),
+  collection({
+    name: "daily_cardiovascular_age",
+    label: "daily cardiovascular age",
+    scope: "daily",
+  }),
+  collection({
+    name: "daily_readiness",
+    label: "daily readiness summary",
+    scope: "daily",
+  }),
+  collection({
+    name: "daily_resilience",
+    label: "daily resilience summary",
+    scope: "daily",
+  }),
+  collection({
+    name: "daily_sleep",
+    label: "daily sleep summary",
+    scope: "daily",
+  }),
+  collection({
+    name: "daily_spo2",
+    label: "daily SpO2 summary",
+    scope: "spo2Daily",
+  }),
+  collection({
+    name: "daily_stress",
+    label: "daily stress summary",
+    scope: "daily",
+  }),
+  collection({
+    name: "enhanced_tag",
+    label: "enhanced tag",
+    scope: "tag",
+  }),
+  collection({
+    name: "heartrate",
+    label: "heart rate sample",
+    scope: "heartrate",
+    window: "datetime",
+    hasDocumentEndpoint: false,
+    supportsLatest: true,
+  }),
+  collection({
+    name: "rest_mode_period",
+    label: "rest mode period",
+    scope: "daily",
+  }),
+  collection({
+    name: "ring_battery_level",
+    label: "ring battery level sample",
+    scope: "daily",
+    window: "datetime",
+    hasDocumentEndpoint: false,
+    supportsLatest: true,
+  }),
+  collection({
+    name: "ring_configuration",
+    label: "ring configuration",
+    scope: "daily",
+    window: "none",
+  }),
+  collection({
+    name: "session",
+    label: "guided or unguided session",
+    scope: "session",
+  }),
+  collection({
+    name: "sleep",
+    label: "sleep period",
+    scope: "daily",
+  }),
+  collection({
+    name: "sleep_time",
+    label: "recommended bedtime window",
+    scope: "daily",
+  }),
+  collection({
+    name: "tag",
+    label: "tag",
+    scope: "tag",
+    note: "Oura has superseded this collection by enhanced tags.",
+  }),
+  collection({
+    name: "vo2_max",
+    path: "vO2_max",
+    label: "VO2 max measurement",
+    scope: "daily",
+  }),
+  collection({
+    name: "workout",
+    label: "workout",
+    scope: "workout",
+  }),
+];
+
+interface OuraDocumentCollectionInput {
+  name: string;
+  path?: string;
+  label: string;
+  scope: string;
+  window?: OuraCollectionWindow;
+  hasDocumentEndpoint?: boolean;
+  supportsLatest?: boolean;
+  note?: string;
+}
+
+/** Apply the defaults shared by most Oura collections: date window, single-document endpoint, no `latest`. */
+function collection(input: OuraDocumentCollectionInput): OuraDocumentCollection {
+  return {
+    name: input.name,
+    path: input.path ?? input.name,
+    label: input.label,
+    scope: input.scope,
+    window: input.window ?? "date",
+    hasDocumentEndpoint: input.hasDocumentEndpoint ?? true,
+    supportsLatest: input.supportsLatest ?? false,
+    note: input.note,
+  };
+}

--- a/src/providers/oura/definition.ts
+++ b/src/providers/oura/definition.ts
@@ -1,0 +1,32 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { ouraActions } from "./actions.ts";
+import { ouraOauthScopes } from "./collections.ts";
+
+const service = "oura";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Oura",
+  description: "Read Oura Ring sleep, readiness, activity, and biometric data from the Oura API v2 user collections.",
+  categories: ["Data"],
+  authTypes: ["oauth2", "api_key"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://cloud.ouraring.com/oauth/authorize",
+      tokenUrl: "https://api.ouraring.com/oauth/token",
+      scopes: ouraOauthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+    },
+    {
+      type: "api_key",
+      label: "Personal Access Token",
+      placeholder: "oura_personal_access_token",
+      description:
+        "Oura personal access token sent as an Authorization Bearer header. Create one at https://cloud.ouraring.com/personal-access-tokens. A personal access token reads only its own account and is not scoped, so it grants every collection this provider exposes.",
+    },
+  ],
+  homepageUrl: "https://ouraring.com",
+  actions: ouraActions,
+};

--- a/src/providers/oura/definition.ts
+++ b/src/providers/oura/definition.ts
@@ -10,7 +10,7 @@ export const provider: ProviderDefinition = {
   displayName: "Oura",
   description: "Read Oura Ring sleep, readiness, activity, and biometric data from the Oura API v2 user collections.",
   categories: ["Data"],
-  authTypes: ["oauth2", "api_key"],
+  authTypes: ["oauth2"],
   auth: [
     {
       type: "oauth2",
@@ -18,13 +18,6 @@ export const provider: ProviderDefinition = {
       tokenUrl: "https://api.ouraring.com/oauth/token",
       scopes: ouraOauthScopes,
       tokenEndpointAuthMethod: "client_secret_post",
-    },
-    {
-      type: "api_key",
-      label: "Personal Access Token",
-      placeholder: "oura_personal_access_token",
-      description:
-        "Oura personal access token sent as an Authorization Bearer header. Create one at https://cloud.ouraring.com/personal-access-tokens. A personal access token reads only its own account and is not scoped, so it grants every collection this provider exposes.",
     },
   ],
   homepageUrl: "https://ouraring.com",

--- a/src/providers/oura/definition.ts
+++ b/src/providers/oura/definition.ts
@@ -18,6 +18,15 @@ export const provider: ProviderDefinition = {
       tokenUrl: "https://api.ouraring.com/oauth/token",
       scopes: ouraOauthScopes,
       tokenEndpointAuthMethod: "client_secret_post",
+      clientSetup: {
+        docsUrl: "https://cloud.ouraring.com/oauth/applications",
+        steps: [
+          "Sign in with the Oura account that owns the app and create a new application.",
+          "Copy the Callback URL below into the application's Redirect URI field; Oura requires an exact match.",
+          "Enable every scope this runtime requests, including `heart_health`, `stress`, `ring_configuration`, and `spo2`. Oura silently drops scopes the application does not enable, and actions that need them fail with 401 at run time.",
+          "Copy the generated Client ID and Client Secret into the fields below.",
+        ],
+      },
     },
   ],
   homepageUrl: "https://ouraring.com",

--- a/src/providers/oura/definition.ts
+++ b/src/providers/oura/definition.ts
@@ -19,11 +19,11 @@ export const provider: ProviderDefinition = {
       scopes: ouraOauthScopes,
       tokenEndpointAuthMethod: "client_secret_post",
       clientSetup: {
-        docsUrl: "https://cloud.ouraring.com/oauth/applications",
+        docsUrl: "https://developer.ouraring.com/",
         steps: [
           "Sign in with the Oura account that owns the app and create a new application.",
           "Copy the Callback URL below into the application's Redirect URI field; Oura requires an exact match.",
-          "Enable every scope this runtime requests, including `heart_health`, `stress`, `ring_configuration`, and `spo2`. Oura silently drops scopes the application does not enable, and actions that need them fail with 401 at run time.",
+          "Enable every scope this runtime requests. Oura silently drops scopes the application does not enable, and actions that need them fail with 401 at run time.",
           "Copy the generated Client ID and Client Secret into the fields below.",
         ],
       },

--- a/src/providers/oura/executors.ts
+++ b/src/providers/oura/executors.ts
@@ -1,7 +1,7 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import {
-  defineBearerProviderExecutors,
+  defineOAuthProviderExecutors,
   defineProviderProxy,
   providerProxyEndpointPrefixes,
 } from "../provider-runtime.ts";
@@ -10,21 +10,18 @@ import { fetchOuraAccountProfile, ouraActionHandlers, parseOuraGrantedScopes } f
 
 const service = "oura";
 
-export const executors: ProviderExecutors = defineBearerProviderExecutors(service, ouraActionHandlers);
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, ouraActionHandlers);
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
   baseUrl: ouraApiBaseUrl,
-  auth: { type: "bearer" },
+  auth: { type: "oauth_bearer" },
   // Webhook subscription endpoints authenticate with the OAuth application's
   // client id/secret rather than the connected user credential.
   allowedEndpoint: providerProxyEndpointPrefixes("/v2/usercollection"),
 });
 
 export const credentialValidators: CredentialValidators = {
-  apiKey(input, { fetcher, signal }) {
-    return fetchOuraAccountProfile(input.apiKey, fetcher, signal);
-  },
   async oauth2(input, { fetcher, signal }) {
     const result = await fetchOuraAccountProfile(input.accessToken, fetcher, signal);
     return {

--- a/src/providers/oura/executors.ts
+++ b/src/providers/oura/executors.ts
@@ -1,0 +1,35 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+
+import {
+  defineBearerProviderExecutors,
+  defineProviderProxy,
+  providerProxyEndpointPrefixes,
+} from "../provider-runtime.ts";
+import { ouraApiBaseUrl } from "./collections.ts";
+import { fetchOuraAccountProfile, ouraActionHandlers, parseOuraGrantedScopes } from "./runtime.ts";
+
+const service = "oura";
+
+export const executors: ProviderExecutors = defineBearerProviderExecutors(service, ouraActionHandlers);
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: ouraApiBaseUrl,
+  auth: { type: "bearer" },
+  // Webhook subscription endpoints authenticate with the OAuth application's
+  // client id/secret rather than the connected user credential.
+  allowedEndpoint: providerProxyEndpointPrefixes("/v2/usercollection"),
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return fetchOuraAccountProfile(input.apiKey, fetcher, signal);
+  },
+  async oauth2(input, { fetcher, signal }) {
+    const result = await fetchOuraAccountProfile(input.accessToken, fetcher, signal);
+    return {
+      ...result,
+      grantedScopes: parseOuraGrantedScopes(input.metadata.scope),
+    };
+  },
+};

--- a/src/providers/oura/runtime.test.ts
+++ b/src/providers/oura/runtime.test.ts
@@ -1,10 +1,11 @@
+import type { JsonSchema } from "../../core/types.ts";
 import type { OAuthProviderContext, ProviderFetch } from "../provider-runtime.ts";
 
 import { describe, expect, it } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
 import { ouraActions } from "./actions.ts";
 import { ouraDocumentCollections, ouraOauthScopes } from "./collections.ts";
-import { fetchOuraAccountProfile, ouraActionHandlers } from "./runtime.ts";
+import { fetchOuraAccountProfile, ouraActionHandlers, parseOuraGrantedScopes } from "./runtime.ts";
 
 describe("Oura action catalog", () => {
   it("derives each action from what its collection actually supports", () => {
@@ -42,6 +43,17 @@ describe("Oura OAuth scopes", () => {
     expect(scopeFor("ring_configuration")).toBe("ring_configuration");
     expect(scopeFor("ring_battery_level")).toBe("ring_configuration");
     expect(scopeFor("daily_spo2")).toBe("spo2");
+  });
+});
+
+describe("Oura list item schemas", () => {
+  it("promises a document id only where Oura serves documents by id", () => {
+    // Heart rate and ring battery level are time series: Oura returns bare
+    // samples with no identifier and no single-document endpoint to use one on.
+    expect(listItemSchema("list_daily_sleep").properties).toHaveProperty("id");
+    expect(listItemSchema("list_heartrate").properties).toBeUndefined();
+    expect(listItemSchema("list_ring_battery_level").properties).toBeUndefined();
+    expect(String(listItemSchema("list_heartrate").description)).not.toContain("`id` is always present");
   });
 });
 
@@ -100,6 +112,22 @@ describe("Oura document requests", () => {
   });
 });
 
+describe("Oura granted scopes", () => {
+  it("reports granted scopes in the same vocabulary the actions require", () => {
+    // Oura grants `extapi:`-prefixed scopes but its 401s, and this catalog,
+    // name them bare, so callers could never match one against the other.
+    expect(parseOuraGrantedScopes("extapi:daily extapi:heart_health")).toEqual(["daily", "heart_health"]);
+  });
+
+  it("keeps a scope that carries no Oura prefix", () => {
+    expect(parseOuraGrantedScopes("daily personal")).toEqual(["daily", "personal"]);
+  });
+
+  it("has nothing to report without a scope string", () => {
+    expect(parseOuraGrantedScopes(undefined)).toEqual([]);
+  });
+});
+
 describe("Oura credential validation", () => {
   it("identifies the account by user id and email", async () => {
     const result = await fetchOuraAccountProfile(
@@ -122,6 +150,12 @@ describe("Oura credential validation", () => {
     );
   });
 });
+
+function listItemSchema(actionName: string): JsonSchema {
+  const action = ouraActions.find(({ name }) => name === actionName);
+  const documents = action?.outputSchema.properties as Record<string, JsonSchema>;
+  return documents.documents!.items as JsonSchema;
+}
 
 function scopeFor(collectionName: string): string | undefined {
   return ouraDocumentCollections.find(({ name }) => name === collectionName)?.scope;

--- a/src/providers/oura/runtime.test.ts
+++ b/src/providers/oura/runtime.test.ts
@@ -1,0 +1,123 @@
+import type { BearerProviderContext, ProviderFetch } from "../provider-runtime.ts";
+
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { ouraActions } from "./actions.ts";
+import { fetchOuraAccountProfile, ouraActionHandlers } from "./runtime.ts";
+
+describe("Oura action catalog", () => {
+  it("publishes a list action per collection and a get action per document endpoint", () => {
+    const names = ouraActions.map(({ name }) => name);
+
+    expect(names).toContain("list_heartrate");
+    expect(names).toContain("get_daily_sleep");
+    // Oura serves heart rate as a time series without a document endpoint.
+    expect(names).not.toContain("get_heartrate");
+  });
+
+  it("only offers a date window where the collection accepts one", () => {
+    expect(inputProperties("list_daily_sleep")).toContain("startDate");
+    expect(inputProperties("list_heartrate")).toEqual(
+      expect.arrayContaining(["startDatetime", "endDatetime", "latest"]),
+    );
+    expect(inputProperties("list_ring_configuration")).toEqual(["nextToken", "fields"]);
+  });
+});
+
+describe("Oura document requests", () => {
+  it("maps the list query onto Oura query parameters", async () => {
+    const requests: string[] = [];
+    const output = await ouraActionHandlers.list_daily_sleep!(
+      { startDate: "2026-08-01", endDate: "2026-08-10", fields: ["score", "day"], nextToken: "page-2" },
+      context(recordingFetcher(requests, { data: [{ id: "doc-1" }], next_token: "page-3" })),
+    );
+
+    expect(requests).toEqual([
+      "https://api.ouraring.com/v2/usercollection/daily_sleep?next_token=page-2&fields=score%2Cday&start_date=2026-08-01&end_date=2026-08-10",
+    ]);
+    expect(output).toEqual({ documents: [{ id: "doc-1" }], nextToken: "page-3" });
+  });
+
+  it("normalizes a missing next_token to null", async () => {
+    const output = await ouraActionHandlers.list_workout!({}, context(jsonFetcher({ data: [], next_token: null })));
+
+    expect(output).toEqual({ documents: [], nextToken: null });
+  });
+
+  it("uses the Oura path segment when it differs from the action name", async () => {
+    const requests: string[] = [];
+    await ouraActionHandlers.get_vo2_max!(
+      { documentId: "doc 1" },
+      context(recordingFetcher(requests, { id: "doc 1" })),
+    );
+
+    expect(requests).toEqual(["https://api.ouraring.com/v2/usercollection/vO2_max/doc%201"]);
+  });
+
+  it("reports an unknown document id as invalid input", async () => {
+    await expect(
+      ouraActionHandlers.get_daily_sleep!(
+        { documentId: "missing" },
+        context(jsonFetcher({ detail: "not found" }, 404)),
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "not found" });
+  });
+
+  it("reports a lapsed subscription as an unauthorized credential", async () => {
+    await expect(
+      ouraActionHandlers.list_daily_sleep!({}, context(jsonFetcher({ detail: "subscription expired" }, 403))),
+    ).rejects.toMatchObject({ status: 401, message: "subscription expired" });
+  });
+
+  it("summarizes validation errors returned as a detail list", async () => {
+    await expect(
+      ouraActionHandlers.list_daily_sleep!(
+        { startDate: "yesterday" },
+        context(jsonFetcher({ detail: [{ msg: "invalid start_date" }, { msg: "invalid end_date" }] }, 422)),
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "invalid start_date; invalid end_date" });
+  });
+});
+
+describe("Oura credential validation", () => {
+  it("identifies the account by user id and email", async () => {
+    const result = await fetchOuraAccountProfile(
+      "oura-token",
+      jsonFetcher({ id: "user-1", email: "runner@example.com", age: 33 }),
+    );
+
+    expect(result.profile).toEqual({ accountId: "user-1", displayName: "runner@example.com" });
+  });
+
+  it("falls back to the user id when the email scope was not granted", async () => {
+    const result = await fetchOuraAccountProfile("oura-token", jsonFetcher({ id: "user-1", email: null }));
+
+    expect(result.profile?.displayName).toBe("Oura user user-1");
+  });
+
+  it("reports a rejected token as invalid input so the user can fix it", async () => {
+    await expect(fetchOuraAccountProfile("bad-token", jsonFetcher({ detail: "invalid token" }, 401))).rejects.toEqual(
+      new ProviderRequestError(400, "invalid token"),
+    );
+  });
+});
+
+function inputProperties(actionName: string): string[] {
+  const action = ouraActions.find(({ name }) => name === actionName);
+  return Object.keys(action?.inputSchema.properties ?? {});
+}
+
+function context(fetcher: ProviderFetch): BearerProviderContext {
+  return { accessToken: "oura-token", fetcher };
+}
+
+function jsonFetcher(payload: unknown, status = 200): ProviderFetch {
+  return async () => Response.json(payload, { status });
+}
+
+function recordingFetcher(requests: string[], payload: unknown, status = 200): ProviderFetch {
+  return async (input) => {
+    requests.push(input instanceof Request ? input.url : input.toString());
+    return Response.json(payload, { status });
+  };
+}

--- a/src/providers/oura/runtime.test.ts
+++ b/src/providers/oura/runtime.test.ts
@@ -1,4 +1,4 @@
-import type { BearerProviderContext, ProviderFetch } from "../provider-runtime.ts";
+import type { OAuthProviderContext, ProviderFetch } from "../provider-runtime.ts";
 
 import { describe, expect, it } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
@@ -105,7 +105,7 @@ function inputProperties(actionName: string): string[] {
   return Object.keys(action?.inputSchema.properties ?? {});
 }
 
-function context(fetcher: ProviderFetch): BearerProviderContext {
+function context(fetcher: ProviderFetch): OAuthProviderContext {
   return { accessToken: "oura-token", fetcher };
 }
 

--- a/src/providers/oura/runtime.test.ts
+++ b/src/providers/oura/runtime.test.ts
@@ -6,20 +6,18 @@ import { ouraActions } from "./actions.ts";
 import { fetchOuraAccountProfile, ouraActionHandlers } from "./runtime.ts";
 
 describe("Oura action catalog", () => {
-  it("publishes a list action per collection and a get action per document endpoint", () => {
-    const names = ouraActions.map(({ name }) => name);
-
-    expect(names).toContain("list_heartrate");
-    expect(names).toContain("get_daily_sleep");
-    // Oura serves heart rate as a time series without a document endpoint.
-    expect(names).not.toContain("get_heartrate");
-  });
-
-  it("only offers a date window where the collection accepts one", () => {
-    expect(inputProperties("list_daily_sleep")).toContain("startDate");
-    expect(inputProperties("list_heartrate")).toEqual(
-      expect.arrayContaining(["startDatetime", "endDatetime", "latest"]),
-    );
+  it("derives each action from what its collection actually supports", () => {
+    // Heart rate is a time series: no document endpoint, timestamps instead of
+    // days, and a `latest` shortcut. Ring configuration takes no time window.
+    expect(ouraActions.map(({ name }) => name)).not.toContain("get_heartrate");
+    expect(inputProperties("list_heartrate")).toEqual([
+      "startDatetime",
+      "endDatetime",
+      "latest",
+      "nextToken",
+      "fields",
+    ]);
+    expect(inputProperties("list_daily_sleep")).toEqual(["startDate", "endDate", "nextToken", "fields"]);
     expect(inputProperties("list_ring_configuration")).toEqual(["nextToken", "fields"]);
   });
 });

--- a/src/providers/oura/runtime.test.ts
+++ b/src/providers/oura/runtime.test.ts
@@ -3,6 +3,7 @@ import type { OAuthProviderContext, ProviderFetch } from "../provider-runtime.ts
 import { describe, expect, it } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
 import { ouraActions } from "./actions.ts";
+import { ouraDocumentCollections, ouraOauthScopes } from "./collections.ts";
 import { fetchOuraAccountProfile, ouraActionHandlers } from "./runtime.ts";
 
 describe("Oura action catalog", () => {
@@ -19,6 +20,28 @@ describe("Oura action catalog", () => {
     ]);
     expect(inputProperties("list_daily_sleep")).toEqual(["startDate", "endDate", "nextToken", "fields"]);
     expect(inputProperties("list_ring_configuration")).toEqual(["nextToken", "fields"]);
+  });
+});
+
+describe("Oura OAuth scopes", () => {
+  it("requests every scope its collections read from", () => {
+    const requested = new Set(ouraOauthScopes);
+    const unrequested = ouraDocumentCollections
+      .filter(({ scope }) => !requested.has(scope))
+      .map(({ name, scope }) => `${name} needs ${scope}`);
+
+    expect(unrequested).toEqual([]);
+  });
+
+  it("uses the scope Oura enforces, not the collection's daily summary neighbours", () => {
+    // Oura gates these behind their own scopes even though they are published
+    // next to the daily summaries; requesting `daily` alone returns 401.
+    expect(scopeFor("daily_cardiovascular_age")).toBe("heart_health");
+    expect(scopeFor("vo2_max")).toBe("heart_health");
+    expect(scopeFor("daily_resilience")).toBe("stress");
+    expect(scopeFor("ring_configuration")).toBe("ring_configuration");
+    expect(scopeFor("ring_battery_level")).toBe("ring_configuration");
+    expect(scopeFor("daily_spo2")).toBe("spo2");
   });
 });
 
@@ -99,6 +122,10 @@ describe("Oura credential validation", () => {
     );
   });
 });
+
+function scopeFor(collectionName: string): string | undefined {
+  return ouraDocumentCollections.find(({ name }) => name === collectionName)?.scope;
+}
 
 function inputProperties(actionName: string): string[] {
   const action = ouraActions.find(({ name }) => name === actionName);

--- a/src/providers/oura/runtime.ts
+++ b/src/providers/oura/runtime.ts
@@ -1,0 +1,289 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { BearerProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { OuraDocumentCollection } from "./collections.ts";
+
+import {
+  compactObject,
+  objectArray,
+  optionalBoolean,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredString,
+} from "../../core/cast.ts";
+import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { ouraApiBaseUrl, ouraDocumentCollections, ouraUserCollectionPath } from "./collections.ts";
+
+const ouraPersonalInfoPath = `${ouraUserCollectionPath}/personal_info`;
+const ouraRequestTimeoutMs = 30_000;
+
+type OuraRequestPhase = "validate" | "execute";
+type OuraQueryValue = string | undefined;
+type OuraActionHandler = ProviderRuntimeHandler<BearerProviderContext>;
+
+interface OuraRequestInput {
+  accessToken: string;
+  path: string;
+  fetcher: ProviderFetch;
+  phase: OuraRequestPhase;
+  query?: Record<string, OuraQueryValue>;
+  /** Report a provider 404 as invalid input; used for document-ID lookups. */
+  notFoundAsInvalidInput?: boolean;
+  signal?: AbortSignal;
+}
+
+/**
+ * Action handlers for every Oura collection action, keyed by provider-local
+ * action name and derived from the same collection table the catalog uses.
+ */
+export const ouraActionHandlers: Record<string, OuraActionHandler> = buildOuraActionHandlers();
+
+/**
+ * Resolve the Oura account behind an access token, used to validate both
+ * personal access tokens and OAuth credentials.
+ */
+export async function fetchOuraAccountProfile(
+  accessToken: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const personalInfo = await requestOuraObject({
+    accessToken,
+    path: ouraPersonalInfoPath,
+    fetcher,
+    phase: "validate",
+    signal,
+  });
+  const userId = requiredString(personalInfo.id, "id", providerOutput);
+  const email = optionalString(personalInfo.email);
+
+  return {
+    profile: {
+      accountId: userId,
+      displayName: email ?? `Oura user ${userId}`,
+    },
+    metadata: compactObject({
+      apiBaseUrl: ouraApiBaseUrl,
+      email,
+      age: personalInfo.age,
+      biologicalSex: optionalString(personalInfo.biological_sex),
+    }),
+  };
+}
+
+/** Space-separated OAuth scope string returned by the Oura token endpoint. */
+export function parseOuraGrantedScopes(value: unknown): string[] {
+  const scope = optionalString(value);
+  if (!scope) {
+    return [];
+  }
+  return scope.split(/\s+/).filter(Boolean);
+}
+
+function buildOuraActionHandlers(): Record<string, OuraActionHandler> {
+  const handlers: Record<string, OuraActionHandler> = {
+    async get_personal_info(_input, context) {
+      return {
+        personalInfo: await requestOuraObject({
+          accessToken: context.accessToken,
+          path: ouraPersonalInfoPath,
+          fetcher: context.fetcher,
+          phase: "execute",
+          signal: context.signal,
+        }),
+      };
+    },
+  };
+
+  for (const collection of ouraDocumentCollections) {
+    handlers[`list_${collection.name}`] = (input, context) => listOuraDocuments(collection, input, context);
+    if (collection.hasDocumentEndpoint) {
+      handlers[`get_${collection.name}`] = (input, context) => getOuraDocument(collection, input, context);
+    }
+  }
+
+  return handlers;
+}
+
+async function listOuraDocuments(
+  collection: OuraDocumentCollection,
+  input: Record<string, unknown>,
+  context: BearerProviderContext,
+): Promise<unknown> {
+  const payload = await requestOuraObject({
+    accessToken: context.accessToken,
+    path: `${ouraUserCollectionPath}/${collection.path}`,
+    fetcher: context.fetcher,
+    phase: "execute",
+    query: listQuery(collection, input),
+    signal: context.signal,
+  });
+
+  return {
+    documents: objectArray(payload.data, "data", providerOutput),
+    nextToken: optionalString(payload.next_token) ?? null,
+  };
+}
+
+async function getOuraDocument(
+  collection: OuraDocumentCollection,
+  input: Record<string, unknown>,
+  context: BearerProviderContext,
+): Promise<unknown> {
+  const documentId = requiredString(input.documentId, "documentId", badInput);
+
+  return {
+    document: await requestOuraObject({
+      accessToken: context.accessToken,
+      path: `${ouraUserCollectionPath}/${collection.path}/${encodeURIComponent(documentId)}`,
+      fetcher: context.fetcher,
+      phase: "execute",
+      notFoundAsInvalidInput: true,
+      signal: context.signal,
+    }),
+  };
+}
+
+function listQuery(collection: OuraDocumentCollection, input: Record<string, unknown>): Record<string, OuraQueryValue> {
+  const query: Record<string, OuraQueryValue> = {
+    next_token: optionalString(input.nextToken),
+    fields: joinCommaSeparated(optionalStringArray(input.fields)),
+  };
+
+  if (collection.window === "date") {
+    query.start_date = optionalString(input.startDate);
+    query.end_date = optionalString(input.endDate);
+  }
+  if (collection.window === "datetime") {
+    query.start_datetime = optionalString(input.startDatetime);
+    query.end_datetime = optionalString(input.endDatetime);
+  }
+  if (collection.supportsLatest) {
+    const latest = optionalBoolean(input.latest);
+    query.latest = latest === undefined ? undefined : String(latest);
+  }
+
+  return compactObject(query);
+}
+
+async function requestOuraObject(input: OuraRequestInput): Promise<Record<string, unknown>> {
+  const url = new URL(input.path, ouraApiBaseUrl);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  const timeout = createProviderTimeout(input.signal, ouraRequestTimeoutMs);
+  try {
+    const response = await input.fetcher(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${input.accessToken}`,
+        "User-Agent": providerUserAgent,
+      },
+      signal: timeout.signal,
+    });
+    const payload = parseJson(await response.text());
+
+    if (!response.ok) {
+      throw mapOuraError({
+        status: response.status,
+        phase: input.phase,
+        payload,
+        notFoundAsInvalidInput: input.notFoundAsInvalidInput,
+      });
+    }
+
+    const object = optionalRecord(payload);
+    if (!object) {
+      throw new ProviderRequestError(502, `oura ${input.path} returned an unexpected response body`);
+    }
+    return object;
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "oura request timed out");
+    }
+    const message = error instanceof Error && error.message ? error.message : "unknown Oura error";
+    throw new ProviderRequestError(502, `oura request failed: ${message}`);
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function parseJson(text: string): unknown {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+interface OuraErrorInput {
+  status: number;
+  phase: OuraRequestPhase;
+  payload: unknown;
+  notFoundAsInvalidInput?: boolean;
+}
+
+function mapOuraError(input: OuraErrorInput): ProviderRequestError {
+  const message = extractOuraErrorMessage(input.payload) ?? `oura request failed with status ${input.status}`;
+
+  if (input.status === 429) {
+    return new ProviderRequestError(429, message);
+  }
+  if (input.status === 401 || input.status === 403) {
+    // A 403 means the Oura subscription lapsed or the scope was not granted;
+    // both are credential problems the user has to fix before retrying.
+    return new ProviderRequestError(input.phase === "validate" ? 400 : 401, message);
+  }
+  if (input.status === 400 || input.status === 422 || (input.status === 404 && input.notFoundAsInvalidInput)) {
+    return new ProviderRequestError(400, message);
+  }
+
+  return new ProviderRequestError(input.status, message);
+}
+
+/**
+ * Oura errors carry a FastAPI `detail`, either a plain message or a list of
+ * validation errors.
+ */
+function extractOuraErrorMessage(payload: unknown): string | undefined {
+  const object = optionalRecord(payload);
+  if (!object) {
+    return undefined;
+  }
+
+  const detail = object.detail;
+  const message = optionalString(detail) ?? optionalString(object.message) ?? optionalString(object.title);
+  if (message) {
+    return message;
+  }
+  if (!Array.isArray(detail)) {
+    return undefined;
+  }
+
+  const messages = detail
+    .map((item) => optionalString(optionalRecord(item)?.msg))
+    .filter((item): item is string => !!item);
+  return messages.length > 0 ? messages.join("; ") : undefined;
+}
+
+function joinCommaSeparated(value: string[] | undefined): string | undefined {
+  return value && value.length > 0 ? value.join(",") : undefined;
+}
+
+function badInput(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function providerOutput(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/oura/runtime.ts
+++ b/src/providers/oura/runtime.ts
@@ -1,6 +1,6 @@
 import type { QueryValue } from "../../core/request.ts";
 import type { CredentialValidationResult } from "../../core/types.ts";
-import type { BearerProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { OAuthProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { OuraDocumentCollection } from "./collections.ts";
 
 import {
@@ -20,7 +20,7 @@ const ouraPersonalInfoPath = `${ouraUserCollectionPath}/personal_info`;
 const ouraRequestTimeoutMs = 30_000;
 
 type OuraRequestPhase = "validate" | "execute";
-type OuraActionHandler = ProviderRuntimeHandler<BearerProviderContext>;
+type OuraActionHandler = ProviderRuntimeHandler<OAuthProviderContext>;
 
 interface OuraRequestInput {
   accessToken: string;
@@ -40,8 +40,8 @@ interface OuraRequestInput {
 export const ouraActionHandlers: Record<string, OuraActionHandler> = buildOuraActionHandlers();
 
 /**
- * Resolve the Oura account behind an access token, used to validate both
- * personal access tokens and OAuth credentials.
+ * Resolve the Oura account behind an access token, used to build the
+ * `oauth2` credential validator's profile.
  */
 export async function fetchOuraAccountProfile(
   accessToken: string,
@@ -109,7 +109,7 @@ function buildOuraActionHandlers(): Record<string, OuraActionHandler> {
 async function listOuraDocuments(
   collection: OuraDocumentCollection,
   input: Record<string, unknown>,
-  context: BearerProviderContext,
+  context: OAuthProviderContext,
 ): Promise<unknown> {
   const payload = await requestOuraObject({
     accessToken: context.accessToken,
@@ -129,7 +129,7 @@ async function listOuraDocuments(
 async function getOuraDocument(
   collection: OuraDocumentCollection,
   input: Record<string, unknown>,
-  context: BearerProviderContext,
+  context: OAuthProviderContext,
 ): Promise<unknown> {
   const documentId = requiredString(input.documentId, "documentId", badInput);
 

--- a/src/providers/oura/runtime.ts
+++ b/src/providers/oura/runtime.ts
@@ -1,3 +1,4 @@
+import type { QueryValue } from "../../core/request.ts";
 import type { CredentialValidationResult } from "../../core/types.ts";
 import type { BearerProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { OuraDocumentCollection } from "./collections.ts";
@@ -11,6 +12,7 @@ import {
   optionalStringArray,
   requiredString,
 } from "../../core/cast.ts";
+import { encodePathSegment, queryParams } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 import { ouraApiBaseUrl, ouraDocumentCollections, ouraUserCollectionPath } from "./collections.ts";
 
@@ -18,7 +20,6 @@ const ouraPersonalInfoPath = `${ouraUserCollectionPath}/personal_info`;
 const ouraRequestTimeoutMs = 30_000;
 
 type OuraRequestPhase = "validate" | "execute";
-type OuraQueryValue = string | undefined;
 type OuraActionHandler = ProviderRuntimeHandler<BearerProviderContext>;
 
 interface OuraRequestInput {
@@ -26,7 +27,7 @@ interface OuraRequestInput {
   path: string;
   fetcher: ProviderFetch;
   phase: OuraRequestPhase;
-  query?: Record<string, OuraQueryValue>;
+  query?: Record<string, string>;
   /** Report a provider 404 as invalid input; used for document-ID lookups. */
   notFoundAsInvalidInput?: boolean;
   signal?: AbortSignal;
@@ -135,7 +136,7 @@ async function getOuraDocument(
   return {
     document: await requestOuraObject({
       accessToken: context.accessToken,
-      path: `${ouraUserCollectionPath}/${collection.path}/${encodeURIComponent(documentId)}`,
+      path: `${ouraUserCollectionPath}/${collection.path}/${encodePathSegment(documentId)}`,
       fetcher: context.fetcher,
       phase: "execute",
       notFoundAsInvalidInput: true,
@@ -144,8 +145,8 @@ async function getOuraDocument(
   };
 }
 
-function listQuery(collection: OuraDocumentCollection, input: Record<string, unknown>): Record<string, OuraQueryValue> {
-  const query: Record<string, OuraQueryValue> = {
+function listQuery(collection: OuraDocumentCollection, input: Record<string, unknown>): Record<string, string> {
+  const query: Record<string, QueryValue> = {
     next_token: optionalString(input.nextToken),
     fields: joinCommaSeparated(optionalStringArray(input.fields)),
   };
@@ -159,19 +160,16 @@ function listQuery(collection: OuraDocumentCollection, input: Record<string, unk
     query.end_datetime = optionalString(input.endDatetime);
   }
   if (collection.supportsLatest) {
-    const latest = optionalBoolean(input.latest);
-    query.latest = latest === undefined ? undefined : String(latest);
+    query.latest = optionalBoolean(input.latest);
   }
 
-  return compactObject(query);
+  return queryParams(query);
 }
 
 async function requestOuraObject(input: OuraRequestInput): Promise<Record<string, unknown>> {
   const url = new URL(input.path, ouraApiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
-    if (value !== undefined) {
-      url.searchParams.set(key, value);
-    }
+    url.searchParams.set(key, value);
   }
 
   const timeout = createProviderTimeout(input.signal, ouraRequestTimeoutMs);

--- a/src/providers/oura/runtime.ts
+++ b/src/providers/oura/runtime.ts
@@ -14,7 +14,12 @@ import {
 } from "../../core/cast.ts";
 import { encodePathSegment, queryParams } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
-import { ouraApiBaseUrl, ouraDocumentCollections, ouraUserCollectionPath } from "./collections.ts";
+import {
+  ouraApiBaseUrl,
+  ouraDocumentCollections,
+  ouraGrantedScopePrefix,
+  ouraUserCollectionPath,
+} from "./collections.ts";
 
 const ouraPersonalInfoPath = `${ouraUserCollectionPath}/personal_info`;
 const ouraRequestTimeoutMs = 30_000;
@@ -78,7 +83,12 @@ export function parseOuraGrantedScopes(value: unknown): string[] {
   if (!scope) {
     return [];
   }
-  return scope.split(/\s+/).filter(Boolean);
+  return scope
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((granted) =>
+      granted.startsWith(ouraGrantedScopePrefix) ? granted.slice(ouraGrantedScopePrefix.length) : granted,
+    );
 }
 
 function buildOuraActionHandlers(): Record<string, OuraActionHandler> {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "Reset Default App"
     },
     "oauthClientSettings": {
+      "setupTitle": "Create the OAuth app",
+      "setupIntro": "Register an OAuth app with {{name}}, then paste its credentials below.",
+      "setupDocsLink": "Open {{name}} app registration",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "Create the OAuth app",
       "setupIntro": "Register an OAuth app with {{name}}, then paste its credentials below.",
-      "setupDocsLink": "Open {{name}} app registration",
+      "setupDocsLink": "Open {{name}} developer portal",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "Créer l'application OAuth",
       "setupIntro": "Enregistrez une application OAuth auprès de {{name}}, puis collez ses identifiants ci-dessous.",
-      "setupDocsLink": "Ouvrir l'enregistrement d'application {{name}}",
+      "setupDocsLink": "Ouvrir le portail développeur {{name}}",
       "callbackUrl": "URL de callback",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "Réinitialiser l’app par défaut"
     },
     "oauthClientSettings": {
+      "setupTitle": "Créer l'application OAuth",
+      "setupIntro": "Enregistrez une application OAuth auprès de {{name}}, puis collez ses identifiants ci-dessous.",
+      "setupDocsLink": "Ouvrir l'enregistrement d'application {{name}}",
       "callbackUrl": "URL de callback",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "OAuth アプリを作成する",
       "setupIntro": "{{name}} で OAuth アプリを登録し、その認証情報を以下に貼り付けてください。",
-      "setupDocsLink": "{{name}} のアプリ登録を開く",
+      "setupDocsLink": "{{name}} デベロッパーポータルを開く",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "デフォルト App をリセット"
     },
     "oauthClientSettings": {
+      "setupTitle": "OAuth アプリを作成する",
+      "setupIntro": "{{name}} で OAuth アプリを登録し、その認証情報を以下に貼り付けてください。",
+      "setupDocsLink": "{{name}} のアプリ登録を開く",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "Создайте приложение OAuth",
       "setupIntro": "Зарегистрируйте приложение OAuth в {{name}}, затем вставьте его учётные данные ниже.",
-      "setupDocsLink": "Открыть регистрацию приложения {{name}}",
+      "setupDocsLink": "Открыть портал разработчика {{name}}",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "Сбросить App по умолчанию"
     },
     "oauthClientSettings": {
+      "setupTitle": "Создайте приложение OAuth",
+      "setupIntro": "Зарегистрируйте приложение OAuth в {{name}}, затем вставьте его учётные данные ниже.",
+      "setupDocsLink": "Открыть регистрацию приложения {{name}}",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "创建 OAuth 应用",
       "setupIntro": "在 {{name}} 注册一个 OAuth 应用，然后将其凭据粘贴到下方。",
-      "setupDocsLink": "打开 {{name}} 应用注册页",
+      "setupDocsLink": "打开 {{name}} 开发者门户",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "重置默认 App"
     },
     "oauthClientSettings": {
+      "setupTitle": "创建 OAuth 应用",
+      "setupIntro": "在 {{name}} 注册一个 OAuth 应用，然后将其凭据粘贴到下方。",
+      "setupDocsLink": "打开 {{name}} 应用注册页",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -243,7 +243,7 @@
     "oauthClientSettings": {
       "setupTitle": "建立 OAuth 應用程式",
       "setupIntro": "在 {{name}} 註冊一個 OAuth 應用程式，然後將其憑證貼到下方。",
-      "setupDocsLink": "開啟 {{name}} 應用程式註冊頁",
+      "setupDocsLink": "開啟 {{name}} 開發者入口網站",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/locales/zh-TW.json
+++ b/web/src/locales/zh-TW.json
@@ -241,6 +241,9 @@
       "resetOAuthClient": "重設預設 App"
     },
     "oauthClientSettings": {
+      "setupTitle": "建立 OAuth 應用程式",
+      "setupIntro": "在 {{name}} 註冊一個 OAuth 應用程式，然後將其憑證貼到下方。",
+      "setupDocsLink": "開啟 {{name}} 應用程式註冊頁",
       "callbackUrl": "Callback URL",
       "clientId": "Client ID",
       "clientSecret": "Client Secret",

--- a/web/src/model.ts
+++ b/web/src/model.ts
@@ -13,7 +13,14 @@ export type AuthDefinition =
       scopes: string[];
       tokenEndpointAuthMethod?: "client_secret_basic" | "client_secret_post" | "none";
       clientConfigFields?: CredentialField[];
+      clientSetup?: OAuthClientSetup;
     };
+
+/** How to register the provider OAuth app, shown while configuring the client. */
+export interface OAuthClientSetup {
+  docsUrl?: string;
+  steps: string[];
+}
 
 export interface CredentialField {
   key: string;

--- a/web/src/oauth-app-form.test.ts
+++ b/web/src/oauth-app-form.test.ts
@@ -1,0 +1,64 @@
+import type { AuthDefinition, ProviderDefinition } from "./model";
+
+import { I18nProvider } from "@embra/i18n/react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { createAppI18n } from "./i18n";
+import { OAuthAppForm } from "./oauth-app-form";
+
+const setupAuth: Extract<AuthDefinition, { type: "oauth2" }> = {
+  type: "oauth2",
+  scopes: [],
+  clientSetup: {
+    docsUrl: "https://provider.example/apps",
+    steps: ["Create the application.", "Enable the `heart_health` scope."],
+  },
+};
+
+const bareAuth: Extract<AuthDefinition, { type: "oauth2" }> = { type: "oauth2", scopes: [] };
+
+function provider(auth: AuthDefinition): ProviderDefinition {
+  return {
+    service: "example",
+    displayName: "Example",
+    categories: [],
+    authTypes: ["oauth2"],
+    auth: [auth],
+    actions: [],
+  };
+}
+
+function markupFor(auth: Extract<AuthDefinition, { type: "oauth2" }>): string {
+  return renderToStaticMarkup(
+    createElement(
+      I18nProvider,
+      { i18n: createAppI18n("en") },
+      createElement(OAuthAppForm, { provider: provider(auth), auth, onRefresh: vi.fn() }),
+    ),
+  );
+}
+
+describe("OAuthAppForm", () => {
+  it("walks the user through registering the provider OAuth app", () => {
+    const markup = markupFor(setupAuth);
+
+    expect(markup).toContain("Create the OAuth app");
+    expect(markup).toContain("Create the application.");
+  });
+
+  it("shows backtick-wrapped values as code rather than literal backticks", () => {
+    const markup = markupFor(setupAuth);
+
+    expect(markup).toContain("<code");
+    expect(markup).toContain(">heart_health</code>");
+    expect(markup).not.toContain("`");
+  });
+
+  it("omits the steps for a provider that documents no setup", () => {
+    const markup = markupFor(bareAuth);
+
+    expect(markup).not.toContain("Create the OAuth app");
+    expect(markup).toContain("Client ID");
+  });
+});

--- a/web/src/oauth-app-form.test.ts
+++ b/web/src/oauth-app-form.test.ts
@@ -12,7 +12,7 @@ const setupAuth: Extract<AuthDefinition, { type: "oauth2" }> = {
   scopes: [],
   clientSetup: {
     docsUrl: "https://provider.example/developers",
-    steps: ["Create the application.", "Enable the `heart_health` scope."],
+    steps: ["Create the application.", "Enable every scope the runtime requests."],
   },
 };
 
@@ -52,14 +52,6 @@ describe("OAuthAppForm", () => {
 
     expect(markup).toContain('href="https://provider.example/developers"');
     expect(markup).toContain("Open Example developer portal");
-  });
-
-  it("shows backtick-wrapped values as code rather than literal backticks", () => {
-    const markup = markupFor(setupAuth);
-
-    expect(markup).toContain("<code");
-    expect(markup).toContain(">heart_health</code>");
-    expect(markup).not.toContain("`");
   });
 
   it("omits the steps for a provider that documents no setup", () => {

--- a/web/src/oauth-app-form.test.ts
+++ b/web/src/oauth-app-form.test.ts
@@ -47,6 +47,13 @@ describe("OAuthAppForm", () => {
     expect(markup).toContain("Create the application.");
   });
 
+  it("links out to the provider's app registration from the steps", () => {
+    const markup = markupFor(setupAuth);
+
+    expect(markup).toContain('href="https://provider.example/apps"');
+    expect(markup).toContain("Open Example app registration");
+  });
+
   it("shows backtick-wrapped values as code rather than literal backticks", () => {
     const markup = markupFor(setupAuth);
 

--- a/web/src/oauth-app-form.test.ts
+++ b/web/src/oauth-app-form.test.ts
@@ -11,7 +11,7 @@ const setupAuth: Extract<AuthDefinition, { type: "oauth2" }> = {
   type: "oauth2",
   scopes: [],
   clientSetup: {
-    docsUrl: "https://provider.example/apps",
+    docsUrl: "https://provider.example/developers",
     steps: ["Create the application.", "Enable the `heart_health` scope."],
   },
 };
@@ -50,8 +50,8 @@ describe("OAuthAppForm", () => {
   it("links out to the provider's app registration from the steps", () => {
     const markup = markupFor(setupAuth);
 
-    expect(markup).toContain('href="https://provider.example/apps"');
-    expect(markup).toContain("Open Example app registration");
+    expect(markup).toContain('href="https://provider.example/developers"');
+    expect(markup).toContain("Open Example developer portal");
   });
 
   it("shows backtick-wrapped values as code rather than literal backticks", () => {

--- a/web/src/oauth-app-form.tsx
+++ b/web/src/oauth-app-form.tsx
@@ -1,8 +1,8 @@
-import type { AuthDefinition, CredentialField, OAuthConfig, ProviderDefinition } from "./model";
+import type { AuthDefinition, CredentialField, OAuthClientSetup, OAuthConfig, ProviderDefinition } from "./model";
 import type { ReactNode, SubmitEvent } from "react";
 
 import { useTranslate } from "@embra/i18n/react";
-import { Settings, Trash2 } from "lucide-react";
+import { ExternalLink, Settings, Trash2 } from "lucide-react";
 import { createElement, Fragment, useEffect, useMemo, useState } from "react";
 import { apiDelete, apiPut } from "./api";
 import { CredentialInput } from "./credential-input";
@@ -42,14 +42,6 @@ export function OAuthAppDialog(props: OAuthAppDialogProps): ReactNode {
             {props.auth.clientSetup
               ? t("providers.oauthClientSettings.setupIntro", { name: props.provider.displayName })
               : props.provider.service}
-            {props.auth.clientSetup?.docsUrl ? (
-              <>
-                {" "}
-                <a href={props.auth.clientSetup.docsUrl} target="_blank" rel="noreferrer noopener">
-                  {t("providers.oauthClientSettings.setupDocsLink", { name: props.provider.displayName })}
-                </a>
-              </>
-            ) : null}
           </DialogDescription>
         </DialogHeader>
         <OAuthAppForm
@@ -117,7 +109,9 @@ export function OAuthAppForm(props: OAuthAppFormProps): ReactNode {
 
   return (
     <form className="form-grid" onSubmit={(event) => void submit(event)}>
-      {props.auth.clientSetup ? <OAuthClientSetupSteps steps={props.auth.clientSetup.steps} /> : null}
+      {props.auth.clientSetup ? (
+        <OAuthClientSetupSteps setup={props.auth.clientSetup} providerName={props.provider.displayName} />
+      ) : null}
       {props.config?.expectedRedirectUri ? (
         <Label className="field">
           <span>{t("providers.oauthClientSettings.callbackUrl")}</span>
@@ -165,16 +159,27 @@ export function OAuthAppForm(props: OAuthAppFormProps): ReactNode {
   );
 }
 
-function OAuthClientSetupSteps(props: { steps: string[] }): ReactNode {
+function OAuthClientSetupSteps(props: { setup: OAuthClientSetup; providerName: string }): ReactNode {
   const t = useTranslate();
   return (
     <section className="rounded-md border bg-muted/40 p-3">
       <h4 className="mb-2 text-sm font-medium">{t("providers.oauthClientSettings.setupTitle")}</h4>
       <ol className="ml-4 list-decimal space-y-1 text-sm text-muted-foreground marker:text-muted-foreground">
-        {props.steps.map((step) => (
+        {props.setup.steps.map((step) => (
           <li key={step}>{renderStepText(step)}</li>
         ))}
       </ol>
+      {props.setup.docsUrl ? (
+        <a
+          className="mt-2 inline-flex items-center gap-1 text-sm underline underline-offset-3 hover:text-foreground"
+          href={props.setup.docsUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {t("providers.oauthClientSettings.setupDocsLink", { name: props.providerName })}
+          <ExternalLink size={14} />
+        </a>
+      ) : null}
     </section>
   );
 }

--- a/web/src/oauth-app-form.tsx
+++ b/web/src/oauth-app-form.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, SubmitEvent } from "react";
 
 import { useTranslate } from "@embra/i18n/react";
 import { ExternalLink, Settings, Trash2 } from "lucide-react";
-import { createElement, Fragment, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { apiDelete, apiPut } from "./api";
 import { CredentialInput } from "./credential-input";
 import { FormStatus } from "./shared-ui";
@@ -166,7 +166,7 @@ function OAuthClientSetupSteps(props: { setup: OAuthClientSetup; providerName: s
       <h4 className="mb-2 text-sm font-medium">{t("providers.oauthClientSettings.setupTitle")}</h4>
       <ol className="ml-4 list-decimal space-y-1 text-sm text-muted-foreground marker:text-muted-foreground">
         {props.setup.steps.map((step) => (
-          <li key={step}>{renderStepText(step)}</li>
+          <li key={step}>{step}</li>
         ))}
       </ol>
       {props.setup.docsUrl ? (
@@ -182,21 +182,6 @@ function OAuthClientSetupSteps(props: { setup: OAuthClientSetup; providerName: s
       ) : null}
     </section>
   );
-}
-
-/**
- * Render a setup step, showing every backtick-wrapped span as code. Splitting
- * on the delimiter keeps the step plain text, so catalog data can never inject
- * markup into the console.
- */
-function renderStepText(step: string): ReactNode[] {
-  return step
-    .split("`")
-    .map((part, index) =>
-      index % 2 === 1
-        ? createElement("code", { key: index, className: "rounded bg-muted px-1 py-0.5 font-mono text-xs" }, part)
-        : createElement(Fragment, { key: index }, part),
-    );
 }
 
 export function clientConfigFieldsFor(auth: AuthDefinition): CredentialField[] {

--- a/web/src/oauth-app-form.tsx
+++ b/web/src/oauth-app-form.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, SubmitEvent } from "react";
 
 import { useTranslate } from "@embra/i18n/react";
 import { Settings, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { createElement, Fragment, useEffect, useMemo, useState } from "react";
 import { apiDelete, apiPut } from "./api";
 import { CredentialInput } from "./credential-input";
 import { FormStatus } from "./shared-ui";
@@ -38,7 +38,19 @@ export function OAuthAppDialog(props: OAuthAppDialogProps): ReactNode {
               name: props.provider.displayName,
             })}
           </DialogTitle>
-          <DialogDescription>{props.provider.service}</DialogDescription>
+          <DialogDescription>
+            {props.auth.clientSetup
+              ? t("providers.oauthClientSettings.setupIntro", { name: props.provider.displayName })
+              : props.provider.service}
+            {props.auth.clientSetup?.docsUrl ? (
+              <>
+                {" "}
+                <a href={props.auth.clientSetup.docsUrl} target="_blank" rel="noreferrer noopener">
+                  {t("providers.oauthClientSettings.setupDocsLink", { name: props.provider.displayName })}
+                </a>
+              </>
+            ) : null}
+          </DialogDescription>
         </DialogHeader>
         <OAuthAppForm
           provider={props.provider}
@@ -105,6 +117,7 @@ export function OAuthAppForm(props: OAuthAppFormProps): ReactNode {
 
   return (
     <form className="form-grid" onSubmit={(event) => void submit(event)}>
+      {props.auth.clientSetup ? <OAuthClientSetupSteps steps={props.auth.clientSetup.steps} /> : null}
       {props.config?.expectedRedirectUri ? (
         <Label className="field">
           <span>{t("providers.oauthClientSettings.callbackUrl")}</span>
@@ -150,6 +163,35 @@ export function OAuthAppForm(props: OAuthAppFormProps): ReactNode {
       {status ? <FormStatus message={status} /> : null}
     </form>
   );
+}
+
+function OAuthClientSetupSteps(props: { steps: string[] }): ReactNode {
+  const t = useTranslate();
+  return (
+    <section className="rounded-md border bg-muted/40 p-3">
+      <h4 className="mb-2 text-sm font-medium">{t("providers.oauthClientSettings.setupTitle")}</h4>
+      <ol className="ml-4 list-decimal space-y-1 text-sm text-muted-foreground marker:text-muted-foreground">
+        {props.steps.map((step) => (
+          <li key={step}>{renderStepText(step)}</li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+/**
+ * Render a setup step, showing every backtick-wrapped span as code. Splitting
+ * on the delimiter keeps the step plain text, so catalog data can never inject
+ * markup into the console.
+ */
+function renderStepText(step: string): ReactNode[] {
+  return step
+    .split("`")
+    .map((part, index) =>
+      index % 2 === 1
+        ? createElement("code", { key: index, className: "rounded bg-muted px-1 py-0.5 font-mono text-xs" }, part)
+        : createElement(Fragment, { key: index }, part),
+    );
 }
 
 export function clientConfigFieldsFor(auth: AuthDefinition): CredentialField[] {


### PR DESCRIPTION
## Summary

Adds an [Oura](https://ouraring.com) provider built on the [Oura API v2](https://cloud.ouraring.com/v2/docs), covering the user data collections: sleep, readiness, activity, stress, heart rate, workouts, tags, and sessions. Verified against a live Oura account.

Oura is OAuth2 only. Personal access tokens were deprecated in December 2025 and can no longer be created, so there is no API key path.

Every collection is declared once in `collections.ts`. The action catalog and the runtime handlers both read that table, so a collection gets its query window, its scope, and its document endpoint in one place.

Things worth flagging:

- **Scopes come from the live API, not the OpenAPI document.** Oura's published security scheme lists 8 scopes. Three are missing from it (`heart_health`, `stress`, `ring_configuration`) and one is named wrong (`spo2Daily`, where the API enforces `spo2`). Asking for a scope Oura does not know is not an error. The consent screen drops it quietly and the action fails much later with a 401. The scope names here are the ones the API itself reports in those 401s, checked against a real token.
- **Two collections are time series.** Heart rate and ring battery level have no document id and no single-document endpoint, so they get `list_*` but no `get_*`, and their list schema does not promise an `id`.
- **Granted scopes are reported without Oura's prefix.** A token grants `extapi:daily` for the scope the request called `daily`. Stripping the prefix lets a caller compare `grantedScopes` against an action's `requiredScopes`.
- **Errors follow Oura's FastAPI shape.** `detail` strings and validation lists are surfaced. A 403 (lapsed subscription or a scope that was never granted) becomes an unauthorized credential. A 404 on a document lookup becomes invalid input.
- **`vO2_max`** is the one path where Oura's URL segment differs from the action name.

This PR also adds a small console change. An OAuth2 provider can now carry setup steps in `clientSetup`, and the console shows them in the dialog where the client id and secret get pasted. Before, the dialog's subtitle was just the service id. For Oura this is where users learn that the app has to enable every scope, which is the mistake that produces those silent 401s. Providers that declare no `clientSetup` look exactly as they did.

> <img width="518" alt="chrome_U7V4zgVz9i" src="https://github.com/user-attachments/assets/f8d9424d-72ed-4929-b44a-f6af3ff5ba91" />
>
> Setup steps

Files: `definition.ts`, `actions.ts`, `collections.ts`, `executors.ts`, `runtime.ts`, `runtime.test.ts` under `src/providers/oura/`, plus `clientSetup` in `src/core/types.ts` and its rendering in `web/src/oauth-app-form.tsx`.

## New actions

35 actions, all locally executable:

| Area | Actions |
| --- | --- |
| Account | `get_personal_info` |
| Daily summaries | `list_daily_activity`, `list_daily_cardiovascular_age`, `list_daily_readiness`, `list_daily_resilience`, `list_daily_sleep`, `list_daily_spo2`, `list_daily_stress` |
| Sleep | `list_sleep`, `list_sleep_time` |
| Activity | `list_workout`, `list_session`, `list_rest_mode_period`, `list_vo2_max` |
| Tags | `list_tag`, `list_enhanced_tag` |
| Ring | `list_ring_configuration`, `list_ring_battery_level` |
| Time series | `list_heartrate` |
| Documents | a `get_*` for each of the 16 collections Oura serves by document id |

## Verification

- `npm run generate:catalog` — 1337 apps, 14035 actions
- `npm run fix-check` — clean
- `npm test` — 793 passed (76 files)
- **Live account run** — 33 of 35 actions returned real data. The 2 skipped are not failures: `session` and `vo2_max` answered 200 with an empty list because the account has no guided sessions or VO2 max measurements, so there was no document id to look up. Every `get_*` round trip returned the same id its `list_*` gave (14 of 14). Pagination was checked across two pages of 1000 heart rate samples, plus the `fields` filter, the `latest` shortcut, a bad document id, and a missing required input.

The live run is what caught the scope bug. Five actions could never have worked for anyone: `list_daily_cardiovascular_age`, `list_vo2_max`, `list_daily_resilience`, `list_ring_configuration`, and `list_ring_battery_level` all returned 401 no matter what the user agreed to, because the authorization request never asked for the scopes Oura wanted. All five return data now. There are regression tests for the scope mapping and for the time series schema.

> <img width="1818" height="909" alt="chrome_0bcWkUw1XC" src="https://github.com/user-attachments/assets/23347600-1e04-424e-acae-29f358238282" />
>
> Connection working and validated end-to-end
