### PR TITLE
fix(oauth): drop unused Bitbucket, Gist, and Harvest scopes

### DIFF
--- a/src/providers/bitbucket/definition.ts
+++ b/src/providers/bitbucket/definition.ts
@@ -13,9 +13,7 @@ export const provider: ProviderDefinition = {
       authorizationUrl: "https://bitbucket.org/site/oauth2/authorize",
       tokenUrl: "https://bitbucket.org/site/oauth2/access_token",
       scopes: [
-        "email",
         "account",
-        "team",
         "project",
         "repository",
         "repository:write",

--- a/src/providers/gist/actions.ts
+++ b/src/providers/gist/actions.ts
@@ -6,7 +6,7 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 const service = "gist";
 
 export const gistRequiredScopes: string[] = ["gist"];
-export const gistOAuthScopes: string[] = ["read:user", ...gistRequiredScopes];
+export const gistOAuthScopes: string[] = [...gistRequiredScopes];
 
 const rawObjectSchema = s.looseObject("A GitHub API object.");
 const nullableString = s.nullable(s.string());

--- a/src/providers/harvest/executors.test.ts
+++ b/src/providers/harvest/executors.test.ts
@@ -8,7 +8,7 @@ const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
   accessToken: "harvest-access-token",
   tokenType: "Bearer",
   profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
-  metadata: { scope: "all" },
+  metadata: { scope: "harvest:all" },
 };
 
 describe("Harvest OAuth credential validation", () => {

--- a/src/providers/harvest/scopes.ts
+++ b/src/providers/harvest/scopes.ts
@@ -1,1 +1,1 @@
-export const harvestOAuthScopes: string[] = ["harvest:all", "all"];
+export const harvestOAuthScopes: string[] = ["harvest:all"];


### PR DESCRIPTION
## Summary

Follow-up to #413 (clear cases only; no full OAuth audit).

- **Bitbucket:** stop requesting obsolete `team` and redundant `email`. Keep `account` (workspace APIs) plus the existing repository / PR / issue / snippet / pipeline / runner scopes.
- **Gist:** stop requesting `read:user`. Keep `gist` write access. Credential validation still uses `GET /user` for public `id` / `login` (and optional public `name` / avatar / html URL).
- **Harvest:** stop requesting `all` (Harvest + Forecast). Keep `harvest:all` as the Harvest-only declared scope. Do not template `harvest:{ACCOUNT_ID}`: one-account is a Harvest OAuth app registration setting; granted `harvest:{ACCOUNT_ID}` is already treated as Harvest access.

**Strava is intentionally unchanged.** hyrious asked to treat `read_all` / `activity:read_all` as a product-capability decision; this PR does not remove them.

## Impact on existing connections

Existing tokens keep their previous grants until the user re-authorizes. New consents are narrower:

- Bitbucket: no `team` membership grant and no primary-email-only `email` scope (`account` still covers profile / workspace identity).
- Gist: no private profile fields from `GET /user`; public identity used for `CredentialProfile` remains.
- Harvest: Forecast authorization is no longer requested. Harvest actions are unchanged. Personal access tokens and older OAuth grants that still carry `all` continue to validate.

Hosted Harvest apps that were registered for Harvest + Forecast should be switched to Harvest-only in Harvest ID so the app config matches this declaration.

## Test plan

- [x] Checked Bitbucket / Gist / Harvest actions and HTTP calls against official scope docs
- [x] `npm run generate:catalog`
- [x] `npm run fix-check`
- [x] `npx vitest run src/providers/harvest/executors.test.ts`

Made with [Cursor](https://cursor.com)