### PR TITLE
fix(providers): keep proxy endpoint literal segments below the base URL

### DIFF
--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -156,6 +156,12 @@ describe("createProviderProxyUrl", () => {
       "https://api.example.com/v1/items",
     );
   });
+
+  it("keeps a colon-suffixed literal segment below the base instead of parsing it as a scheme", () => {
+    expect(createProviderProxyUrl("https://api.example.com/v1/", "/groups:batchDelete").toString()).toBe(
+      "https://api.example.com/v1/groups:batchDelete",
+    );
+  });
 });
 
 const apiKeyCredential: ResolvedCredential = {

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -162,6 +162,12 @@ describe("createProviderProxyUrl", () => {
       "https://api.example.com/v1/groups:batchDelete",
     );
   });
+
+  it("keeps a scheme-like segment with an authority below the base instead of switching origin", () => {
+    expect(createProviderProxyUrl("https://api.example.com/v1/", "/custom://evil.example/x").toString()).toBe(
+      "https://api.example.com/v1/custom://evil.example/x",
+    );
+  });
 });
 
 const apiKeyCredential: ResolvedCredential = {

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -310,7 +310,7 @@ const defaultProviderErrorMaxResponseBytes = 64 * 1024;
 export function createProviderProxyUrl(baseUrl: string, endpointInput: unknown, queryInput?: unknown): URL {
   const endpoint = normalizeProviderProxyEndpoint(endpointInput);
   const base = new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
-  const url = new URL(endpoint.slice(1), base);
+  const url = new URL(`./${endpoint.slice(1)}`, base);
   if (url.origin !== base.origin) {
     throw new ProviderRequestError(400, "endpoint must stay on the provider origin");
   }


### PR DESCRIPTION
## Summary

`createProviderProxyUrl` resolves the supplied endpoint against the base with `new URL()`. A literal path segment containing a colon (for example the Pi-hole batch suffix `groups:batchDelete`) is re-parsed by `new URL()` as a URL **scheme**, producing `groups:` instead of joining the segment below the base origin — which then trips the origin check.

Prefixing the endpoint with `./` makes it join below the base as a literal path.

## Tests

- Added a regression test asserting a colon-bearing literal segment stays below the base.
- `npm run fix-check` green; shared provider runtime test suite passes.
