### PR TITLE
feat: add Reddit provider

### DIFF
--- a/src/oauth/oauth-token.test.ts
+++ b/src/oauth/oauth-token.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { providerUserAgent } from "../providers/provider-runtime.ts";
 import { requestAuthorizationCodeToken, requestRefreshToken } from "./oauth-token.ts";
 
 const authorizationCodeRequest = {
@@ -52,7 +53,11 @@ describe("OAuth token requests", () => {
 
     expect(fetcher).toHaveBeenCalledOnce();
     const init = fetcher.mock.calls[0]?.[1];
-    expect(init).toMatchObject({ method: "POST", redirect: "manual" });
+    expect(init).toMatchObject({
+      method: "POST",
+      redirect: "manual",
+      headers: { "user-agent": providerUserAgent },
+    });
     expect(String(init?.body)).toContain("client_secret=client-secret");
     expect(String(init?.body)).toContain("code=authorization-code");
   });

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -2,7 +2,7 @@ import type { OAuth2AuthDefinition, ResolvedCredential } from "../core/types.ts"
 
 import { optionalRecord, optionalString, requiredString } from "../core/cast.ts";
 import { readBoundedResponseBytes } from "../core/request.ts";
-import { providerFetch } from "../providers/provider-runtime.ts";
+import { providerFetch, providerUserAgent } from "../providers/provider-runtime.ts";
 
 const oauthTokenRequestTimeoutMs = 30_000;
 const oauthTokenResponseMaxBytes = 1024 * 1024;
@@ -67,6 +67,7 @@ async function requestToken(input: TokenRequest): Promise<Extract<ResolvedCreden
   }
   const headers: Record<string, string> = {
     accept: "application/json",
+    "user-agent": providerUserAgent,
   };
   let body: BodyInit;
 

