### PR TITLE
feat(providers): add Pi-hole FTL provider (40 actions)

### DIFF
--- a/src/providers/pi_hole/actions.ts
+++ b/src/providers/pi_hole/actions.ts
@@ -1,0 +1,641 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "pi_hole";
+
+const emptyInputSchema = s.actionInput({}, [], "No input is required for this action.");
+
+const blockingStatusSchema = s.stringEnum("The Pi-hole blocking status.", ["enabled", "disabled", "failed", "unknown"]);
+const blockingStatusOutput = s.actionOutput(
+  {
+    blocking: blockingStatusSchema,
+    timer: s.nullable(
+      s.number("Remaining seconds until the blocking mode is toggled automatically, or null when no timer is active."),
+    ),
+  },
+  "The current Pi-hole DNS blocking status.",
+);
+
+const topQueryInput = s.actionInput(
+  {
+    count: s.integer("Maximum number of entries to return."),
+    blocked: s.boolean("Only include blocked queries in the result."),
+  },
+  [],
+  "Input parameters for a Pi-hole top-entries query.",
+);
+
+const groupIdsInput = s.array(
+  "The group IDs the item belongs to; defaults to group 0 when omitted.",
+  s.integer("One Pi-hole group ID."),
+);
+
+const listTypeSchema = s.stringEnum("Whether the list is an allowlist or a blocklist.", ["allow", "block"]);
+const domainTypeSchema = s.stringEnum("Whether the domain entry allows or denies the domain.", ["allow", "deny"]);
+const domainKindSchema = s.stringEnum("Whether the domain entry matches exactly or as a regular expression.", [
+  "exact",
+  "regex",
+]);
+
+function itemOrItems(description: string, itemField: string): JsonSchema {
+  return s.anyOf(description, [
+    s.string(`The single ${itemField} value.`),
+    s.array(`One or more ${itemField} values.`, s.string(`One ${itemField} value.`)),
+  ]);
+}
+
+const processedOutputSchema = s.actionOutput(
+  {
+    processed: s.nullable(
+      s.looseRequiredObject("The write result reported by the instance.", {
+        success: s.array("The items that were written successfully.", s.string("One written item.")),
+        errors: s.array(
+          "The items that could not be written, with their error messages.",
+          s.looseObject("One failed item and its error message."),
+        ),
+      }),
+    ),
+  },
+  "The Pi-hole write result.",
+);
+
+const deletedOutputSchema = s.actionOutput(
+  { deleted: s.boolean("Whether the item was deleted.") },
+  "The deletion result.",
+);
+
+export const piHoleActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_overview",
+    description:
+      "Fetch the Pi-hole activity overview: total and blocked queries, blocked query percentage, unique clients and domains, and the blocking and gravity list status.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { summary: s.looseObject("The Pi-hole overview payload returned by the instance.") },
+      "The Pi-hole activity overview.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_dns_blocking_status",
+    description: "Fetch whether Pi-hole DNS blocking is currently enabled, disabled, failed, or unknown.",
+    inputSchema: emptyInputSchema,
+    outputSchema: blockingStatusOutput,
+  }),
+  defineProviderAction(service, {
+    name: "set_dns_blocking",
+    description:
+      "Enable or disable Pi-hole DNS blocking, optionally for a limited time after which the opposite mode is restored automatically.",
+    inputSchema: s.actionInput(
+      {
+        blocking: s.boolean("Whether DNS blocking should be enabled."),
+        timer: s.nullable(
+          s.number(
+            "Optional timer in seconds after which the opposite blocking mode is applied automatically; pass null to cancel a running timer.",
+          ),
+        ),
+      },
+      ["blocking"],
+      "Input parameters for changing the Pi-hole DNS blocking status.",
+    ),
+    outputSchema: blockingStatusOutput,
+  }),
+  defineProviderAction(service, {
+    name: "get_queries",
+    description:
+      "Query the Pi-hole DNS log with optional filters. By default returns the most recent queries; each response exposes a cursor for the next chunk.",
+    inputSchema: s.actionInput(
+      {
+        from: s.number("Only return queries from this Unix timestamp onward."),
+        until: s.number("Only return queries up to this Unix timestamp."),
+        length: s.integer("Maximum number of results to return."),
+        start: s.integer("Offset from the first record."),
+        cursor: s.integer("Database ID of the most recent query to show; use the cursor of a previous response."),
+        domain: s.string("Filter by queried domain, * wildcards supported."),
+        clientIp: s.string("Filter by requesting client IP address, * wildcards supported."),
+        clientName: s.string("Filter by requesting client hostname, * wildcards supported."),
+        upstream: s.string(
+          "Filter by upstream destination (may also be cache, blocklist, or permitted), * wildcards supported.",
+        ),
+        type: s.string("Filter by query type, for example A or AAAA."),
+        status: s.string("Filter by query status, for example GRAVITY or FORWARDED."),
+        reply: s.string("Filter by reply type, for example NODATA or NXDOMAIN."),
+        dnssec: s.string("Filter by DNSSEC status, for example SECURE or INSECURE."),
+        disk: s.boolean("Read queries from the long-term on-disk database instead of the in-memory database."),
+      },
+      [],
+      "Input parameters for querying the Pi-hole DNS log.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        queries: s.array("The Pi-hole query records.", s.looseObject("One Pi-hole query record.")),
+        cursor: s.nullableInteger("Database ID of the most recent query shown, for the next chunk."),
+        recordsTotal: s.integer("Total number of available queries."),
+        recordsFiltered: s.integer("Number of available queries after filtering."),
+        earliestTimestamp: s.nullable(
+          s.number("Earliest timestamp of queries held in the in-memory database (Unix time)."),
+        ),
+        earliestTimestampDisk: s.nullable(
+          s.number("Earliest timestamp of queries held in the long-term on-disk database (Unix time)."),
+        ),
+      },
+      "The requested Pi-hole query records.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_query_types",
+    description: "Fetch the number of queries of each DNS query type that Pi-hole has seen.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { types: s.looseObject("Query type counts keyed by DNS query type, for example A or AAAA.") },
+      "The Pi-hole query type counts.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_top_domains",
+    description: "Fetch the domains Pi-hole has handled the most, optionally limited to blocked ones.",
+    inputSchema: topQueryInput,
+    outputSchema: s.actionOutput(
+      {
+        domains: s.array("The top domain entries.", s.looseObject("One Pi-hole top domain entry.")),
+        totalQueries: s.integer("Total number of queries in the requested window."),
+        blockedQueries: s.integer("Number of blocked queries in the requested window."),
+      },
+      "The Pi-hole top domains.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_top_clients",
+    description: "Fetch the clients that have queried Pi-hole the most, optionally limited to blocked ones.",
+    inputSchema: topQueryInput,
+    outputSchema: s.actionOutput(
+      {
+        clients: s.array("The top client entries.", s.looseObject("One Pi-hole top client entry.")),
+        totalQueries: s.integer("Total number of queries in the requested window."),
+        blockedQueries: s.integer("Number of blocked queries in the requested window."),
+      },
+      "The Pi-hole top clients.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_recent_blocked",
+    description: "Fetch the domains most recently blocked by Pi-hole.",
+    inputSchema: s.actionInput(
+      {
+        count: s.integer("Maximum number of blocked domains to return."),
+      },
+      [],
+      "Input parameters for listing the most recently blocked domains.",
+    ),
+    outputSchema: s.actionOutput(
+      { blocked: s.array("The most recently blocked domains.", s.string("One blocked domain name.")) },
+      "The most recently blocked domains.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_upstreams",
+    description: "Fetch metrics about Pi-hole's DNS upstream destinations, including response times.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        upstreams: s.array("The upstream destination entries.", s.looseObject("One Pi-hole upstream entry.")),
+        forwardedQueries: s.integer("Number of queries forwarded to upstream destinations."),
+        totalQueries: s.integer("Total number of queries in the window."),
+      },
+      "The Pi-hole upstream metrics.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_history",
+    description:
+      "Fetch the Pi-hole activity graph data: query totals over time with cached, blocked, and forwarded splits.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { history: s.array("The activity graph entries over time.", s.looseObject("One Pi-hole activity graph entry.")) },
+      "The Pi-hole activity graph data.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "search_domain",
+    description:
+      "Search whether a domain appears in Pi-hole's allowlists, blocklists, or gravity lists, to understand why it is blocked or allowed.",
+    inputSchema: s.actionInput(
+      {
+        domain: s.nonEmptyString("The domain (or part of it) to search for in Pi-hole's lists."),
+        partial: s.boolean("Allow partial matches; may not find complex regex entries."),
+        maxResults: s.integer("Maximum number of results per match type; the instance caps this internally."),
+      },
+      ["domain"],
+      "Input parameters for searching Pi-hole's lists.",
+    ),
+    outputSchema: s.actionOutput(
+      { search: s.looseObject("The Pi-hole search result payload.") },
+      "The Pi-hole list search result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_config",
+    description: "Fetch the current Pi-hole configuration, such as DNS settings, privacy level, and API settings.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { config: s.looseObject("The Pi-hole configuration payload returned by the instance.") },
+      "The current Pi-hole configuration.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "update_config",
+    description:
+      "Change part of the Pi-hole configuration, for example DNS upstreams, the privacy level, or API settings. The provided fields are merged into the current configuration.",
+    inputSchema: s.actionInput(
+      {
+        config: s.looseObject(
+          "The Pi-hole configuration fields to change, using the same structure as the configuration payload.",
+        ),
+        restart: s.boolean(
+          "Whether the instance may restart its DNS server when the change requires it; defaults to true. Pass false to apply the change without a disruptive DNS restart.",
+        ),
+      },
+      ["config"],
+      "Input parameters for changing the Pi-hole configuration.",
+    ),
+    outputSchema: s.actionOutput(
+      { config: s.looseObject("The updated Pi-hole configuration payload.") },
+      "The updated Pi-hole configuration.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "run_gravity",
+    description:
+      "Run the Pi-hole gravity update to refresh the blocklists. The instance streams the gravity log; the action reports a best-effort status from the log plus the tail of the stream.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        status: s.nullableString(
+          "Best-effort gravity outcome inferred from the stream: success, failed, or null when the stream gives no clear signal.",
+        ),
+        output: s.string("The tail of the gravity log stream as relayed by the instance."),
+      },
+      "The Pi-hole gravity run result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "restart_dns",
+    description: "Restart Pi-hole's DNS server and reload its DNS configuration.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { status: s.nullableString("The restart result status returned by the instance, normally success.") },
+      "The DNS restart result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "flush_dns_logs",
+    description: "Flush the Pi-hole DNS query log.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { status: s.nullableString("The flush result status returned by the instance, normally success.") },
+      "The DNS log flush result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_groups",
+    description: "List all Pi-hole groups and their memberships.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { groups: s.array("The Pi-hole groups.", s.looseObject("One Pi-hole group.")) },
+      "The Pi-hole groups.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_group",
+    description: "Create one or more Pi-hole groups, optionally with a comment and enabled state.",
+    inputSchema: s.actionInput(
+      {
+        name: itemOrItems("The group name, or an array of group names to create.", "group name"),
+        comment: s.nullableString("An optional comment for the group."),
+        enabled: s.boolean("Whether the group is enabled; defaults to true."),
+      },
+      ["name"],
+      "Input parameters for creating one or more Pi-hole groups.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "update_group",
+    description: "Update one Pi-hole group: rename it, or change its comment or enabled state.",
+    inputSchema: s.actionInput(
+      {
+        name: s.nonEmptyString("The current group name to update."),
+        newName: s.nonEmptyString("The new group name when renaming the group."),
+        comment: s.nullableString("The new comment for the group; pass null to clear it."),
+        enabled: s.boolean("Whether the group is enabled."),
+      },
+      ["name"],
+      "Input parameters for updating one Pi-hole group.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_group",
+    description: "Delete one Pi-hole group by name.",
+    inputSchema: s.actionInput(
+      { name: s.nonEmptyString("The name of the group to delete.") },
+      ["name"],
+      "Input parameters for deleting one Pi-hole group.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "list_lists",
+    description: "List the Pi-hole allowlists and blocklists (subscription lists).",
+    inputSchema: s.actionInput(
+      { type: listTypeSchema },
+      [],
+      "Input parameters for listing Pi-hole lists; restrict to one list type when needed.",
+    ),
+    outputSchema: s.actionOutput(
+      { lists: s.array("The Pi-hole lists.", s.looseObject("One Pi-hole list.")) },
+      "The Pi-hole lists.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "add_list",
+    description: "Add one or more allowlist or blocklist entries (addresses) to Pi-hole.",
+    inputSchema: s.actionInput(
+      {
+        address: itemOrItems(
+          "The list address, for example https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts, or an array of addresses.",
+          "list address",
+        ),
+        type: listTypeSchema,
+        comment: s.nullableString("An optional comment for the list."),
+        groups: groupIdsInput,
+        enabled: s.boolean("Whether the list is enabled; defaults to true."),
+      },
+      ["address", "type"],
+      "Input parameters for adding one or more Pi-hole lists.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "update_list",
+    description: "Update one Pi-hole list: change its comment, enabled state, or group memberships.",
+    inputSchema: s.actionInput(
+      {
+        address: s.nonEmptyString("The address of the list to update."),
+        type: listTypeSchema,
+        comment: s.nullableString("The new comment for the list; pass null to clear it."),
+        groups: groupIdsInput,
+        enabled: s.boolean("Whether the list is enabled."),
+      },
+      ["address", "type"],
+      "Input parameters for updating one Pi-hole list.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_list",
+    description: "Delete one Pi-hole allowlist or blocklist entry by address.",
+    inputSchema: s.actionInput(
+      {
+        address: s.nonEmptyString("The address of the list to delete."),
+        type: listTypeSchema,
+      },
+      ["address", "type"],
+      "Input parameters for deleting one Pi-hole list.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "list_domains",
+    description: "List the individual Pi-hole domain entries, optionally restricted to one type or kind.",
+    inputSchema: s.actionInput(
+      {
+        type: domainTypeSchema,
+        kind: domainKindSchema,
+      },
+      [],
+      "Input parameters for listing Pi-hole domain entries.",
+    ),
+    outputSchema: s.actionOutput(
+      { domains: s.array("The Pi-hole domain entries.", s.looseObject("One Pi-hole domain entry.")) },
+      "The Pi-hole domain entries.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "add_domain",
+    description: "Add one or more allow or deny domain entries to Pi-hole, either exact or as regular expressions.",
+    inputSchema: s.actionInput(
+      {
+        domain: itemOrItems("The domain to add, or an array of domains.", "domain"),
+        type: domainTypeSchema,
+        kind: domainKindSchema,
+        comment: s.nullableString("An optional comment for the entry."),
+        groups: groupIdsInput,
+        enabled: s.boolean("Whether the entry is enabled; defaults to true."),
+      },
+      ["domain", "type", "kind"],
+      "Input parameters for adding one or more Pi-hole domain entries.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "update_domain",
+    description: "Update one Pi-hole domain entry: change its comment, enabled state, or group memberships.",
+    inputSchema: s.actionInput(
+      {
+        type: domainTypeSchema,
+        kind: domainKindSchema,
+        domain: s.nonEmptyString("The domain of the entry to update."),
+        comment: s.nullableString("The new comment for the entry; pass null to clear it."),
+        groups: groupIdsInput,
+        enabled: s.boolean("Whether the entry is enabled."),
+      },
+      ["type", "kind", "domain"],
+      "Input parameters for updating one Pi-hole domain entry.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_domain",
+    description: "Delete one Pi-hole allow or deny domain entry.",
+    inputSchema: s.actionInput(
+      {
+        type: domainTypeSchema,
+        kind: domainKindSchema,
+        domain: s.nonEmptyString("The domain of the entry to delete."),
+      },
+      ["type", "kind", "domain"],
+      "Input parameters for deleting one Pi-hole domain entry.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "list_clients",
+    description: "List all Pi-hole clients and their group memberships.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { clients: s.array("The Pi-hole clients.", s.looseObject("One Pi-hole client.")) },
+      "The Pi-hole clients.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_client",
+    description: "Register one or more Pi-hole clients identified by IP address, MAC address, hostname, or interface.",
+    inputSchema: s.actionInput(
+      {
+        client: itemOrItems(
+          "The client identifier (IP / MAC / hostname / interface), or an array of identifiers.",
+          "client identifier",
+        ),
+        comment: s.nullableString("An optional comment for the client."),
+        groups: groupIdsInput,
+      },
+      ["client"],
+      "Input parameters for registering one or more Pi-hole clients.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "update_client",
+    description: "Update one Pi-hole client's comment or group memberships.",
+    inputSchema: s.actionInput(
+      {
+        client: s.nonEmptyString("The client identifier to update (IP / MAC / hostname / interface)."),
+        comment: s.nullableString("The new comment for the client; pass null to clear it."),
+        groups: groupIdsInput,
+      },
+      ["client"],
+      "Input parameters for updating one Pi-hole client.",
+    ),
+    outputSchema: processedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "delete_client",
+    description: "Delete one Pi-hole client entry by identifier.",
+    inputSchema: s.actionInput(
+      {
+        client: s.nonEmptyString("The client identifier to delete (IP / MAC / hostname / interface)."),
+      },
+      ["client"],
+      "Input parameters for deleting one Pi-hole client.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "batch_delete_groups",
+    description:
+      "Delete multiple Pi-hole groups by name in one request. Reports deleted=false when none of the groups exist.",
+    inputSchema: s.actionInput(
+      { items: s.array("The group names to delete.", s.nonEmptyString("One group name.")) },
+      ["items"],
+      "Input parameters for deleting multiple Pi-hole groups.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "batch_delete_lists",
+    description:
+      "Delete multiple Pi-hole allowlist or blocklist entries in one request. Reports deleted=false when none of the entries exist.",
+    inputSchema: s.actionInput(
+      {
+        items: s.array(
+          "The list entries to delete.",
+          s.requiredObject("One list entry to delete.", {
+            address: s.nonEmptyString("The address of the list entry."),
+            type: listTypeSchema,
+          }),
+        ),
+      },
+      ["items"],
+      "Input parameters for deleting multiple Pi-hole lists.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "batch_delete_domains",
+    description:
+      "Delete multiple Pi-hole domain entries in one request. Reports deleted=false when none of the entries exist.",
+    inputSchema: s.actionInput(
+      {
+        items: s.array(
+          "The domain entries to delete.",
+          s.requiredObject("One domain entry to delete.", {
+            domain: s.nonEmptyString("The domain of the entry."),
+            type: domainTypeSchema,
+            kind: domainKindSchema,
+          }),
+        ),
+      },
+      ["items"],
+      "Input parameters for deleting multiple Pi-hole domain entries.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "batch_delete_clients",
+    description:
+      "Delete multiple Pi-hole client entries in one request. Reports deleted=false when none of the clients exist.",
+    inputSchema: s.actionInput(
+      {
+        items: s.array(
+          "The client identifiers to delete (IP / MAC / hostname / interface).",
+          s.nonEmptyString("One client identifier."),
+        ),
+      },
+      ["items"],
+      "Input parameters for deleting multiple Pi-hole clients.",
+    ),
+    outputSchema: deletedOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_dhcp_leases",
+    description: "Fetch the currently active DHCP leases assigned by the Pi-hole DHCP server.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { leases: s.array("The active DHCP leases.", s.looseObject("One active DHCP lease.")) },
+      "The active Pi-hole DHCP leases.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_network_devices",
+    description: "Fetch the devices seen on the local network by Pi-hole.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { devices: s.array("The network devices seen by Pi-hole.", s.looseObject("One network device.")) },
+      "The network devices seen by Pi-hole.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "export_backup",
+    description:
+      "Create a complete Pi-hole teleporter backup archive (teleporter.zip) with all settings, lists, and clients.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        file: s.requiredObject("The backup archive metadata.", {
+          fileId: s.nullableString("Transit file id when stored locally."),
+          downloadUrl: s.nullableString("Download URL of the stored transit file."),
+          name: s.nonEmptyString("The archive file name."),
+          mimeType: s.string("The archive MIME type."),
+          sizeBytes: s.integer("The archive size in bytes."),
+          data: s.nullableString("The archive content base64-encoded when no transit storage is available."),
+        }),
+      },
+      "The Pi-hole teleporter backup archive.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "import_backup",
+    description: "Restore a Pi-hole teleporter backup archive (a previously exported teleporter.zip) to this instance.",
+    inputSchema: s.actionInput(
+      { file: s.transitFile("The teleporter archive to restore.") },
+      ["file"],
+      "Input parameters for restoring one Pi-hole backup archive.",
+    ),
+    outputSchema: s.actionOutput(
+      { files: s.array("The files restored from the archive.", s.string("The name of a restored file.")) },
+      "The Pi-hole teleporter import result.",
+    ),
+  }),
+];

--- a/src/providers/pi_hole/definition.ts
+++ b/src/providers/pi_hole/definition.ts
@@ -1,0 +1,48 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { piHoleActions } from "./actions.ts";
+
+const service = "pi_hole";
+
+/**
+ * Pi-hole provider backed by a user-configured Pi-hole instance.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Pi-hole",
+  categories: ["Infrastructure"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "Application Password",
+      placeholder: "PI_HOLE_APP_PASSWORD",
+      description:
+        "Pi-hole application password used to authenticate against the instance API. Use an application password, not your account password, because application passwords bypass two-factor authentication. Create one from your Pi-hole web interface under Settings -> All settings -> API.",
+      extraFields: [
+        {
+          key: "baseUrl",
+          label: "Instance Base URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "http://pi.hole",
+          description:
+            "The root URL for your Pi-hole instance, for example http://pi.hole or https://pi.hole:8443. The API is served below this root.",
+        },
+        {
+          key: "apiPath",
+          label: "API Path",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "api",
+          description:
+            "The URL path below the instance root where the Pi-hole API is served, normally api. Change this only when a reverse proxy rewrites the API to a different subpath.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://pi-hole.net",
+  actions: piHoleActions,
+};

--- a/src/providers/pi_hole/executors.test.ts
+++ b/src/providers/pi_hole/executors.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { proxy } from "./executors.ts";
+import { clearPiHoleSessionCache } from "./runtime.ts";
 
 const lanInstanceUrl = "http://192.168.150.53:8084";
 
@@ -33,6 +34,7 @@ describe("pi_hole proxy", () => {
   afterEach(() => {
     setDefaultGuardedFetchDnsLookup(null);
     setPrivateNetworkAccessAllowed(false);
+    clearPiHoleSessionCache();
     vi.unstubAllGlobals();
   });
 

--- a/src/providers/pi_hole/executors.test.ts
+++ b/src/providers/pi_hole/executors.test.ts
@@ -1,0 +1,113 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { proxy } from "./executors.ts";
+
+const lanInstanceUrl = "http://192.168.150.53:8084";
+
+function apiKeyCredential(): Extract<ResolvedCredential, { authType: "api_key" }> {
+  return {
+    authType: "api_key",
+    apiKey: "app-password",
+    values: { baseUrl: lanInstanceUrl, apiPath: "api" },
+    profile: { accountId: "pi_hole:test", displayName: "Pi-hole test", grantedScopes: [] },
+    metadata: {},
+  };
+}
+
+function executionContext(): ExecutionContext {
+  const credential = apiKeyCredential();
+  return { getCredential: async () => credential };
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+describe("pi_hole proxy", () => {
+  afterEach(() => {
+    setDefaultGuardedFetchDnsLookup(null);
+    setPrivateNetworkAccessAllowed(false);
+    vi.unstubAllGlobals();
+  });
+
+  it("logs in with the app password and proxies a session-authenticated request", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async (hostname) => [
+      { address: hostname === "192.168.150.53" ? "192.168.150.53" : "93.184.216.34", family: 4 },
+    ]);
+
+    const requests: CapturedRequest[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: url.toString(),
+        method: init?.method ?? "GET",
+        headers,
+        body: init?.body ? String(init?.body) : undefined,
+      });
+      if (url.pathname === "/api/auth") {
+        return Response.json({
+          session: { valid: true, sid: "sid-1", validity: 600, csrf: "csrf", totp: false, message: "ok" },
+          took: 0.1,
+        });
+      }
+      if (url.pathname === "/api/stats/summary") {
+        return Response.json({ queries: 42, took: 0.1 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await proxy({ method: "GET", endpoint: "/stats/summary" }, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected proxy success, got: ${result.error.message}`);
+    }
+    expect(result.response.status).toBe(200);
+    expect(result.response.data).toMatchObject({ queries: 42 });
+
+    const authCall = requests.find((request) => request.url.endsWith("/api/auth"))!;
+    expect(authCall.method).toBe("POST");
+    expect(JSON.parse(authCall.body ?? "{}")).toEqual({ password: "app-password" });
+
+    const summaryCall = requests.find((request) => request.url.endsWith("/api/stats/summary"))!;
+    expect(summaryCall.url).toBe(`${lanInstanceUrl}/api/stats/summary`);
+    expect(summaryCall.headers.get("x-ftl-sid")).toBe("sid-1");
+    expect(summaryCall.headers.get("accept")).toBe("application/json");
+  });
+
+  it("rejects the proxy base URL on a LAN instance without the private-network opt-in", async () => {
+    setDefaultGuardedFetchDnsLookup(async (hostname) => [
+      { address: hostname === "192.168.150.53" ? "192.168.150.53" : "93.184.216.34", family: 4 },
+    ]);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await proxy({ method: "GET", endpoint: "/stats/summary" }, executionContext());
+
+    if (result.ok) {
+      throw new Error("expected proxy to reject the LAN base URL");
+    }
+    expect(result.error.message).toContain("private or reserved IP addresses");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports missing credentials as an explicit 401", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal("fetch", vi.fn());
+
+    const result = await proxy({ method: "GET", endpoint: "/stats/summary" }, { getCredential: async () => undefined });
+
+    if (result.ok) {
+      throw new Error("expected proxy to reject missing credentials");
+    }
+    expect(result.error.message).toContain("Configure pi_hole API key credentials first.");
+  });
+});

--- a/src/providers/pi_hole/executors.ts
+++ b/src/providers/pi_hole/executors.ts
@@ -1,0 +1,95 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { PiHoleActionContext, PiHoleActionHandler } from "./runtime.ts";
+
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  combineProviderActionHandlers,
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
+import { piHoleManagementActionHandlers } from "./runtime-management.ts";
+import {
+  ensurePiHoleSession,
+  piHoleActionHandlers,
+  resolvePiHoleApiPath,
+  resolvePiHoleBaseUrl,
+  validatePiHoleCredential,
+} from "./runtime.ts";
+
+const service = "pi_hole";
+
+function resolvePiHoleApiRoot(context: ExecutionContext): Promise<string> {
+  return requireApiKeyCredential(context, service).then((credential) => {
+    const baseUrl = resolvePiHoleBaseUrl({ values: credential.values, metadata: credential.metadata });
+    const apiPath = resolvePiHoleApiPath({ values: credential.values, metadata: credential.metadata });
+    return `${baseUrl.replace(/\/+$/, "")}/${apiPath}/`;
+  });
+}
+
+export const executors: ProviderExecutors = defineProviderExecutors<PiHoleActionContext>({
+  service,
+  handlers: combineProviderActionHandlers<"pi_hole", PiHoleActionHandler>(
+    service,
+    piHoleActionHandlers,
+    piHoleManagementActionHandlers,
+  ),
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<PiHoleActionContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return {
+      appPassword: credential.apiKey,
+      baseUrl: resolvePiHoleBaseUrl({ values: credential.values, metadata: credential.metadata }),
+      apiPath: resolvePiHoleApiPath({ values: credential.values, metadata: credential.metadata }),
+      transitFiles: context.transitFiles,
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: resolvePiHoleApiRoot,
+  // The API authenticates with a per-session SID, which cannot be expressed as
+  // a static header, so the proxy attaches it during request customization.
+  auth: { type: "none" },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  async customizeRequest({ context, headers, fetcher }) {
+    const credential = await requireApiKeyCredential(context, service);
+    const sid = await ensurePiHoleSession({
+      appPassword: credential.apiKey,
+      baseUrl: resolvePiHoleBaseUrl({ values: credential.values, metadata: credential.metadata }),
+      apiPath: resolvePiHoleApiPath({ values: credential.values, metadata: credential.metadata }),
+      fetcher,
+      signal: context.signal,
+    });
+    if (sid) {
+      headers.set("x-ftl-sid", sid);
+    }
+    if (!headers.has("accept")) {
+      headers.set("accept", "application/json");
+    }
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    // Re-guard the shared validator fetcher with Pi-hole's private-network
+    // opt-in so validating a private instance baseUrl works when the
+    // deployment allows it (createProviderFetch unwraps an already-guarded
+    // fetcher).
+    const guardedFetcher = createProviderFetch({
+      fetch: fetcher,
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+    return validatePiHoleCredential(input, guardedFetcher, signal);
+  },
+};

--- a/src/providers/pi_hole/runtime-management.test.ts
+++ b/src/providers/pi_hole/runtime-management.test.ts
@@ -1,0 +1,466 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { piHoleManagementActionHandlers } from "./runtime-management.ts";
+import { clearPiHoleSessionCache, piHoleActionHandlers } from "./runtime.ts";
+import { createTestContext, sessionResponse } from "./test-helpers.ts";
+
+afterEach(() => clearPiHoleSessionCache());
+
+const handlers = { ...piHoleActionHandlers, ...piHoleManagementActionHandlers };
+
+function processedResponse(): Response {
+  return Response.json(
+    {
+      processed: {
+        success: [{ item: "example.com" }],
+        errors: [{ item: "other.com", error: "The item is already present" }],
+      },
+      took: 0.1,
+    },
+    { status: 201 },
+  );
+}
+
+describe("group management", () => {
+  it("creates a group with body fields carried through", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/groups") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    const result = await handlers.create_group!(
+      { name: "Home-Automation", comment: "smart home devices", enabled: false },
+      context,
+    );
+    expect(result).toEqual({
+      processed: { success: ["example.com"], errors: [{ item: "other.com", error: "The item is already present" }] },
+    });
+
+    const post = requests.find((request) => request.method === "POST" && request.url.pathname === "/api/groups")!;
+    expect(post.body).toEqual({ name: "Home-Automation", comment: "smart home devices", enabled: false });
+  });
+
+  it("sends an array of group names through as-is", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/groups") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.create_group!({ name: ["A", "B", "C"] }, context);
+
+    const post = requests.find((request) => request.method === "POST" && request.url.pathname === "/api/groups")!;
+    expect(post.body).toEqual({ name: ["A", "B", "C"] });
+  });
+
+  it("renames a group while preserving the current comment and enabled state", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/groups") {
+        return Response.json({ groups: [{ name: "Old Name", comment: "keep me", enabled: false }], took: 0.1 });
+      }
+      if (request.method === "PUT" && request.url.pathname === "/api/groups/Old%20Name") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_group!({ name: "Old Name", newName: "New Name" }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.url.pathname).toBe("/api/groups/Old%20Name");
+    expect(put.body).toEqual({ name: "New Name", comment: "keep me", enabled: false });
+  });
+
+  it("preserves an existing comment when only disabling a group", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/groups") {
+        return Response.json({ groups: [{ name: "Test", comment: "existing", enabled: true }], took: 0.1 });
+      }
+      if (request.method === "PUT" && request.url.pathname === "/api/groups/Test") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_group!({ name: "Test", enabled: false }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.body).toEqual({ name: "Test", comment: "existing", enabled: false });
+  });
+
+  it("explicitly clearing a comment is honored", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/groups") {
+        return Response.json({ groups: [{ name: "Test", comment: "existing", enabled: true }], took: 0.1 });
+      }
+      if (request.method === "PUT") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_group!({ name: "Test", comment: null }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.body).toEqual({ name: "Test", comment: null, enabled: true });
+  });
+
+  it("reports a missing group as not found", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/groups") {
+        return Response.json({ groups: [{ name: "Other", comment: null, enabled: true }], took: 0.1 });
+      }
+      return undefined;
+    });
+
+    await expect(handlers.update_group!({ name: "Missing" }, context)).rejects.toThrow(
+      "Pi-hole item not found: group Missing",
+    );
+  });
+
+  it("deletes a group and reports success", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "DELETE" && request.url.pathname === "/api/groups/Test") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    const result = await handlers.delete_group!({ name: "Test" }, context);
+    expect(result).toEqual({ deleted: true });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]!.method).toBe("DELETE");
+  });
+});
+
+describe("list management", () => {
+  it("adds a blocklist with the required type query and body fields", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/lists") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.add_list!(
+      {
+        address: "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
+        type: "block",
+        comment: "StevenBlack",
+        groups: [1, 2],
+        enabled: true,
+      },
+      context,
+    );
+
+    const post = requests.find((request) => request.method === "POST" && request.url.pathname === "/api/lists")!;
+    expect(post.url.searchParams.get("type")).toBe("block");
+    expect(post.body).toEqual({
+      address: "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
+      comment: "StevenBlack",
+      groups: [1, 2],
+      enabled: true,
+    });
+  });
+
+  it("preserves the current comment when only toggling a list", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/lists") {
+        return Response.json({
+          lists: [{ address: "https://hosts/file.txt", type: "block", comment: "keep", enabled: true, groups: [0] }],
+          took: 0.1,
+        });
+      }
+      if (request.method === "PUT") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_list!({ address: "https://hosts/file.txt", type: "block", enabled: false }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.url.searchParams.get("type")).toBe("block");
+    expect(put.body).toEqual({ comment: "keep", enabled: false });
+  });
+
+  it("deletes a list with the type query and an encoded address", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "DELETE" && request.url.pathname.startsWith("/api/lists/")) {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    await handlers.delete_list!({ address: "https://hosts/file.txt", type: "allow" }, context);
+
+    const del = requests.find((request) => request.method === "DELETE")!;
+    expect(del.url.pathname).toBe("/api/lists/https%3A%2F%2Fhosts%2Ffile.txt");
+    expect(del.url.searchParams.get("type")).toBe("allow");
+  });
+});
+
+describe("domain management", () => {
+  it("adds an exact allow entry with body fields", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/domains/allow/exact") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.add_domain!({ domain: "example.com", type: "allow", kind: "exact", enabled: false }, context);
+
+    const post = requests.find(
+      (request) => request.method === "POST" && request.url.pathname === "/api/domains/allow/exact",
+    )!;
+    expect(post.body).toEqual({ domain: "example.com", enabled: false });
+  });
+
+  it("lists domains with the requested path narrowing", async () => {
+    const paths: string[] = [];
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      paths.push(request.url.pathname);
+      return Response.json({ domains: [], took: 0.1 });
+    });
+
+    await handlers.list_domains!({}, context);
+    await handlers.list_domains!({ type: "deny" }, context);
+    await handlers.list_domains!({ type: "allow", kind: "regex" }, context);
+
+    expect(paths).toEqual(["/api/domains", "/api/domains/deny", "/api/domains/allow/regex"]);
+  });
+
+  it("deletes a domain entry via its type, kind, and encoded domain", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    await handlers.delete_domain!({ type: "deny", kind: "regex", domain: "ads*.example" }, context);
+
+    const del = requests.find((request) => request.method === "DELETE")!;
+    // Wildcards are left literal (they are part of the regex item), and the
+    // server URL-decodes encoded bytes before matching the item.
+    expect(del.url.pathname).toBe("/api/domains/deny/regex/ads*.example");
+  });
+});
+
+describe("client management", () => {
+  it("updates a client comment and groups while preserving the current comment when only groups change", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/clients") {
+        return Response.json({
+          clients: [{ client: "192.168.1.5", name: "living-room", comment: "existing", groups: [0] }],
+          took: 0.1,
+        });
+      }
+      if (request.method === "PUT" && request.url.pathname === "/api/clients/192.168.1.5") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_client!({ client: "192.168.1.5", comment: "living room", groups: [1] }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.url.pathname).toBe("/api/clients/192.168.1.5");
+    expect(put.body).toEqual({ comment: "living room", groups: [1] });
+  });
+
+  it("looks a client up by its resolved hostname", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/clients") {
+        return Response.json({
+          clients: [{ client: "10.0.0.9", name: "nas.lan", comment: "old", groups: [0] }],
+          took: 0.1,
+        });
+      }
+      if (request.method === "PUT" && request.url.pathname === "/api/clients/10.0.0.9") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_client!({ client: "nas.lan", comment: "nas" }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    // The write endpoint must target the canonical stored identifier, not the
+    // hostname alias used to find the client.
+    expect(put.url.pathname).toBe("/api/clients/10.0.0.9");
+    expect(put.body).toEqual({ comment: "nas" });
+  });
+
+  it("deletes a client by identifier", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "DELETE" && request.url.pathname === "/api/clients/%3Aeth0") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    const result = await handlers.delete_client!({ client: ":eth0" }, context);
+    expect(result).toEqual({ deleted: true });
+    const del = requests.find((request) => request.method === "DELETE")!;
+    // Colons are percent-encoded in the path and decoded by the server before
+    // the client identifier is matched.
+    expect(del.url.pathname).toBe("/api/clients/%3Aeth0");
+  });
+});
+
+describe("batch deletes", () => {
+  it("deletes multiple groups with the item body shape", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/groups:batchDelete") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    const result = await handlers.batch_delete_groups!({ items: ["A", "B"] }, context);
+    expect(result).toEqual({ deleted: true });
+    const post = requests.find((request) => request.url.pathname === "/api/groups:batchDelete")!;
+    expect(post.body).toEqual([{ item: "A" }, { item: "B" }]);
+  });
+
+  it("deletes multiple lists with per-entry type", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/lists:batchDelete") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    await handlers.batch_delete_lists!(
+      {
+        items: [
+          { address: "https://a.example/list", type: "block" },
+          { address: "https://b.example/list", type: "allow" },
+        ],
+      },
+      context,
+    );
+
+    const post = requests.find((request) => request.url.pathname === "/api/lists:batchDelete")!;
+    expect(post.url.searchParams.has("type")).toBe(false);
+    expect(post.body).toEqual([
+      { item: "https://a.example/list", type: "block" },
+      { item: "https://b.example/list", type: "allow" },
+    ]);
+  });
+
+  it("deletes multiple domains with per-entry type and kind", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/domains:batchDelete") {
+        return new Response(null, { status: 204 });
+      }
+      return undefined;
+    });
+
+    await handlers.batch_delete_domains!(
+      {
+        items: [{ domain: "a.example", type: "allow", kind: "exact" }],
+      },
+      context,
+    );
+
+    const post = requests.find((request) => request.url.pathname === "/api/domains:batchDelete")!;
+    expect(post.body).toEqual([{ item: "a.example", type: "allow", kind: "exact" }]);
+  });
+
+  it("reports deleted=false when the instance finds no matching items", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/clients:batchDelete") {
+        return new Response(null, { status: 404 });
+      }
+      return undefined;
+    });
+
+    const result = await handlers.batch_delete_clients!({ items: ["10.0.0.1", "10.0.0.2"] }, context);
+    expect(result).toEqual({ deleted: false });
+  });
+});
+
+describe("network reads", () => {
+  it.each([
+    ["get_dhcp_leases", "/api/dhcp/leases", "leases"],
+    ["get_network_devices", "/api/network/devices", "devices"],
+  ] as const)("%s passes through its payload array", async (name, pathname, key) => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.url.pathname === pathname) {
+        return Response.json({ [key]: [{ id: 1 }], took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await handlers[name]!({}, context);
+    expect(result).toEqual({ [key]: [{ id: 1 }] });
+  });
+});

--- a/src/providers/pi_hole/runtime-management.test.ts
+++ b/src/providers/pi_hole/runtime-management.test.ts
@@ -210,7 +210,7 @@ describe("list management", () => {
 
     const put = requests.find((request) => request.method === "PUT")!;
     expect(put.url.searchParams.get("type")).toBe("block");
-    expect(put.body).toEqual({ comment: "keep", enabled: false });
+    expect(put.body).toEqual({ comment: "keep", enabled: false, groups: [0] });
   });
 
   it("deletes a list with the type query and an encoded address", async () => {
@@ -287,6 +287,39 @@ describe("domain management", () => {
     // server URL-decodes encoded bytes before matching the item.
     expect(del.url.pathname).toBe("/api/domains/deny/regex/ads*.example");
   });
+
+  it("preserves group memberships when only updating the comment", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "GET" && request.url.pathname === "/api/domains/allow/exact") {
+        return Response.json({
+          domains: [
+            {
+              domain: "example.com",
+              type: "allow",
+              kind: "exact",
+              comment: "keep",
+              enabled: true,
+              groups: [0, 2],
+            },
+          ],
+          took: 0.1,
+        });
+      }
+      if (request.method === "PUT") {
+        return processedResponse();
+      }
+      return undefined;
+    });
+
+    await handlers.update_domain!({ type: "allow", kind: "exact", domain: "example.com", comment: "new" }, context);
+
+    const put = requests.find((request) => request.method === "PUT")!;
+    expect(put.url.pathname).toBe("/api/domains/allow/exact/example.com");
+    expect(put.body).toEqual({ comment: "new", groups: [0, 2], enabled: true });
+  });
 });
 
 describe("client management", () => {
@@ -337,7 +370,7 @@ describe("client management", () => {
     // The write endpoint must target the canonical stored identifier, not the
     // hostname alias used to find the client.
     expect(put.url.pathname).toBe("/api/clients/10.0.0.9");
-    expect(put.body).toEqual({ comment: "nas" });
+    expect(put.body).toEqual({ comment: "nas", groups: [0] });
   });
 
   it("deletes a client by identifier", async () => {

--- a/src/providers/pi_hole/runtime-management.ts
+++ b/src/providers/pi_hole/runtime-management.ts
@@ -1,0 +1,447 @@
+import type { ProviderActionHandlerSubset } from "../provider-runtime.ts";
+import type { PiHoleActionContext, PiHoleActionHandler, PiHoleRequestOptions } from "./runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalIntegerLike,
+  optionalObjectArray,
+  optionalRecord,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { requestPiHoleJson } from "./runtime.ts";
+
+function piHoleInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function readRequiredString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, piHoleInputError);
+}
+
+function readRecordPayload(payload: unknown): Record<string, unknown> {
+  return optionalRecord(payload) ?? {};
+}
+
+function readStringArrayPayload(value: unknown, fieldName: string): unknown {
+  if (typeof value === "string" || Array.isArray(value)) {
+    return value;
+  }
+  throw new ProviderRequestError(400, `${fieldName} must be a string or an array of strings`);
+}
+
+function readGroupsPayload(input: Record<string, unknown>): number[] | undefined {
+  const groups = Array.isArray(input.groups) ? input.groups : undefined;
+  if (groups === undefined) {
+    return undefined;
+  }
+  // Coerce numeric strings so an ID like "1" never silently becomes the
+  // default group 0; anything else is a clear input error.
+  return groups.map((value) => {
+    const parsed = optionalIntegerLike(value, "groups", piHoleInputError);
+    if (parsed === undefined) {
+      throw piHoleInputError("groups must be an array of group IDs");
+    }
+    return parsed;
+  });
+}
+
+/**
+ * Normalize the `{ processed: { success, errors } }` response returned by the
+ * write endpoints of the list management API.
+ */
+function readProcessedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const processed = optionalRecord(payload.processed);
+  if (!processed) {
+    return { processed: null };
+  }
+  return {
+    processed: {
+      success: optionalObjectArray(processed.success, "Pi-hole processed success response").map((entry) =>
+        optionalString(entry.item),
+      ),
+      errors: optionalObjectArray(processed.errors, "Pi-hole processed errors response").map((entry) => ({
+        item: optionalString(entry.item),
+        error: optionalString(entry.error),
+      })),
+    },
+  };
+}
+
+async function deleteListedItem(options: Omit<PiHoleRequestOptions, "method">): Promise<{ deleted: boolean }> {
+  await requestPiHoleJson({ ...options, method: "DELETE" });
+  return { deleted: true };
+}
+
+/**
+ * The FTL write endpoints replace the whole record: any field omitted from a
+ * PUT payload is reset to its server default (comment cleared, enabled forced
+ * to true). Read-modify-write keeps the action contract safe: unspecified
+ * fields are carried over from the current record instead of being wiped.
+ */
+async function readResourceItems(
+  context: PiHoleActionContext,
+  path: string,
+  key: string,
+): Promise<Array<Record<string, unknown>>> {
+  const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path }));
+  return optionalObjectArray(payload[key], `Pi-hole ${key} response`);
+}
+
+function requireExistingItem(
+  items: Array<Record<string, unknown>>,
+  match: (entry: Record<string, unknown>) => boolean,
+  description: string,
+): Record<string, unknown> {
+  const current = items.find(match);
+  if (!current) {
+    throw new ProviderRequestError(404, `Pi-hole item not found: ${description}`);
+  }
+  return current;
+}
+
+function normalizeListType(value: string): string {
+  return value.toLowerCase();
+}
+
+function readBatchStringItems(value: unknown, fieldName: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(400, `${fieldName} must be an array of item identifiers`);
+  }
+  return value.map((entry) => {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      throw new ProviderRequestError(400, `${fieldName} items must be non-empty strings`);
+    }
+    return entry;
+  });
+}
+
+function readBatchEntries(
+  value: unknown,
+  fieldName: string,
+  readEntry: (entry: Record<string, unknown>) => { item: string; [key: string]: unknown },
+): Array<{ item: string; [key: string]: unknown }> {
+  if (!Array.isArray(value)) {
+    throw new ProviderRequestError(400, `${fieldName} must be an array of objects`);
+  }
+  return value.map((entry) => {
+    const record = optionalRecord(entry);
+    if (!record) {
+      throw new ProviderRequestError(400, `${fieldName} entries must be objects`);
+    }
+    return readEntry(record);
+  });
+}
+
+/**
+ * The batch-delete endpoints report 404 when none of the requested items
+ * matched. Report that case as a non-deleting outcome instead of an error.
+ */
+async function batchDeletePiHoleItems(
+  context: PiHoleActionContext,
+  path: string,
+  body: unknown[],
+): Promise<{ deleted: boolean }> {
+  try {
+    await requestPiHoleJson({ context, method: "POST", path, body });
+    return { deleted: true };
+  } catch (error) {
+    if (error instanceof ProviderRequestError && error.status === 404) {
+      return { deleted: false };
+    }
+    throw error;
+  }
+}
+
+function effectiveOptionalString(provided: unknown, current: unknown): string | null | undefined {
+  if (provided !== undefined) {
+    return optionalString(provided) ?? null;
+  }
+  return optionalString(current) ?? null;
+}
+
+function effectiveOptionalBoolean(provided: unknown, current: unknown): boolean | undefined {
+  if (provided !== undefined) {
+    return optionalBoolean(provided);
+  }
+  return optionalBoolean(current) ?? true;
+}
+
+export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHoleActionHandler> = {
+  async list_groups(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "groups" }));
+    return { groups: optionalObjectArray(payload.groups, "Pi-hole groups response") };
+  },
+  async create_group(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "POST",
+        path: "groups",
+        body: {
+          name: readStringArrayPayload(input.name, "name"),
+          ...(input.comment !== undefined ? { comment: optionalString(input.comment) ?? null } : {}),
+          ...(input.enabled !== undefined ? { enabled: optionalBoolean(input.enabled) } : {}),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async update_group(input, context) {
+    const name = readRequiredString(input.name, "name");
+    const items = await readResourceItems(context, "groups", "groups");
+    const current = requireExistingItem(items, (entry) => optionalString(entry.name) === name, `group ${name}`);
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "PUT",
+        path: `groups/${encodeURIComponent(name)}`,
+        body: {
+          name:
+            input.newName !== undefined
+              ? readRequiredString(input.newName, "newName")
+              : (optionalString(current.name) ?? name),
+          comment: effectiveOptionalString(input.comment, current.comment),
+          enabled: effectiveOptionalBoolean(input.enabled, current.enabled),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async delete_group(input, context) {
+    const name = readRequiredString(input.name, "name");
+    return deleteListedItem({ context, path: `groups/${encodeURIComponent(name)}` });
+  },
+
+  async list_lists(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: "lists",
+        query: { type: optionalString(input.type) },
+      }),
+    );
+    return { lists: optionalObjectArray(payload.lists, "Pi-hole lists response") };
+  },
+  async add_list(input, context) {
+    const type = readRequiredString(input.type, "type");
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "POST",
+        path: "lists",
+        query: { type },
+        body: {
+          address: readStringArrayPayload(input.address, "address"),
+          ...(input.comment !== undefined ? { comment: optionalString(input.comment) ?? null } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          ...(input.enabled !== undefined ? { enabled: optionalBoolean(input.enabled) } : {}),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async update_list(input, context) {
+    const type = normalizeListType(readRequiredString(input.type, "type"));
+    const address = readRequiredString(input.address, "address");
+    const items = await readResourceItems(context, "lists", "lists");
+    const current = requireExistingItem(
+      items,
+      (entry) => optionalString(entry.address) === address && optionalString(entry.type) === type,
+      `list ${address}`,
+    );
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "PUT",
+        path: `lists/${encodeURIComponent(address)}`,
+        query: { type },
+        body: {
+          comment: effectiveOptionalString(input.comment, current.comment),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          enabled: effectiveOptionalBoolean(input.enabled, current.enabled),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async delete_list(input, context) {
+    const type = readRequiredString(input.type, "type");
+    const address = readRequiredString(input.address, "address");
+    return deleteListedItem({ context, path: `lists/${encodeURIComponent(address)}`, query: { type } });
+  },
+
+  async list_domains(input, context) {
+    const type = optionalString(input.type);
+    const kind = optionalString(input.kind);
+    const normalizedType = type !== undefined ? normalizeListType(type) : undefined;
+    const normalizedKind = kind !== undefined ? normalizeListType(kind) : undefined;
+    const path =
+      normalizedType !== undefined && normalizedKind !== undefined
+        ? `domains/${normalizedType}/${normalizedKind}`
+        : normalizedType !== undefined
+          ? `domains/${normalizedType}`
+          : "domains";
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path }));
+    return { domains: optionalObjectArray(payload.domains, "Pi-hole domains response") };
+  },
+  async add_domain(input, context) {
+    const type = normalizeListType(readRequiredString(input.type, "type"));
+    const kind = normalizeListType(readRequiredString(input.kind, "kind"));
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "POST",
+        path: `domains/${type}/${kind}`,
+        body: {
+          domain: readStringArrayPayload(input.domain, "domain"),
+          ...(input.comment !== undefined ? { comment: optionalString(input.comment) ?? null } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          ...(input.enabled !== undefined ? { enabled: optionalBoolean(input.enabled) } : {}),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async update_domain(input, context) {
+    const type = normalizeListType(readRequiredString(input.type, "type"));
+    const kind = normalizeListType(readRequiredString(input.kind, "kind"));
+    const domain = readRequiredString(input.domain, "domain");
+    const items = await readResourceItems(context, `domains/${type}/${kind}`, "domains");
+    const current = requireExistingItem(
+      items,
+      (entry) => (optionalString(entry.domain) ?? "").toLowerCase() === domain.toLowerCase(),
+      `domain ${domain}`,
+    );
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "PUT",
+        path: `domains/${type}/${kind}/${encodeURIComponent(domain)}`,
+        body: {
+          comment: effectiveOptionalString(input.comment, current.comment),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          enabled: effectiveOptionalBoolean(input.enabled, current.enabled),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async delete_domain(input, context) {
+    const type = normalizeListType(readRequiredString(input.type, "type"));
+    const kind = normalizeListType(readRequiredString(input.kind, "kind"));
+    const domain = readRequiredString(input.domain, "domain");
+    return deleteListedItem({ context, path: `domains/${type}/${kind}/${encodeURIComponent(domain)}` });
+  },
+
+  async list_clients(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "clients" }));
+    return { clients: optionalObjectArray(payload.clients, "Pi-hole clients response") };
+  },
+  async create_client(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "POST",
+        path: "clients",
+        body: {
+          client: readStringArrayPayload(input.client, "client"),
+          ...(input.comment !== undefined ? { comment: optionalString(input.comment) ?? null } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async update_client(input, context) {
+    const client = readRequiredString(input.client, "client");
+    const items = await readResourceItems(context, "clients", "clients");
+    const current = requireExistingItem(
+      items,
+      (entry) => {
+        const identifier = optionalString(entry.client);
+        return identifier === client || optionalString(entry.name) === client;
+      },
+      `client ${client}`,
+    );
+    // The write endpoint matches against the canonical stored identifier, so
+    // when the caller used a hostname alias the PUT must target the stored
+    // identifier, not the alias.
+    const targetIdentifier = optionalString(current.client) ?? client;
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "PUT",
+        path: `clients/${encodeURIComponent(targetIdentifier)}`,
+        body: {
+          comment: effectiveOptionalString(input.comment, current.comment),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+        },
+      }),
+    );
+    return readProcessedPayload(payload);
+  },
+  async delete_client(input, context) {
+    const client = readRequiredString(input.client, "client");
+    return deleteListedItem({ context, path: `clients/${encodeURIComponent(client)}` });
+  },
+  async batch_delete_groups(input, context) {
+    const items = readBatchStringItems(input.items, "items");
+    return batchDeletePiHoleItems(
+      context,
+      "groups:batchDelete",
+      items.map((item) => ({ item })),
+    );
+  },
+  async batch_delete_lists(input, context) {
+    return batchDeletePiHoleItems(
+      context,
+      "lists:batchDelete",
+      readBatchEntries(input.items, "items", (entry) => {
+        const address = requiredString(entry.address, "address", piHoleInputError);
+        const type = normalizeListType(requiredString(entry.type, "type", piHoleInputError));
+        if (type !== "allow" && type !== "block") {
+          throw new ProviderRequestError(400, "type must be either allow or block");
+        }
+        return { item: address, type };
+      }),
+    );
+  },
+  async batch_delete_domains(input, context) {
+    return batchDeletePiHoleItems(
+      context,
+      "domains:batchDelete",
+      readBatchEntries(input.items, "items", (entry) => {
+        const domain = requiredString(entry.domain, "domain", piHoleInputError);
+        const type = normalizeListType(requiredString(entry.type, "type", piHoleInputError));
+        if (type !== "allow" && type !== "deny") {
+          throw new ProviderRequestError(400, "type must be either allow or deny");
+        }
+        const kind = normalizeListType(requiredString(entry.kind, "kind", piHoleInputError));
+        if (kind !== "exact" && kind !== "regex") {
+          throw new ProviderRequestError(400, "kind must be either exact or regex");
+        }
+        return { item: domain, type, kind };
+      }),
+    );
+  },
+  async batch_delete_clients(input, context) {
+    const items = readBatchStringItems(input.items, "items");
+    return batchDeletePiHoleItems(
+      context,
+      "clients:batchDelete",
+      items.map((item) => ({ item })),
+    );
+  },
+
+  async get_dhcp_leases(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "dhcp/leases" }));
+    return { leases: optionalObjectArray(payload.leases, "Pi-hole DHCP leases response") };
+  },
+  async get_network_devices(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "network/devices" }));
+    return { devices: optionalObjectArray(payload.devices, "Pi-hole network devices response") };
+  },
+};

--- a/src/providers/pi_hole/runtime-management.ts
+++ b/src/providers/pi_hole/runtime-management.ts
@@ -215,18 +215,19 @@ export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hol
   },
 
   async list_lists(input, context) {
+    const type = optionalString(input.type);
     const payload = readRecordPayload(
       await requestPiHoleJson({
         context,
         method: "GET",
         path: "lists",
-        query: { type: optionalString(input.type) },
+        query: type === undefined ? undefined : { type: normalizeListType(type) },
       }),
     );
     return { lists: optionalObjectArray(payload.lists, "Pi-hole lists response") };
   },
   async add_list(input, context) {
-    const type = readRequiredString(input.type, "type");
+    const type = normalizeListType(readRequiredString(input.type, "type"));
     const payload = readRecordPayload(
       await requestPiHoleJson({
         context,
@@ -260,7 +261,7 @@ export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hol
         query: { type },
         body: {
           comment: effectiveOptionalString(input.comment, current.comment),
-          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : { groups: current.groups }),
           enabled: effectiveOptionalBoolean(input.enabled, current.enabled),
         },
       }),
@@ -268,7 +269,7 @@ export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hol
     return readProcessedPayload(payload);
   },
   async delete_list(input, context) {
-    const type = readRequiredString(input.type, "type");
+    const type = normalizeListType(readRequiredString(input.type, "type"));
     const address = readRequiredString(input.address, "address");
     return deleteListedItem({ context, path: `lists/${encodeURIComponent(address)}`, query: { type } });
   },
@@ -322,7 +323,7 @@ export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hol
         path: `domains/${type}/${kind}/${encodeURIComponent(domain)}`,
         body: {
           comment: effectiveOptionalString(input.comment, current.comment),
-          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : { groups: current.groups }),
           enabled: effectiveOptionalBoolean(input.enabled, current.enabled),
         },
       }),
