### PR TITLE
fix(gmail): handle empty list responses

### DIFF
--- a/src/providers/gmail/executors.test.ts
+++ b/src/providers/gmail/executors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { gmailActionHandlers } from "./executors.ts";
+
+function actionContext(fetcher: typeof fetch) {
+  return {
+    userId: "me",
+    accessToken: "gmail-token",
+    fetcher,
+  };
+}
+
+describe("Gmail list actions", () => {
+  it("returns an empty filter list for a successful empty response", async () => {
+    await expect(
+      gmailActionHandlers.list_filters(
+        {},
+        actionContext(async () => new Response(null, { status: 200 })),
+      ),
+    ).resolves.toEqual({ filters: [] });
+  });
+
+  it("returns an empty forwarding-address list for a successful empty response", async () => {
+    await expect(
+      gmailActionHandlers.list_forwarding_addresses(
+        {},
+        actionContext(async () => new Response(null, { status: 200 })),
+      ),
+    ).resolves.toEqual({ forwardingAddresses: [] });
+  });
+
+  it("maps a malformed successful response to a provider response error", async () => {
+    await expect(
+      gmailActionHandlers.list_filters(
+        {},
+        actionContext(async () => new Response("not-json", { status: 200 })),
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Gmail response must be valid JSON",
+    });
+  });
+});

--- a/src/providers/gmail/executors.test.ts
+++ b/src/providers/gmail/executors.test.ts
@@ -36,7 +36,7 @@ describe("Gmail list actions", () => {
       ),
     ).rejects.toMatchObject({
       status: 502,
-      message: "Gmail response must be valid JSON",
+      message: "gmail filters list response must be valid JSON",
     });
   });
 });

--- a/src/providers/gmail/executors.ts
+++ b/src/providers/gmail/executors.ts
@@ -806,7 +806,7 @@ async function listHistory(input: Record<string, unknown>, userId: string, acces
 
 async function listFilters(userId: string, accessToken: string, fetcher: typeof fetch) {
   const payload = normalizeNullableObjectResponse(
-    await fetchNullableJson(gmailUserUrl(userId, "settings", "filters"), accessToken, fetcher),
+    await fetchNullableJson(gmailUserUrl(userId, "settings", "filters"), accessToken, fetcher, "gmail filters list"),
     "gmail filters list",
   );
   const filters = payload.filter;
@@ -880,7 +880,12 @@ async function updateSettingsResource(
 
 async function listForwardingAddresses(userId: string, accessToken: string, fetcher: typeof fetch) {
   const payload = normalizeNullableObjectResponse(
-    await fetchNullableJson(gmailUserUrl(userId, "settings", "forwardingAddresses"), accessToken, fetcher),
+    await fetchNullableJson(
+      gmailUserUrl(userId, "settings", "forwardingAddresses"),
+      accessToken,
+      fetcher,
+      "gmail forwarding addresses list",
+    ),
     "gmail forwarding addresses list",
   );
   const forwardingAddresses = payload.forwardingAddresses;
@@ -1018,10 +1023,15 @@ async function fetchJson<T>(url: string, accessToken: string, fetcher: typeof fe
   return (await response.json()) as T;
 }
 
-async function fetchNullableJson(url: string, accessToken: string, fetcher: typeof fetch): Promise<unknown> {
+async function fetchNullableJson(
+  url: string,
+  accessToken: string,
+  fetcher: typeof fetch,
+  operation: string,
+): Promise<unknown> {
   return readProviderJsonBody(await sendGmailRequest(url, accessToken, fetcher), {
     emptyBody: null,
-    invalidJsonMessage: "Gmail response must be valid JSON",
+    invalidJsonMessage: `${operation} response must be valid JSON`,
   });
 }
 

--- a/src/providers/gmail/executors.ts
+++ b/src/providers/gmail/executors.ts
@@ -2,7 +2,12 @@ import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { GmailDraftResource, GmailMessageResource, GmailThreadResource } from "./message.ts";
 
-import { defineProviderExecutors, ProviderRequestError, requireOAuthCredential } from "../provider-runtime.ts";
+import {
+  defineProviderExecutors,
+  ProviderRequestError,
+  readProviderJsonBody,
+  requireOAuthCredential,
+} from "../provider-runtime.ts";
 import {
   buildRecipients,
   encodeMimeMessage,
@@ -801,7 +806,7 @@ async function listHistory(input: Record<string, unknown>, userId: string, acces
 
 async function listFilters(userId: string, accessToken: string, fetcher: typeof fetch) {
   const payload = normalizeNullableObjectResponse(
-    await fetchJson<unknown>(gmailUserUrl(userId, "settings", "filters"), accessToken, fetcher),
+    await fetchNullableJson(gmailUserUrl(userId, "settings", "filters"), accessToken, fetcher),
     "gmail filters list",
   );
   const filters = payload.filter;
@@ -875,7 +880,7 @@ async function updateSettingsResource(
 
 async function listForwardingAddresses(userId: string, accessToken: string, fetcher: typeof fetch) {
   const payload = normalizeNullableObjectResponse(
-    await fetchJson<unknown>(gmailUserUrl(userId, "settings", "forwardingAddresses"), accessToken, fetcher),
+    await fetchNullableJson(gmailUserUrl(userId, "settings", "forwardingAddresses"), accessToken, fetcher),
     "gmail forwarding addresses list",
   );
   const forwardingAddresses = payload.forwardingAddresses;
@@ -1009,16 +1014,31 @@ function normalizeNullableObjectResponse(value: unknown, operation: string) {
 }
 
 async function fetchJson<T>(url: string, accessToken: string, fetcher: typeof fetch, init: RequestInit = {}) {
-  const requestInit = buildGmailRequestInit(accessToken, init);
-  const response = await fetcher(url, requestInit);
-  await assertGmailResponse(response);
+  const response = await sendGmailRequest(url, accessToken, fetcher, init);
   return (await response.json()) as T;
 }
 
+async function fetchNullableJson(url: string, accessToken: string, fetcher: typeof fetch): Promise<unknown> {
+  return readProviderJsonBody(await sendGmailRequest(url, accessToken, fetcher), {
+    emptyBody: null,
+    invalidJsonMessage: "Gmail response must be valid JSON",
+  });
+}
+
 async function fetchEmpty(url: string, accessToken: string, fetcher: typeof fetch, init: RequestInit = {}) {
+  await sendGmailRequest(url, accessToken, fetcher, init);
+}
+
+async function sendGmailRequest(
+  url: string,
+  accessToken: string,
+  fetcher: typeof fetch,
+  init: RequestInit = {},
+): Promise<Response> {
   const requestInit = buildGmailRequestInit(accessToken, init);
   const response = await fetcher(url, requestInit);
   await assertGmailResponse(response);
+  return response;
 }
 
 function buildGmailRequestInit(accessToken: string, init: RequestInit) {


### PR DESCRIPTION
## Summary

- treat successful empty bodies from Gmail filter listings as an empty filter list
- apply the same handling to forwarding-address listings, which use the same optional-list response shape
- keep malformed non-empty responses as structured 502 provider errors

## Testing

- `npm run fix-check`
- `npm test` (145 passed, 1 skipped; 1326 tests passed, 4 skipped)