--- a/src/providers/reddit/actions.ts
+++ b/src/providers/reddit/actions.ts
@@ -1,0 +1,177 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { redditEditScope, redditIdentityScope, redditReadScope, redditSubmitScope } from "./scopes.ts";
+
+const service = "reddit";
+
+const rawObjectSchema = s.looseObject("The raw object returned by the Reddit Data API.");
+const fullnameSchema = s.nonEmptyString(
+  "A Reddit fullname such as t3_postid for a post or t1_commentid for a comment.",
+);
+const paginationFields: Record<string, JsonSchema> = {
+  after: s.nullableString("The fullname cursor for the next page, or null."),
+  before: s.nullableString("The fullname cursor for the previous page, or null."),
+};
+const listingInputFields: Record<string, JsonSchema> = {
+  subreddit: s.nonEmptyString("The subreddit name without the r/ prefix."),
+  limit: s.integer("The maximum number of items to return, from 1 through 100.", {
+    minimum: 1,
+    maximum: 100,
+  }),
+  after: s.string("The Reddit fullname cursor after which to continue the listing."),
+  before: s.string("The Reddit fullname cursor before which to continue the listing."),
+};
+const listingOutputSchema = s.object("A normalized page of Reddit posts.", {
+  posts: s.array("The posts returned in this page.", rawObjectSchema),
+  ...paginationFields,
+});
+
+function action(input: {
+  name: string;
+  description: string;
+  requiredScopes: string[];
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}): ActionDefinition {
+  return defineProviderAction(service, {
+    ...input,
+    providerPermissions: input.requiredScopes,
+  });
+}
+
+export const redditActions: ActionDefinition[] = [
+  action({
+    name: "get_me",
+    description: "Get the profile of the authenticated Reddit account.",
+    requiredScopes: [redditIdentityScope],
+    inputSchema: s.object({}, { description: "The input payload for the authenticated Reddit profile." }),
+    outputSchema: s.object("The authenticated Reddit profile response.", { account: rawObjectSchema }),
+  }),
+  action({
+    name: "list_posts",
+    description: "List posts from a subreddit using a supported Reddit sort order.",
+    requiredScopes: [redditReadScope],
+    inputSchema: s.object(
+      "The input payload for listing Reddit posts.",
+      {
+        ...listingInputFields,
+        sort: s.stringEnum("The Reddit listing sort order.", ["hot", "new", "top", "controversial", "rising"]),
+        time: s.stringEnum("The time range for top or controversial listings.", [
+          "hour",
+          "day",
+          "week",
+          "month",
+          "year",
+          "all",
+        ]),
+      },
+      { optional: ["sort", "time", "limit", "after", "before"] },
+    ),
+    outputSchema: listingOutputSchema,
+  }),
+  action({
+    name: "search_posts",
+    description: "Search Reddit posts globally or within one subreddit.",
+    requiredScopes: [redditReadScope],
+    inputSchema: s.object(
+      "The input payload for searching Reddit posts.",
+      {
+        query: s.nonEmptyString("The Reddit search query."),
+        subreddit: listingInputFields.subreddit,
+        sort: s.stringEnum("The Reddit search sort order.", ["relevance", "hot", "top", "new", "comments"]),
+        time: s.stringEnum("The search time range.", ["hour", "day", "week", "month", "year", "all"]),
+        limit: listingInputFields.limit,
+        after: listingInputFields.after,
+        before: listingInputFields.before,
+      },
+      { optional: ["subreddit", "sort", "time", "limit", "after", "before"] },
+    ),
+    outputSchema: listingOutputSchema,
+  }),
+  action({
+    name: "get_post_comments",
+    description: "Get a Reddit post and its comment tree.",
+    requiredScopes: [redditReadScope],
+    inputSchema: s.object(
+      "The input payload for retrieving a Reddit comment tree.",
+      {
+        postId: s.nonEmptyString("The base-36 Reddit post ID without the t3_ prefix."),
+        subreddit: listingInputFields.subreddit,
+        sort: s.stringEnum("The comment sort order.", [
+          "confidence",
+          "top",
+          "new",
+          "controversial",
+          "old",
+          "random",
+          "qa",
+          "live",
+        ]),
+        limit: s.positiveInteger("The maximum number of comments to return."),
+        depth: s.positiveInteger("The maximum depth of comment subtrees to return."),
+      },
+      { optional: ["subreddit", "sort", "limit", "depth"] },
+    ),
+    outputSchema: s.object("A Reddit post and its recursive comment listing.", {
+      post: rawObjectSchema,
+      comments: s.array("The top-level comment things, including nested replies.", rawObjectSchema),
+    }),
+  }),
+  action({
+    name: "create_post",
+    description: "Create a text or link post in a subreddit as the authenticated Reddit user.",
+    requiredScopes: [redditSubmitScope],
+    inputSchema: s.object(
+      "The input payload for creating a Reddit post.",
+      {
+        subreddit: listingInputFields.subreddit,
+        title: s.nonEmptyString("The title of the Reddit post.", { maxLength: 300 }),
+        kind: s.stringEnum("Whether to create a text post or link post.", ["self", "link"]),
+        text: s.string("The Markdown body for a text post."),
+        url: s.url("The destination URL for a link post."),
+        flairId: s.string("The subreddit link flair template ID to apply.", { maxLength: 36 }),
+        flairText: s.string("The custom link flair text to apply when supported.", { maxLength: 64 }),
+        sendReplies: s.boolean("Whether Reddit should send inbox replies for the post."),
+        nsfw: s.boolean("Whether the post should be marked not safe for work."),
+        spoiler: s.boolean("Whether the post should be marked as a spoiler."),
+      },
+      { optional: ["text", "url", "flairId", "flairText", "sendReplies", "nsfw", "spoiler"] },
+    ),
+    outputSchema: s.object("The Reddit post created by the request.", {
+      post: rawObjectSchema,
+      url: s.nullableString("The resulting Reddit post URL, or null."),
+    }),
+  }),
+  action({
+    name: "create_comment",
+    description: "Reply to a Reddit post or comment as the authenticated Reddit user.",
+    requiredScopes: [redditSubmitScope],
+    inputSchema: s.object("The input payload for creating a Reddit comment.", {
+      parentFullname: fullnameSchema,
+      text: s.nonEmptyString("The Markdown body of the comment."),
+    }),
+    outputSchema: s.object("The Reddit comment created by the request.", { comment: rawObjectSchema }),
+  }),
+  action({
+    name: "edit_content",
+    description: "Replace the body of the authenticated user's Reddit comment or text post.",
+    requiredScopes: [redditEditScope],
+    inputSchema: s.object("The input payload for editing Reddit content.", {
+      fullname: fullnameSchema,
+      text: s.nonEmptyString("The replacement Markdown body."),
+    }),
+    outputSchema: s.object("The Reddit content returned after editing.", { content: rawObjectSchema }),
+  }),
+  action({
+    name: "delete_content",
+    description: "Permanently delete the authenticated user's Reddit post or comment.",
+    requiredScopes: [redditEditScope],
+    inputSchema: s.object("The input payload for deleting Reddit content.", { fullname: fullnameSchema }),
+    outputSchema: s.object("The result of deleting Reddit content.", {
+      accepted: s.boolean("Whether Reddit accepted the deletion request."),
+      fullname: fullnameSchema,
+    }),
+  }),
+];