@@ -377,7 +378,7 @@ export const piHoleManagementActionHandlers: ProviderActionHandlerSubset<"pi_hol
         path: `clients/${encodeURIComponent(targetIdentifier)}`,
         body: {
           comment: effectiveOptionalString(input.comment, current.comment),
-          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : {}),
+          ...(input.groups !== undefined ? { groups: readGroupsPayload(input) } : { groups: current.groups }),
         },
       }),
     );

--- a/src/providers/pi_hole/runtime.test.ts
+++ b/src/providers/pi_hole/runtime.test.ts
@@ -1,5 +1,3 @@
-import type { PiHoleActionContext } from "./runtime.ts";
-
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
@@ -434,6 +432,7 @@ describe("teleporter backup and restore", () => {
         name: "teleporter.zip",
         mimeType: "application/zip",
         sizeBytes: zipBytes.length,
+        data: null,
       },
     });
     expect(create).toHaveBeenCalledTimes(1);
@@ -460,6 +459,8 @@ describe("teleporter backup and restore", () => {
         name: "teleporter.zip",
         mimeType: "application/zip",
         sizeBytes: zipBytes.length,
+        fileId: null,
+        downloadUrl: null,
         data: Buffer.from(zipBytes).toString("base64"),
       },
     });

--- a/src/providers/pi_hole/runtime.test.ts
+++ b/src/providers/pi_hole/runtime.test.ts
@@ -1,0 +1,556 @@
+import type { PiHoleActionContext } from "./runtime.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  clearPiHoleSessionCache,
+  normalizePiHoleApiPath,
+  normalizePiHoleBaseUrl,
+  piHoleActionHandlers,
+  validatePiHoleCredential,
+} from "./runtime.ts";
+import { createTestContext, sessionResponse } from "./test-helpers.ts";
+
+afterEach(() => {
+  setPrivateNetworkAccessAllowed(false);
+  clearPiHoleSessionCache();
+});
+
+describe("normalizePiHoleBaseUrl", () => {
+  it("allows a public host", () => {
+    expect(normalizePiHoleBaseUrl("https://pi.example.com")).toBe("https://pi.example.com");
+  });
+
+  it("keeps an instance mounted below a path prefix", () => {
+    expect(normalizePiHoleBaseUrl("https://example.com/pihole/")).toBe("https://example.com/pihole");
+  });
+
+  it("strips a trailing api segment users often paste from API docs", () => {
+    expect(normalizePiHoleBaseUrl("https://pi.hole/api")).toBe("https://pi.hole");
+    expect(normalizePiHoleBaseUrl("http://pi.hole/API/")).toBe("http://pi.hole");
+    expect(normalizePiHoleBaseUrl("https://example.com/pihole/api")).toBe("https://example.com/pihole");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizePiHoleBaseUrl("http://10.0.0.2")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizePiHoleBaseUrl("http://10.0.0.2")).toBe("http://10.0.0.2");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizePiHoleBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizePiHoleBaseUrl("http://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizePiHoleBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+
+  it("rejects URLs carrying user info, query, or hash", () => {
+    expect(() => normalizePiHoleBaseUrl("https://user:pass@pi.hole")).toThrow("clean instance root URL");
+    expect(() => normalizePiHoleBaseUrl("https://pi.hole?x=1")).toThrow("clean instance root URL");
+  });
+});
+
+describe("normalizePiHoleApiPath", () => {
+  it("defaults to the standard api segment", () => {
+    expect(normalizePiHoleApiPath(undefined)).toBe("api");
+  });
+
+  it("strips surrounding slashes", () => {
+    expect(normalizePiHoleApiPath("/pihole/api/")).toBe("pihole/api");
+  });
+});
+
+describe("Pi-hole session handling", () => {
+  it("shares one login across concurrent cold-start requests", async () => {
+    let authCalls = 0;
+    let resolved = 0;
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        authCalls += 1;
+        return sessionResponse("sid-1");
+      }
+      if (request.url.pathname === "/api/stats/summary") {
+        return Promise.resolve().then(() => {
+          resolved += 1;
+          return Response.json({ domains_being_blocked: 2, took: 0.1 });
+        });
+      }
+      return undefined;
+    });
+
+    const results = await Promise.all([
+      piHoleActionHandlers.get_overview!({}, context),
+      piHoleActionHandlers.get_overview!({}, context),
+      piHoleActionHandlers.get_overview!({}, context),
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(authCalls).toBe(1);
+    expect(resolved).toBe(3);
+  });
+
+  it("logs in with the application password and reuses the session", async () => {
+    let authCalls = 0;
+    let summaryCalls = 0;
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        authCalls += 1;
+        expect(request.body).toEqual({ password: "app-password" });
+        return sessionResponse("sid-1");
+      }
+      if (request.url.pathname === "/api/stats/summary") {
+        summaryCalls += 1;
+        expect(request.headers.get("x-ftl-sid")).toBe("sid-1");
+        return Response.json({ domains_being_blocked: 5, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const first = await piHoleActionHandlers.get_overview!({}, context);
+    expect(first).toEqual({ summary: { domains_being_blocked: 5 } });
+
+    const second = await piHoleActionHandlers.get_overview!({}, context);
+    expect(second).toEqual({ summary: { domains_being_blocked: 5 } });
+
+    expect(authCalls).toBe(1);
+    expect(summaryCalls).toBe(2);
+    expect(
+      requests.filter((request) => request.method === "POST" && request.url.pathname === "/api/auth"),
+    ).toHaveLength(1);
+  });
+
+  it("re-authenticates once when the server rejects the cached session", async () => {
+    let dnsCalls = 0;
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse(`sid-${dnsCalls}`);
+      }
+      if (request.url.pathname === "/api/dns/blocking") {
+        dnsCalls += 1;
+        if (dnsCalls === 1) {
+          return Response.json(
+            { error: { key: "unauthorized", message: "Unauthorized", hint: null }, took: 0.1 },
+            { status: 401 },
+          );
+        }
+        expect(request.headers.get("x-ftl-sid")).toBe("sid-1");
+        return Response.json({ blocking: "enabled", timer: null, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.get_dns_blocking_status!({}, context);
+    expect(result).toEqual({ blocking: "enabled", timer: null });
+    expect(dnsCalls).toBe(2);
+    expect(requests.filter((request) => request.url.pathname === "/api/auth")).toHaveLength(2);
+  });
+
+  it("surfaces an invalid application password", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.url.pathname === "/api/auth") {
+        // The spec reports a rejected password as 200 with an invalid session.
+        return Response.json({
+          session: { valid: false, sid: null, validity: -1, totp: false, message: "password incorrect" },
+          took: 0.1,
+        });
+      }
+      return undefined;
+    });
+
+    await expect(piHoleActionHandlers.get_overview!({}, context)).rejects.toThrow(
+      "Invalid Pi-hole application password",
+    );
+  });
+});
+
+describe("update_config", () => {
+  it("sends the config under a root config key", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "PATCH" && request.url.pathname === "/api/config") {
+        return Response.json({ config: { dns: { upstreams: ["9.9.9.9"] } }, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.update_config!({ config: { dns: { upstreams: ["9.9.9.9"] } } }, context);
+    expect(result).toEqual({ config: { dns: { upstreams: ["9.9.9.9"] } } });
+
+    const patch = requests.find((request) => request.method === "PATCH" && request.url.pathname === "/api/config")!;
+    expect(patch.body).toEqual({ config: { dns: { upstreams: ["9.9.9.9"] } } });
+    expect(patch.url.searchParams.has("restart")).toBe(false);
+  });
+
+  it("passes restart=false through to the query string", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "PATCH" && request.url.pathname === "/api/config") {
+        return Response.json({ config: {}, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    await piHoleActionHandlers.update_config!({ config: { dns: { upstreams: ["9.9.9.9"] } }, restart: false }, context);
+
+    const patch = requests.find((request) => request.method === "PATCH" && request.url.pathname === "/api/config")!;
+    expect(patch.url.searchParams.get("restart")).toBe("false");
+  });
+
+  it("coerces a string restart value instead of silently restarting DNS", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "PATCH" && request.url.pathname === "/api/config") {
+        return Response.json({ config: {}, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    await piHoleActionHandlers.update_config!(
+      { config: { dns: { upstreams: ["9.9.9.9"] } }, restart: "false" },
+      context,
+    );
+
+    const patch = requests.find((request) => request.method === "PATCH" && request.url.pathname === "/api/config")!;
+    expect(patch.url.searchParams.get("restart")).toBe("false");
+  });
+});
+
+describe("action endpoints", () => {
+  it.each([
+    ["restart_dns", "/api/action/restartdns"],
+    ["flush_dns_logs", "/api/action/flush/logs"],
+  ] as const)("maps %s to its status response", async (name, pathname) => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === pathname) {
+        return Response.json({ status: "success", took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers[name]!({}, context);
+    expect(result).toEqual({ status: "success" });
+  });
+
+  it("relays the gravity log stream with a best-effort status", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/action/gravity") {
+        return new Response("  [i] Pulling blocklist source list...\n  [✓] Done.\n", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return undefined;
+    });
+
+    const result = (await piHoleActionHandlers.run_gravity!({}, context)) as { status: string | null; output: string };
+    expect(result).toEqual({
+      status: "success",
+      output: "[i] Pulling blocklist source list...\n  [✓] Done.",
+    });
+  });
+
+  it("flags a failed gravity run from error markers in the stream", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/action/gravity") {
+        return new Response("  [✗] Failed to download https://invalid.example/blocklist\n", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return undefined;
+    });
+
+    const result = (await piHoleActionHandlers.run_gravity!({}, context)) as { status: string | null; output: string };
+    expect(result.status).toBe("failed");
+  });
+
+  it("leaves the status unknown when the stream gives no clear signal", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/action/gravity") {
+        return new Response("  [i] Starting...\n", { status: 200, headers: { "content-type": "text/plain" } });
+      }
+      return undefined;
+    });
+
+    const result = (await piHoleActionHandlers.run_gravity!({}, context)) as { status: string | null; output: string };
+    expect(result.status).toBeNull();
+    expect(result.output).toBe("[i] Starting...");
+  });
+});
+
+describe("set_dns_blocking", () => {
+  it("maps blocking and timer to the request body", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/dns/blocking") {
+        return Response.json({ blocking: "disabled", timer: 60, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.set_dns_blocking!({ blocking: false, timer: 60 }, context);
+    expect(result).toEqual({ blocking: "disabled", timer: 60 });
+
+    const blockingRequest = requests.find(
+      (request) => request.method === "POST" && request.url.pathname === "/api/dns/blocking",
+    )!;
+    expect(blockingRequest.body).toEqual({ blocking: false, timer: 60 });
+  });
+
+  it("omits the timer when not provided and cancels it when explicitly null", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/dns/blocking") {
+        return Response.json({ blocking: "enabled", timer: null, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    await piHoleActionHandlers.set_dns_blocking!({ blocking: true }, context);
+    await piHoleActionHandlers.set_dns_blocking!({ blocking: true, timer: null }, context);
+
+    const blockingRequests = requests.filter(
+      (request) => request.method === "POST" && request.url.pathname === "/api/dns/blocking",
+    );
+    expect(blockingRequests[0]!.body).toEqual({ blocking: true });
+    expect(blockingRequests[1]!.body).toEqual({ blocking: true, timer: null });
+  });
+});
+
+describe("get_queries", () => {
+  it("maps input filters to query parameters", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.url.pathname === "/api/queries") {
+        return Response.json({
+          queries: [{ id: 1, domain: "example.com", status: "FORWARDED" }],
+          cursor: 42,
+          recordsTotal: 100,
+          recordsFiltered: 1,
+          earliest_timestamp: 1580000000,
+          earliest_timestamp_disk: 1580000000,
+          took: 0.1,
+        });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.get_queries!(
+      { domain: "example.com", length: 50, status: "FORWARDED", disk: true },
+      context,
+    );
+    expect(result).toEqual({
+      queries: [{ id: 1, domain: "example.com", status: "FORWARDED" }],
+      cursor: 42,
+      recordsTotal: 100,
+      recordsFiltered: 1,
+      earliestTimestamp: 1580000000,
+      earliestTimestampDisk: 1580000000,
+    });
+
+    const queryUrl = requests.find((request) => request.url.pathname === "/api/queries")!.url;
+    expect(queryUrl.searchParams.get("domain")).toBe("example.com");
+    expect(queryUrl.searchParams.get("length")).toBe("50");
+    expect(queryUrl.searchParams.get("status")).toBe("FORWARDED");
+    expect(queryUrl.searchParams.get("disk")).toBe("true");
+  });
+});
+
+describe("search_domain", () => {
+  it("builds the path and limits from the input", async () => {
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.url.pathname === "/api/search/doubleclick.net") {
+        return Response.json({ search: { domains: [], gravity: [], results: { total: 0 } }, took: 0.1 });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.search_domain!({ domain: "doubleclick.net", maxResults: 20 }, context);
+    expect(result).toEqual({ search: { domains: [], gravity: [], results: { total: 0 } } });
+
+    const searchUrl = requests.find((request) => request.url.pathname === "/api/search/doubleclick.net")!.url;
+    expect(searchUrl.searchParams.get("N")).toBe("20");
+  });
+});
+
+describe("teleporter backup and restore", () => {
+  const zipBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00]);
+
+  it("stores the exported archive in the transit file store", async () => {
+    const create = vi.fn(async (file: File) => ({
+      fileId: "tf-1",
+      downloadUrl: "http://download/tf-1",
+      sizeBytes: file.size,
+      name: file.name,
+      mimeType: file.type,
+    }));
+    const transitFiles = { maxBytes: 2 ** 20, create, read: vi.fn(), delete: vi.fn(async () => true) };
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.url.pathname === "/api/teleporter") {
+        return new Response(zipBytes, { status: 200, headers: { "content-type": "application/zip" } });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.export_backup!({}, { ...context, transitFiles });
+
+    expect(result).toEqual({
+      file: {
+        fileId: "tf-1",
+        downloadUrl: "http://download/tf-1",
+        name: "teleporter.zip",
+        mimeType: "application/zip",
+        sizeBytes: zipBytes.length,
+      },
+    });
+    expect(create).toHaveBeenCalledTimes(1);
+    const uploaded = create.mock.calls[0]![0] as File;
+    expect(uploaded.name).toBe("teleporter.zip");
+    expect(uploaded.type).toBe("application/zip");
+  });
+
+  it("falls back to base64 data when transit storage is unavailable", async () => {
+    const { context } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.url.pathname === "/api/teleporter") {
+        return new Response(zipBytes, { status: 200, headers: { "content-type": "application/zip" } });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.export_backup!({}, context);
+
+    expect(result).toEqual({
+      file: {
+        name: "teleporter.zip",
+        mimeType: "application/zip",
+        sizeBytes: zipBytes.length,
+        data: Buffer.from(zipBytes).toString("base64"),
+      },
+    });
+  });
+
+  it("uploads the transit file as a multipart form on import", async () => {
+    const stored = {
+      name: "teleporter.zip",
+      mimeType: "application/zip",
+      sizeBytes: 4,
+      file: new File(["abcd"], "teleporter.zip", { type: "application/zip" }),
+    };
+    const transitFiles = {
+      maxBytes: 2 ** 20,
+      create: vi.fn(),
+      read: vi.fn(async () => stored),
+      delete: vi.fn(async () => true),
+    };
+    const { context, requests } = createTestContext((request) => {
+      if (request.method === "POST" && request.url.pathname === "/api/auth") {
+        return sessionResponse("sid");
+      }
+      if (request.method === "POST" && request.url.pathname === "/api/teleporter") {
+        // FTL returns the list of restored file paths as strings, not objects.
+        return Response.json({
+          files: ["etc/pihole/pihole.toml", "etc/pihole/gravity.db->group"],
+          took: 0.1,
+        });
+      }
+      return undefined;
+    });
+
+    const result = await piHoleActionHandlers.import_backup!(
+      { file: { fileId: "tf-1" } },
+      { ...context, transitFiles },
+    );
+
+    expect(result).toEqual({ files: ["etc/pihole/pihole.toml", "etc/pihole/gravity.db->group"] });
+    const post = requests.find((request) => request.method === "POST" && request.url.pathname === "/api/teleporter")!;
+    // The multipart boundary is generated by the transport, so the request
+    // must not carry a fixed content-type header.
+    expect(post.headers.get("content-type")).toBeNull();
+    // FTL only accepts the upload in a "file" field (field_found in
+    // teleporter.c), so the wire contract must expose exactly that field.
+    expect(post.body instanceof FormData).toBe(true);
+    const uploadedFile = (post.body as FormData).get("file");
+    expect(uploadedFile instanceof File).toBe(true);
+    expect((uploadedFile as File).name).toBe("teleporter.zip");
+  });
+});
+
+describe("validatePiHoleCredential", () => {
+  it("returns profile metadata after a successful login", async () => {
+    const fetcher: typeof fetch = async (input) => {
+      expect(new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url).pathname).toBe(
+        "/api/auth",
+      );
+      return sessionResponse("sid");
+    };
+
+    const result = await validatePiHoleCredential(
+      { apiKey: "app-password", values: { baseUrl: "http://pi.hole", apiPath: "api" } },
+      fetcher,
+    );
+    expect(result.profile?.accountId).toBe("pi_hole:http://pi.hole");
+    expect(result.profile?.displayName).toBe("Pi-hole (http://pi.hole)");
+    expect(result.metadata?.baseUrl).toBe("http://pi.hole");
+    expect(result.metadata?.apiPath).toBe("api");
+  });
+
+  it("rejects an invalid application password", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json({
+        session: { valid: false, sid: null, validity: -1, totp: false, message: "password incorrect" },
+        took: 0.1,
+      });
+
+    await expect(
+      validatePiHoleCredential({ apiKey: "wrong", values: { baseUrl: "http://pi.hole" } }, fetcher),
+    ).rejects.toThrow("Invalid Pi-hole application password");
+  });
+
+  it("hints at application passwords when two-factor authentication is enabled", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json({
+        session: { valid: false, sid: null, validity: -1, totp: true, message: "password incorrect" },
+        took: 0.1,
+      });
+
+    await expect(
+      validatePiHoleCredential({ apiKey: "password", values: { baseUrl: "http://pi.hole" } }, fetcher),
+    ).rejects.toThrow("two-factor authentication");
+  });
+});

