### PR TITLE
feat(mcdonalds): add China MCP provider

### DIFF
--- a/src/providers/mcdonalds_cn_mcp/actions.ts
+++ b/src/providers/mcdonalds_cn_mcp/actions.ts
@@ -1,0 +1,59 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "mcdonalds_cn_mcp";
+
+const toolAnnotationsSchema = s.looseObject("MCP behavior hints supplied by McDonald's China.", {
+  title: s.optional(s.string("A human-readable title for the tool.")),
+  readOnlyHint: s.optional(s.boolean("Whether the tool is expected not to modify McDonald's China data.")),
+  destructiveHint: s.optional(s.boolean("Whether the tool may perform a destructive operation.")),
+  idempotentHint: s.optional(
+    s.boolean("Whether repeated calls with the same arguments are expected to have no additional effect."),
+  ),
+  openWorldHint: s.optional(s.boolean("Whether the tool may interact with entities outside McDonald's China.")),
+});
+
+const mcpToolSummarySchema = s.object(
+  "A tool currently exposed by the connected McDonald's China MCP account.",
+  {
+    name: s.nonEmptyString("The exact McDonald's China MCP tool name to pass to call_tool."),
+    description: s.string("The current tool description supplied by McDonald's China MCP."),
+    annotations: toolAnnotationsSchema,
+    inputSchema: s.looseObject("The current JSON Schema for the tool arguments, supplied by McDonald's China MCP."),
+  },
+  { optional: ["description", "annotations"] },
+);
+
+export const mcdonaldsCnMcpActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_tools",
+    description:
+      "Discover the current McDonald's China ordering, coupon, campaign, and points-mall MCP tools with their live input schemas and behavior annotations.",
+    inputSchema: s.object("No input is required.", {}),
+    outputSchema: s.object("The current McDonald's China MCP tool catalog.", {
+      tools: s.array("Tools currently exposed to the connected McDonald's China account.", mcpToolSummarySchema),
+    }),
+    followUpActions: ["mcdonalds_cn_mcp.call_tool"],
+  }),
+  defineProviderAction(service, {
+    name: "call_tool",
+    description:
+      "Call a current McDonald's China MCP tool with JSON arguments. Discover the tool first and confirm the user's intent before actions that create an address, claim coupons, redeem points, or create an order.",
+    inputSchema: s.object(
+      "Input for invoking one current McDonald's China MCP tool.",
+      {
+        toolName: s.nonEmptyString("The exact tool name returned by list_tools."),
+        arguments: s.looseObject("JSON arguments matching the inputSchema returned for the selected tool."),
+      },
+      { optional: ["arguments"] },
+    ),
+    outputSchema: s.object("The normalized result returned by the McDonald's China MCP tool.", {
+      result: s.unknown(
+        "The tool result. Structured MCP content is returned directly; otherwise the MCP content envelope is preserved.",
+      ),
+    }),
+    followUpActions: ["mcdonalds_cn_mcp.list_tools"],
+  }),
+];