--- a/src/providers/reddit/definition.ts
+++ b/src/providers/reddit/definition.ts
@@ -1,0 +1,37 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { redditActions } from "./actions.ts";
+import { redditOAuthScopes } from "./scopes.ts";
+
+const service = "reddit";
+
+/** Reddit provider backed by the official OAuth Data API. */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Reddit",
+  description: "Search and read Reddit discussions, and manage posts or comments for the authenticated user.",
+  categories: ["Social", "Marketing"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://www.reddit.com/api/v1/authorize",
+      tokenUrl: "https://www.reddit.com/api/v1/access_token",
+      scopes: redditOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_basic",
+      authorizationParams: {
+        duration: "permanent",
+      },
+      clientSetup: {
+        docsUrl: "https://www.reddit.com/prefs/apps",
+        steps: [
+          "Create a Reddit web application and register the Callback URL shown below as its redirect URI.",
+          "Copy the application's Client ID and Client Secret into the fields below.",
+          "Review Reddit's Developer Terms and Data API Terms before using the connection.",
+        ],
+      },
+    },
+  ],
+  homepageUrl: "https://www.reddit.com",
+  actions: redditActions,
+};

--- a/src/providers/reddit/executors.ts
+++ b/src/providers/reddit/executors.ts
@@ -1,0 +1,278 @@
+import type { CredentialValidationResult, CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderActionHandlers } from "../provider-runtime.ts";
+
+import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import {
+  defineOAuthProviderExecutors,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+} from "../provider-runtime.ts";
+
+const service = "reddit";
+const redditApiBaseUrl = "https://oauth.reddit.com";
+
+type RedditActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
+
+interface RedditRequestOptions {
+  path: string;
+  method?: "GET" | "POST";
+  query?: Record<string, string | number | undefined>;
+  form?: Record<string, string | number | boolean | undefined>;
+}
+
+export const redditActionHandlers: ProviderActionHandlers<"reddit", RedditActionHandler> = {
+  async get_me(_input, context) {
+    return { account: requireRedditObject(await redditRequest(context, { path: "/api/v1/me" }), "account") };
+  },
+  async list_posts(input, context) {
+    const subreddit = encodeURIComponent(requireInputString(input.subreddit, "subreddit"));
+    const sort = optionalString(input.sort) ?? "hot";
+    return normalizeListing(
+      await redditRequest(context, {
+        path: `/r/${subreddit}/${sort}`,
+        query: buildListingQuery(input),
+      }),
+    );
+  },
+  async search_posts(input, context) {
+    const subreddit = optionalString(input.subreddit);
+    return normalizeListing(
+      await redditRequest(context, {
+        path: subreddit ? `/r/${encodeURIComponent(subreddit)}/search` : "/search",
+        query: {
+          ...buildListingQuery(input),
+          q: requireInputString(input.query, "query"),
+          restrict_sr: subreddit ? "true" : undefined,
+          sort: optionalString(input.sort) ?? "relevance",
+          t: optionalString(input.time) ?? "all",
+        },
+      }),
+    );
+  },
+  async get_post_comments(input, context) {
+    const postId = encodeURIComponent(requireInputString(input.postId, "postId"));
+    const subreddit = optionalString(input.subreddit);
+    const payload = await redditRequest(context, {
+      path: subreddit ? `/r/${encodeURIComponent(subreddit)}/comments/${postId}` : `/comments/${postId}`,
+      query: {
+        raw_json: 1,
+        sort: optionalString(input.sort),
+        limit: optionalInteger(input.limit),
+        depth: optionalInteger(input.depth),
+      },
+    });
+    if (!Array.isArray(payload) || payload.length < 2) {
+      throw new ProviderRequestError(502, "Reddit returned an invalid comment tree");
+    }
+    return {
+      post: listingChildren(payload[0])[0] ?? {},
+      comments: listingChildren(payload[1]),
+    };
+  },
+  async create_post(input, context) {
+    const kind = requireInputString(input.kind, "kind");
+    if (kind == "self" && input.url != null) {
+      throw new ProviderRequestError(400, "url is only valid for a link post");
+    }
+    if (kind == "link" && !optionalString(input.url)) {
+      throw new ProviderRequestError(400, "url is required for a link post");
+    }
+    const data = requireRedditApiData(
+      await redditRequest(context, {
+        path: "/api/submit",
+        method: "POST",
+        form: {
+          api_type: "json",
+          sr: requireInputString(input.subreddit, "subreddit"),
+          title: requireInputString(input.title, "title"),
+          kind,
+          text: optionalString(input.text),
+          url: optionalString(input.url),
+          flair_id: optionalString(input.flairId),
+          flair_text: optionalString(input.flairText),
+          sendreplies: optionalBoolean(input.sendReplies),
+          nsfw: optionalBoolean(input.nsfw),
+          spoiler: optionalBoolean(input.spoiler),
+          resubmit: true,
+        },
+      }),
+      "create post",
+    );
+    return {
+      post: firstRedditThing(data) ?? data,
+      url: optionalString(data.url) ?? null,
+    };
+  },
+  async create_comment(input, context) {
+    const data = requireRedditApiData(
+      await redditRequest(context, {
+        path: "/api/comment",
+        method: "POST",
+        form: {
+          api_type: "json",
+          thing_id: requireContentFullname(input.parentFullname, "parentFullname"),
+          text: requireInputString(input.text, "text"),
+        },
+      }),
+      "create comment",
+    );
+    return { comment: firstRedditThing(data) ?? data };
+  },
+  async edit_content(input, context) {
+    const data = requireRedditApiData(
+      await redditRequest(context, {
+        path: "/api/editusertext",
+        method: "POST",
+        form: {
+          api_type: "json",
+          thing_id: requireContentFullname(input.fullname, "fullname"),
+          text: requireInputString(input.text, "text"),
+        },
+      }),
+      "edit content",
+    );
+    return { content: firstRedditThing(data) ?? data };
+  },
+  async delete_content(input, context) {
+    const fullname = requireContentFullname(input.fullname, "fullname");
+    await redditRequest(context, {
+      path: "/api/del",
+      method: "POST",
+      form: { id: fullname },
+    });
+    return { accepted: true, fullname };
+  },
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, redditActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    const account = requireRedditObject(
+      await redditRequest({ accessToken: input.accessToken, fetcher, signal }, { path: "/api/v1/me" }),
+      "account",
+    );
+    const id = optionalString(account.id);
+    const name = optionalString(account.name);
+    if (!id || !name) {
+      throw new ProviderRequestError(502, "Reddit account response is missing an id or name");
+    }
+    return {
+      profile: {
+        accountId: id,
+        displayName: `u/${name}`,
+      },
+      metadata: {
+        isModerator: optionalBoolean(account.is_mod) ?? false,
+      },
+    };
+  },
+};
+
+async function redditRequest(context: OAuthProviderContext, options: RedditRequestOptions): Promise<unknown> {
+  const url = new URL(options.path, redditApiBaseUrl);
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value != null) url.searchParams.set(key, String(value));
+  }
+
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    authorization: `Bearer ${context.accessToken}`,
+    "user-agent": providerUserAgent,
+  };
+  let body: URLSearchParams | undefined;
+  if (options.form) {
+    body = new URLSearchParams();
+    for (const [key, value] of Object.entries(options.form)) {
+      if (value != null) body.set(key, String(value));
+    }
+    headers["content-type"] = "application/x-www-form-urlencoded";
+  }
+
+  const response = await context.fetcher(url, {
+    method: options.method ?? "GET",
+    headers,
+    body,
+    signal: context.signal,
+  });
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: {},
+    invalidJsonMessage: "Reddit returned invalid JSON",
+  });
+  if (!response.ok) {
+    const object = optionalRecord(payload);
+    const message = optionalString(object?.message) ?? optionalString(object?.error) ?? "Reddit request failed";
+    throw new ProviderRequestError(response.status, message, payload);
+  }
+  return payload;
+}
+
+function normalizeListing(payload: unknown): Record<string, unknown> {
+  const listing = requireRedditObject(payload, "listing");
+  const data = requireRedditObject(listing.data, "listing data");
+  return {
+    posts: listingChildren(listing),
+    after: optionalString(data.after) ?? null,
+    before: optionalString(data.before) ?? null,
+  };
+}
+
+function listingChildren(payload: unknown): Record<string, unknown>[] {
+  const listing = optionalRecord(payload);
+  const data = optionalRecord(listing?.data);
+  if (!Array.isArray(data?.children)) return [];
+  return data.children.flatMap((child) => {
+    const object = optionalRecord(child);
+    const childData = optionalRecord(object?.data);
+    return childData ? [childData] : [];
+  });
+}
+
+function buildListingQuery(input: Record<string, unknown>): Record<string, string | number | undefined> {
+  return {
+    raw_json: 1,
+    limit: optionalInteger(input.limit) ?? 25,
+    after: optionalString(input.after),
+    before: optionalString(input.before),
+    t: optionalString(input.time),
+  };
+}
+
+function requireRedditApiData(payload: unknown, operation: string): Record<string, unknown> {
+  const root = requireRedditObject(payload, `${operation} response`);
+  const json = requireRedditObject(root.json, `${operation} JSON response`);
+  if (Array.isArray(json.errors) && json.errors.length > 0) {
+    const first = json.errors[0];
+    const message = Array.isArray(first) ? first.map(String).join(": ") : String(first);
+    const code = Array.isArray(first) ? optionalString(first[0]) : undefined;
+    throw new ProviderRequestError(code == "RATELIMIT" ? 429 : 400, `Reddit ${operation} failed: ${message}`);
+  }
+  return requireRedditObject(json.data, `${operation} response data`);
+}
+
+function firstRedditThing(data: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!Array.isArray(data.things)) return undefined;
+  const first = optionalRecord(data.things[0]);
+  return optionalRecord(first?.data) ?? first;
+}
+
+function requireRedditObject(value: unknown, label: string): Record<string, unknown> {
+  const object = optionalRecord(value);
+  if (!object) throw new ProviderRequestError(502, `Reddit ${label} is missing`);
+  return object;
+}
+
+function requireInputString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
+}
+
+function requireContentFullname(value: unknown, fieldName: string): string {
+  const fullname = requireInputString(value, fieldName);
+  if (!fullname.startsWith("t1_") && !fullname.startsWith("t3_")) {
+    throw new ProviderRequestError(400, `${fieldName} must be a Reddit post or comment fullname`);
+  }
+  return fullname;
+}