--- a/src/providers/pi_hole/runtime.ts
+++ b/src/providers/pi_hole/runtime.ts
@@ -29,6 +29,7 @@ const defaultPiHoleApiPath = "api";
 const piHoleGravityOutputTailChars = 2_000;
 // Keep in sync with the server-side upload cap (FTL MAXFILESIZE).
 const piHoleTeleporterMaxBytes = 50 * 1024 * 1024;
+const piHoleNoAuthCacheTtlMs = 5 * 60_000;
 
 export const piHoleCredentialHelpUrl = "https://docs.pi-hole.net/api/";
 
@@ -170,8 +171,9 @@ async function authenticatePiHole(context: PiHoleActionContext): Promise<PiHoleS
   if (session?.valid === true) {
     const sid = optionalString(session.sid);
     if (sid === undefined) {
-      // No authentication is required on this server; cache the no-auth state.
-      return { sid: null, expiresAt: Number.POSITIVE_INFINITY };
+      // No authentication is required on this server; cache the no-auth state for a
+      // bounded time so the proxy picks it up if authentication is enabled later.
+      return { sid: null, expiresAt: Date.now() + piHoleNoAuthCacheTtlMs };
     }
     const validitySeconds = optionalNumber(session.validity) ?? 0;
     // Leave a small buffer so the cached session expires before the server does.
@@ -381,7 +383,15 @@ export const piHoleActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHole
     const blocking = requiredBoolean(input.blocking, "blocking", piHoleInputError);
     const body: Record<string, unknown> = { blocking };
     if (input.timer !== undefined) {
-      body.timer = typeof input.timer === "number" ? input.timer : null;
+      if (input.timer === null) {
+        body.timer = null;
+      } else {
+        const timer = optionalNumber(input.timer);
+        if (timer === undefined) {
+          throw piHoleInputError("timer must be a number or null");
+        }
+        body.timer = timer;
+      }
     }
     const payload = readRecordPayload(await requestPiHoleJson({ context, method: "POST", path: "dns/blocking", body }));
     return readBlockingStatus(payload);
@@ -495,6 +505,9 @@ export const piHoleActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHole
   async update_config(input, context) {
     const config = requiredRecord(input.config, "config", piHoleInputError);
     const restart = input.restart === undefined ? undefined : readRestartFlag(input.restart);
+    if (input.restart !== undefined && restart === undefined) {
+      throw piHoleInputError("restart must be a boolean");
+    }
     const payload = readRecordPayload(
       await requestPiHoleJson({
         context,
@@ -557,6 +570,7 @@ export const piHoleActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHole
           name: upload.name,
           mimeType: upload.mimeType,
           sizeBytes: upload.sizeBytes,
+          data: null,
         },
       };
     }
@@ -565,6 +579,8 @@ export const piHoleActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHole
         name,
         mimeType,
         sizeBytes: bytes.length,
+        fileId: null,
+        downloadUrl: null,
         data: encodePiHoleBase64(bytes),
       },
     };
