### PR TITLE
feat(cloudflare_r2): add generate_presigned_url for custom credentials

### DIFF
--- a/examples/cloudflare-r2-presigned-url.ts
+++ b/examples/cloudflare-r2-presigned-url.ts
@@ -1,0 +1,250 @@
+import type { ExecutionContext, ResolvedCredential } from "../src/core/types.ts";
+
+import { Buffer } from "node:buffer";
+import { optionalRecord } from "../src/core/cast.ts";
+import { parseEgressTrustedHosts, setEgressTrustedHosts } from "../src/core/request.ts";
+import { executors } from "../src/providers/cloudflare_r2/executors.ts";
+import {
+  createCloudflareR2PresignedUrl,
+  deriveCloudflareR2S3SecretAccessKey,
+} from "../src/providers/cloudflare_r2/s3-presign.ts";
+import { providerFetch } from "../src/providers/provider-runtime.ts";
+
+const requiredEnvironment = ["R2_ACCOUNT_ID", "R2_BUCKET"] as const;
+
+async function main(): Promise<void> {
+  // Examples call providerFetch directly, so they must apply the same VPN/split-DNS
+  // host exception the server process loads from this env var at startup.
+  setEgressTrustedHosts(parseEgressTrustedHosts(process.env.OOMOL_CONNECT_EGRESS_TRUSTED_HOSTS));
+
+  const accountId = process.env.R2_ACCOUNT_ID?.trim();
+  const bucketName = process.env.R2_BUCKET?.trim();
+  const apiToken = process.env.R2_API_TOKEN?.trim();
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID?.trim();
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY?.trim();
+  const missing: string[] = requiredEnvironment.filter((name) => !process.env[name]?.trim());
+  if (!apiToken && !(accessKeyId && secretAccessKey)) {
+    missing.push("R2_API_TOKEN or R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY");
+  }
+  if (missing.length > 0) {
+    console.log(
+      `Skip Cloudflare R2 presigned URL example: missing ${missing.join(", ")}. ` +
+        "The current custom-credential path needs R2_API_TOKEN, R2_ACCOUNT_ID, and R2_BUCKET.",
+    );
+    return;
+  }
+
+  const objectKey = process.env.R2_OBJECT_KEY?.trim() || `oomol-connect/presign-live/${Date.now()}.txt`;
+  const jurisdiction = process.env.R2_JURISDICTION?.trim();
+  const body = `oomol-connect r2 presign live test ${new Date().toISOString()}\n`;
+  const contentType = "text/plain";
+  const expiresSeconds = 300;
+  const path = apiToken ? "generate_presigned_url" : "s3-presign-helper";
+  let signedUrl: string | undefined;
+
+  if (!apiToken) {
+    console.log(
+      "Using R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY. This signs with the helper only and does not exercise cloudflare_r2.generate_presigned_url.",
+    );
+  }
+
+  const shared = {
+    accountId: accountId!,
+    bucketName: bucketName!,
+    objectKey,
+    expiresSeconds,
+    jurisdiction,
+    apiToken,
+    accessKeyId,
+    secretAccessKey,
+  };
+
+  try {
+    const put = await createSignedRequest({ ...shared, method: "PUT", contentType });
+    signedUrl = put.url;
+    const putResponse = await providerFetch(put.url, {
+      method: "PUT",
+      headers: put.requiredHeaders,
+      body,
+    });
+    await assertOk("PUT", putResponse, put.url);
+
+    const head = await createSignedRequest({ ...shared, method: "HEAD" });
+    const headResponse = await providerFetch(head.url, { method: "HEAD" });
+    await assertOk("HEAD", headResponse, head.url);
+    const contentLength = headResponse.headers.get("content-length");
+    if (contentLength == null) {
+      // Node's fetch often omits content-length on HEAD even when the object exists.
+      // GET below still verifies the uploaded body.
+      console.log("HEAD omitted content-length; GET will verify the object body.");
+    } else if (contentLength !== String(Buffer.byteLength(body))) {
+      throw new Error(`HEAD content-length mismatch: expected ${Buffer.byteLength(body)}, received ${contentLength}`);
+    }
+
+    const get = await createSignedRequest({ ...shared, method: "GET" });
+    const getResponse = await providerFetch(get.url);
+    await assertOk("GET", getResponse, get.url);
+    const downloaded = await getResponse.text();
+    if (downloaded !== body) {
+      throw new Error("GET body did not match the uploaded object");
+    }
+
+    console.log("Cloudflare R2 presigned GET/PUT/HEAD live test passed.");
+    console.log(
+      JSON.stringify(
+        {
+          bucketName,
+          objectKey,
+          putStatus: putResponse.status,
+          headStatus: headResponse.status,
+          getStatus: getResponse.status,
+          expiresAt: get.expiresAt,
+          path,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (signedUrl) {
+      try {
+        await deleteObject({ ...shared, signedUrl });
+        console.log(`Deleted live-test object ${objectKey}.`);
+      } catch (error) {
+        console.error("Failed to delete the live-test object.", error);
+      }
+    }
+  }
+}
+
+interface SignedRequestInput {
+  accountId: string;
+  bucketName: string;
+  objectKey: string;
+  method: "GET" | "PUT" | "HEAD";
+  expiresSeconds: number;
+  contentType?: string;
+  jurisdiction?: string;
+  apiToken?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+async function createSignedRequest(input: SignedRequestInput) {
+  if (input.apiToken) {
+    const result = await executors["cloudflare_r2.generate_presigned_url"]!(
+      {
+        accountId: input.accountId,
+        bucketName: input.bucketName,
+        objectKey: input.objectKey,
+        method: input.method,
+        expiresSeconds: input.expiresSeconds,
+        contentType: input.contentType,
+        jurisdiction: input.jurisdiction,
+      },
+      createActionContext(input.apiToken, input.accountId),
+    );
+    if (!result.ok) {
+      throw new Error(`${input.method} generate_presigned_url failed: ${result.error?.message ?? "unknown error"}`);
+    }
+    const output = optionalRecord(result.output);
+    if (!output) {
+      throw new Error(`${input.method} generate_presigned_url returned no output`);
+    }
+    return {
+      url: String(output.url),
+      expiresAt: String(output.expiresAt),
+      requiredHeaders: (optionalRecord(output.requiredHeaders) ?? {}) as Record<string, string>,
+    };
+  }
+
+  const signed = createCloudflareR2PresignedUrl({
+    accountId: input.accountId,
+    accessKeyId: input.accessKeyId!,
+    secretAccessKey: input.secretAccessKey!,
+    bucketName: input.bucketName,
+    objectKey: input.objectKey,
+    method: input.method,
+    expiresSeconds: input.expiresSeconds,
+    contentType: input.contentType,
+    jurisdiction: input.jurisdiction,
+  });
+  return {
+    url: signed.url,
+    expiresAt: signed.expiresAt,
+    requiredHeaders: signed.requiredHeaders,
+  };
+}
+
+async function deleteObject(input: {
+  accountId: string;
+  bucketName: string;
+  objectKey: string;
+  jurisdiction?: string;
+  apiToken?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  signedUrl: string;
+}): Promise<void> {
+  const accessKeyId = input.accessKeyId ?? new URL(input.signedUrl).searchParams.get("X-Amz-Credential")?.split("/")[0];
+  const secretAccessKey =
+    input.secretAccessKey ?? (input.apiToken ? deriveCloudflareR2S3SecretAccessKey(input.apiToken) : undefined);
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error("Unable to derive S3 credentials for live-test cleanup");
+  }
+
+  const signed = createCloudflareR2PresignedUrl({
+    accountId: input.accountId,
+    accessKeyId,
+    secretAccessKey,
+    bucketName: input.bucketName,
+    objectKey: input.objectKey,
+    method: "DELETE",
+    expiresSeconds: 60,
+    jurisdiction: input.jurisdiction,
+  });
+  const response = await providerFetch(signed.url, { method: "DELETE" });
+  if (!response.ok && response.status !== 404) {
+    const details = await response.text().catch(() => "");
+    throw new Error(`DELETE cleanup failed with HTTP ${response.status}${details ? `: ${details.slice(0, 300)}` : ""}`);
+  }
+}
+
+function createActionContext(apiToken: string, accountId: string): ExecutionContext {
+  const credential: ResolvedCredential = {
+    authType: "custom_credential",
+    values: {
+      apiKey: apiToken,
+      accountId,
+    },
+    profile: {
+      accountId,
+      displayName: "Cloudflare R2 live example",
+      grantedScopes: [],
+    },
+    metadata: { accountId },
+  };
+  return {
+    async getCredential(service) {
+      return service === "cloudflare_r2" ? credential : undefined;
+    },
+  };
+}
+
+async function assertOk(method: string, response: Response, url: string): Promise<void> {
+  if (response.ok) {
+    console.log(`${method} ${safeUrl(url)} -> ${response.status}`);
+    return;
+  }
+  const details = await response.text().catch(() => "");
+  throw new Error(
+    `${method} ${safeUrl(url)} failed with HTTP ${response.status}${details ? `: ${details.slice(0, 500)}` : ""}`,
+  );
+}
+
+function safeUrl(value: string): string {
+  const url = new URL(value);
+  return `${url.origin}${url.pathname}`;
+}
+
+await main();

--- a/examples/cloudflare-r2-presigned-url.ts
+++ b/examples/cloudflare-r2-presigned-url.ts
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
   if (missing.length > 0) {
     console.log(
       `Skip Cloudflare R2 presigned URL example: missing ${missing.join(", ")}. ` +
-        "The current custom-credential path needs R2_API_TOKEN, R2_ACCOUNT_ID, and R2_BUCKET.",
+        "It needs R2_ACCOUNT_ID, R2_BUCKET, and either R2_API_TOKEN or R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY.",
     );
     return;
   }
@@ -112,7 +112,10 @@ async function main(): Promise<void> {
         await deleteObject({ ...shared, signedUrl });
         console.log(`Deleted live-test object ${objectKey}.`);
       } catch (error) {
+        // A leaked live-test object must fail the run, but rethrowing here would
+        // replace the error the try block is already propagating.
         console.error("Failed to delete the live-test object.", error);
+        process.exitCode = 1;
       }
     }
   }
@@ -177,7 +180,7 @@ async function createSignedRequest(input: SignedRequestInput) {
   };
 }
 
