### PR TITLE
fix(providers): treat empty org/account lists as valid credentials (Bugsnag, Ringba)

### DIFF
--- a/src/providers/bugsnag/executors.test.ts
+++ b/src/providers/bugsnag/executors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("Bugsnag credential validation", () => {
+  it("accepts a valid user identity when the organization list is empty", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "bugsnag-token", values: {} },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://api.bugsnag.com/user");
+          expect(new Headers(init?.headers).get("authorization")).toBe("token bugsnag-token");
+          return Response.json({
+            id: "user-42",
+            name: "Ada Lovelace",
+            email: "ada@example.com",
+          });
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      profile: { accountId: "user-42", displayName: "Ada Lovelace" },
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl: "https://api.bugsnag.com",
+        validationEndpoint: "/user",
+        userId: "user-42",
+        email: "ada@example.com",
+        name: "Ada Lovelace",
+      },
+    });
+  });
+
+  it("uses the user email as the display name when the name is missing", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "bugsnag-token", values: {} },
+      {
+        fetcher: async () =>
+          Response.json({
+            id: "user-42",
+            email: "ada@example.com",
+          }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "user-42", displayName: "ada@example.com" },
+      metadata: { validationEndpoint: "/user", userId: "user-42", email: "ada@example.com" },
+    });
+  });
+
+  it("rejects a current-user response that is missing an id", async () => {
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "bugsnag-token", values: {} },
+        {
+          fetcher: async () => Response.json({ email: "ada@example.com" }),
+        },
+      ),
+    ).rejects.toMatchObject({ status: 502, message: "bugsnag user id is required." });
+  });
+});

--- a/src/providers/bugsnag/runtime.ts
+++ b/src/providers/bugsnag/runtime.ts
@@ -53,37 +53,29 @@ export async function validateBugsnagCredential(input: {
 }): Promise<CredentialValidationResult> {
   const { payload } = await requestBugsnagJson({
     apiKey: input.apiKey,
-    path: "/user/organizations",
+    path: "/user",
     fetcher: input.fetcher,
     signal: input.signal,
     phase: "validate",
   });
 
-  const organizations = requireArrayPayload(payload, "bugsnag organizations");
-  if (organizations.length === 0) {
-    throw new ProviderRequestError(
-      502,
-      "bugsnag organizations response did not include an accessible organization",
-      payload,
-    );
-  }
-
-  const organization = requireResponseRecord(organizations[0], "bugsnag organization");
-  const organizationId = requiredString(organization.id, "bugsnag organization id", providerOutputError);
-  const organizationSlug = optionalString(organization.slug);
-  const accountLabel = optionalString(organization.name) ?? organizationSlug ?? "Bugsnag Personal Auth Token";
+  const user = requireResponseRecord(payload, "bugsnag user");
+  const userId = requiredString(user.id, "bugsnag user id", providerOutputError);
+  const email = optionalString(user.email);
+  const name = optionalString(user.name);
 
   return {
     profile: {
-      accountId: organizationId,
-      displayName: accountLabel,
+      accountId: userId,
+      displayName: name ?? email ?? "Bugsnag Personal Auth Token",
     },
     grantedScopes: [],
     metadata: {
       apiBaseUrl: bugsnagApiBaseUrl,
-      validationEndpoint: "/user/organizations",
-      organizationId,
-      ...(organizationSlug ? { organizationSlug } : {}),
+      validationEndpoint: "/user",
+      userId,
+      ...(email ? { email } : {}),
+      ...(name ? { name } : {}),
     },
   };
 }

--- a/src/providers/ringba/executors.test.ts
+++ b/src/providers/ringba/executors.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("Ringba credential validation", () => {
+  it("accepts a valid token when Ringba has not provisioned an account yet", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "ringba-token", values: {} },
+      {
+        fetcher: async (url, init) => {
+          expect(url.toString()).toBe("https://api.ringba.com/v2/ringbaaccounts");
+          expect(new Headers(init?.headers).get("authorization")).toBe("Token ringba-token");
+          return Response.json({ account: [] });
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      profile: { accountId: "ringba", displayName: "Ringba API Token" },
+      grantedScopes: [],
+      metadata: {
+        accountId: undefined,
+        accessibleAccountIds: [],
+      },
+    });
+  });
+
+  it("treats a missing account field as an empty account list", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "ringba-token", values: {} },
+      {
+        fetcher: async () => Response.json({}),
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "ringba", displayName: "Ringba API Token" },
+      metadata: { accessibleAccountIds: [] },
+    });
+  });
+
+  it("treats a successful empty body as an empty account list", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "ringba-token", values: {} },
+      {
+        fetcher: async () => new Response(null, { status: 200 }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "ringba" },
+      metadata: { accessibleAccountIds: [] },
+    });
+  });
+
+  it("still records a requested account when the token can access it", async () => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "ringba-token", values: { accountId: "RA-1" } },
+      {
+        fetcher: async () =>
+          Response.json({
+            account: [
+              { accountId: "RA-1", name: "Primary" },
+              { id: "RA-2", name: "Secondary" },
+            ],
+          }),
+      },
+    );
+
+    expect(result).toEqual({
+      profile: { accountId: "RA-1", displayName: "Primary" },
+      grantedScopes: [],
+      metadata: {
+        accountId: "RA-1",
+        accessibleAccountIds: ["RA-1", "RA-2"],
+      },
+    });
+  });
+
+  it("rejects a requested accountId that is not in the accessible list", async () => {
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "ringba-token", values: { accountId: "RA-missing" } },
+        {
+          fetcher: async () => Response.json({ account: [{ accountId: "RA-1", name: "Primary" }] }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Ringba accountId is not accessible with the provided API token",
+    });
+  });
+});

--- a/src/providers/ringba/runtime.ts
+++ b/src/providers/ringba/runtime.ts
@@ -46,9 +46,6 @@ export async function validateRingbaCredential(
     const accountId = optionalString(account.accountId) ?? optionalString(account.id);
     return accountId ? [accountId] : [];
   });
-  if (accessibleAccountIds.length === 0) {
-    throw new ProviderRequestError(502, "Ringba returned no accessible account");
-  }
   const normalizedRequestedAccountId = requestedAccountId?.trim() || undefined;
   if (normalizedRequestedAccountId && !accessibleAccountIds.includes(normalizedRequestedAccountId)) {
     throw new ProviderRequestError(400, "Ringba accountId is not accessible with the provided API token");


### PR DESCRIPTION
## Summary
- Treat an empty Bugsnag organization list as a valid token by validating `GET /user` instead of requiring a non-empty `GET /user/organizations`.
- Treat a successful empty Ringba account list (`{ account: [] }`, omitted `account`, or empty 200 body) as a valid token; a requested `accountId` that is not in the list still returns 400.
- Profile identity follows Harvest [#388](https://github.com/oomol-lab/open-connector/pull/388): Bugsnag uses the user id/name, Ringba keeps the generic token label until an account is selected.

Closes #414

## Test plan
- [x] Bugsnag: `GET /user` 200 with id → valid; must not call `/user/organizations`; missing `user.id` → 502
- [x] Ringba: empty `account` / omitted `account` / empty 200 body → valid; accessible requested `accountId` still recorded; unknown `accountId` → 400
- [x] `npm run fix-check`


Made with [Cursor](https://cursor.com)