### PR TITLE
feat(runtime): propagate request cancellation into credential validators

### DIFF
--- a/src/connection-service.test.ts
+++ b/src/connection-service.test.ts
@@ -362,6 +362,93 @@ describe("ConnectionService", () => {
     expect(nativeFetchThis).toBeUndefined();
   });
 
+  it("propagates a request signal to credential validators and aborts them without storing the credential", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    let validationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      validationStarted = resolve;
+    });
+    const service = createService([apiKeyProvider], {
+      providerLoader: new FakeProviderLoader({
+        async apiKey(_input, options) {
+          receivedSignal = options.signal;
+          validationStarted?.();
+          await new Promise<void>((_resolve, reject) => {
+            if (!options.signal) {
+              reject(new Error("request signal missing"));
+              return;
+            }
+            options.signal.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+          });
+        },
+      }),
+    });
+
+    const connectPromise = service.connectWithApiKey("uptimerobot", {
+      values: {
+        apiKey: "valid-key",
+        accountId: "account-1",
+      },
+      signal: controller.signal,
+    });
+    await started;
+    controller.abort();
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "connection_cancelled",
+      message: "Credential validation was cancelled.",
+    });
+    expect(receivedSignal).toBe(controller.signal);
+    expect(receivedSignal?.aborted).toBe(true);
+    await expect(service.getCredential("uptimerobot")).resolves.toBeUndefined();
+  });
+
+  it("does not load credential validators for an already cancelled connection request", async () => {
+    const providerLoader = new FakeProviderLoader({
+      async apiKey() {
+        return {};
+      },
+    });
+    const loadValidators = vi.spyOn(providerLoader, "loadCredentialValidators");
+    const controller = new AbortController();
+    controller.abort();
+    const service = createService([apiKeyProvider], { providerLoader });
+
+    await expect(
+      service.connectWithApiKey("uptimerobot", {
+        values: {
+          apiKey: "valid-key",
+          accountId: "account-1",
+        },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({
+      code: "connection_cancelled",
+    });
+    expect(loadValidators).not.toHaveBeenCalled();
+    await expect(service.getCredential("uptimerobot")).resolves.toBeUndefined();
+  });
+
+  it("does not create a cancellation signal for callers that omit one", async () => {
+    const service = createService([apiKeyProvider], {
+      providerLoader: new FakeProviderLoader({
+        async apiKey(_input, options) {
+          expect(options.signal).toBeUndefined();
+        },
+      }),
+    });
+
+    await expect(
+      service.connectWithApiKey("uptimerobot", {
+        values: {
+          apiKey: "valid-key",
+          accountId: "account-1",
+        },
+      }),
+    ).resolves.toMatchObject({ service: "uptimerobot", configured: true });
+  });
+
   it("exposes connection profiles to local users and agents", async () => {
     const service = createService([apiKeyProvider], {
       providerLoader: new FakeProviderLoader({
@@ -431,6 +518,44 @@ describe("ConnectionService", () => {
       authType: "oauth2",
       accessToken: "access-token",
     });
+  });
+
+  it("does not store OAuth credentials when validation is cancelled", async () => {
+    const controller = new AbortController();
+    let validationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      validationStarted = resolve;
+    });
+    const service = createService([oauthProvider], {
+      providerLoader: new FakeProviderLoader({
+        async oauth2(_input, options) {
+          validationStarted?.();
+          await new Promise<void>((_resolve, reject) => {
+            options.signal?.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+          });
+        },
+      }),
+    });
+
+    const connectPromise = service.setOAuthCredential(
+      "example",
+      {
+        authType: "oauth2",
+        accessToken: "access-token",
+        tokenType: "Bearer",
+        profile: testProfile,
+        metadata: {},
+      },
+      undefined,
+      controller.signal,
+    );
+    await started;
+    controller.abort();
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "connection_cancelled",
+    });
+    await expect(service.getCredential("example")).resolves.toBeUndefined();
   });
 
   it("refreshes expired OAuth credentials before returning them", async () => {

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -5,6 +5,7 @@ import type {
   CredentialDefinition,
   CredentialProfile,
   CredentialValidationResult,
+  CredentialValidatorOptions,
   CustomCredentialAuthDefinition,
   ProviderDefinition,
   ResolvedCredential,
@@ -39,6 +40,7 @@ export interface ConnectionSummary {
 export interface ConnectWithCredentialInput {
   connectionName?: string;
   values?: Record<string, unknown>;
+  signal?: AbortSignal;
 }
 
 export interface ConnectWithoutAuthInput {
@@ -289,10 +291,11 @@ export class ConnectionService {
         "api_key",
         createApiKeyFields(auth),
         values,
-        await this.validateApiKeyCredential(service, { apiKey, values }),
+        await this.validateApiKeyCredential(service, { apiKey, values }, input.signal),
       ),
     };
     const connectionName = normalizeConnectionName(input.connectionName);
+    this.assertNotCancelled(input.signal);
     const stored = await this.store.set(service, connectionName, credential);
 
     return this.createStoredConnectionSummary(provider, stored.id, connectionName, credential);
@@ -318,10 +321,11 @@ export class ConnectionService {
         "custom_credential",
         auth.fields,
         values,
-        await this.validateCustomCredential(service, { values }),
+        await this.validateCustomCredential(service, { values }, input.signal),
       ),
     };
     const connectionName = normalizeConnectionName(input.connectionName);
+    this.assertNotCancelled(input.signal);
     const stored = await this.store.set(service, connectionName, credential);
 
     return this.createStoredConnectionSummary(provider, stored.id, connectionName, credential);
@@ -331,6 +335,7 @@ export class ConnectionService {
     service: string,
     credential: Extract<ResolvedCredential, { authType: "oauth2" }>,
     connectionNameInput?: string,
+    signal?: AbortSignal,
   ): Promise<ConnectionSummary> {
     const provider = this.getAvailableProvider(service);
     if (!this.supportsAuth(provider, "oauth2")) {
@@ -340,12 +345,13 @@ export class ConnectionService {
     const connectionName = normalizeConnectionName(connectionNameInput);
     let validation: CredentialValidationResult = {};
     try {
-      validation = await this.validateOAuthCredential(service, credential);
+      validation = await this.validateOAuthCredential(service, credential, signal);
     } catch (error) {
       if (!(error instanceof ConnectionError && error.code === "credential_verification_failed")) {
         throw error;
       }
     }
+    this.assertNotCancelled(signal);
     const storedCredential = {
       ...credential,
       ...this.mergeCredentialRuntimeData(provider, "oauth2", credential, validation),
@@ -464,33 +470,50 @@ export class ConnectionService {
   private async validateApiKeyCredential(
     service: string,
     input: ApiKeyCredentialValidationInput,
+    signal?: AbortSignal,
   ): Promise<CredentialValidationResult> {
+    this.assertNotCancelled(signal);
     const validators = await this.providerLoader.loadCredentialValidators(service);
-    return this.runCredentialValidator(service, () => validators?.apiKey?.(input, this.createValidatorOptions()));
+    return this.runCredentialValidator(
+      service,
+      () => validators?.apiKey?.(input, this.createValidatorOptions(signal)),
+      signal,
+    );
   }
 
   private async validateCustomCredential(
     service: string,
     input: CustomCredentialValidationInput,
+    signal?: AbortSignal,
   ): Promise<CredentialValidationResult> {
+    this.assertNotCancelled(signal);
     const validators = await this.providerLoader.loadCredentialValidators(service);
-    return this.runCredentialValidator(service, () =>
-      validators?.customCredential?.(input, this.createValidatorOptions()),
+    return this.runCredentialValidator(
+      service,
+      () => validators?.customCredential?.(input, this.createValidatorOptions(signal)),
+      signal,
     );
   }
 
   private async validateOAuthCredential(
     service: string,
     credential: Extract<ResolvedCredential, { authType: "oauth2" }>,
+    signal?: AbortSignal,
   ): Promise<CredentialValidationResult> {
+    this.assertNotCancelled(signal);
     const validators = await this.providerLoader.loadCredentialValidators(service);
-    return this.runCredentialValidator(service, () => validators?.oauth2?.(credential, this.createValidatorOptions()));
+    return this.runCredentialValidator(
+      service,
+      () => validators?.oauth2?.(credential, this.createValidatorOptions(signal)),
+      signal,
+    );
   }
 
-  private createValidatorOptions() {
+  private createValidatorOptions(signal?: AbortSignal): CredentialValidatorOptions {
     return {
       fetcher: providerFetch,
       logger: this.logger,
+      signal,
     };
   }
 
@@ -560,14 +583,27 @@ export class ConnectionService {
   private async runCredentialValidator(
     service: string,
     validate: CredentialValidatorCall,
+    signal?: AbortSignal,
   ): Promise<CredentialValidationResult> {
+    this.assertNotCancelled(signal);
     try {
-      return (await validate()) ?? {};
+      const result = (await validate()) ?? {};
+      this.assertNotCancelled(signal);
+      return result;
     } catch (error) {
+      if (signal?.aborted) {
+        throw cancelledConnectionError();
+      }
       throw new ConnectionError(
         "credential_verification_failed",
         error instanceof Error ? error.message : `${service} credential verification failed.`,
       );
+    }
+  }
+
+  private assertNotCancelled(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+      throw cancelledConnectionError();
     }
   }
 
@@ -724,4 +760,8 @@ export class ConnectionError extends Error {
     super(message);
     this.code = code;
   }
+}
+
+function cancelledConnectionError(): ConnectionError {
+  return new ConnectionError("connection_cancelled", "Credential validation was cancelled.");
 }

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -355,6 +355,32 @@ describe("OAuthFlowService", () => {
     await expect(services.connections.getCredential("example")).resolves.toBeUndefined();
   });
 
+  it("does not store OAuth credentials when the callback signal is already cancelled", async () => {
+    const services = createServices([oauthProvider]);
+    await services.clientConfigs.upsertConfig({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      extra: {
+        tenant: "default",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ access_token: "access-token", token_type: "Bearer" })),
+    );
+    const controller = new AbortController();
+    controller.abort();
+
+    const started = await services.flow.startAuthorization({ service: "example" });
+    await expect(
+      services.flow.completeAuthorization({ state: started.state, code: "code", signal: controller.signal }),
+    ).rejects.toMatchObject({
+      code: "connection_cancelled",
+    });
+    await expect(services.connections.getCredential("example")).resolves.toBeUndefined();
+  });
+
   it("stores Slack's user grant outside token metadata", async () => {
     const services = createServices([{ ...slackProvider, actions: [] }]);
     await services.clientConfigs.upsertConfig({

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -27,6 +27,7 @@ export interface OAuthAuthorizationStartInput {
 export interface OAuthAuthorizationCompleteInput {
   state: string;
   code: string;
+  signal?: AbortSignal;
 }
 
 /**
@@ -179,7 +180,7 @@ export class OAuthFlowService {
       },
     };
 
-    await this.connections.setOAuthCredential(pending.service, oauthCredential, pending.connectionName);
+    await this.connections.setOAuthCredential(pending.service, oauthCredential, pending.connectionName, input.signal);
     return {
       service: pending.service,
       connected: true,

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -993,6 +993,54 @@ describe("ConnectServer", () => {
     });
   });
 
+  it("propagates HTTP request cancellation to credential validation", async () => {
+    const controller = new AbortController();
+    let validationStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      validationStarted = resolve;
+    });
+    let validationSignal: AbortSignal | undefined;
+    const { entries, logger } = createTestLogger();
+    const providerLoader = new HangingCredentialValidatorLoader((signal) => {
+      validationSignal = signal;
+      validationStarted?.();
+    });
+    const app = createTestServer([apiKeyProvider], { logger, providerLoader }).createApp();
+    const request = new Request("http://localhost/api/connections/example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authType: "api_key", values: { apiKey: "example-key" } }),
+      signal: controller.signal,
+    });
+
+    const responsePromise = app.fetch(request);
+    await started;
+    controller.abort();
+    const response = await responsePromise;
+
+    expect(validationSignal?.aborted).toBe(true);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "connection_cancelled",
+        message: "Credential validation was cancelled.",
+      },
+    });
+    expect(entries).toContainEqual({
+      level: "info",
+      fields: expect.objectContaining({ errorCode: "connection_cancelled" }),
+      message: "connection cancelled",
+    });
+    expect(entries).not.toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "connection failed",
+      }),
+    );
+    const connections = await app.request("/api/connections");
+    await expect(connections.json()).resolves.toEqual([]);
+  });
+
   it("logs failed action runs with error codes", async () => {
     const { entries, logger } = createTestLogger();
     const app = createTestServer(
@@ -3640,6 +3688,42 @@ class EmptyProviderLoader implements IProviderLoader {
 
   async loadCredentialValidators(): Promise<undefined> {
     return undefined;
+  }
+}
+
+class HangingCredentialValidatorLoader implements IProviderLoader {
+  private readonly onStarted: (signal: AbortSignal | undefined) => void;
+
+  constructor(onStarted: (signal: AbortSignal | undefined) => void) {
+    this.onStarted = onStarted;
+  }
+
+  async loadActionExecutor(): Promise<never> {
+    throw new Error("No actions are available in this test.");
+  }
+
+  async loadProxyExecutor(): Promise<ProviderProxyExecutor | undefined> {
+    return undefined;
+  }
+
+  async loadCredentialValidators(): Promise<{
+    apiKey(
+      _input: { apiKey: string; values: Record<string, string> },
+      options: { signal?: AbortSignal },
+    ): Promise<void>;
+  }> {
+    return {
+      apiKey: async (_input, options) => {
+        this.onStarted(options.signal);
+        await new Promise<void>((_resolve, reject) => {
+          if (!options.signal) {
+            reject(new Error("request signal missing"));
+            return;
+          }
+          options.signal.addEventListener("abort", () => reject(new Error("request aborted")), { once: true });
+        });
+      },
+    };
   }
 }
 

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -816,7 +816,11 @@ export class ConnectServer {
       this.options.logger?.info(logContext, "connection started");
       return this.writeConnectionResult(
         context,
-        this.options.connections.connectWithApiKey(service, { values, connectionName }),
+        this.options.connections.connectWithApiKey(service, {
+          values,
+          connectionName,
+          signal: context.req.raw.signal,
+        }),
         logContext,
       );
     }
@@ -824,7 +828,11 @@ export class ConnectServer {
       this.options.logger?.info(logContext, "connection started");
       return this.writeConnectionResult(
         context,
-        this.options.connections.connectWithCustomCredential(service, { values, connectionName }),
+        this.options.connections.connectWithCustomCredential(service, {
+          values,
+          connectionName,
+          signal: context.req.raw.signal,
+        }),
         logContext,
       );
     }
@@ -1025,7 +1033,13 @@ export class ConnectServer {
 
     let service: string;
     try {
-      service = (await this.options.oauthFlow.completeAuthorization({ state, code })).service;
+      service = (
+        await this.options.oauthFlow.completeAuthorization({
+          state,
+          code,
+          signal: context.req.raw.signal,
+        })
+      ).service;
       this.options.logger?.info(
         {
           ...logContext,
@@ -1035,12 +1049,13 @@ export class ConnectServer {
       );
     } catch (error) {
       if (error instanceof OAuthFlowError || error instanceof ConnectionError) {
-        this.options.logger?.warn(
+        const cancelled = error instanceof ConnectionError && error.code === "connection_cancelled";
+        this.options.logger?.[cancelled ? "info" : "warn"](
           {
             ...logContext,
             errorCode: error.code,
           },
-          "oauth callback failed",
+          cancelled ? "oauth callback cancelled" : "oauth callback failed",
         );
         return jsonError(context, error.code === "unknown_service" ? 404 : 400, error.code, error.message);
       }
@@ -1067,12 +1082,17 @@ export class ConnectServer {
     } catch (error) {
       if (error instanceof ConnectionError) {
         if (logContext) {
-          this.options.logger?.warn(
+          const cancelled = error.code === "connection_cancelled";
+          this.options.logger?.[cancelled ? "info" : "warn"](
             {
               ...logContext,
               errorCode: error.code,
             },
-            logContext.operation === "disconnect" ? "connection disconnect failed" : "connection failed",
+            cancelled
+              ? "connection cancelled"
+              : logContext.operation === "disconnect"
+                ? "connection disconnect failed"
+                : "connection failed",
           );
         }
         return jsonError(context, error.code === "unknown_service" ? 404 : 400, error.code, error.message);


### PR DESCRIPTION
## Summary

- thread inbound HTTP and OAuth callback `AbortSignal` into `ConnectionService.createValidatorOptions()` so credential validators receive `CredentialValidatorOptions.signal`
- classify aborted validation as `connection_cancelled`, do not persist the connection, and keep cancellation out of `credential_verification_failed` / warning noise
- skip loading validators when the request is already cancelled, matching #384
- cover ConnectionService, HTTP upsert, and OAuth callback cancellation

No default validation deadline or provider-local timeout is introduced.

## Test plan

- [x] `npm test -- --run src/connection-service.test.ts src/oauth/oauth-flow-service.test.ts src/server/connect-server.test.ts`
- [x] `npm run fix-check`
- [ ] Abort an in-flight `PUT /api/connections/:service` and confirm `connection_cancelled`, no stored connection
- [ ] Abort an OAuth callback during identity validation and confirm the credential is not stored

Closes #391


Made with [Cursor](https://cursor.com)