-async function deleteObject(input: {
+interface DeleteObjectInput {
   accountId: string;
   bucketName: string;
   objectKey: string;
@@ -186,7 +189,11 @@ async function deleteObject(input: {
   accessKeyId?: string;
   secretAccessKey?: string;
   signedUrl: string;
-}): Promise<void> {
+}
+
+async function deleteObject(input: DeleteObjectInput): Promise<void> {
+  // generate_presigned_url deliberately does not sign DELETE and never returns the
+  // token id, so cleanup recovers the Access Key ID from the signed URL credential.
   const accessKeyId = input.accessKeyId ?? new URL(input.signedUrl).searchParams.get("X-Amz-Credential")?.split("/")[0];
   const secretAccessKey =
     input.secretAccessKey ?? (input.apiToken ? deriveCloudflareR2S3SecretAccessKey(input.apiToken) : undefined);

--- a/examples/cloudflare-r2-presigned-url.ts
+++ b/examples/cloudflare-r2-presigned-url.ts
@@ -34,7 +34,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  const objectKey = process.env.R2_OBJECT_KEY?.trim() || `oomol-connect/presign-live/${Date.now()}.txt`;
+  const objectKeyPrefix = process.env.R2_OBJECT_KEY?.trim().replace(/\/+$/, "") || "oomol-connect/presign-live";
+  const objectKey = `${objectKeyPrefix}/${Date.now()}.txt`;
   const jurisdiction = process.env.R2_JURISDICTION?.trim();
   const body = `oomol-connect r2 presign live test ${new Date().toISOString()}\n`;
   const contentType = "text/plain";

--- a/src/core/aws-sigv4.test.ts
+++ b/src/core/aws-sigv4.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createAwsSigV4PresignedUrl, encodeRfc3986, sha256Hex } from "./aws-sigv4.ts";
+
+describe("AWS SigV4 presign helper", () => {
+  it("matches the AWS GET query-string auth example", () => {
+    const source = new URL("https://examplebucket.s3.amazonaws.com/test.txt");
+    const signed = createAwsSigV4PresignedUrl({
+      credential: {
+        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      },
+      method: "GET",
+      url: source,
+      region: "us-east-1",
+      expiresSeconds: 86400,
+      now: new Date("2013-05-24T00:00:00Z"),
+    });
+
+    expect(source.search).toBe("");
+    expect(signed).toBe(
+      "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404",
+    );
+  });
+
+  it("produces a deterministic query-string signature", () => {
+    const url = new URL("https://examplebucket.s3.us-east-1.amazonaws.com/test.txt");
+    const first = createAwsSigV4PresignedUrl({
+      credential: {
+        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      },
+      method: "GET",
+      url,
+      region: "us-east-1",
+      expiresSeconds: 86400,
+      now: new Date("2013-05-24T00:00:00Z"),
+    });
+    const parsed = new URL(first);
+
+    expect(parsed.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(parsed.searchParams.get("X-Amz-Credential")).toBe("AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request");
+    expect(parsed.searchParams.get("X-Amz-Date")).toBe("20130524T000000Z");
+    expect(parsed.searchParams.get("X-Amz-Expires")).toBe("86400");
+    expect(parsed.searchParams.get("X-Amz-SignedHeaders")).toBe("host");
+    expect(parsed.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
+
+    const second = createAwsSigV4PresignedUrl({
+      credential: {
+        accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      },
+      method: "GET",
+      url: new URL("https://examplebucket.s3.us-east-1.amazonaws.com/test.txt"),
+      region: "us-east-1",
+      expiresSeconds: 86400,
+      now: new Date("2013-05-24T00:00:00Z"),
+    });
+    expect(second).toBe(first);
+  });
+
+  it("encodes reserved characters with RFC 3986 rules", () => {
+    expect(encodeRfc3986("file!'()*")).toBe("file%21%27%28%29%2A");
+    expect(sha256Hex("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+});

--- a/src/core/aws-sigv4.test.ts
+++ b/src/core/aws-sigv4.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createAwsSigV4PresignedUrl, encodeRfc3986, sha256Hex } from "./aws-sigv4.ts";
+import {
+  buildCanonicalHeaders,
+  canonicalizeSearchParams,
+  createAwsSigV4PresignedUrl,
+  encodeRfc3986,
+  sha256Hex,
+} from "./aws-sigv4.ts";
 
 describe("AWS SigV4 presign helper", () => {
   it("matches the AWS GET query-string auth example", () => {
@@ -61,5 +67,95 @@ describe("AWS SigV4 presign helper", () => {
   it("encodes reserved characters with RFC 3986 rules", () => {
     expect(encodeRfc3986("file!'()*")).toBe("file%21%27%28%29%2A");
     expect(sha256Hex("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+
+  it("collapses tabs and repeated spaces in header values", () => {
+    const headers = new Headers({
+      "content-type": "text/plain; \t charset=utf-8",
+      "x-amz-meta-note": "  leading and\ttrailing  ",
+    });
+
+    expect(buildCanonicalHeaders(headers)).toEqual({
+      "content-type": "text/plain; charset=utf-8",
+      "x-amz-meta-note": "leading and trailing",
+    });
+  });
+
+  it("signs collapsible header whitespace the same as the single-space form", () => {
+    const presign = (contentType: string): string =>
+      createAwsSigV4PresignedUrl({
+        credential: {
+          accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+          secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        },
+        method: "PUT",
+        url: new URL("https://examplebucket.s3.us-east-1.amazonaws.com/test.txt"),
+        region: "us-east-1",
+        expiresSeconds: 3600,
+        headers: { "content-type": contentType },
+        now: new Date("2013-05-24T00:00:00Z"),
+      });
+    const expected = presign("text/plain; charset=utf-8");
+
+    expect(presign("text/plain;\tcharset=utf-8")).toBe(expected);
+    expect(presign("text/plain;  charset=utf-8")).toBe(expected);
+    expect(presign("  text/plain; \t \t charset=utf-8  ")).toBe(expected);
+  });
+
+  it("sorts canonical headers and query parameters by code point", () => {
+    const headers = new Headers({
+      content_type: "underscore",
+      "content-type": "hyphen",
+      host: "example.com",
+    });
+
+    // Code point order puts "-" (0x2D) before "_" (0x5F); `localeCompare` reverses them.
+    expect(Object.keys(buildCanonicalHeaders(headers))).toEqual(["content-type", "content_type", "host"]);
+
+    const query = new URLSearchParams([
+      ["content_type", "1"],
+      ["content-type", "2"],
+      ["a", "3"],
+      ["Z", "4"],
+    ]);
+
+    // "Z" (0x5A) sorts before "a" (0x61) in code point order; `localeCompare` reverses that too.
+    expect(canonicalizeSearchParams(query)).toBe("Z=4&a=3&content-type=2&content_type=1");
+  });
+
+  it("emits the signed canonical query verbatim", () => {
+    const signed = createAwsSigV4PresignedUrl({
+      credential: {
+        accessKeyId: "AK~IAIOSFODNN7EXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        sessionToken: "AQoDYXdzEJr//////////wEaABC+de/f0g==",
+      },
+      method: "GET",
+      url: new URL("https://examplebucket.s3.us-east-1.amazonaws.com/test.txt"),
+      region: "us-east-1",
+      expiresSeconds: 3600,
+      now: new Date("2013-05-24T00:00:00Z"),
+    });
+    const search = new URL(signed).search;
+    const parameters = search.slice(1).split("&");
+    const signature = parameters.at(-1) ?? "";
+    const canonicalQuery = canonicalizeSearchParams(
+      new URLSearchParams([
+        ["X-Amz-Algorithm", "AWS4-HMAC-SHA256"],
+        ["X-Amz-Credential", "AK~IAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"],
+        ["X-Amz-Date", "20130524T000000Z"],
+        ["X-Amz-Expires", "3600"],
+        ["X-Amz-SignedHeaders", "host"],
+        ["X-Amz-Security-Token", "AQoDYXdzEJr//////////wEaABC+de/f0g=="],
+      ]),
+    );
+
+    expect(parameters.slice(0, -1).join("&")).toBe(canonicalQuery);
+    expect(signature).toMatch(/^X-Amz-Signature=[0-9a-f]{64}$/);
+    // `~` is unreserved in RFC 3986, so it must stay literal rather than become %7E.
+    expect(search).toContain("AK~IAIOSFODNN7EXAMPLE");
+    expect(search).not.toContain("%7E");
+    // `+`, `/`, and `=` in the session token stay percent-encoded, not form-urlencoded.
+    expect(search).toContain("X-Amz-Security-Token=AQoDYXdzEJr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaABC%2Bde%2Ff0g%3D%3D");
   });
 });

--- a/src/core/aws-sigv4.ts
+++ b/src/core/aws-sigv4.ts
@@ -1,0 +1,227 @@
+import { Buffer } from "node:buffer";
+import { createHash, createHmac } from "node:crypto";
+
+const defaultAwsServiceName = "s3";
+
+/**
+ * Access key material used by AWS Signature Version 4.
+ */
+export interface AwsSigV4Credential {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+/**
+ * Query-string presign input. `url` must already contain the signed host and
+ * path; existing search parameters are replaced with the SigV4 query.
+ */
+export interface AwsSigV4PresignInput {
+  credential: AwsSigV4Credential;
+  method: string;
+  url: URL;
+  region: string;
+  expiresSeconds: number;
+  service?: string;
+  headers?: Record<string, string | undefined>;
+  now?: Date;
+}
+
+/**
+ * Header-based SigV4 signing input used for direct S3 requests.
+ */
+export interface AwsSigV4SignHeadersInput {
+  credential: AwsSigV4Credential;
+  method: string;
+  url: URL;
+  headers: Record<string, string>;
+  payloadHash: string;
+  region: string;
+  service?: string;
+  now?: Date;
+}
+
+/**
+ * Build an AWS SigV4 query-string presigned URL. Signing is local; the function
+ * does not send a network request.
+ */
+export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string {
+  const now = input.now ?? new Date();
+  const amzDate = formatAmzDate(now);
+  const dateStamp = amzDate.slice(0, 8);
+  const service = input.service ?? defaultAwsServiceName;
+  const credentialScope = `${dateStamp}/${input.region}/${service}/aws4_request`;
+  const url = new URL(input.url.href);
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(input.headers ?? {})) {
+    if (!value) {
+      continue;
+    }
+    headers.set(key, value);
+  }
+  headers.set("host", url.host);
+  const canonicalHeaders = buildCanonicalHeaders(headers);
+  const signedHeaders = Object.keys(canonicalHeaders).join(";");
+  const query = new URLSearchParams();
+  query.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+  query.set("X-Amz-Credential", `${input.credential.accessKeyId}/${credentialScope}`);
+  query.set("X-Amz-Date", amzDate);
+  query.set("X-Amz-Expires", String(input.expiresSeconds));
+  query.set("X-Amz-SignedHeaders", signedHeaders);
+  if (input.credential.sessionToken) {
+    query.set("X-Amz-Security-Token", input.credential.sessionToken);
+  }
+  url.search = canonicalizeSearchParams(query);
+  const canonicalRequest = [
+    input.method,
+    url.pathname,
+    url.search.slice(1),
+    formatCanonicalHeaders(canonicalHeaders),
+    signedHeaders,
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
+  const signature = hmacHex(
+    getAwsSigningKey(input.credential.secretAccessKey, dateStamp, input.region, service),
+    stringToSign,
+  );
+  url.searchParams.set("X-Amz-Signature", signature);
+  return url.toString();
+}
+
+/**
+ * Sign an AWS request with SigV4 Authorization and x-amz-date headers.
+ */
+export function signAwsSigV4Headers(input: AwsSigV4SignHeadersInput): { headers: Headers } {
+  const now = input.now ?? new Date();
+  const amzDate = formatAmzDate(now);
+  const dateStamp = amzDate.slice(0, 8);
+  const service = input.service ?? defaultAwsServiceName;
+  const credentialScope = `${dateStamp}/${input.region}/${service}/aws4_request`;
+  const headers = new Headers(input.headers);
+  headers.set("x-amz-date", amzDate);
+  if (input.credential.sessionToken) {
+    headers.set("x-amz-security-token", input.credential.sessionToken);
+  }
+  const canonicalHeaders = buildCanonicalHeaders(headers);
+  const signedHeaders = Object.keys(canonicalHeaders).join(";");
+  const canonicalRequest = [
+    input.method,
+    input.url.pathname,
+    input.url.search.slice(1),
+    formatCanonicalHeaders(canonicalHeaders),
+    signedHeaders,
+    input.payloadHash,
+  ].join("\n");
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
+  const authorization = [
+    `AWS4-HMAC-SHA256 Credential=${input.credential.accessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${hmacHex(getAwsSigningKey(input.credential.secretAccessKey, dateStamp, input.region, service), stringToSign)}`,
+  ].join(", ");
+  headers.set("authorization", authorization);
+  return { headers };
+}
+
+/**
+ * Encode a value with the RFC 3986 rules AWS SigV4 uses for canonical query
+ * strings and S3 object-key segments.
+ */
+export function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value)
+    .replaceAll("!", "%21")
+    .replaceAll("'", "%27")
+    .replaceAll("(", "%28")
+    .replaceAll(")", "%29")
+    .replaceAll("*", "%2A");
+}
+
+/**
+ * Encode an S3 object key, preserving `/` as a path delimiter.
+ */
+export function encodeS3ObjectKey(value: string): string {
+  return value
+    .split("/")
+    .map((segment) => encodeRfc3986(segment))
+    .join("/");
+}
+
+/**
+ * Sort and encode query parameters the way AWS SigV4 canonical requests require.
+ */
+export function canonicalizeSearchParams(searchParams: URLSearchParams): string {
+  const entries = Array.from(searchParams.entries()).map(([key, value]) => ({
+    key: encodeRfc3986(key),
+    value: encodeRfc3986(value),
+  }));
+  entries.sort((left, right) => {
+    if (left.key === right.key) {
+      return left.value.localeCompare(right.value);
+    }
+    return left.key.localeCompare(right.key);
+  });
+  return entries.map((entry) => `${entry.key}=${entry.value}`).join("&");
+}
+
+/**
+ * Lowercase, trim, and sort headers for a SigV4 canonical request.
+ */
+export function buildCanonicalHeaders(headers: Headers): Record<string, string> {
+  const entries = Array.from(headers.entries()).map(([key, value]) => ({
+    key: key.toLowerCase(),
+    value: collapseHeaderWhitespace(value),
+  }));
+  entries.sort((left, right) => left.key.localeCompare(right.key));
+  return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
+}
+
+/**
+ * Format canonical headers as `name:value` lines terminated by a blank line.
+ */
+export function formatCanonicalHeaders(headers: Record<string, string>): string {
+  return `${Object.entries(headers)
+    .map(([key, value]) => `${key}:${value}`)
+    .join("\n")}\n`;
+}
+
+/**
+ * Format a timestamp as the AWS `yyyyMMddTHHmmssZ` amz-date value.
+ */
+export function formatAmzDate(value: Date): string {
+  const year = String(value.getUTCFullYear()).padStart(4, "0");
+  const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(value.getUTCDate()).padStart(2, "0");
+  const hours = String(value.getUTCHours()).padStart(2, "0");
+  const minutes = String(value.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(value.getUTCSeconds()).padStart(2, "0");
+  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
+/**
+ * SHA-256 hex digest used by SigV4 payload and string-to-sign hashes.
+ */
+export function sha256Hex(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/**
+ * Derive the AWS SigV4 signing key for a date, region, and service.
+ */
+export function getAwsSigningKey(secretAccessKey: string, dateStamp: string, region: string, service: string): Buffer {
+  const kDate = hmacSha256(`AWS4${secretAccessKey}`, dateStamp);
+  const kRegion = hmacSha256(kDate, region);
+  const kService = hmacSha256(kRegion, service);
+  return hmacSha256(kService, "aws4_request");
+}
+
+function hmacSha256(key: string | Buffer, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function hmacHex(key: Buffer, value: string): string {
+  return createHmac("sha256", key).update(value).digest("hex");
+}
+
+function collapseHeaderWhitespace(value: string): string {
+  return value.trim().split(" ").filter(Boolean).join(" ");
+}

--- a/src/core/aws-sigv4.ts
+++ b/src/core/aws-sigv4.ts
@@ -28,20 +28,6 @@ export interface AwsSigV4PresignInput {
 }
 
 /**
- * Header-based SigV4 signing input used for direct S3 requests.
- */
-export interface AwsSigV4SignHeadersInput {
-  credential: AwsSigV4Credential;
-  method: string;
-  url: URL;
-  headers: Record<string, string>;
-  payloadHash: string;
-  region: string;
-  service?: string;
-  now?: Date;
-}
-
-/**
  * Build an AWS SigV4 query-string presigned URL. Signing is local; the function
  * does not send a network request.
  */
@@ -71,11 +57,11 @@ export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string 
   if (input.credential.sessionToken) {
     query.set("X-Amz-Security-Token", input.credential.sessionToken);
   }
-  url.search = canonicalizeSearchParams(query);
+  const canonicalQuery = canonicalizeSearchParams(query);
   const canonicalRequest = [
     input.method,
     url.pathname,
-    url.search.slice(1),
+    canonicalQuery,
     formatCanonicalHeaders(canonicalHeaders),
     signedHeaders,
     "UNSIGNED-PAYLOAD",
@@ -85,42 +71,11 @@ export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string 
     getAwsSigningKey(input.credential.secretAccessKey, dateStamp, input.region, service),
     stringToSign,
   );
-  url.searchParams.set("X-Amz-Signature", signature);
+  // Append the signature to the canonical query text instead of going through
+  // `url.searchParams`, whose setter re-serializes as form-urlencoded and would
+  // diverge from the signed bytes for `~`, space, and `*`.
+  url.search = `${canonicalQuery}&X-Amz-Signature=${signature}`;
   return url.toString();
-}
-
-/**
- * Sign an AWS request with SigV4 Authorization and x-amz-date headers.
- */
-export function signAwsSigV4Headers(input: AwsSigV4SignHeadersInput): { headers: Headers } {
-  const now = input.now ?? new Date();
-  const amzDate = formatAmzDate(now);
-  const dateStamp = amzDate.slice(0, 8);
-  const service = input.service ?? defaultAwsServiceName;
-  const credentialScope = `${dateStamp}/${input.region}/${service}/aws4_request`;
-  const headers = new Headers(input.headers);
-  headers.set("x-amz-date", amzDate);
-  if (input.credential.sessionToken) {
-    headers.set("x-amz-security-token", input.credential.sessionToken);
-  }
-  const canonicalHeaders = buildCanonicalHeaders(headers);
-  const signedHeaders = Object.keys(canonicalHeaders).join(";");
-  const canonicalRequest = [
-    input.method,
-    input.url.pathname,
-    input.url.search.slice(1),
-    formatCanonicalHeaders(canonicalHeaders),
-    signedHeaders,
-    input.payloadHash,
-  ].join("\n");
-  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${input.credential.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${hmacHex(getAwsSigningKey(input.credential.secretAccessKey, dateStamp, input.region, service), stringToSign)}`,
-  ].join(", ");
-  headers.set("authorization", authorization);
-  return { headers };
 }
 
 /**
@@ -147,7 +102,8 @@ export function encodeS3ObjectKey(value: string): string {
 }
 
 /**
- * Sort and encode query parameters the way AWS SigV4 canonical requests require.
+ * Encode query parameters and sort them by code point, the byte order AWS SigV4
+ * canonical requests require.
  */
 export function canonicalizeSearchParams(searchParams: URLSearchParams): string {
   const entries = Array.from(searchParams.entries()).map(([key, value]) => ({
@@ -156,22 +112,23 @@ export function canonicalizeSearchParams(searchParams: URLSearchParams): string 
   }));
   entries.sort((left, right) => {
     if (left.key === right.key) {
-      return left.value.localeCompare(right.value);
+      return compareCodePoints(left.value, right.value);
     }
-    return left.key.localeCompare(right.key);
+    return compareCodePoints(left.key, right.key);
   });
   return entries.map((entry) => `${entry.key}=${entry.value}`).join("&");
 }
 
 /**
- * Lowercase, trim, and sort headers for a SigV4 canonical request.
+ * Lowercase header names, collapse whitespace in header values, and sort the
+ * headers by code point for a SigV4 canonical request.
  */
 export function buildCanonicalHeaders(headers: Headers): Record<string, string> {
   const entries = Array.from(headers.entries()).map(([key, value]) => ({
     key: key.toLowerCase(),
     value: collapseHeaderWhitespace(value),
   }));
-  entries.sort((left, right) => left.key.localeCompare(right.key));
+  entries.sort((left, right) => compareCodePoints(left.key, right.key));
   return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
 }
 
@@ -223,5 +180,16 @@ function hmacHex(key: Buffer, value: string): string {
 }
 
 function collapseHeaderWhitespace(value: string): string {
-  return value.trim().split(" ").filter(Boolean).join(" ");
+  return value.trim().replaceAll(/\s+/g, " ");
+}
+
+/**
+ * SigV4 sorts canonical headers and query parameters by byte order, so compare
+ * code points instead of using the locale/ICU dependent `localeCompare`.
+ */
+function compareCodePoints(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  return left > right ? 1 : 0;
 }

--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -300,4 +300,46 @@ export const cloudflareR2Actions: ActionDefinition[] = [
       deleted: s.boolean("Whether the delete request succeeded."),
     }),
   }),
+  defineProviderAction(service, {
+    name: "generate_presigned_url",
+    description:
+      "Generate a pre-signed R2 URL for a single GET, PUT, or HEAD request. Requires a custom API token credential; OAuth connections cannot mint R2 S3 signatures.",
+    requiredScopes: [r2ReadScope, r2WriteScope],
+    providerPermissions: [r2ReadPermission, r2WritePermission],
+    inputSchema: s.object(
+      "The input payload for this action.",
+      {
+        accountId: accountIdSchema,
+        bucketName: bucketNameSchema,
+        objectKey: s.nonEmptyString("The complete R2 object key. Slashes are preserved as key delimiters."),
+        method: s.stringEnum(["GET", "PUT", "HEAD"], {
+          description: "The HTTP method that the signed URL should allow.",
+          default: "GET",
+        }),
+        expiresSeconds: s.integer("How long the signed URL remains valid, in seconds.", {
+          minimum: 1,
+          maximum: 604800,
+          default: 3600,
+        }),
+        contentType: s.string("The Content-Type that must be sent with a signed PUT request."),
+        jurisdiction: jurisdictionSchema,
+      },
+      {
+        required: ["bucketName", "objectKey"],
+        optional: ["accountId", "method", "expiresSeconds", "contentType", "jurisdiction"],
+      },
+    ),
+    outputSchema: s.object("The output payload for this action.", {
+      bucketName: s.string("The bucket used to build the signed URL."),
+      objectKey: s.string("The object key used to build the signed URL."),
+      method: s.string("The signed HTTP method."),
+      expiresSeconds: s.integer("The URL validity duration in seconds."),
+      expiresAt: s.dateTime("The timestamp when the signed URL expires."),
+      url: s.string("The generated pre-signed URL."),
+      requiredHeaders: s.record(
+        "HTTP headers that were included in the signature and must be sent with the request.",
+        s.string("A signed header value."),
+      ),
+    }),
+  }),
 ];

--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -5,6 +5,9 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 
 const service = "cloudflare_r2";
 
+/** The jurisdictions R2 accepts in the `cf-r2-jurisdiction` header and in the S3 endpoint host. */
+export const cloudflareR2Jurisdictions = ["default", "eu", "fedramp", "us"] as const;
+
 const r2ReadScope = "workers-r2.read";
 const r2WriteScope = "workers-r2.write";
 const r2ReadPermission = "Workers R2 Storage Read";
@@ -15,9 +18,7 @@ const accountIdSchema = s.nonEmptyString(
 );
 const bucketNameSchema = s.string("The R2 bucket name.", { minLength: 3, maxLength: 64 });
 const jurisdictionSchema = s.stringEnum("The jurisdiction where objects in the bucket are guaranteed to be stored.", [
-  "default",
-  "eu",
-  "fedramp",
+  ...cloudflareR2Jurisdictions,
 ]);
 const locationSchema = s.stringEnum("The R2 bucket region hint.", ["apac", "eeur", "enam", "weur", "wnam", "oc"]);
 const storageClassSchema = s.stringEnum("The default storage class for newly uploaded objects.", [
@@ -321,7 +322,9 @@ export const cloudflareR2Actions: ActionDefinition[] = [
           maximum: 604800,
           default: 3600,
         }),
-        contentType: s.string("The Content-Type that must be sent with a signed PUT request."),
+        contentType: s.string(
+          "The Content-Type that must be sent with a signed PUT request. Ignored for GET and HEAD.",
+        ),
         jurisdiction: jurisdictionSchema,
       },
       {

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { executors } from "./executors.ts";
+import { credentialValidators, executors } from "./executors.ts";
 
 interface CapturedRequest {
   url: URL;
@@ -229,6 +229,98 @@ describe("Cloudflare R2 generate_presigned_url", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("signs the us jurisdiction host", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      jurisdiction: "us",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(new URL(String(readPresignedOutput(result).url)).hostname).toBe("account-1.us.r2.cloudflarestorage.com");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown jurisdiction with the allowed values", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      jurisdiction: "moon",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "jurisdiction must be one of default, eu, fedramp, us",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects DELETE because the action only signs GET, PUT, and HEAD", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      method: "DELETE",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "method must be GET, PUT, or HEAD",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects dot segments in the signed object key", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({ bucketName: "documents", objectKey: "a/../secret" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectKey must not contain . or .. path segments",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a contentType that is not a valid HTTP header value", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      method: "PUT",
+      contentType: "text/plain\r\nx-evil: 1",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "contentType must be a valid HTTP header value",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("discovers the token ID when custom-credential metadata omitted it", async () => {
     const requests = stubJsonResponses([
       {
@@ -275,6 +367,32 @@ describe("Cloudflare R2 generate_presigned_url", () => {
     ]);
   });
 
+  it("rejects a token that is no longer active", async () => {
+    const requests = stubJsonResponses([
+      {
+        success: true,
+        result: { id: "verified-token-id", status: "disabled" },
+      },
+    ]);
+
+    const result = await executePresign(
+      { bucketName: "documents", objectKey: "notes.txt" },
+      {
+        ...customCredential,
+        metadata: { accountId: "account-1" },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "cloudflare token is not active: disabled",
+      },
+    });
+    expect(requests).toHaveLength(1);
+  });
+
   it("rejects OAuth credentials without calling Cloudflare", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
@@ -318,6 +436,43 @@ describe("Cloudflare R2 generate_presigned_url", () => {
       },
     });
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("Cloudflare R2 custom credential validation", () => {
+  it("stores the verified token ID so presign calls skip token verification", async () => {
+    const paths: string[] = [];
+    const responses = [
+      Response.json({ success: true, result: { buckets: [{ name: "documents" }] } }),
+      Response.json({ success: true, result: { id: "token-id-1", status: "active" } }),
+    ];
+
+    const result = await credentialValidators.customCredential!(
+      { values: { apiKey: "cf-api-token-secret", accountId: "account-1" } },
+      {
+        fetcher: async (url) => {
+          paths.push(new URL(url.toString()).pathname);
+          const response = responses.shift();
+          if (!response) {
+            throw new Error(`Unexpected Cloudflare R2 request to ${url.toString()}`);
+          }
+          return response;
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: "account-1", displayName: "Cloudflare R2 - documents" },
+      grantedScopes: [],
+      metadata: {
+        validationEndpoint: "/accounts/account-1/r2/buckets?per_page=1",
+        accountId: "account-1",
+        firstBucketName: "documents",
+        tokenId: "token-id-1",
+        tokenStatus: "active",
+      },
+    });
+    expect(paths).toEqual(["/client/v4/accounts/account-1/r2/buckets", "/client/v4/user/tokens/verify"]);
   });
 });
 

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -300,6 +300,22 @@ describe("Cloudflare R2 generate_presigned_url", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects a signed object key with an unpaired Unicode surrogate", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({ bucketName: "documents", objectKey: "file\ud800" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "objectKey must contain valid Unicode",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("rejects a contentType that is not a valid HTTP header value", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -17,6 +17,16 @@ const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
   metadata: { accountId: "account-1" },
 };
 
+const customCredential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
+  authType: "custom_credential",
+  values: {
+    apiKey: "cf-api-token-secret",
+    accountId: "account-1",
+  },
+  profile: { accountId: "account-1", displayName: "Cloudflare R2 test", grantedScopes: [] },
+  metadata: { accountId: "account-1", tokenId: "token-id-1" },
+};
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -138,6 +148,179 @@ describe("Cloudflare R2 download_object", () => {
   });
 });
 
+describe("Cloudflare R2 generate_presigned_url", () => {
+  it("signs locally from a custom API token without sending a network request", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "reports/annual report #1.txt",
+      method: "HEAD",
+      expiresSeconds: 120,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        bucketName: "documents",
+        objectKey: "reports/annual report #1.txt",
+        method: "HEAD",
+        expiresSeconds: 120,
+        requiredHeaders: {},
+      },
+    });
+    expect(result.ok).toBe(true);
+    const output = readPresignedOutput(result);
+    const url = new URL(String(output.url));
+    expect(url.hostname).toBe("account-1.r2.cloudflarestorage.com");
+    expect(url.pathname).toBe("/documents/reports/annual%20report%20%231.txt");
+    expect(url.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(url.searchParams.get("X-Amz-Credential")).toMatch(/^token-id-1\/\d{8}\/auto\/s3\/aws4_request$/);
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("120");
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toBe("host");
+    expect(url.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
+    expect(typeof output.expiresAt).toBe("string");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("defaults method to GET and expiresSeconds to 3600", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        method: "GET",
+        expiresSeconds: 3600,
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("includes signed Content-Type headers for PUT URLs", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      method: "PUT",
+      contentType: "text/plain",
+      jurisdiction: "eu",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        method: "PUT",
+        requiredHeaders: { "content-type": "text/plain" },
+      },
+    });
+    expect(result.ok).toBe(true);
+    const url = new URL(String(readPresignedOutput(result).url));
+    expect(url.hostname).toBe("account-1.eu.r2.cloudflarestorage.com");
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toBe("content-type;host");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("discovers the token ID when custom-credential metadata omitted it", async () => {
+    const requests = stubJsonResponses([
+      {
+        success: true,
+        result: { id: "verified-token-id", status: "active" },
+      },
+    ]);
+
+    const result = await executePresign(
+      { bucketName: "documents", objectKey: "notes.txt", method: "GET" },
+      {
+        ...customCredential,
+        metadata: { accountId: "account-1" },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    const url = new URL(String(readPresignedOutput(result).url));
+    expect(url.searchParams.get("X-Amz-Credential")).toMatch(/^verified-token-id\//);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.pathname).toBe("/client/v4/user/tokens/verify");
+  });
+
+  it("falls back to account token verification after a user-token verify failure", async () => {
+    const requests = stubResponses([
+      new Response(JSON.stringify({ success: false, errors: [{ message: "not a user token" }] }), { status: 400 }),
+      new Response(JSON.stringify({ success: true, result: { id: "account-token-id", status: "active" } })),
+    ]);
+
+    const result = await executePresign(
+      { bucketName: "documents", objectKey: "notes.txt", method: "GET" },
+      {
+        ...customCredential,
+        metadata: { accountId: "account-1" },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    const url = new URL(String(readPresignedOutput(result).url));
+    expect(url.searchParams.get("X-Amz-Credential")).toMatch(/^account-token-id\//);
+    expect(requests.map((request) => request.url.pathname)).toEqual([
+      "/client/v4/user/tokens/verify",
+      "/client/v4/accounts/account-1/tokens/verify",
+    ]);
+  });
+
+  it("rejects OAuth credentials without calling Cloudflare", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({ bucketName: "documents", objectKey: "notes.txt" }, oauthCredential);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message:
+          "cloudflare_r2.generate_presigned_url requires a custom API token credential. OAuth connections cannot mint R2 S3 signatures.",
+        details: {
+          status: 400,
+          details: {
+            action: "cloudflare_r2.generate_presigned_url",
+            authType: "oauth2",
+            requiredAuthType: "custom_credential",
+          },
+        },
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects expiresSeconds outside the allowed range without sending a network request", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePresign({
+      bucketName: "documents",
+      objectKey: "notes.txt",
+      expiresSeconds: 604801,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "expiresSeconds must be an integer between 1 and 604800",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
 function stubResponses(responses: Response[]): CapturedRequest[] {
   const requests: CapturedRequest[] = [];
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -154,6 +337,10 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
     return response;
   });
   return requests;
+}
+
+function stubJsonResponses(payloads: unknown[]): CapturedRequest[] {
+  return stubResponses(payloads.map((payload) => new Response(JSON.stringify(payload))));
 }
 
 function createTransitFileStore(maxBytes: number): {
@@ -193,4 +380,19 @@ async function executeDownload(input: Record<string, unknown>, transitFiles?: Tr
     context.transitFiles = transitFiles;
   }
   return executors["cloudflare_r2.download_object"]!(input, context);
+}
+
+async function executePresign(input: Record<string, unknown>, credential: ResolvedCredential = customCredential) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("cloudflare_r2");
+      return credential;
+    },
+  };
+  return executors["cloudflare_r2.generate_presigned_url"]!(input, context);
+}
+
+function readPresignedOutput(result: { ok: boolean; output?: unknown }): Record<string, unknown> {
+  expect(result.output).toEqual(expect.any(Object));
+  return result.output as Record<string, unknown>;
 }

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -6,6 +6,7 @@ import type { CloudflareR2PresignedMethod } from "./s3-presign.ts";
 
 import {
   compactObject,
+  integer,
   optionalInteger,
   optionalRecord,
   optionalString,
@@ -109,6 +110,10 @@ export async function validateCloudflareR2Credential(
   const result = optionalRecord(envelope.result);
   const buckets = normalizeR2BucketList(result?.buckets ?? []);
   const firstBucket = buckets[0];
+  // The verified token id is the R2 S3 Access Key ID, so storing it here keeps
+  // generate_presigned_url from re-verifying the token on every call.
+  const verification = await verifyCloudflareR2ApiToken(apiToken, accountId, { fetcher, signal });
+  assertActiveCloudflareR2Token(verification);
   return {
     profile: {
       accountId,
@@ -119,6 +124,8 @@ export async function validateCloudflareR2Credential(
       validationEndpoint: `/accounts/${accountId}/r2/buckets?per_page=1`,
       accountId,
       firstBucketName: optionalString(firstBucket?.name),
+      tokenId: verification.tokenId,
+      tokenStatus: verification.tokenStatus,
     }),
   };
 }
@@ -393,7 +400,7 @@ async function generatePresignedUrl(input: Record<string, unknown>, context: Clo
   const objectKey = readObjectKey(input);
   const method = normalizePresignedMethod(input.method);
   const expiresSeconds = normalizeExpiresSeconds(input.expiresSeconds);
-  const contentType = method === "PUT" ? optionalString(input.contentType) : undefined;
+  const contentType = method === "PUT" ? normalizeContentType(input.contentType) : undefined;
   const jurisdiction = optionalString(input.jurisdiction);
   const accessKeyId = await resolveR2S3AccessKeyId(accountId, context);
 
@@ -419,10 +426,10 @@ async function resolveR2S3AccessKeyId(accountId: string, context: CloudflareR2Co
   if (existing) {
     return existing;
   }
+  // Connections validated before validateCloudflareR2Credential stored tokenId
+  // still have to discover it here.
   const verification = await verifyCloudflareR2ApiToken(context.accessToken, accountId, context);
-  if (verification.tokenStatus && verification.tokenStatus !== "active") {
-    throw new ProviderRequestError(400, `cloudflare token is not active: ${verification.tokenStatus}`);
-  }
+  assertActiveCloudflareR2Token(verification);
   if (!verification.tokenId) {
     throw new ProviderRequestError(
       400,
@@ -458,6 +465,8 @@ async function verifyCloudflareR2ApiTokenAt(
   path: string,
   context: { fetcher: typeof fetch; signal?: AbortSignal },
 ): Promise<CloudflareR2TokenVerification> {
+  // The "validate" phase is deliberate: normalizeCloudflareR2Error collapses 400/401/403/404
+  // to 400 only there, which is what lets the user-token to account-token fallback fire.
   const envelope = await cloudflareR2RequestEnvelope(apiToken, { path }, context, "validate");
   const verification = readObject(envelope.result, "cloudflare token verification");
   return {
@@ -465,6 +474,12 @@ async function verifyCloudflareR2ApiTokenAt(
     tokenStatus: optionalString(verification.status),
     validationEndpoint: path,
   };
+}
+
+function assertActiveCloudflareR2Token(verification: CloudflareR2TokenVerification): void {
+  if (verification.tokenStatus && verification.tokenStatus !== "active") {
+    throw new ProviderRequestError(400, `cloudflare token is not active: ${verification.tokenStatus}`);
+  }
 }
 
 function normalizePresignedMethod(value: unknown): Exclude<CloudflareR2PresignedMethod, "DELETE"> {
@@ -481,11 +496,25 @@ function normalizeExpiresSeconds(value: unknown): number {
   if (value === undefined) {
     return defaultPresignExpiresSeconds;
   }
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > maxPresignExpiresSeconds) {
+  const parsed = integer(value, "expiresSeconds", providerInputError);
+  if (parsed < 1 || parsed > maxPresignExpiresSeconds) {
     throw providerInputError("expiresSeconds must be an integer between 1 and 604800");
   }
   return parsed;
+}
+
+function normalizeContentType(value: unknown): string | undefined {
+  const contentType = optionalString(value);
+  if (!contentType) {
+    return undefined;
+  }
+  try {
+    // A CRLF or NUL would make the signer's Headers.set throw a raw TypeError.
+    new Headers({ "content-type": contentType });
+  } catch {
+    throw providerInputError("contentType must be a valid HTTP header value");
+  }
+  return contentType;
 }
 
 function readObjectKey(input: Record<string, unknown>): string {

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -2,6 +2,7 @@ import type { CredentialValidationResult, TransitFileWriter } from "../../core/t
 import type { CloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { CloudflareR2PresignedMethod } from "./s3-presign.ts";
 
 import {
   compactObject,
@@ -14,6 +15,7 @@ import {
 import { queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { createCloudflareR2PresignedUrl, deriveCloudflareR2S3SecretAccessKey } from "./s3-presign.ts";
 
 export interface CloudflareR2Context {
   authType: "custom_credential" | "oauth2";
@@ -82,6 +84,9 @@ export const cloudflareR2ActionHandlers: ProviderActionHandlers<
   },
   delete_bucket_cors_policy(input, context) {
     return deleteBucketCorsPolicy(input, context);
+  },
+  generate_presigned_url(input, context) {
+    return generatePresignedUrl(input, context);
   },
 };
 
@@ -207,13 +212,7 @@ async function downloadObject(input: Record<string, unknown>, context: Cloudflar
 
   const accountId = resolveAccountId(input, context);
   const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
-  const objectKey = requiredRawString(input.objectKey, "objectKey", providerInputError);
-  if (objectKey.length === 0) {
-    throw providerInputError("objectKey must not be empty");
-  }
-  if (objectKey.split("/").some((segment) => segment === "." || segment === "..")) {
-    throw providerInputError("objectKey must not contain . or .. path segments");
-  }
+  const objectKey = readObjectKey(input);
   const url = buildCloudflareR2Url(
     `/accounts/${encodeURIComponent(accountId)}/r2/buckets/${encodeURIComponent(bucketName)}/objects/${encodeR2ObjectKey(objectKey)}`,
   );
@@ -371,6 +370,133 @@ async function deleteBucketCorsPolicy(input: Record<string, unknown>, context: C
     bucketName,
     deleted: true,
   };
+}
+
+const defaultPresignExpiresSeconds = 3600;
+const maxPresignExpiresSeconds = 604800;
+
+async function generatePresignedUrl(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {
+  if (context.authType !== "custom_credential") {
+    throw new ProviderRequestError(
+      400,
+      "cloudflare_r2.generate_presigned_url requires a custom API token credential. OAuth connections cannot mint R2 S3 signatures.",
+      {
+        action: "cloudflare_r2.generate_presigned_url",
+        authType: context.authType,
+        requiredAuthType: "custom_credential",
+      },
+    );
+  }
+
+  const accountId = resolveAccountId(input, context);
+  const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
+  const objectKey = readObjectKey(input);
+  const method = normalizePresignedMethod(input.method);
+  const expiresSeconds = normalizeExpiresSeconds(input.expiresSeconds);
+  const contentType = method === "PUT" ? optionalString(input.contentType) : undefined;
+  const jurisdiction = optionalString(input.jurisdiction);
+  const accessKeyId = await resolveR2S3AccessKeyId(accountId, context);
+
+  return {
+    bucketName,
+    objectKey,
+    ...createCloudflareR2PresignedUrl({
+      accountId,
+      accessKeyId,
+      secretAccessKey: deriveCloudflareR2S3SecretAccessKey(context.accessToken),
+      bucketName,
+      objectKey,
+      method,
+      expiresSeconds,
+      contentType,
+      jurisdiction,
+    }),
+  };
+}
+
+async function resolveR2S3AccessKeyId(accountId: string, context: CloudflareR2Context): Promise<string> {
+  const existing = optionalString(context.metadata.tokenId);
+  if (existing) {
+    return existing;
+  }
+  const verification = await verifyCloudflareR2ApiToken(context.accessToken, accountId, context);
+  if (verification.tokenStatus && verification.tokenStatus !== "active") {
+    throw new ProviderRequestError(400, `cloudflare token is not active: ${verification.tokenStatus}`);
+  }
+  if (!verification.tokenId) {
+    throw new ProviderRequestError(
+      400,
+      "Unable to derive R2 S3 Access Key ID from this API token. cloudflare_r2.generate_presigned_url requires a custom API token that can be verified.",
+    );
+  }
+  return verification.tokenId;
+}
+
+interface CloudflareR2TokenVerification {
+  tokenId?: string;
+  tokenStatus?: string;
+  validationEndpoint: string;
+}
+
+async function verifyCloudflareR2ApiToken(
+  apiToken: string,
+  accountId: string,
+  context: { fetcher: typeof fetch; signal?: AbortSignal },
+): Promise<CloudflareR2TokenVerification> {
+  try {
+    return await verifyCloudflareR2ApiTokenAt(apiToken, "/user/tokens/verify", context);
+  } catch (error) {
+    if (!(error instanceof ProviderRequestError) || error.status !== 400) {
+      throw error;
+    }
+    return verifyCloudflareR2ApiTokenAt(apiToken, `/accounts/${encodeURIComponent(accountId)}/tokens/verify`, context);
+  }
+}
+
+async function verifyCloudflareR2ApiTokenAt(
+  apiToken: string,
+  path: string,
+  context: { fetcher: typeof fetch; signal?: AbortSignal },
+): Promise<CloudflareR2TokenVerification> {
+  const envelope = await cloudflareR2RequestEnvelope(apiToken, { path }, context, "validate");
+  const verification = readObject(envelope.result, "cloudflare token verification");
+  return {
+    tokenId: optionalString(verification.id),
+    tokenStatus: optionalString(verification.status),
+    validationEndpoint: path,
+  };
+}
+
+function normalizePresignedMethod(value: unknown): Exclude<CloudflareR2PresignedMethod, "DELETE"> {
+  if (value === undefined || value === "GET") {
+    return "GET";
+  }
+  if (value === "PUT" || value === "HEAD") {
+    return value;
+  }
+  throw providerInputError("method must be GET, PUT, or HEAD");
+}
+
+function normalizeExpiresSeconds(value: unknown): number {
+  if (value === undefined) {
+    return defaultPresignExpiresSeconds;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > maxPresignExpiresSeconds) {
+    throw providerInputError("expiresSeconds must be an integer between 1 and 604800");
+  }
+  return parsed;
+}
+
+function readObjectKey(input: Record<string, unknown>): string {
+  const objectKey = requiredRawString(input.objectKey, "objectKey", providerInputError);
+  if (objectKey.length === 0) {
+    throw providerInputError("objectKey must not be empty");
+  }
+  if (objectKey.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw providerInputError("objectKey must not contain . or .. path segments");
+  }
+  return objectKey;
 }
 
 function resolveAccountId(input: Record<string, unknown>, context: CloudflareR2Context): string {

--- a/src/providers/cloudflare_r2/s3-presign.test.ts
+++ b/src/providers/cloudflare_r2/s3-presign.test.ts
@@ -51,6 +51,22 @@ describe("Cloudflare R2 S3 presign helper", () => {
     expect(result.requiredHeaders).toEqual({});
   });
 
+  it("reports expiration from the second-precision signing time", () => {
+    const result = createCloudflareR2PresignedUrl({
+      accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+      accessKeyId: "token-id-1",
+      secretAccessKey: "secret",
+      bucketName: "documents",
+      objectKey: "file.txt",
+      method: "GET",
+      expiresSeconds: 60,
+      now: new Date("2026-08-22T00:00:00.999Z"),
+    });
+
+    expect(new URL(result.url).searchParams.get("X-Amz-Date")).toBe("20260822T000000Z");
+    expect(result.expiresAt).toBe("2026-08-22T00:01:00.000Z");
+  });
+
   it("derives the S3 secret as the SHA-256 hex digest of the API token", () => {
     expect(deriveCloudflareR2S3SecretAccessKey("cf-api-token-secret")).toBe(
       "c954a48febbdcd595a54a6d658b123e08a05bbb9d97b7a733a7d928b31c47a81",
@@ -90,4 +106,18 @@ describe("Cloudflare R2 S3 presign helper", () => {
       }),
     ).toThrow(ProviderRequestError);
   });
+
+  for (const [field, input] of [
+    ["bucketName", { bucketName: "documents\ud800", objectKey: "file.txt" }],
+    ["objectKey", { bucketName: "documents", objectKey: "file\ud800" }],
+  ] as const) {
+    it(`rejects non-well-formed Unicode in ${field}`, () => {
+      expect(() =>
+        createCloudflareR2S3ObjectUrl({
+          accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+          ...input,
+        }),
+      ).toThrow(`${field} must contain valid Unicode`);
+    });
+  }
 });

--- a/src/providers/cloudflare_r2/s3-presign.test.ts
+++ b/src/providers/cloudflare_r2/s3-presign.test.ts
@@ -57,6 +57,23 @@ describe("Cloudflare R2 S3 presign helper", () => {
     );
   });
 
+  it("rejects dot segments that the URL parser would resolve away", () => {
+    expect(() =>
+      createCloudflareR2S3ObjectUrl({
+        accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+        bucketName: "..",
+        objectKey: "file.txt",
+      }),
+    ).toThrow(ProviderRequestError);
+    expect(() =>
+      createCloudflareR2S3ObjectUrl({
+        accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+        bucketName: "documents",
+        objectKey: "../x",
+      }),
+    ).toThrow(ProviderRequestError);
+  });
+
   it("rejects account IDs that would change the R2 S3 origin", () => {
     expect(() =>
       createCloudflareR2S3ObjectUrl({

--- a/src/providers/cloudflare_r2/s3-presign.test.ts
+++ b/src/providers/cloudflare_r2/s3-presign.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createCloudflareR2PresignedUrl,
+  createCloudflareR2S3ObjectUrl,
+  deriveCloudflareR2S3SecretAccessKey,
+} from "./s3-presign.ts";
+
+describe("Cloudflare R2 S3 presign helper", () => {
+  it("signs a path-style R2 URL with region auto", () => {
+    const result = createCloudflareR2PresignedUrl({
+      accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+      accessKeyId: "token-id-1",
+      secretAccessKey: "secret",
+      bucketName: "documents",
+      objectKey: "reports/annual report #1.txt",
+      method: "PUT",
+      expiresSeconds: 120,
+      contentType: "text/plain",
+      now: new Date("2026-08-22T00:00:00Z"),
+    });
+
+    const url = new URL(result.url);
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("023e105f4ecef8ad9ca31a8372d0c353.r2.cloudflarestorage.com");
+    expect(url.pathname).toBe("/documents/reports/annual%20report%20%231.txt");
+    expect(url.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(url.searchParams.get("X-Amz-Credential")).toBe("token-id-1/20260822/auto/s3/aws4_request");
+    expect(url.searchParams.get("X-Amz-Date")).toBe("20260822T000000Z");
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("120");
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toBe("content-type;host");
+    expect(url.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.expiresAt).toBe("2026-08-22T00:02:00.000Z");
+    expect(result.requiredHeaders).toEqual({ "content-type": "text/plain" });
+  });
+
+  it("uses the jurisdiction-specific S3 host", () => {
+    const result = createCloudflareR2PresignedUrl({
+      accountId: "023e105f4ecef8ad9ca31a8372d0c353",
+      accessKeyId: "token-id-1",
+      secretAccessKey: "secret",
+      bucketName: "documents",
+      objectKey: "file.txt",
+      method: "GET",
+      expiresSeconds: 60,
+      jurisdiction: "eu",
+      now: new Date("2026-08-22T00:00:00Z"),
+    });
+
+    expect(new URL(result.url).hostname).toBe("023e105f4ecef8ad9ca31a8372d0c353.eu.r2.cloudflarestorage.com");
+    expect(result.requiredHeaders).toEqual({});
+  });
+
+  it("derives the S3 secret as the SHA-256 hex digest of the API token", () => {
+    expect(deriveCloudflareR2S3SecretAccessKey("cf-api-token-secret")).toBe(
+      "c954a48febbdcd595a54a6d658b123e08a05bbb9d97b7a733a7d928b31c47a81",
+    );
+  });
+
+  it("rejects account IDs that would change the R2 S3 origin", () => {
+    expect(() =>
+      createCloudflareR2S3ObjectUrl({
+        accountId: "evil.example#",
+        bucketName: "documents",
+        objectKey: "file.txt",
+      }),
+    ).toThrow(ProviderRequestError);
+    expect(() =>
+      createCloudflareR2S3ObjectUrl({
+        accountId: "user@evil.example",
+        bucketName: "documents",
+        objectKey: "file.txt",
+      }),
+    ).toThrow(ProviderRequestError);
+  });
+});

--- a/src/providers/cloudflare_r2/s3-presign.ts
+++ b/src/providers/cloudflare_r2/s3-presign.ts
@@ -1,0 +1,109 @@
+import { createAwsSigV4PresignedUrl, encodeRfc3986, encodeS3ObjectKey, sha256Hex } from "../../core/aws-sigv4.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+
+const r2S3Region = "auto";
+const r2S3Service = "s3";
+
+export type CloudflareR2PresignedMethod = "GET" | "PUT" | "HEAD" | "DELETE";
+
+export interface CloudflareR2PresignedUrlInput {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucketName: string;
+  objectKey: string;
+  method: CloudflareR2PresignedMethod;
+  expiresSeconds: number;
+  contentType?: string;
+  jurisdiction?: string;
+  now?: Date;
+}
+
+export interface CloudflareR2PresignedUrl {
+  url: string;
+  method: CloudflareR2PresignedMethod;
+  expiresSeconds: number;
+  expiresAt: string;
+  requiredHeaders: Record<string, string>;
+}
+
+/**
+ * Derive the R2 S3 Secret Access Key from a Cloudflare API token value.
+ * Cloudflare documents this as the SHA-256 hex digest of the token secret.
+ * https://developers.cloudflare.com/r2/api/tokens/#get-s3-api-credentials-from-an-api-token
+ */
+export function deriveCloudflareR2S3SecretAccessKey(apiToken: string): string {
+  return sha256Hex(apiToken);
+}
+
+/**
+ * Generate an R2 S3 presigned URL locally with AWS SigV4. This does not send a
+ * network request.
+ */
+export function createCloudflareR2PresignedUrl(input: CloudflareR2PresignedUrlInput): CloudflareR2PresignedUrl {
+  const now = input.now ?? new Date();
+  const requiredHeaders: Record<string, string> = {};
+  if (input.contentType) {
+    requiredHeaders["content-type"] = input.contentType;
+  }
+  const url = createAwsSigV4PresignedUrl({
+    credential: {
+      accessKeyId: input.accessKeyId,
+      secretAccessKey: input.secretAccessKey,
+    },
+    method: input.method,
+    url: createCloudflareR2S3ObjectUrl(input),
+    region: r2S3Region,
+    service: r2S3Service,
+    expiresSeconds: input.expiresSeconds,
+    headers: requiredHeaders,
+    now,
+  });
+  return {
+    url,
+    method: input.method,
+    expiresSeconds: input.expiresSeconds,
+    expiresAt: new Date(now.getTime() + input.expiresSeconds * 1000).toISOString(),
+    requiredHeaders,
+  };
+}
+
+export function createCloudflareR2S3ObjectUrl(input: {
+  accountId: string;
+  bucketName: string;
+  objectKey: string;
+  jurisdiction?: string;
+}): URL {
+  const expectedHost = buildCloudflareR2S3Host(input.accountId, input.jurisdiction);
+  const url = assertPublicHttpUrl(`https://${expectedHost}`, {
+    fieldName: "accountId",
+    createError: (message) => new ProviderRequestError(400, message),
+  });
+  if (
+    url.host !== expectedHost.toLowerCase() ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw invalidR2S3Endpoint();
+  }
+  url.pathname = `/${encodeRfc3986(input.bucketName)}/${encodeS3ObjectKey(input.objectKey)}`;
+  return url;
+}
+
+function buildCloudflareR2S3Host(accountId: string, jurisdiction: string | undefined): string {
+  if (!jurisdiction || jurisdiction === "default") {
+    return `${accountId}.r2.cloudflarestorage.com`;
+  }
+  if (jurisdiction === "eu" || jurisdiction === "fedramp") {
+    return `${accountId}.${jurisdiction}.r2.cloudflarestorage.com`;
+  }
+  throw new ProviderRequestError(400, "jurisdiction must be default, eu, or fedramp");
+}
+
+function invalidR2S3Endpoint(): ProviderRequestError {
+  return new ProviderRequestError(400, "accountId and jurisdiction must form a valid R2 S3 endpoint");
+}

--- a/src/providers/cloudflare_r2/s3-presign.ts
+++ b/src/providers/cloudflare_r2/s3-presign.ts
@@ -43,7 +43,7 @@ export function deriveCloudflareR2S3SecretAccessKey(apiToken: string): string {
  * network request.
  */
 export function createCloudflareR2PresignedUrl(input: CloudflareR2PresignedUrlInput): CloudflareR2PresignedUrl {
-  const now = input.now ?? new Date();
+  const now = new Date(Math.floor((input.now ?? new Date()).getTime() / 1000) * 1000);
   const requiredHeaders: Record<string, string> = {};
   if (input.contentType) {
     requiredHeaders["content-type"] = input.contentType;
@@ -76,6 +76,12 @@ export function createCloudflareR2S3ObjectUrl(input: {
   objectKey: string;
   jurisdiction?: string;
 }): URL {
+  if (!input.bucketName.isWellFormed()) {
+    throw new ProviderRequestError(400, "bucketName must contain valid Unicode");
+  }
+  if (!input.objectKey.isWellFormed()) {
+    throw new ProviderRequestError(400, "objectKey must contain valid Unicode");
+  }
   const expectedHost = buildCloudflareR2S3Host(input.accountId, input.jurisdiction);
   const url = assertPublicHttpUrl(`https://${expectedHost}`, {
     fieldName: "accountId",

--- a/src/providers/cloudflare_r2/s3-presign.ts
+++ b/src/providers/cloudflare_r2/s3-presign.ts
@@ -1,6 +1,7 @@
 import { createAwsSigV4PresignedUrl, encodeRfc3986, encodeS3ObjectKey, sha256Hex } from "../../core/aws-sigv4.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import { ProviderRequestError } from "../provider-runtime.ts";
+import { cloudflareR2Jurisdictions } from "./actions.ts";
 
 const r2S3Region = "auto";
 const r2S3Service = "s3";
@@ -90,7 +91,13 @@ export function createCloudflareR2S3ObjectUrl(input: {
   ) {
     throw invalidR2S3Endpoint();
   }
-  url.pathname = `/${encodeRfc3986(input.bucketName)}/${encodeS3ObjectKey(input.objectKey)}`;
+  const pathname = `/${encodeRfc3986(input.bucketName)}/${encodeS3ObjectKey(input.objectKey)}`;
+  url.pathname = pathname;
+  // The WHATWG parser resolves `.` and `..` segments, so a normalized pathname
+  // would sign a URL for a different bucket or key than the caller asked for.
+  if (url.pathname !== pathname) {
+    throw new ProviderRequestError(400, "bucketName and objectKey must not contain . or .. path segments");
+  }
   return url;
 }
 
@@ -98,10 +105,11 @@ function buildCloudflareR2S3Host(accountId: string, jurisdiction: string | undef
   if (!jurisdiction || jurisdiction === "default") {
     return `${accountId}.r2.cloudflarestorage.com`;
   }
-  if (jurisdiction === "eu" || jurisdiction === "fedramp") {
-    return `${accountId}.${jurisdiction}.r2.cloudflarestorage.com`;
+  const allowedJurisdictions = cloudflareR2Jurisdictions as readonly string[];
+  if (!allowedJurisdictions.includes(jurisdiction)) {
+    throw new ProviderRequestError(400, `jurisdiction must be one of ${allowedJurisdictions.join(", ")}`);
   }
-  throw new ProviderRequestError(400, "jurisdiction must be default, eu, or fedramp");
+  return `${accountId}.${jurisdiction}.r2.cloudflarestorage.com`;
 }
 
 function invalidR2S3Endpoint(): ProviderRequestError {


### PR DESCRIPTION
## Summary
- Add `cloudflare_r2.generate_presigned_url` for the current custom-credential path (Cloudflare API token + account id). Signing is local SigV4 against `{accountId}.r2.cloudflarestorage.com`.
- OAuth credentials are rejected with a structured `invalid_input` error. Relay `put_object` and OAuth signed URLs are out of this PR.
- Live-tested against a real R2 bucket: presigned PUT, HEAD, and GET succeeded (GET body matched the uploaded object); the test object was deleted afterward.

Refs #390 (custom-credential slice only; OAuth signed URLs and relay `put_object` remain open there).

## Test plan
- [x] Unit tests for SigV4 / R2 path-style signing / action defaults / OAuth rejection
- [x] Live custom-credential PUT → HEAD → GET (body match) → DELETE
- [ ] Reviewer: `npm run fix-check`

Made with [Cursor](https://cursor.com)
