### PR TITLE
fix(google-analytics): remove redundant full OAuth scope

### DIFF
--- a/src/providers/google_analytics/scopes.ts
+++ b/src/providers/google_analytics/scopes.ts
@@ -1,11 +1,6 @@
 export const googleAnalyticsReadonlyScope = "https://www.googleapis.com/auth/analytics.readonly";
 export const googleAnalyticsEditScope = "https://www.googleapis.com/auth/analytics.edit";
-export const googleAnalyticsFullScope = "https://www.googleapis.com/auth/analytics";
 
 export const googleAnalyticsReadScopes: string[] = [googleAnalyticsReadonlyScope];
 export const googleAnalyticsWriteScopes: string[] = [googleAnalyticsEditScope];
-export const googleAnalyticsOAuthScopes: string[] = [
-  googleAnalyticsReadonlyScope,
-  googleAnalyticsEditScope,
-  googleAnalyticsFullScope,
-];
+export const googleAnalyticsOAuthScopes: string[] = [googleAnalyticsReadonlyScope, googleAnalyticsEditScope];


### PR DESCRIPTION
## Summary

- remove `https://www.googleapis.com/auth/analytics` from the Google Analytics OAuth request
- keep the action-level `analytics.readonly` and `analytics.edit` scope mappings unchanged

## Why

Every existing Google Analytics action declares either `googleAnalyticsReadScopes` or `googleAnalyticsWriteScopes`. None of the 28 actions requires the broader full Analytics scope.

Google's API documentation authorizes the covered read operations with `analytics.readonly` (or `analytics.edit`) and write operations with `analytics.edit`. Requesting `analytics` in addition to those scopes does not enable any current action, but it broadens the consent request and adds unnecessary OAuth verification burden.

Removing the unused scope keeps the provider aligned with least privilege while preserving all existing action capabilities.

References:
- https://developers.google.com/analytics/devguides/config/admin/v1/rest/v1beta/accounts/getDataSharingSettings#authorization-scopes
- https://developers.google.com/analytics/devguides/config/admin/v1/rest/v1alpha/properties/create#authorization-scopes
- https://developers.google.com/analytics/devguides/reporting/data/v1/quickstart

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` — 138 passed, 1 skipped; 1304 tests passed, 4 skipped
- verified the generated provider definition requests exactly `analytics.readonly` and `analytics.edit`, and all 28 actions require only those scopes