--- a/src/providers/mcdonalds_cn_mcp/definition.ts
+++ b/src/providers/mcdonalds_cn_mcp/definition.ts
@@ -1,0 +1,28 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { mcdonaldsCnMcpActions } from "./actions.ts";
+
+const service = "mcdonalds_cn_mcp";
+
+/**
+ * McDonald's China provider backed by the official Streamable HTTP MCP service.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "McDonald's China MCP",
+  description:
+    "Discover and use McDonald's China tools for stores, menus, ordering, coupons, campaigns, points, and the points mall through the official MCP service.",
+  categories: ["Location", "Productivity"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "MCP Token",
+      placeholder: "Paste your McDonald's China MCP Token",
+      description:
+        "The MCP Token sent to https://mcp.mcd.cn as an Authorization Bearer token. Sign in and activate MCP access at https://open.mcd.cn/mcp/doc, then copy the token from the console. Keep it private because it is linked to your McDonald's China account.",
+    },
+  ],
+  homepageUrl: "https://open.mcd.cn/mcp/doc",
+  actions: mcdonaldsCnMcpActions,
+};

--- a/src/providers/mcdonalds_cn_mcp/executors.ts
+++ b/src/providers/mcdonalds_cn_mcp/executors.ts
@@ -1,0 +1,27 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+
+import { defineApiKeyProviderExecutors, defineProviderProxy, providerUserAgent } from "../provider-runtime.ts";
+import { mcdonaldsCnMcpActionHandlers, mcdonaldsCnMcpEndpoint, validateMcdonaldsCnMcpCredential } from "./runtime.ts";
+
+const service = "mcdonalds_cn_mcp";
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, mcdonaldsCnMcpActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: mcdonaldsCnMcpEndpoint,
+  auth: { type: "api_key_authorization", prefix: "Bearer " },
+  allowedEndpoint: (endpoint) => endpoint === "/",
+  customizeRequest({ headers }) {
+    headers.set("user-agent", providerUserAgent);
+  },
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }) {
+    return validateMcdonaldsCnMcpCredential(input.apiKey, fetcher, signal);
+  },
+};

--- a/src/providers/mcdonalds_cn_mcp/runtime.ts
+++ b/src/providers/mcdonalds_cn_mcp/runtime.ts
@@ -1,0 +1,195 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type { ApiKeyProviderContext, ProviderActionHandlers, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { Client } from "@modelcontextprotocol/client";
+
+import { ProtocolError, SdkError, SdkErrorCode, SdkHttpError, UnauthorizedError } from "@modelcontextprotocol/client";
+import { createHash } from "node:crypto";
+import { optionalRecord, requiredString } from "../../core/cast.ts";
+import { withMcpClient } from "../mcp-client.ts";
+import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+
+export const mcdonaldsCnMcpEndpoint = "https://mcp.mcd.cn";
+const requestTimeoutMs = 60_000;
+
+type McdonaldsCnMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+export const mcdonaldsCnMcpActionHandlers: ProviderActionHandlers<
+  "mcdonalds_cn_mcp",
+  ProviderRuntimeHandler<ApiKeyProviderContext>
+> = {
+  async list_tools(_input, context) {
+    return { tools: await discoverMcdonaldsCnMcpTools(context) };
+  },
+  async call_tool(input, context) {
+    const toolName = requiredString(input.toolName, "toolName", providerInputError);
+    const argumentsValue = readToolArguments(input.arguments);
+    const result = await withMcdonaldsCnMcpClient(context, async (client) => {
+      const toolResult = await client.callTool(
+        { name: toolName, arguments: argumentsValue },
+        { timeout: requestTimeoutMs, signal: context.signal },
+      );
+      return normalizeMcdonaldsCnMcpToolResult(toolName, toolResult);
+    });
+    return { result };
+  },
+};
+
+export async function validateMcdonaldsCnMcpCredential(
+  apiKey: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context: ApiKeyProviderContext = { apiKey, fetcher, signal };
+  const tools = await discoverMcdonaldsCnMcpTools(context);
+  if (tools.length === 0) {
+    throw new ProviderRequestError(502, "McDonald's China MCP did not expose any tools for this token");
+  }
+
+  const tokenHash = hashMcdonaldsCnMcpToken(apiKey);
+  return {
+    profile: {
+      accountId: `mcdonalds-cn:mcp:${tokenHash}`,
+      displayName: `McDonald's China MCP · ${tokenHash.slice(-6)}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpEndpoint: mcdonaldsCnMcpEndpoint,
+      discoveredToolCount: tools.length,
+      mcpTools: tools.map((tool) => tool.name).sort(),
+    },
+  };
+}
+
+async function discoverMcdonaldsCnMcpTools(context: ApiKeyProviderContext): Promise<
+  Array<{
+    name: string;
+    description?: string;
+    annotations?: Record<string, unknown>;
+    inputSchema: Record<string, unknown>;
+  }>
+> {
+  return withMcdonaldsCnMcpClient(context, async (client) => {
+    const result = await client.listTools({}, { timeout: requestTimeoutMs, signal: context.signal });
+    return result.tools.map((tool) => {
+      const summary: {
+        name: string;
+        description?: string;
+        annotations?: Record<string, unknown>;
+        inputSchema: Record<string, unknown>;
+      } = {
+        name: tool.name,
+        inputSchema: tool.inputSchema,
+      };
+      if (tool.description) summary.description = tool.description;
+      if (tool.annotations) summary.annotations = tool.annotations;
+      return summary;
+    });
+  });
+}
+
+async function withMcdonaldsCnMcpClient<T>(
+  context: ApiKeyProviderContext,
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  const headers = new Headers({
+    authorization: `Bearer ${context.apiKey}`,
+    "user-agent": providerUserAgent,
+  });
+  return withMcpClient(
+    {
+      endpoint: new URL(mcdonaldsCnMcpEndpoint),
+      transport: "streamable_http",
+      fetcher: context.fetcher,
+      headers,
+      redirect: "error",
+      signal: context.signal,
+      protocolVersion: "legacy",
+      mapError: mapMcdonaldsCnMcpError,
+    },
+    run,
+  );
+}
+
+function readToolArguments(value: unknown): Record<string, unknown> {
+  if (value === undefined) return {};
+  const argumentsValue = optionalRecord(value);
+  if (!argumentsValue) {
+    throw new ProviderRequestError(400, "arguments must be a JSON object");
+  }
+  return argumentsValue;
+}
+
+function normalizeMcdonaldsCnMcpToolResult(toolName: string, result: McdonaldsCnMcpToolResult): unknown {
+  if ("content" in result && result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `McDonald's China MCP tool ${toolName} returned an error: ${formatMcdonaldsCnMcpToolContent(result)}`,
+      result,
+    );
+  }
+  if ("toolResult" in result) return result;
+  return result.structuredContent ?? result;
+}
+
+function formatMcdonaldsCnMcpToolContent(result: McdonaldsCnMcpToolResult): string {
+  const content = "content" in result && Array.isArray(result.content) ? result.content : [];
+  const text = content
+    .map((item) => {
+      if (item.type === "text") return item.text;
+      if (item.type === "resource") return "text" in item.resource ? item.resource.text : item.resource.uri;
+      if (item.type === "resource_link") return item.uri;
+      return item.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+  return text.slice(0, 300) || "empty error content";
+}
+
+function mapMcdonaldsCnMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) return error;
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "McDonald's China MCP Token is invalid or expired", error);
+  }
+  if (error instanceof SdkHttpError) {
+    const status = error.status;
+    return new ProviderRequestError(
+      status === 401 || status === 403
+        ? 401
+        : status === 429
+          ? 429
+          : status && status >= 400 && status < 500
+            ? 400
+            : 502,
+      `McDonald's China MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof SdkError && error.code === SdkErrorCode.RequestTimeout) {
+    return new ProviderRequestError(504, "McDonald's China MCP request timed out", error);
+  }
+  if (error instanceof ProtocolError) {
+    return new ProviderRequestError(502, `McDonald's China MCP request failed: ${error.message}`, error);
+  }
+  if (isAbortError(error)) {
+    return new ProviderRequestError(504, "McDonald's China MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error
+      ? `McDonald's China MCP request failed: ${error.message}`
+      : "McDonald's China MCP request failed",
+    error,
+  );
+}
+
+function hashMcdonaldsCnMcpToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}


### PR DESCRIPTION
## Summary

- add a separate `mcdonalds_cn_mcp` provider backed by the official Streamable HTTP endpoint
- discover current MCP tools, behavior annotations, and live input schemas before calls
- validate MCP Tokens and proxy requests through the SSRF-guarded provider fetch with legacy MCP protocol compatibility and stable error mapping

## Validation

- `npm run generate:catalog`
- `npm run fix-check`

## Notes

- the existing `mcdonalds_cn` merchant Open Platform provider remains unchanged
- full test suite was not run; this provider follows the shared dynamic MCP runtime pattern