--- a/src/providers/reddit/scopes.ts
+++ b/src/providers/reddit/scopes.ts
@@ -1,0 +1,6 @@
+export const redditIdentityScope = "identity";
+export const redditReadScope = "read";
+export const redditSubmitScope = "submit";
+export const redditEditScope = "edit";
+
+export const redditOAuthScopes: string[] = [redditIdentityScope, redditReadScope, redditSubmitScope, redditEditScope];


### PR DESCRIPTION
## Summary

- add a native Reddit OAuth provider using the official Data API
- support profile lookup, subreddit listings, post search, comment trees, and authenticated post/comment mutations
- preserve Reddit listing cursors and fullnames in structured responses
- send the shared provider User-Agent during OAuth token requests as required by Reddit
- route all Reddit API egress through the shared SSRF-guarded provider fetch

## Actions

- `reddit.get_me`
- `reddit.list_posts`
- `reddit.search_posts`
- `reddit.get_post_comments`
- `reddit.create_post`
- `reddit.create_comment`
- `reddit.edit_content`
- `reddit.delete_content`

All actions are locally executable with a user-provided Reddit OAuth application.

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (146 passed, 1 skipped; 1331 tests passed, 4 skipped)
- `npm test -- src/oauth/oauth-token.test.ts`

Provider-local tests were intentionally omitted because this is a migration from the hosted connector and the request/response mapping is covered at its source. The shared OAuth User-Agent behavior has a targeted assertion.

Resolves #406