### PR TITLE
fix(oauth): validate Supabase and Xero with identity endpoints

### DIFF
--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -3,8 +3,10 @@ import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeAction } from "../../core/execution.ts";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
 import { provider } from "./definition.ts";
-import { executors } from "./executors.ts";
+import { credentialValidators, executors } from "./executors.ts";
+import { supabaseProviderScopes } from "./scopes.ts";
 
 interface CapturedRequest {
   url: URL;
@@ -28,6 +30,77 @@ beforeEach(() => {
 afterEach(() => {
   setDefaultGuardedFetchDnsLookup(undefined);
   vi.unstubAllGlobals();
+});
+
+describe("Supabase credential validation", () => {
+  it("validates OAuth through /v1/profile and uses gotrue_id as the account identity", async () => {
+    const calls: string[] = [];
+    const result = await credentialValidators.oauth2!(oauthCredential, {
+      fetcher: async (input) => {
+        calls.push(String(input));
+        return Response.json({
+          gotrue_id: "11111111-2222-3333-4444-555555555555",
+          primary_email: "ada@example.com",
+          username: "ada",
+        });
+      },
+    });
+
+    expect(calls).toEqual(["https://api.supabase.com/v1/profile"]);
+    expect(result).toEqual({
+      profile: {
+        accountId: "11111111-2222-3333-4444-555555555555",
+        displayName: "ada",
+        grantedScopes: supabaseProviderScopes,
+      },
+      metadata: {
+        validationEndpoint: "/profile",
+        gotrueId: "11111111-2222-3333-4444-555555555555",
+        username: "ada",
+        primaryEmail: "ada@example.com",
+      },
+    });
+  });
+
+  it("rejects an OAuth profile response that is missing gotrue_id", async () => {
+    await expect(
+      credentialValidators.oauth2!(oauthCredential, {
+        fetcher: async () => Response.json({ primary_email: "ada@example.com", username: "ada" }),
+      }),
+    ).rejects.toEqual(new ProviderRequestError(502, "malformed supabase response: profile.gotrue_id is required."));
+  });
+
+  it("rejects unauthorized OAuth profile responses", async () => {
+    await expect(
+      credentialValidators.oauth2!(oauthCredential, {
+        fetcher: async () => Response.json({ message: "invalid token" }, { status: 401 }),
+      }),
+    ).rejects.toMatchObject({ status: 400, message: "invalid token" });
+  });
+
+  it("keeps API-key validation on organizations even when the list is empty", async () => {
+    const calls: string[] = [];
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "sbp_test", values: {} },
+      {
+        fetcher: async (input) => {
+          calls.push(String(input));
+          return Response.json([]);
+        },
+      },
+    );
+
+    expect(calls).toEqual(["https://api.supabase.com/v1/organizations"]);
+    expect(result).toMatchObject({
+      profile: { displayName: "Supabase OAuth" },
+      metadata: {
+        validationEndpoint: "/organizations",
+        organizationCount: 0,
+        organizations: [],
+        identitySource: "access_token_fingerprint",
+      },
+    });
+  });
 });
 
 describe("Supabase download_storage_object", () => {

--- a/src/providers/supabase/executors.ts
+++ b/src/providers/supabase/executors.ts
@@ -1,17 +1,17 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 
 import { defineBearerProviderExecutors } from "../provider-runtime.ts";
-import { supabaseActionHandlers, validateSupabaseCredential } from "./runtime.ts";
+import { supabaseActionHandlers, validateSupabaseCredential, validateSupabaseOAuthCredential } from "./runtime.ts";
 
 const service = "supabase";
 
 export const executors: ProviderExecutors = defineBearerProviderExecutors(service, supabaseActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
-  async apiKey(input, { fetcher }) {
-    return validateSupabaseCredential(input.apiKey, fetcher);
+  async apiKey(input, { fetcher, signal }) {
+    return validateSupabaseCredential(input.apiKey, fetcher, signal);
   },
-  async oauth2(input, { fetcher }) {
-    return validateSupabaseCredential(input.accessToken, fetcher);
+  async oauth2(input, { fetcher, signal }) {
+    return validateSupabaseOAuthCredential(input.accessToken, fetcher, signal);
   },
 };

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -130,6 +130,7 @@ export const supabaseActionHandlers: ProviderActionHandlers<"supabase", Supabase
 export async function validateSupabaseCredential(
   accessToken: string,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<{
   profile: {
     accountId: string;
@@ -143,6 +144,7 @@ export async function validateSupabaseCredential(
       await requestSupabaseJson({
         accessToken,
         fetcher,
+        signal,
         phase: "validate",
         path: "/organizations",
       }),
@@ -166,6 +168,48 @@ export async function validateSupabaseCredential(
           ? "organization_fingerprint"
           : "access_token_fingerprint",
     },
+  };
+}
+
+export async function validateSupabaseOAuthCredential(
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<{
+  profile: {
+    accountId: string;
+    displayName: string;
+    grantedScopes: string[];
+  };
+  metadata: Record<string, unknown>;
+}> {
+  const profile = requiredRecord(
+    await requestSupabaseJson({
+      accessToken,
+      fetcher,
+      signal,
+      phase: "validate",
+      path: "/profile",
+    }),
+    "profile",
+    providerMalformedError,
+  );
+  const gotrueId = requiredString(profile.gotrue_id, "profile.gotrue_id", providerMalformedError);
+  const username = optionalString(profile.username);
+  const primaryEmail = optionalString(profile.primary_email);
+
+  return {
+    profile: {
+      accountId: gotrueId,
+      displayName: username || primaryEmail || "Supabase User",
+      grantedScopes: supabaseProviderScopes,
+    },
+    metadata: compactObject({
+      validationEndpoint: "/profile",
+      gotrueId,
+      username,
+      primaryEmail,
+    }),
   };
 }
 
@@ -663,6 +707,7 @@ async function requestSupabaseJson(options: {
   accessToken?: string;
   context?: BearerProviderContext;
   fetcher?: typeof fetch;
+  signal?: AbortSignal;
   phase?: SupabaseRequestPhase;
   method?: SupabaseRequestOptions["method"];
   path: string;
@@ -696,7 +741,7 @@ async function requestSupabaseJson(options: {
       method: options.method ?? (options.body ? "POST" : "GET"),
       headers: supabaseHeaders(accessToken, Boolean(options.body)),
       body: options.body ? JSON.stringify(options.body) : undefined,
-      signal: options.context?.signal,
+      signal: options.signal ?? options.context?.signal,
     });
   } catch (error) {
     throw new ProviderRequestError(

--- a/src/providers/xero/executors.test.ts
+++ b/src/providers/xero/executors.test.ts
@@ -3,9 +3,7 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { describe, expect, it } from "vitest";
 import { ProviderRequestError } from "../provider-runtime.ts";
-import { provider } from "./definition.ts";
 import { credentialValidators, xeroActionHandlers } from "./executors.ts";
-import { xeroEmailScope, xeroOAuthScopes, xeroOpenIdScope, xeroProfileScope } from "./scopes.ts";
 
 interface RecordedRequest {
   url: string;
@@ -99,9 +97,10 @@ const userinfoFixture = {
 };
 
 describe("credentialValidators", () => {
-  it("maps OpenID userinfo to the credential profile", async () => {
+  it("accepts a valid identity when no organisation is connected", async () => {
     const { fetcher, requests } = createFetcher({
       "https://identity.xero.com/connect/userinfo": userinfoFixture,
+      "https://api.xero.com/connections": [],
     });
     await expect(credentialValidators.oauth2!(oauthCredential, { fetcher })).resolves.toEqual({
       profile: { accountId: "f7a1382e-c791-4cae-93be-1b912c6a7c6e", displayName: "Ada Lovelace" },
@@ -125,18 +124,6 @@ describe("credentialValidators", () => {
       status: 400,
       message: "invalid_token",
     });
-  });
-});
-
-describe("OAuth scopes", () => {
-  it("requests OpenID Connect scopes required for userinfo", () => {
-    expect(xeroOAuthScopes).toEqual(
-      expect.arrayContaining([xeroOpenIdScope, xeroProfileScope, xeroEmailScope, "offline_access"]),
-    );
-    expect(xeroOAuthScopes.slice(0, 3)).toEqual(["openid", "profile", "email"]);
-    expect(provider.auth).toEqual(
-      expect.arrayContaining([expect.objectContaining({ type: "oauth2", scopes: xeroOAuthScopes })]),
-    );
   });
 });
 

--- a/src/providers/xero/executors.test.ts
+++ b/src/providers/xero/executors.test.ts
@@ -1,7 +1,11 @@
+import type { ResolvedCredential } from "../../core/types.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { provider } from "./definition.ts";
 import { credentialValidators, xeroActionHandlers } from "./executors.ts";
+import { xeroEmailScope, xeroOAuthScopes, xeroOpenIdScope, xeroProfileScope } from "./scopes.ts";
 
 interface RecordedRequest {
   url: string;
@@ -40,6 +44,13 @@ function createFetcher(routes: Record<string, unknown | ((request: RecordedReque
 }
 
 const accessToken = "test-access-token";
+const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken,
+  tokenType: "Bearer",
+  profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+  metadata: {},
+};
 const connectionsFixture = [{ tenantId: "tenant-123", tenantName: "Demo Company", tenantType: "ORG" }];
 const contactsFixture = [
   {
@@ -79,31 +90,53 @@ const invoiceFixture = {
   ],
 };
 
+const userinfoFixture = {
+  sub: "f7a1382e-c791-4cae-93be-1b912c6a7c6e",
+  xero_userid: "f7a1382e-c791-4cae-93be-1b912c6a7c6e",
+  name: "Ada Lovelace",
+  preferred_username: "ada@example.com",
+  email: "ada@example.com",
+};
+
 describe("credentialValidators", () => {
-  it("maps the first connection to the credential profile", async () => {
-    const { fetcher } = createFetcher({ "https://api.xero.com/connections": connectionsFixture });
-    await expect(
-      credentialValidators.oauth2?.(
-        { authType: "oauth2", accessToken, profile: null as never, metadata: {} } as never,
-        {
-          fetcher,
-        } as never,
-      ),
-    ).resolves.toEqual({
-      profile: { accountId: "tenant-123", displayName: "Demo Company" },
+  it("maps OpenID userinfo to the credential profile", async () => {
+    const { fetcher, requests } = createFetcher({
+      "https://identity.xero.com/connect/userinfo": userinfoFixture,
     });
+    await expect(credentialValidators.oauth2!(oauthCredential, { fetcher })).resolves.toEqual({
+      profile: { accountId: "f7a1382e-c791-4cae-93be-1b912c6a7c6e", displayName: "Ada Lovelace" },
+      metadata: { validationEndpoint: "https://identity.xero.com/connect/userinfo" },
+    });
+    expect(requests.map((request) => request.url)).toEqual(["https://identity.xero.com/connect/userinfo"]);
   });
 
-  it("leaves profile defaults to the connection service when no organisation is connected", async () => {
-    const { fetcher } = createFetcher({ "https://api.xero.com/connections": [] });
-    await expect(
-      credentialValidators.oauth2?.(
-        { authType: "oauth2", accessToken, profile: null as never, metadata: {} } as never,
-        {
-          fetcher,
-        } as never,
-      ),
-    ).resolves.toBeUndefined();
+  it("rejects userinfo payloads that are missing an identity", async () => {
+    const { fetcher } = createFetcher({
+      "https://identity.xero.com/connect/userinfo": { name: "Ada Lovelace", email: "ada@example.com" },
+    });
+    await expect(credentialValidators.oauth2!(oauthCredential, { fetcher })).rejects.toEqual(
+      new ProviderRequestError(502, "Xero userinfo response is missing sub"),
+    );
+  });
+
+  it("rejects unauthorized userinfo responses", async () => {
+    const fetcher: ProviderFetch = async () => Response.json({ error: "invalid_token" }, { status: 401 });
+    await expect(credentialValidators.oauth2!(oauthCredential, { fetcher })).rejects.toMatchObject({
+      status: 400,
+      message: "invalid_token",
+    });
+  });
+});
+
+describe("OAuth scopes", () => {
+  it("requests OpenID Connect scopes required for userinfo", () => {
+    expect(xeroOAuthScopes).toEqual(
+      expect.arrayContaining([xeroOpenIdScope, xeroProfileScope, xeroEmailScope, "offline_access"]),
+    );
+    expect(xeroOAuthScopes.slice(0, 3)).toEqual(["openid", "profile", "email"]);
+    expect(provider.auth).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "oauth2", scopes: xeroOAuthScopes })]),
+    );
   });
 });
 

--- a/src/providers/xero/executors.ts
+++ b/src/providers/xero/executors.ts
@@ -3,12 +3,15 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { OAuthProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { optionalInteger, optionalNumber, optionalString, requiredString } from "../../core/cast.ts";
-import { arrayPayload, definedBody, objectPayload, requestJson } from "../http-json-runtime.ts";
+import { arrayPayload, definedBody, firstString, objectPayload, requestJson } from "../http-json-runtime.ts";
 import { defineOAuthProviderExecutors, ProviderRequestError } from "../provider-runtime.ts";
 
 const service = "xero";
 const apiBaseUrl = "https://api.xero.com/api.xro/2.0";
 const identityBaseUrl = "https://api.xero.com";
+const xeroUserinfoBaseUrl = "https://identity.xero.com";
+const xeroUserinfoPath = "/connect/userinfo";
+const xeroUserinfoUrl = `${xeroUserinfoBaseUrl}${xeroUserinfoPath}`;
 const apiPackage = "OpenConnector";
 
 type XeroHandler = ProviderRuntimeHandler<OAuthProviderContext>;
@@ -203,23 +206,30 @@ export const xeroActionHandlers: ProviderActionHandlers<"xero", XeroHandler> = {
 export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, xeroActionHandlers);
 
 export const credentialValidators: CredentialValidators = {
-  async oauth2(input, { fetcher }) {
-    const payload = await requestJson({
-      providerName: service,
-      baseUrl: identityBaseUrl,
-      path: "/connections",
-      fetcher,
-      headers: bearerHeaders(input.accessToken),
-    });
-    const tenants = arrayPayload(payload, "connections");
-    const first = tenants.length > 0 ? optionalRecordValue(tenants[0]) : undefined;
-    if (!first) {
-      return;
+  async oauth2(input, { fetcher, signal }) {
+    const payload = objectPayload(
+      await requestJson({
+        providerName: service,
+        baseUrl: xeroUserinfoBaseUrl,
+        path: xeroUserinfoPath,
+        fetcher,
+        signal,
+        headers: bearerHeaders(input.accessToken),
+        phase: "validate",
+      }),
+      "Xero userinfo",
+    );
+    const accountId = optionalString(payload.sub) ?? optionalString(payload.xero_userid);
+    if (!accountId) {
+      throw new ProviderRequestError(502, "Xero userinfo response is missing sub");
     }
     return {
       profile: {
-        accountId: optionalString(first.tenantId),
-        displayName: optionalString(first.tenantName),
+        accountId,
+        displayName: firstString(payload, ["name", "preferred_username", "email"]) ?? accountId,
+      },
+      metadata: {
+        validationEndpoint: xeroUserinfoUrl,
       },
     };
   },

--- a/src/providers/xero/scopes.ts
+++ b/src/providers/xero/scopes.ts
@@ -20,6 +20,10 @@ export const xeroProfitAndLossReadScope = "accounting.reports.profitandloss.read
 export const xeroBalanceSheetReadScope = "accounting.reports.balancesheet.read";
 export const xeroContactsWriteScope = "accounting.contacts";
 export const xeroInvoicesWriteScope = "accounting.invoices";
+/** OpenID Connect scopes required to call GET https://identity.xero.com/connect/userinfo. */
+export const xeroOpenIdScope = "openid";
+export const xeroProfileScope = "profile";
+export const xeroEmailScope = "email";
 /** Required for a refresh token. Without it, Xero access lasts 30 minutes and then dies. */
 export const xeroOfflineAccessScope = "offline_access";
 
@@ -40,5 +44,12 @@ export const xeroReadOnlyScopes: string[] = [
 /** Read-write scopes needed by create/update actions such as creating invoices. */
 export const xeroWriteScopes: string[] = [xeroContactsWriteScope, xeroInvoicesWriteScope];
 
-/** Scopes declared on the OAuth app. `offline_access` is required so the runtime can refresh. */
-export const xeroOAuthScopes: string[] = [...xeroReadOnlyScopes, ...xeroWriteScopes, xeroOfflineAccessScope];
+/** Scopes declared on the OAuth app. OIDC scopes are required for userinfo; `offline_access` is required so the runtime can refresh. */
+export const xeroOAuthScopes: string[] = [
+  xeroOpenIdScope,
+  xeroProfileScope,
+  xeroEmailScope,
+  ...xeroReadOnlyScopes,
+  ...xeroWriteScopes,
+  xeroOfflineAccessScope,
+];


### PR DESCRIPTION
## Summary
- Follow-up to #388: Harvest empty-account identity already landed; this completes the remainder hyrious accepted on #382.
- Supabase: OAuth validation uses `GET /v1/profile` and `gotrue_id` as the stable account identity. API-key validation still probes `/v1/organizations`.
- Xero: request `openid profile email`, validate via `GET https://identity.xero.com/connect/userinfo`, and leave `/connections` for tenant discovery during action execution.
- Existing Xero connections without OIDC scopes will need to re-consent before userinfo works.
- TickTick/Dida365, Atlassian site discovery, MCP probes, and API-key validators stay out of scope.

Related to #382

## Test plan
- [x] Supabase OAuth uses `/v1/profile` and `gotrue_id`; does not call `/organizations`
- [x] Supabase API-key still probes `/organizations` and accepts an empty list
- [x] Xero OAuth uses userinfo and does not call `/connections` even when that list is empty
- [x] Xero `list_organisations` / tenant resolution still use `/connections`
- [x] `npm run fix-check`


Made with [Cursor](https://cursor.com)