### PR TITLE
fix(ssrf): use shared assertPublicHttpUrl on remaining self-hosted base URLs

### DIFF
--- a/src/providers/countly/executors.test.ts
+++ b/src/providers/countly/executors.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeBaseUrl } from "./executors.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeBaseUrl", () => {
+  it("allows a public host", () => {
+    expect(normalizeBaseUrl("https://countly.example.com")).toBe("https://countly.example.com");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/countly/executors.ts
+++ b/src/providers/countly/executors.ts
@@ -1,7 +1,7 @@
 import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
 import { compactObject, optionalRecord, optionalString, optionalStringArray, requiredString } from "../../core/cast.ts";
-import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderFetch,
   defineProviderExecutors,
@@ -21,16 +21,19 @@ interface Context {
 }
 const inputError = (message: string) => new ProviderRequestError(400, message);
 
-function normalizeBaseUrl(value: unknown): string {
+export function normalizeBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const text = requiredString(value, "baseUrl", inputError);
-  let url: URL;
-  try {
-    url = new URL(text);
-  } catch {
-    throw inputError("baseUrl must be a valid http(s) URL");
-  }
-  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.pathname !== "/")
+  const url = assertPublicHttpUrl(text, {
+    fieldName: "baseUrl",
+    createError: inputError,
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password || url.pathname !== "/") {
     throw inputError("baseUrl must be an HTTP(S) instance root URL without credentials or a path");
+  }
   url.search = "";
   url.hash = "";
   const normalized = url.toString();

--- a/src/providers/invoice_ninja/runtime.test.ts
+++ b/src/providers/invoice_ninja/runtime.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeInvoiceNinjaUrls } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeInvoiceNinjaUrls", () => {
+  it("allows a public host and keeps the /api/v1 suffix on the API base", () => {
+    expect(normalizeInvoiceNinjaUrls("https://ninja.example.com/api/v1")).toEqual({
+      instanceUrl: "https://ninja.example.com",
+      apiBaseUrl: "https://ninja.example.com/api/v1",
+    });
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeInvoiceNinjaUrls("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeInvoiceNinjaUrls("https://10.0.0.5")).toEqual({
+      instanceUrl: "https://10.0.0.5",
+      apiBaseUrl: "https://10.0.0.5/api/v1",
+    });
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeInvoiceNinjaUrls("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeInvoiceNinjaUrls("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeInvoiceNinjaUrls("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/invoice_ninja/runtime.ts
+++ b/src/providers/invoice_ninja/runtime.ts
@@ -1,6 +1,7 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const defaultInstanceUrl = "https://invoicing.co";
@@ -175,14 +176,16 @@ function resolveInvoiceNinjaProxyBaseUrl(context: { providerMetadata: Record<str
   return storedApiBaseUrl(context.providerMetadata);
 }
 
-export function normalizeInvoiceNinjaUrls(value: unknown): { instanceUrl: string; apiBaseUrl: string } {
+export function normalizeInvoiceNinjaUrls(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): { instanceUrl: string; apiBaseUrl: string } {
   const raw = typeof value === "string" && value.trim() ? value.trim() : defaultInstanceUrl;
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    throw new InvoiceNinjaError("invalid_input", "instanceUrl must be a valid HTTPS URL", 400);
-  }
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "instanceUrl",
+    createError: (message) => new InvoiceNinjaError("invalid_input", message, 400),
+    allowPrivateNetwork,
+  });
   if (url.protocol !== "https:") {
     throw new InvoiceNinjaError("invalid_input", "instanceUrl must use HTTPS", 400);
   }

--- a/src/providers/mailcoach/runtime.test.ts
+++ b/src/providers/mailcoach/runtime.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeMailcoachBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeMailcoachBaseUrl", () => {
+  it("allows a public host and strips the /api suffix", () => {
+    expect(normalizeMailcoachBaseUrl("https://mailcoach.example.com/api")).toBe("https://mailcoach.example.com");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeMailcoachBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeMailcoachBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeMailcoachBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeMailcoachBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeMailcoachBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/mailcoach/runtime.ts
+++ b/src/providers/mailcoach/runtime.ts
@@ -10,6 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 type MailcoachRequestMode = "validate" | "execute";
@@ -198,19 +199,21 @@ export async function validateMailcoachCredential(
   };
 }
 
-export function normalizeMailcoachBaseUrl(input?: string): string {
+export function normalizeMailcoachBaseUrl(
+  input?: string,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const raw = input?.trim();
   if (!raw) {
     throw new ProviderRequestError(400, "baseUrl is required");
   }
 
   const withProtocol = raw.includes("://") ? raw : `https://${raw}`;
-  let parsed: URL;
-  try {
-    parsed = new URL(withProtocol);
-  } catch {
-    throw new ProviderRequestError(400, "baseUrl must be a valid URL");
-  }
+  const parsed = assertPublicHttpUrl(withProtocol, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
 
   if (parsed.protocol !== "https:") {
     throw new ProviderRequestError(400, "baseUrl must use https");

--- a/src/providers/mautic/runtime.test.ts
+++ b/src/providers/mautic/runtime.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeMauticBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeMauticBaseUrl", () => {
+  it("allows a public host and appends /api/", () => {
+    expect(normalizeMauticBaseUrl("https://mautic.example.com")).toBe("https://mautic.example.com/api/");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeMauticBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeMauticBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5/api/");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeMauticBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeMauticBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeMauticBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/mautic/runtime.ts
+++ b/src/providers/mautic/runtime.ts
@@ -2,6 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 
 import { Buffer } from "node:buffer";
 import { compactObject, optionalInteger, optionalRecord, optionalString, positiveInteger } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 type MauticCredential = {
@@ -157,18 +158,20 @@ export async function validateMauticCredential(
   };
 }
 
-export function normalizeMauticBaseUrl(value: string): string {
+export function normalizeMauticBaseUrl(
+  value: string,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const trimmed = value.trim();
   if (!trimmed) {
     throw new MauticError("invalid_input", "baseUrl is required", 400);
   }
 
-  let url: URL;
-  try {
-    url = new URL(trimmed);
-  } catch {
-    throw new MauticError("invalid_input", "baseUrl must be a valid URL", 400);
-  }
+  const url = assertPublicHttpUrl(trimmed, {
+    fieldName: "baseUrl",
+    createError: (message) => new MauticError("invalid_input", message, 400),
+    allowPrivateNetwork,
+  });
   if (url.protocol !== "https:") {
     throw new MauticError(
       "invalid_input",

--- a/src/providers/onlyoffice_docspace/runtime.test.ts
+++ b/src/providers/onlyoffice_docspace/runtime.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizePortalUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizePortalUrl", () => {
+  it("allows a public host and returns the origin", () => {
+    expect(normalizePortalUrl("https://docspace.example.com/welcome")).toBe("https://docspace.example.com");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizePortalUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizePortalUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizePortalUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizePortalUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizePortalUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/onlyoffice_docspace/runtime.ts
+++ b/src/providers/onlyoffice_docspace/runtime.ts
@@ -4,6 +4,7 @@ import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { createHash } from "node:crypto";
 import { objectArray, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const requestTimeoutMs = 30_000;
@@ -17,14 +18,16 @@ export interface OnlyofficeContext {
 }
 type Phase = "validate" | "execute";
 
-export function normalizePortalUrl(value: unknown): string {
+export function normalizePortalUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   if (typeof value !== "string" || !value.trim()) throw new ProviderRequestError(400, "portalUrl is required");
-  let url: URL;
-  try {
-    url = new URL(value.trim());
-  } catch {
-    throw new ProviderRequestError(400, "portalUrl must be a valid HTTPS URL");
-  }
+  const url = assertPublicHttpUrl(value.trim(), {
+    fieldName: "portalUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   if (url.protocol !== "https:") throw new ProviderRequestError(400, "portalUrl must use HTTPS");
   if (url.username || url.password || url.search || url.hash)
     throw new ProviderRequestError(400, "portalUrl must not include credentials, query parameters, or a fragment");

--- a/src/providers/splunk_http_event_collector/runtime.test.ts
+++ b/src/providers/splunk_http_event_collector/runtime.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeSplunkHecBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeSplunkHecBaseUrl", () => {
+  it("allows a public host and strips collector paths", () => {
+    expect(normalizeSplunkHecBaseUrl("https://hec.example.com:8088/services/collector")).toBe(
+      "https://hec.example.com:8088",
+    );
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeSplunkHecBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeSplunkHecBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeSplunkHecBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeSplunkHecBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeSplunkHecBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+});

--- a/src/providers/splunk_http_event_collector/runtime.ts
+++ b/src/providers/splunk_http_event_collector/runtime.ts
@@ -2,6 +2,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { SplunkHttpEventCollectorActionName } from "./actions.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 interface ApiKeyProviderActionInput {
@@ -216,18 +217,20 @@ function resolveCredential(apiKey: string, baseUrlInput: unknown): SplunkHecCred
   };
 }
 
-function normalizeSplunkHecBaseUrl(value: unknown) {
+export function normalizeSplunkHecBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   const rawValue = optionalString(value)?.trim();
   if (!rawValue) {
     throw new ProviderRequestError(400, "baseUrl is required");
   }
 
-  let url: URL;
-  try {
-    url = new URL(rawValue);
-  } catch {
-    throw new ProviderRequestError(400, "baseUrl must be a valid URL");
-  }
+  const url = assertPublicHttpUrl(rawValue, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   if (url.protocol !== "https:") {
     throw new ProviderRequestError(400, "baseUrl must be an HTTPS URL");
   }


### PR DESCRIPTION
## Summary
- Follow-up to #381 / #386. The remaining self-hosted HTTP providers that pass `allowPrivateNetwork: isPrivateNetworkAccessAllowed` into executors/proxy still normalized the instance URL with a bespoke `new URL()` check.
- Replace that shared host-safety check with `assertPublicHttpUrl(..., { allowPrivateNetwork })` on Countly (`baseUrl`), Invoice Ninja (`instanceUrl`), Mailcoach (`baseUrl`), Mautic (`baseUrl`), ONLYOFFICE DocSpace (`portalUrl`), and Splunk HEC (`baseUrl`), keeping each provider's existing protocol, path, and credential rules.
- Fetcher and base-URL validation now share the same private-network opt-in. Loopback, link-local, reserved, cloud-metadata, and literal IPv6 targets stay blocked even when `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` is on.
- MQTT is intentionally unchanged: it is not HTTP. The broker already opens through `openGuardedWebSocket` → `assertGuardedEgressUrl` with `allowPrivateNetwork`. `assertPublicHttpUrl` rejects non-`http`/`https` schemes, so it is the wrong guard for `ws`/`wss` (same exclusion as #381 / #389).
- Rechecked the #389 list with `rg` on this branch; no false positives in that HTTP set. hyrious asked for one focused PR rather than batches.

Closes #389

## Test plan
- [x] `npx vitest run` on the six new provider URL tests (18 passing)
- [x] `npm run fix-check`
- [ ] Confirm a public instance URL still normalizes as before (Mailcoach `/api` strip, Mautic `/api/` suffix, Invoice Ninja `/api/v1`, Splunk collector path, ONLYOFFICE origin)
- [ ] Confirm `https://10.0.0.5` is rejected unless the deployment opt-in is on
- [ ] Confirm `169.254.169.254`, `[::ffff:169.254.169.254]`, and `metadata.google.internal` stay rejected with the opt-in enabled


Made with [Cursor](https://cursor.com)