@@ -593,7 +609,12 @@ export async function validatePiHoleCredential(
   const baseUrl = normalizePiHoleBaseUrl(input.values.baseUrl);
   const apiPath = normalizePiHoleApiPath(input.values.apiPath);
 
-  await authenticatePiHole({ appPassword, baseUrl, apiPath, fetcher, signal });
+  const context = { appPassword, baseUrl, apiPath, fetcher, signal };
+  const session = await authenticatePiHole(context);
+  if (session.sid) {
+    // Validation is a one-shot check, so release the session seat immediately.
+    await performPiHoleRequest({ context, method: "DELETE", path: "auth", sid: session.sid }).catch(() => {});
+  }
 
   return {
     profile: {

--- a/src/providers/pi_hole/runtime.ts
+++ b/src/providers/pi_hole/runtime.ts
@@ -1,0 +1,623 @@
+import type { CredentialValidationResult, TransitFileStore } from "../../core/types.ts";
+import type { ProviderActionHandlerSubset, ProviderFetch } from "../provider-runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalNumber,
+  optionalObjectArray,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredBoolean,
+  requiredRecord,
+  requiredString,
+  stringArray,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed, readBoundedResponseBytes } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+  readProviderTextBody,
+  readTransitFileInput,
+} from "../provider-runtime.ts";
+
+const piHoleRequestTimeoutMs = 30_000;
+const defaultPiHoleApiPath = "api";
+const piHoleGravityOutputTailChars = 2_000;
+// Keep in sync with the server-side upload cap (FTL MAXFILESIZE).
+const piHoleTeleporterMaxBytes = 50 * 1024 * 1024;
+
+export const piHoleCredentialHelpUrl = "https://docs.pi-hole.net/api/";
+
+export interface PiHoleActionContext {
+  appPassword: string;
+  baseUrl: string;
+  apiPath: string;
+  transitFiles?: TransitFileStore;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export type PiHoleActionHandler = (input: Record<string, unknown>, context: PiHoleActionContext) => Promise<unknown>;
+
+export type PiHoleQueryValue = string | number | boolean | undefined;
+
+export interface PiHoleRequestOptions {
+  context: PiHoleActionContext;
+  method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+  path: string;
+  query?: Record<string, PiHoleQueryValue>;
+  body?: Record<string, unknown> | readonly unknown[] | FormData;
+}
+
+interface PiHoleSessionEntry {
+  sid: string | null;
+  expiresAt: number;
+}
+
+/**
+ * Cache sessions per instance: re-logging in for every action would consume
+ * the instance's session seats. In-flight logins are shared so concurrent
+ * cold-start requests do not exhaust them.
+ */
+const piHoleSessionCache = new Map<string, PiHoleSessionEntry>();
+const piHoleLoginInFlight = new Map<string, Promise<PiHoleSessionEntry>>();
+
+function piHoleSessionCacheKey(context: PiHoleActionContext): string {
+  return `${context.baseUrl}|${context.apiPath}|${context.appPassword}`;
+}
+
+/** Exposed for the test harness. */
+export function clearPiHoleSessionCache(): void {
+  piHoleSessionCache.clear();
+  piHoleLoginInFlight.clear();
+}
+
+/**
+ * Release the session currently held in the cache. Best-effort logout used by
+ * short-lived callers such as the E2E harness; a failed logout is ignored
+ * because the session expires on its own.
+ */
+export async function logoutPiHoleSession(context: PiHoleActionContext): Promise<void> {
+  const key = piHoleSessionCacheKey(context);
+  const entry = piHoleSessionCache.get(key);
+  piHoleSessionCache.delete(key);
+  if (!entry?.sid) {
+    return;
+  }
+  try {
+    await performPiHoleRequest({ context, method: "DELETE", path: "auth", sid: entry.sid });
+  } catch {}
+}
+
+function buildPiHoleApiUrl(
+  context: PiHoleActionContext,
+  path: string,
+  query?: Record<string, PiHoleQueryValue>,
+): string {
+  const base = ensureTrailingSlash(context.baseUrl);
+  const prefix = `${base}${stripSlashes(context.apiPath)}/`;
+  const url = new URL(`./${stripLeadingSlash(path)}`, prefix);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+async function performPiHoleRequest(options: PiHoleRequestOptions & { sid: string | null }): Promise<Response> {
+  const { context } = options;
+  const url = buildPiHoleApiUrl(context, options.path, options.query);
+  const headers = new Headers({ accept: "application/json", "user-agent": providerUserAgent });
+  if (options.sid) {
+    headers.set("x-ftl-sid", options.sid);
+  }
+
+  let body: BodyInit | undefined;
+  if (options.body instanceof FormData) {
+    body = options.body;
+  } else if (options.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(options.body);
+  }
+
+  const timeout = createProviderTimeout(context.signal, piHoleRequestTimeoutMs);
+  try {
+    return await context.fetcher(url, {
+      method: options.method,
+      headers,
+      body,
+      signal: timeout.signal,
+    });
+  } catch (error) {
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "Pi-hole request timed out");
+    }
+    throw error;
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+async function readPiHolePayload(response: Response): Promise<unknown> {
+  return readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "Pi-hole returned an invalid JSON response",
+  });
+}
+
+function mapPiHoleHttpError(status: number, payload: unknown): ProviderRequestError {
+  const error = optionalRecord(optionalRecord(payload)?.error);
+  const message = optionalString(error?.message) ?? optionalString(optionalRecord(payload)?.message);
+  return new ProviderRequestError(status, message ?? `Pi-hole request failed with HTTP ${status}`, payload);
+}
+
+async function authenticatePiHole(context: PiHoleActionContext): Promise<PiHoleSessionEntry> {
+  const response = await performPiHoleRequest({
+    context,
+    method: "POST",
+    path: "auth",
+    body: { password: context.appPassword },
+    sid: null,
+  });
+  const payload = await readPiHolePayload(response);
+  const session = optionalRecord(optionalRecord(payload)?.session);
+  if (session?.valid === true) {
+    const sid = optionalString(session.sid);
+    if (sid === undefined) {
+      // No authentication is required on this server; cache the no-auth state.
+      return { sid: null, expiresAt: Number.POSITIVE_INFINITY };
+    }
+    const validitySeconds = optionalNumber(session.validity) ?? 0;
+    // Leave a small buffer so the cached session expires before the server does.
+    return { sid, expiresAt: Date.now() + Math.max(0, validitySeconds - 5) * 1000 };
+  }
+
+  if (!response.ok) {
+    // HTTP-level failures (rate limiting, invalid TOTP, malformed requests) carry a structured error body.
+    throw mapPiHoleHttpError(response.status, payload);
+  }
+
+  // A 200 response with an invalid session means the password was rejected.
+  if (session?.totp === true) {
+    throw new ProviderRequestError(
+      401,
+      "Pi-hole login failed: two-factor authentication is enabled, so use an application password instead of your account password.",
+    );
+  }
+  throw new ProviderRequestError(401, "Invalid Pi-hole application password.");
+}
+
+export async function ensurePiHoleSession(context: PiHoleActionContext): Promise<string | null> {
+  const key = piHoleSessionCacheKey(context);
+  const cached = piHoleSessionCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.sid;
+  }
+
+  const inFlight = piHoleLoginInFlight.get(key);
+  if (inFlight) {
+    return (await inFlight).sid;
+  }
+
+  const login = authenticatePiHole(context)
+    .then((session) => {
+      piHoleSessionCache.set(key, session);
+      return session;
+    })
+    .finally(() => {
+      piHoleLoginInFlight.delete(key);
+    });
+  piHoleLoginInFlight.set(key, login);
+  return (await login).sid;
+}
+
+export async function requestPiHoleJson(options: PiHoleRequestOptions): Promise<unknown> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const sid = await ensurePiHoleSession(options.context);
+    const response = await performPiHoleRequest({ ...options, sid });
+    const payload = await readPiHolePayload(response);
+    if (response.ok) {
+      return payload;
+    }
+    if (response.status === 401 && attempt === 0) {
+      piHoleSessionCache.delete(piHoleSessionCacheKey(options.context));
+      continue;
+    }
+    throw mapPiHoleHttpError(response.status, payload);
+  }
+  throw new ProviderRequestError(401, "Pi-hole rejected the session after re-authentication.");
+}
+
+/** Raw-response variant for binary endpoints that cannot be read as JSON. */
+async function requestPiHoleResponse(options: PiHoleRequestOptions): Promise<Response> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const sid = await ensurePiHoleSession(options.context);
+    const response = await performPiHoleRequest({ ...options, sid });
+    if (response.ok) {
+      return response;
+    }
+    if (response.status === 401 && attempt === 0) {
+      piHoleSessionCache.delete(piHoleSessionCacheKey(options.context));
+      continue;
+    }
+    const payload = await readPiHolePayload(response).catch(() => null);
+    throw mapPiHoleHttpError(response.status, payload);
+  }
+  throw new ProviderRequestError(401, "Pi-hole rejected the session after re-authentication.");
+}
+
+function encodePiHoleBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+export function normalizePiHoleBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
+  // Private instance targets are allowed only with the deployment opt-in.
+  const raw = optionalString(value)?.trim();
+  if (!raw) {
+    throw new ProviderRequestError(400, "baseUrl is required");
+  }
+
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password || url.search || url.hash) {
+    throw new ProviderRequestError(400, "baseUrl must be a clean instance root URL");
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+  // Users often paste the API root (https://pi.hole/api) as the instance URL;
+  // the API path is appended below the root, so drop a trailing api segment to
+  // avoid double-prefixing every request.
+  if (/\/api$/i.test(url.pathname)) {
+    url.pathname = url.pathname.replace(/\/api$/i, "") || "/";
+  }
+  return url.pathname === "/" ? url.origin : `${url.origin}${url.pathname}`;
+}
+
+export function normalizePiHoleApiPath(value: unknown): string {
+  const raw = optionalString(value)?.trim();
+  const normalized = stripSlashes(raw ?? "");
+  if (!normalized) {
+    return defaultPiHoleApiPath;
+  }
+  if (/[\s?#]/.test(normalized) || normalized.split("/").includes("..")) {
+    throw new ProviderRequestError(400, "apiPath must be a URL path segment such as api");
+  }
+  return normalized;
+}
+
+export function resolvePiHoleBaseUrl(input: {
+  values?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}): string {
+  const value = optionalString(input.metadata?.baseUrl) ?? optionalString(input.values?.baseUrl);
+  return normalizePiHoleBaseUrl(value);
+}
+
+export function resolvePiHoleApiPath(input: {
+  values?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}): string {
+  const value = optionalString(input.metadata?.apiPath) ?? optionalString(input.values?.apiPath);
+  return normalizePiHoleApiPath(value);
+}
+
+function piHoleInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function readRequiredString(value: unknown, fieldName: string): string {
+  return requiredString(value, fieldName, piHoleInputError);
+}
+
+function readRecordPayload(payload: unknown): Record<string, unknown> {
+  return optionalRecord(payload) ?? {};
+}
+
+function stripPiHoleTook(payload: Record<string, unknown>): Record<string, unknown> {
+  const { took: _took, ...rest } = payload;
+  return rest;
+}
+
+function readBlockingStatus(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    blocking: optionalString(payload.blocking),
+    timer: optionalNumber(payload.timer) ?? null,
+  };
+}
+
+function readGravityStatus(text: string): string | null {
+  if (/\[✗\]|\berror\b|\bfatal\b|\bfailed\b/i.test(text)) {
+    return "failed";
+  }
+  if (/\[✓\]\s*done|\bdone\.?\s*$/im.test(text.trimEnd())) {
+    return "success";
+  }
+  return null;
+}
+
+function readRestartFlag(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+  return undefined;
+}
+
+export const piHoleActionHandlers: ProviderActionHandlerSubset<"pi_hole", PiHoleActionHandler> = {
+  async get_overview(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "stats/summary" }));
+    return { summary: stripPiHoleTook(payload) };
+  },
+  async get_dns_blocking_status(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "dns/blocking" }));
+    return readBlockingStatus(payload);
+  },
+  async set_dns_blocking(input, context) {
+    const blocking = requiredBoolean(input.blocking, "blocking", piHoleInputError);
+    const body: Record<string, unknown> = { blocking };
+    if (input.timer !== undefined) {
+      body.timer = typeof input.timer === "number" ? input.timer : null;
+    }
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "POST", path: "dns/blocking", body }));
+    return readBlockingStatus(payload);
+  },
+  async get_queries(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: "queries",
+        query: {
+          from: optionalNumber(input.from),
+          until: optionalNumber(input.until),
+          length: optionalInteger(input.length),
+          start: optionalInteger(input.start),
+          cursor: optionalInteger(input.cursor),
+          domain: optionalString(input.domain),
+          client_ip: optionalString(input.clientIp),
+          client_name: optionalString(input.clientName),
+          upstream: optionalString(input.upstream),
+          type: optionalString(input.type),
+          status: optionalString(input.status),
+          reply: optionalString(input.reply),
+          dnssec: optionalString(input.dnssec),
+          disk: optionalBoolean(input.disk),
+        },
+      }),
+    );
+    return {
+      queries: optionalObjectArray(payload.queries, "Pi-hole queries response"),
+      cursor: optionalInteger(payload.cursor) ?? null,
+      recordsTotal: optionalInteger(payload.recordsTotal) ?? 0,
+      recordsFiltered: optionalInteger(payload.recordsFiltered) ?? 0,
+      earliestTimestamp: optionalNumber(payload.earliest_timestamp) ?? null,
+      earliestTimestampDisk: optionalNumber(payload.earliest_timestamp_disk) ?? null,
+    };
+  },
+  async get_query_types(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "stats/query_types" }));
+    return { types: optionalRecord(payload.types) ?? {} };
+  },
+  async get_top_domains(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: "stats/top_domains",
+        query: { count: optionalInteger(input.count), blocked: optionalBoolean(input.blocked) },
+      }),
+    );
+    return {
+      domains: optionalObjectArray(payload.domains, "Pi-hole top domains response"),
+      totalQueries: optionalInteger(payload.total_queries) ?? 0,
+      blockedQueries: optionalInteger(payload.blocked_queries) ?? 0,
+    };
+  },
+  async get_top_clients(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: "stats/top_clients",
+        query: { count: optionalInteger(input.count), blocked: optionalBoolean(input.blocked) },
+      }),
+    );
+    return {
+      clients: optionalObjectArray(payload.clients, "Pi-hole top clients response"),
+      totalQueries: optionalInteger(payload.total_queries) ?? 0,
+      blockedQueries: optionalInteger(payload.blocked_queries) ?? 0,
+    };
+  },
+  async get_recent_blocked(input, context) {
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: "stats/recent_blocked",
+        query: { count: optionalInteger(input.count) },
+      }),
+    );
+    return { blocked: stringArray(payload.blocked, "Pi-hole recent blocked response") };
+  },
+  async get_upstreams(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "stats/upstreams" }));
+    return {
+      upstreams: optionalObjectArray(payload.upstreams, "Pi-hole upstreams response"),
+      forwardedQueries: optionalInteger(payload.forwarded_queries) ?? 0,
+      totalQueries: optionalInteger(payload.total_queries) ?? 0,
+    };
+  },
+  async get_history(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "history" }));
+    return { history: optionalObjectArray(payload.history, "Pi-hole history response") };
+  },
+  async search_domain(input, context) {
+    const domain = readRequiredString(input.domain, "domain");
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "GET",
+        path: `search/${encodeURIComponent(domain)}`,
+        query: { partial: optionalBoolean(input.partial), N: optionalInteger(input.maxResults) },
+      }),
+    );
+    return { search: optionalRecord(payload.search) ?? {} };
+  },
+  async get_config(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "GET", path: "config" }));
+    return { config: optionalRecord(payload.config) ?? {} };
+  },
+  async update_config(input, context) {
+    const config = requiredRecord(input.config, "config", piHoleInputError);
+    const restart = input.restart === undefined ? undefined : readRestartFlag(input.restart);
+    const payload = readRecordPayload(
+      await requestPiHoleJson({
+        context,
+        method: "PATCH",
+        path: "config",
+        query: restart === undefined ? undefined : { restart },
+        body: { config },
+      }),
+    );
+    return { config: optionalRecord(payload.config) ?? {} };
+  },
+  async run_gravity(_input, context) {
+    // POST /api/action/gravity streams the gravity log as text/plain (chunked)
+    // rather than returning JSON, so read it as text and relay a tail of the
+    // log alongside a best-effort status.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const sid = await ensurePiHoleSession(context);
+      const response = await performPiHoleRequest({ context, method: "POST", path: "action/gravity", sid });
+      const text = await readProviderTextBody(response, "Pi-hole gravity response");
+      if (response.ok) {
+        const trimmed = text.trim();
+        return {
+          status: readGravityStatus(trimmed),
+          output:
+            trimmed.length > piHoleGravityOutputTailChars ? trimmed.slice(-piHoleGravityOutputTailChars) : trimmed,
+        };
+      }
+      if (response.status === 401 && attempt === 0) {
+        piHoleSessionCache.delete(piHoleSessionCacheKey(context));
+        continue;
+      }
+      throw mapPiHoleHttpError(response.status, text);
+    }
+    throw new ProviderRequestError(401, "Pi-hole rejected the session after re-authentication.");
+  },
+  async restart_dns(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "POST", path: "action/restartdns" }));
+    return { status: optionalString(payload.status) ?? null };
+  },
+  async flush_dns_logs(_input, context) {
+    const payload = readRecordPayload(await requestPiHoleJson({ context, method: "POST", path: "action/flush/logs" }));
+    return { status: optionalString(payload.status) ?? null };
+  },
+  async export_backup(_input, context) {
+    const response = await requestPiHoleResponse({ context, method: "GET", path: "teleporter" });
+    const maxBytes = context.transitFiles?.maxBytes ?? piHoleTeleporterMaxBytes;
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes,
+      fieldName: "teleporter export",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    const name = "teleporter.zip";
+    const mimeType = optionalString(response.headers.get("content-type")) ?? "application/zip";
+    if (context.transitFiles) {
+      const upload = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+      return {
+        file: {
+          fileId: upload.fileId,
+          downloadUrl: upload.downloadUrl,
+          name: upload.name,
+          mimeType: upload.mimeType,
+          sizeBytes: upload.sizeBytes,
+        },
+      };
+    }
+    return {
+      file: {
+        name,
+        mimeType,
+        sizeBytes: bytes.length,
+        data: encodePiHoleBase64(bytes),
+      },
+    };
+  },
+  async import_backup(input, context) {
+    const file = await readTransitFileInput(input.file, context);
+    const form = new FormData();
+    form.append("file", new File([file.file], file.name, { type: file.mimeType ?? "application/zip" }));
+    const payload = readRecordPayload(
+      await requestPiHoleJson({ context, method: "POST", path: "teleporter", body: form }),
+    );
+    return { files: optionalStringArray(payload.files) ?? [] };
+  },
+};
+
+/**
+ * The validator fetcher must already be re-guarded with the same
+ * private-network opt-in as the provider executors.
+ */
+export async function validatePiHoleCredential(
+  input: { apiKey: string; values: Record<string, string> },
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const appPassword = readRequiredString(input.apiKey, "apiKey");
+  const baseUrl = normalizePiHoleBaseUrl(input.values.baseUrl);
+  const apiPath = normalizePiHoleApiPath(input.values.apiPath);
+
+  await authenticatePiHole({ appPassword, baseUrl, apiPath, fetcher, signal });
+
+  return {
+    profile: {
+      accountId: `pi_hole:${baseUrl}`,
+      displayName: `Pi-hole (${baseUrl})`,
+      grantedScopes: [],
+    },
+    grantedScopes: [],
+    metadata: {
+      baseUrl,
+      apiPath,
+      credentialHelpUrl: piHoleCredentialHelpUrl,
+    },
+  };
+}
+
+function stripLeadingSlash(value: string): string {
+  return value.replace(/^\/+/, "");
+}
+
+function stripSlashes(value: string): string {
+  return value.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}

