### PR TITLE
fix(slack): accept Bearer user tokens

### DIFF
--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -398,14 +398,11 @@ describe("OAuthFlowService", () => {
       if (String(url).endsWith("/oauth.v2.user.access")) {
         return Response.json({
           ok: true,
-          access_token: "user-access",
+          access_token: "xoxp-user-access",
           refresh_token: "user-refresh",
-          token_type: "user",
+          token_type: "Bearer",
           expires_in: 43_200,
-          authed_user: {
-            id: "U123",
-            scope: "channels:read,chat:write,search:read",
-          },
+          scope: "channels:read,chat:write,search:read",
         });
       }
       return Response.json({
@@ -433,15 +430,12 @@ describe("OAuthFlowService", () => {
 
     await expect(services.connections.getCredential("slack")).resolves.toMatchObject({
       authType: "oauth2",
-      accessToken: "user-access",
+      accessToken: "xoxp-user-access",
       refreshToken: "user-refresh",
-      tokenType: "user",
+      tokenType: "Bearer",
       metadata: {
-        rawTokenType: "user",
-        authed_user: {
-          id: "U123",
-          scope: "channels:read,chat:write,search:read",
-        },
+        rawTokenType: "Bearer",
+        scope: "channels:read,chat:write,search:read",
       },
     });
     await expect(services.connections.getCredential("slackbot")).resolves.toMatchObject({

--- a/src/providers/slack/executors.test.ts
+++ b/src/providers/slack/executors.test.ts
@@ -14,9 +14,21 @@ describe("Slack authorization paths", () => {
       rawTokenType: "user",
       execute: slackbotExecutors["slackbot.list_channels"]!,
     },
-  ])("rejects the other authorization path for $actionId", async ({ rawTokenType, execute }) => {
+    {
+      actionId: "slack.list_channels",
+      rawTokenType: "Bearer",
+      accessToken: "xoxb-bot-token",
+      execute: slackExecutors["slack.list_channels"]!,
+    },
+    {
+      actionId: "slackbot.list_channels",
+      rawTokenType: "Bearer",
+      accessToken: "xoxp-user-token",
+      execute: slackbotExecutors["slackbot.list_channels"]!,
+    },
+  ])("rejects the other authorization path for $actionId", async ({ rawTokenType, accessToken, execute }) => {
     const context: ExecutionContext = {
-      getCredential: async () => oauthCredential(rawTokenType),
+      getCredential: async () => oauthCredential(rawTokenType, {}, accessToken),
     };
 
     await expect(execute({}, context)).resolves.toMatchObject({
@@ -38,9 +50,15 @@ describe("Slack authorization paths", () => {
       rawTokenType: "bot",
       execute: slackbotExecutors["slackbot.open_conversation"]!,
     },
-  ])("allows the matching authorization path for $actionId", async ({ rawTokenType, execute }) => {
+    {
+      actionId: "slack.open_conversation",
+      rawTokenType: "Bearer",
+      accessToken: "xoxp-user-token",
+      execute: slackExecutors["slack.open_conversation"]!,
+    },
+  ])("allows the matching authorization path for $actionId", async ({ rawTokenType, accessToken, execute }) => {
     const context: ExecutionContext = {
-      getCredential: async () => oauthCredential(rawTokenType),
+      getCredential: async () => oauthCredential(rawTokenType, {}, accessToken),
     };
 
     await expect(execute({ userIds: [] }, context)).resolves.toMatchObject({
@@ -55,6 +73,7 @@ describe("Slack authorization paths", () => {
   it.each([
     {
       tokenType: "user",
+      accessToken: "access-token",
       metadata: {
         rawTokenType: "user",
         scope: "channels:read",
@@ -63,7 +82,17 @@ describe("Slack authorization paths", () => {
       scopes: ["chat:write", "search:read"],
     },
     {
+      tokenType: "Bearer user",
+      accessToken: "xoxp-user-token",
+      metadata: {
+        rawTokenType: "Bearer",
+        scope: "channels:read,chat:write,search:read",
+      },
+      scopes: ["channels:read", "chat:write", "search:read"],
+    },
+    {
       tokenType: "bot",
+      accessToken: "access-token",
       metadata: {
         rawTokenType: "bot",
         scope: "channels:read,chat:write",
@@ -71,11 +100,11 @@ describe("Slack authorization paths", () => {
       },
       scopes: ["channels:read", "chat:write"],
     },
-  ])("reads scopes from a $tokenType token response", async ({ tokenType, metadata, scopes }) => {
-    const result = await credentialValidators.oauth2!(oauthCredential(tokenType, metadata), {
+  ])("reads scopes from a $tokenType token response", async ({ accessToken, tokenType, metadata, scopes }) => {
+    const result = await credentialValidators.oauth2!(oauthCredential(tokenType, metadata, accessToken), {
       fetcher: async (url, init) => {
         expect(url.toString()).toBe("https://slack.com/api/auth.test");
-        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer access-token");
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${accessToken}`);
         return Response.json({ ok: true, team: "Example workspace", user_id: "U123" });
       },
     });
@@ -90,10 +119,14 @@ describe("Slack authorization paths", () => {
   });
 });
 
-function oauthCredential(rawTokenType: string, metadata: Record<string, unknown> = {}): OAuthCredential {
+function oauthCredential(
+  rawTokenType: string,
+  metadata: Record<string, unknown> = {},
+  accessToken = "access-token",
+): OAuthCredential {
   return {
     authType: "oauth2",
-    accessToken: "access-token",
+    accessToken,
     tokenType: rawTokenType,
     profile: {
       accountId: "U123",

--- a/src/providers/slack/runtime.ts
+++ b/src/providers/slack/runtime.ts
@@ -49,7 +49,7 @@ export function defineSlackProviderExecutors(
     handlers,
     async createContext(context, fetcher): Promise<SlackActionContext> {
       const credential = await requireOAuthCredential(context, service);
-      if (credential.metadata.rawTokenType != tokenKind) {
+      if (readSlackTokenKind(credential.accessToken, credential.metadata) != tokenKind) {
         throw new ProviderRequestError(
           401,
           `Reconnect ${service} with ${tokenKind} authorization before running its actions.`,
@@ -155,7 +155,7 @@ export const slackCredentialValidators: CredentialValidators = {
       method: "auth.test",
     });
 
-    const responseScopes = readSlackCredentialScopes(input.metadata);
+    const responseScopes = readSlackCredentialScopes(input.accessToken, input.metadata);
 
     return {
       profile: {
@@ -837,10 +837,27 @@ function readSlackScopes(value: unknown): string[] {
     .filter(Boolean);
 }
 
-function readSlackCredentialScopes(metadata: Record<string, unknown>): string[] {
-  switch (metadata.rawTokenType) {
+function readSlackTokenKind(accessToken: string, metadata: Record<string, unknown>): SlackOAuthTokenKind | undefined {
+  const rawTokenType = metadata.rawTokenType;
+  if (rawTokenType == "bot") {
+    return "bot";
+  }
+  if (rawTokenType == "user") {
+    return "user";
+  }
+  if (accessToken.startsWith("xoxb-")) {
+    return "bot";
+  }
+  if (accessToken.startsWith("xoxp-")) {
+    return "user";
+  }
+  return undefined;
+}
+
+function readSlackCredentialScopes(accessToken: string, metadata: Record<string, unknown>): string[] {
+  switch (readSlackTokenKind(accessToken, metadata)) {
     case "user":
-      return uniqueSlackScopes(readSlackScopes(optionalRecord(metadata.authed_user)?.scope));
+      return uniqueSlackScopes(readSlackScopes(optionalRecord(metadata.authed_user)?.scope ?? metadata.scope));
     case "bot":
       return uniqueSlackScopes(readSlackScopes(metadata.scope));
     default:


### PR DESCRIPTION
## Summary

- resolve Slack authorization kind from explicit `bot`/`user` metadata or the `xoxb-`/`xoxp-` access-token prefix
- read user scopes from the top-level OAuth response when `authed_user.scope` is absent
- replace the Slack user OAuth fixture with the real `oauth.v2.user.access` response shape and cover matching and cross-path Bearer tokens

Closes #411

## Verification

- `npm run fix-check`
- `npm exec vitest run -- src/providers/slack/executors.test.ts src/oauth/oauth-flow-service.test.ts`