### PR TITLE
fix(ssrf): keep DNS validation on input-resolved provider hosts

### DIFF
--- a/src/providers/alpaca/executors.test.ts
+++ b/src/providers/alpaca/executors.test.ts
@@ -1,9 +1,11 @@
 import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { credentialValidators, executors, proxy } from "./executors.ts";
 
 afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
   vi.unstubAllGlobals();
 });
 
@@ -141,6 +143,48 @@ describe("Alpaca credentials", () => {
     );
   });
 });
+
+describe("Alpaca environment resolver DNS", () => {
+  it("rejects an environment host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+    const context: ExecutionContext = { getCredential: async () => apiKeyCredential() };
+
+    const result = await executors["alpaca.get_account"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proxy request to an environment host that resolves to cloud metadata", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+    const context: ExecutionContext = { getCredential: async () => apiKeyCredential() };
+
+    const result = await proxy!({ endpoint: "/v2/account", method: "GET" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+function apiKeyCredential(): Extract<ResolvedCredential, { authType: "api_key" }> {
+  return {
+    authType: "api_key",
+    apiKey: "alpaca-secret-key",
+    values: { apiKeyId: "alpaca-key-id", environment: "live" },
+    profile: { accountId: "alpaca", displayName: "Alpaca", grantedScopes: [] },
+    metadata: {},
+  };
+}
 
 function oauthCredential(
   metadata: Record<string, unknown> = { scope: "data" },

--- a/src/providers/alpaca/executors.ts
+++ b/src/providers/alpaca/executors.ts
@@ -32,12 +32,11 @@ const service = "alpaca";
 const paperTradingBaseUrl = "https://paper-api.alpaca.markets";
 const liveTradingBaseUrl = "https://api.alpaca.markets";
 const dataBaseUrl = "https://data.alpaca.markets";
-const alpacaFetch = createProviderFetch({ skipDnsValidation: true });
+const alpacaFetch = createProviderFetch();
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: alpacaActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     return resolveAlpacaActionContext(context, fetcher);
   },

--- a/src/providers/boldsign/executors.test.ts
+++ b/src/providers/boldsign/executors.test.ts
@@ -1,0 +1,38 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "api_key" }> = {
+  authType: "api_key",
+  apiKey: "boldsign-token",
+  values: { region: "eu" },
+  profile: { accountId: "boldsign:eu", displayName: "BoldSign EU API Key", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("BoldSign region resolver DNS", () => {
+  it("rejects an allowlisted API host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["boldsign.get_api_credits"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/boldsign/executors.ts
+++ b/src/providers/boldsign/executors.ts
@@ -29,7 +29,6 @@ export const executors: ProviderExecutors = defineProviderExecutors<BoldSignActi
       signal: context.signal,
     };
   },
-  skipDnsValidation: true,
 });
 
 export const credentialValidators: CredentialValidators = {
@@ -51,5 +50,4 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     "https://api-ca.boldsign.com",
     "https://api-au.boldsign.com",
   ],
-  skipDnsValidation: true,
 });

--- a/src/providers/dropbox/executors.test.ts
+++ b/src/providers/dropbox/executors.test.ts
@@ -2,8 +2,9 @@ import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { executeAction } from "../../core/execution.ts";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { provider } from "./definition.ts";
-import { executors } from "./executors.ts";
+import { executors, proxy } from "./executors.ts";
 
 interface CapturedRequest {
   url: URL;
@@ -20,7 +21,42 @@ const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
 };
 
 afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
   vi.unstubAllGlobals();
+});
+
+const dnsContext: ExecutionContext = {
+  getCredential: async () => oauthCredential,
+};
+
+describe("Dropbox host DNS validation", () => {
+  it("rejects an action host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["dropbox.get_current_account"]!({}, dnsContext);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proxy base URL that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await proxy({ endpoint: "/files/download", method: "POST" }, dnsContext);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("Dropbox transit downloads", () => {

--- a/src/providers/dropbox/executors.ts
+++ b/src/providers/dropbox/executors.ts
@@ -30,7 +30,7 @@ import {
 
 const dropboxApiBaseUrl = "https://api.dropboxapi.com/2";
 const dropboxContentBaseUrl = "https://content.dropboxapi.com/2";
-const dropboxFetch = createProviderFetch({ skipDnsValidation: true });
+const dropboxFetch = createProviderFetch();
 const dropboxMaxSimpleUploadBytes = 150 * 1024 * 1024;
 const dropboxContentEndpointPrefixes = [
   "/files/download",
@@ -132,9 +132,7 @@ export const dropboxActionHandlers: ProviderActionHandlers<"dropbox", ActionHand
   },
 };
 
-export const executors: ProviderExecutors = defineOAuthProviderExecutors("dropbox", dropboxActionHandlers, {
-  skipDnsValidation: true,
-});
+export const executors: ProviderExecutors = defineOAuthProviderExecutors("dropbox", dropboxActionHandlers);
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {

--- a/src/providers/getresponse/executors.test.ts
+++ b/src/providers/getresponse/executors.test.ts
@@ -1,0 +1,38 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "api_key" }> = {
+  authType: "api_key",
+  apiKey: "getresponse-key",
+  values: { maxApiBaseUrl: "https://api3.getresponse360.com/v3", domain: "example.com" },
+  profile: { accountId: "getresponse", displayName: "GetResponse", grantedScopes: [] },
+  metadata: { apiBaseUrl: "https://api3.getresponse360.com/v3", domain: "example.com" },
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("GetResponse MAX API base URL DNS", () => {
+  it("rejects an allowlisted MAX host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["getresponse.list_campaigns"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "provider_error", message: "GetResponse request failed" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/getresponse/executors.ts
+++ b/src/providers/getresponse/executors.ts
@@ -25,7 +25,6 @@ const handlers: Record<string, (input: Record<string, unknown>, context: Getresp
 export const executors: ProviderExecutors = defineProviderExecutors({
   service: "getresponse",
   handlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, "getresponse");
     return { apiKey: credential.apiKey, values: credential.values, metadata: credential.metadata, fetcher };

--- a/src/providers/paypal/executors.test.ts
+++ b/src/providers/paypal/executors.test.ts
@@ -1,0 +1,41 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    environment: "live",
+  },
+  profile: { accountId: "live:client-id", displayName: "PayPal Live", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("PayPal environment resolver DNS", () => {
+  it("rejects an allowlisted API host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["paypal.get_balances"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/paypal/executors.ts
+++ b/src/providers/paypal/executors.ts
@@ -8,7 +8,6 @@ type PayPalContext = Awaited<ReturnType<typeof createPayPalActionContext>>;
 export const executors: ProviderExecutors = defineProviderExecutors({
   service: "paypal",
   handlers: paypalActionHandlers,
-  skipDnsValidation: true,
   async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<PayPalContext> {
     const credential = await requireCustomCredential(context, "paypal");
     return createPayPalActionContext(credential.values, fetcher);

--- a/src/providers/sslmate_cert_spotter_api/executors.test.ts
+++ b/src/providers/sslmate_cert_spotter_api/executors.test.ts
@@ -1,0 +1,55 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors, proxy } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "api_key" }> = {
+  authType: "api_key",
+  apiKey: "sslmate-api-key",
+  values: {},
+  profile: { accountId: "api_key", displayName: "SSLMate API Key", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("Cert Spotter resolver DNS", () => {
+  it("rejects an allowlisted API host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["sslmate_cert_spotter_api.list_certificate_issuances"]!(
+      { domain: "example.com" },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proxy target host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await proxy({ method: "GET", endpoint: "/ct-search/issuances" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/sslmate_cert_spotter_api/executors.ts
+++ b/src/providers/sslmate_cert_spotter_api/executors.ts
@@ -23,11 +23,9 @@ import {
 const service = "sslmate_cert_spotter_api";
 const ctSearchProxyPrefix = "/ct-search";
 
-const certSpotterFetch = createProviderFetch({ skipDnsValidation: true });
+const certSpotterFetch = createProviderFetch();
 
-export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, certSpotterActionHandlers, {
-  skipDnsValidation: true,
-});
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, certSpotterActionHandlers);
 
 export const proxy: ProviderProxyExecutor = async (input, context) => {
   try {

--- a/src/providers/tidb/executors.test.ts
+++ b/src/providers/tidb/executors.test.ts
@@ -1,0 +1,54 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { executors, proxy } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    publicKey: "public-key",
+    privateKey: "private-key",
+  },
+  profile: { accountId: "public-key", displayName: "TiDB Cloud", grantedScopes: [] },
+  metadata: {},
+};
+
+const context: ExecutionContext = {
+  getCredential: async () => credential,
+};
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(null);
+  vi.unstubAllGlobals();
+});
+
+describe("TiDB Cloud API family resolver DNS", () => {
+  it("rejects an allowlisted API host that resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await executors["tidb.list_clusters"]!({ apiFamily: "starter_essential" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a proxy endpoint family whose host resolves to cloud metadata before any fetch", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await proxy({ method: "GET", endpoint: "/iam/apikeys" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("must not resolve to private or reserved IP addresses") },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/tidb/executors.ts
+++ b/src/providers/tidb/executors.ts
@@ -16,12 +16,11 @@ import { requestTiDBProxy, resolveTiDBProxyTarget, tidbActionHandlers, validateT
 
 const service = "tidb";
 
-const tidbFetch = createProviderFetch({ skipDnsValidation: true });
+const tidbFetch = createProviderFetch();
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
   handlers: tidbActionHandlers,
-  skipDnsValidation: true,
   async createContext(context, fetcher) {
     const credential = await requireCustomCredential(context, service);
     return {


### PR DESCRIPTION
Follow-up to #387 finishing issue #397. On main, getresponse, paypal, and alpaca still paired `skipDnsValidation: true` with an egress host selected by a credential field (`maxApiBaseUrl` for GetResponse MAX, `environment` for the other two), so a request whose allowlisted official domain resolves to a private or cloud-metadata address was never rejected.

A full audit of the remaining flagged providers turned up four more cases the issue did not list, same class with a different selector: boldsign picks its API origin from the credential `region`, tidb from the `apiFamily` action input, and dropbox and sslmate_cert_spotter_api from the proxy endpoint prefix. Providers whose hosts are hardcoded literals keep the flag, as AGENTS.md allows.

The flag is removed from every fetch path in those seven providers (executor options, proxy options, and `createProviderFetch` instances), and each provider gains a regression test that stubs the DNS lookup to 169.254.169.254 and asserts the executor and proxy paths fail closed without any outbound fetch. The full provider test suite, oxlint, and oxfmt all pass.

Closes #397