--- a/src/providers/pi_hole/test-helpers.ts
+++ b/src/providers/pi_hole/test-helpers.ts
@@ -1,0 +1,45 @@
+import type { PiHoleActionContext } from "./runtime.ts";
+
+export interface CapturedRequest {
+  url: URL;
+  method: string;
+  headers: Headers;
+  body: unknown;
+}
+
+export function createTestContext(respond: (request: CapturedRequest) => Response | Promise<Response> | undefined): {
+  context: PiHoleActionContext;
+  requests: CapturedRequest[];
+} {
+  const requests: CapturedRequest[] = [];
+  const fetcher: typeof fetch = async (input, init) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+    const headers = new Headers(init?.headers);
+    const request: CapturedRequest = {
+      url,
+      method: init?.method ?? "GET",
+      headers,
+      body:
+        init?.body instanceof FormData
+          ? init?.body
+          : init?.body !== undefined
+            ? JSON.parse(String(init?.body))
+            : undefined,
+    };
+    requests.push(request);
+
+    return (await respond(request)) ?? new Response(null, { status: 404 });
+  };
+
+  return {
+    context: { appPassword: "app-password", baseUrl: "http://pi.hole", apiPath: "api", fetcher },
+    requests,
+  };
+}
+
+export function sessionResponse(sid: string): Response {
+  return Response.json({
+    session: { valid: true, sid, validity: 600, csrf: "csrf", totp: false, message: "correct password" },
+    took: 0.1,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a Pi-hole FTL (v6) provider with 40 actions:

- Overview, DNS blocking status/control (with timer support), query log with filters and pagination cursors, query types, top domains/clients, recently blocked domains, upstream metrics, history, domain list search
- Configuration read and partial updates (`update_config`, including `restart: false`), gravity update
- Management CRUD: groups, lists (allow/block), domain entries (allow/deny), clients; batch deletes for each
- DHCP leases and network devices reads
- Teleporter export (`teleporter.zip` via transit files with base64 fallback) and import (multipart `file` field; the `files` result is a string array per FTL's contract)

Runtime notes:

- Session-based auth (`X-FTL-SID`) with a per-instance session cache and a single in-flight login; best-effort logout to release session seats
- Egress uses the shared SSRF-guarded fetch with the private-network opt-in threaded through executors and the credential validator
- The proxy attaches the session id per request (FTL has no static Bearer token), so it uses `auth: "none"` + `customizeRequest`
- The shared `createProviderProxyUrl` hardening is submitted as a separate PR

## Tests

- 55 provider unit tests; `npm run fix-check` green on this branch
- Real-device verification was performed against a live instance (DNS control, full CRUD, config writes under `app_sudo`, teleporter export/import, read-only endpoints); that E2E harness intentionally lives outside this PR as a local runnable script
