### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,14 @@ jobs:
       TEST_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/open_connector_test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # No step needs the persisted GITHUB_TOKEN in git config; dropping it
           # keeps `npm ci` postinstall scripts from reading it (zizmor hardening).
           persist-credentials: false
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/pr-maintainer-edits.yml
+++ b/.github/workflows/pr-maintainer-edits.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Comment when maintainer edits are disabled
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- maintainer-edits-check -->';

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -56,12 +56,12 @@ jobs:
       CHART_PATH: deploy/helm/open-connector
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v4.2.4
 
@@ -95,13 +95,13 @@ jobs:
       OCI_REPO: oci://ghcr.io/${{ github.repository_owner }}/charts
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Helm
         id: setup-helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v4.2.4
 


### PR DESCRIPTION
Workflow runs warn that "Node.js 20 is deprecated" because several pinned actions still declare `runs.using: node20`. This moves each of them to its node24 release, keeping every line's existing pin style: tag-pinned refs get the floating major tag, SHA-pinned refs get the new commit SHA plus an updated version comment.

- `actions/checkout` in _ci.yml_: `v4` to `v7`
- `actions/checkout` in _publish-helm.yml_ (both jobs): `11d5960` v4.4.0 to `3d3c42e` v7.0.1
- `actions/setup-node` in _ci.yml_: `v4` to `v7`
- `actions/github-script` in _pr-maintainer-edits.yml_: `v7` to `v8`
- `azure/setup-helm` in _publish-helm.yml_ (both jobs): `1a275c3` v4.3.1 to `9bc31f4` v5.0.1

No input adaptations were needed. `always-auth`, removed in setup-node v7, is unused, and the setup-node step already passes `cache: npm` explicitly so the v6 npm-only auto-cache change does not apply. No workflow checks out a PR head ref under `pull_request_target` or `workflow_run`, which is the one case where checkout v7 changes fork behaviour. Setup-helm v5 is input-compatible and both SHAs were resolved from the upstream tags. github-script stops at v8 deliberately: v8 is the plain node24 bump, while v9 is ESM-only and would break inline `script:` blocks.

One node20 warning survives this PR. `narayann7/star-history-action` in _star-history.yml_ is a composite action that nests `actions/setup-node@v4` internally, so the warning comes from upstream and cannot be fixed from this repo. Its v1.0.5 does not fix it either, and the ref stays SHA-pinned because the action holds `contents: write`.
