### PR TITLE
feat(providers): add Box OAuth provider

### DIFF
--- a/src/providers/box/actions.ts
+++ b/src/providers/box/actions.ts
@@ -1,0 +1,289 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+import { boxProviderScopes } from "./scopes.ts";
+
+const service = "box";
+const emptyInput = s.object({}, { description: "No input is required for this action." });
+const itemTypes = ["file", "folder", "web_link"];
+
+const itemSchema = s.looseRequiredObject(
+  "A Box file, folder, or web link with stable identifying metadata.",
+  {
+    id: s.nonEmptyString("The Box item identifier."),
+    type: s.stringEnum(itemTypes, { description: "The Box item type." }),
+    name: s.nonEmptyString("The item name."),
+    etag: s.optional(s.nullableString("The item entity tag when available.")),
+    sequenceId: s.optional(s.nullableString("The item sequence identifier when available.")),
+    description: s.optional(s.nullableString("The item description when available.")),
+    sizeBytes: s.optional(s.nullableInteger("The file size in bytes when available.")),
+    parent: s.optional(s.nullable(s.looseObject({}, { description: "The parent folder reference." }))),
+    pathCollection: s.optional(s.nullable(s.looseObject({}, { description: "The item's Box path collection." }))),
+    sharedLink: s.optional(s.nullable(s.looseObject({}, { description: "Shared-link metadata when available." }))),
+    createdAt: s.optional(s.nullableString("The creation timestamp when available.")),
+    modifiedAt: s.optional(s.nullableString("The modification timestamp when available.")),
+  },
+  {
+    optional: [
+      "etag",
+      "sequenceId",
+      "description",
+      "sizeBytes",
+      "parent",
+      "pathCollection",
+      "sharedLink",
+      "createdAt",
+      "modifiedAt",
+    ],
+  },
+);
+
+const itemOutput = s.requiredObject("A Box item result.", { item: itemSchema });
+const idInput = (key: "fileId" | "folderId", description: string): JsonSchema =>
+  s.requiredObject(description, {
+    [key]: s.nonEmptyString(`The Box ${key === "fileId" ? "file" : "folder"} identifier.`),
+  });
+
+const listOutput = s.object(
+  {
+    entries: s.array(itemSchema, { description: "The Box items in this page." }),
+    limit: s.positiveInteger("The page size returned by Box."),
+    offset: s.optional(s.nonNegativeInteger("The offset returned for offset-based pagination.")),
+    totalCount: s.optional(s.nonNegativeInteger("The Box total count estimate for offset-based pagination.")),
+    nextMarker: s.optional(s.nullableString("The marker for the next page, or null when there is no next page.")),
+    previousMarker: s.optional(s.nullableString("The marker for the previous page when available.")),
+  },
+  { description: "A page of Box items.", required: ["entries", "limit", "nextMarker"] },
+);
+
+const fileInput = s.requiredObject("A local transit file to upload to Box.", {
+  fileId: s.nonEmptyString("The local transit file identifier."),
+});
+
+function action(
+  name: string,
+  description: string,
+  inputSchema: JsonSchema,
+  outputSchema: JsonSchema,
+  scope: string,
+  followUpActions?: string[],
+): ActionDefinition {
+  return defineProviderAction(service, {
+    name,
+    description,
+    requiredScopes: [scope],
+    providerPermissions: [scope],
+    inputSchema,
+    outputSchema,
+    followUpActions,
+  });
+}
+
+export const boxActions: ActionDefinition[] = [
+  action(
+    "get_current_user",
+    "Get the Box user represented by the current OAuth connection.",
+    emptyInput,
+    s.requiredObject("The authenticated Box user.", {
+      id: s.nonEmptyString("The Box user identifier."),
+      type: s.literal("user", { description: "The Box resource type." }),
+      name: s.nonEmptyString("The user's display name."),
+      login: s.email("The user's primary email address."),
+      status: s.optional(s.string("The Box account status.")),
+      spaceAmount: s.optional(s.nonNegativeInteger("The available storage in bytes.")),
+      spaceUsed: s.optional(s.nonNegativeInteger("The used storage in bytes.")),
+      maxUploadSize: s.optional(s.nonNegativeInteger("The maximum individual upload size in bytes.")),
+    }),
+    boxProviderScopes.read,
+  ),
+  action(
+    "get_file",
+    "Get metadata for a Box file.",
+    idInput("fileId", "Identify the file to retrieve."),
+    itemOutput,
+    boxProviderScopes.read,
+    ["box.download_file"],
+  ),
+  action(
+    "get_folder",
+    "Get metadata for a Box folder.",
+    idInput("folderId", "Identify the folder to retrieve."),
+    itemOutput,
+    boxProviderScopes.read,
+    ["box.list_folder_items"],
+  ),
+  action(
+    "list_folder_items",
+    "List files, folders, and web links in a Box folder using marker or offset pagination.",
+    s.object(
+      {
+        folderId: s.nonEmptyString("The folder identifier. Use 0 for the root folder."),
+        useMarker: s.optional(s.boolean("Whether to use marker-based pagination.")),
+        marker: s.optional(s.nonEmptyString("The marker from a previous page.")),
+        offset: s.optional(s.nonNegativeInteger("The zero-based offset for offset pagination.")),
+        limit: s.optional(s.positiveInteger("The maximum number of items to return.", { maximum: 1000 })),
+        sort: s.optional(s.stringEnum(["id", "name", "date", "size"], { description: "The secondary sort field." })),
+        direction: s.optional(s.stringEnum(["ASC", "DESC"], { description: "The sort direction." })),
+      },
+      { description: "Select a folder page.", required: ["folderId"] },
+    ),
+    listOutput,
+    boxProviderScopes.read,
+    ["box.list_folder_items_continue"],
+  ),
+  action(
+    "list_folder_items_continue",
+    "Continue a marker-based Box folder listing.",
+    s.requiredObject("Continue a folder listing from its next marker.", {
+      folderId: s.nonEmptyString("The folder identifier."),
+      marker: s.nonEmptyString("The next marker returned by Box."),
+      limit: s.optional(s.positiveInteger("The maximum number of items to return.", { maximum: 1000 })),
+    }),
+    listOutput,
+    boxProviderScopes.read,
+    ["box.list_folder_items_continue"],
+  ),
+  action(
+    "search",
+    "Search Box content available to the authenticated user.",
+    s.object(
+      {
+        query: s.nonEmptyString("The search query."),
+        type: s.optional(s.stringEnum(itemTypes, { description: "Limit results to one item type." })),
+        ancestorFolderIds: s.optional(s.array(s.nonEmptyString("A Box ancestor folder identifier."))),
+        fileExtensions: s.optional(s.array(s.nonEmptyString("A file extension without a leading dot."))),
+        contentTypes: s.optional(
+          s.array(
+            s.stringEnum(["name", "description", "file_content", "comments", "tags"], {
+              description: "The content field to search.",
+            }),
+          ),
+        ),
+        limit: s.optional(s.positiveInteger("The maximum number of results.", { maximum: 200 })),
+        offset: s.optional(s.nonNegativeInteger("The zero-based search offset.")),
+        sort: s.optional(s.stringEnum(["modified_at", "relevance"], { description: "The search sort field." })),
+        direction: s.optional(s.stringEnum(["ASC", "DESC"], { description: "The sort direction." })),
+      },
+      { description: "Search criteria for Box content.", required: ["query"] },
+    ),
+    s.requiredObject("A page of Box search results.", {
+      entries: s.array(itemSchema, { description: "The matching Box items." }),
+      limit: s.positiveInteger("The page size returned by Box."),
+      offset: s.nonNegativeInteger("The current result offset."),
+      totalCount: s.nonNegativeInteger("The Box total count estimate."),
+      nextOffset: s.nullableInteger("The next offset, or null when no further page is indicated."),
+    }),
+    boxProviderScopes.read,
+  ),
+  action(
+    "download_file",
+    "Download a Box file into local transit storage.",
+    s.object(
+      {
+        fileId: s.nonEmptyString("The Box file identifier."),
+        fileName: s.optional(s.nonEmptyString("An optional local transit file name.")),
+      },
+      { required: ["fileId"] },
+    ),
+    s.requiredObject("A Box file stored in local transit storage.", {
+      item: itemSchema,
+      file: s.requiredObject("The local transit file.", {
+        fileId: s.nonEmptyString("The local transit file identifier."),
+        downloadUrl: s.url("The local transit download URL."),
+        sizeBytes: s.nonNegativeInteger("The stored file size in bytes."),
+        name: s.nonEmptyString("The stored file name."),
+        mimeType: s.nonEmptyString("The stored file MIME type."),
+      }),
+    }),
+    boxProviderScopes.read,
+  ),
+  action(
+    "create_folder",
+    "Create a folder in Box.",
+    s.requiredObject("Define the new Box folder.", {
+      name: s.nonEmptyString("The folder name.", { maxLength: 255 }),
+      parentFolderId: s.nonEmptyString("The parent folder identifier. Use 0 for the root folder."),
+    }),
+    itemOutput,
+    boxProviderScopes.write,
+  ),
+  action(
+    "upload_file",
+    "Upload a local transit file of up to 50 MB to Box.",
+    s.requiredObject("Define the Box upload.", {
+      file: fileInput,
+      name: s.nonEmptyString("The file name to create in Box."),
+      parentFolderId: s.nonEmptyString("The parent folder identifier. Use 0 for the root folder."),
+      contentCreatedAt: s.optional(s.dateTime("The original content creation timestamp.")),
+      contentModifiedAt: s.optional(s.dateTime("The original content modification timestamp.")),
+    }),
+    itemOutput,
+    boxProviderScopes.write,
+  ),
+  action(
+    "update_file",
+    "Rename, move, or update the description of a Box file.",
+    s.object(
+      {
+        fileId: s.nonEmptyString("The Box file identifier."),
+        name: s.optional(s.nonEmptyString("A new file name.")),
+        description: s.optional(s.string({ description: "A new file description.", maxLength: 256 })),
+        parentFolderId: s.optional(s.nonEmptyString("A new parent folder identifier.")),
+        etag: s.optional(s.nonEmptyString("The last observed entity tag for optimistic concurrency.")),
+      },
+      { required: ["fileId"] },
+    ),
+    itemOutput,
+    boxProviderScopes.write,
+  ),
+  action(
+    "update_folder",
+    "Rename, move, or update the description of a Box folder.",
+    s.object(
+      {
+        folderId: s.nonEmptyString("The Box folder identifier."),
+        name: s.optional(s.nonEmptyString("A new folder name.")),
+        description: s.optional(s.string({ description: "A new folder description.", maxLength: 256 })),
+        parentFolderId: s.optional(s.nonEmptyString("A new parent folder identifier.")),
+        etag: s.optional(s.nonEmptyString("The last observed entity tag for optimistic concurrency.")),
+      },
+      { required: ["folderId"] },
+    ),
+    itemOutput,
+    boxProviderScopes.write,
+  ),
+  action(
+    "delete_file",
+    "Move a Box file to the trash.",
+    s.object(
+      {
+        fileId: s.nonEmptyString("The Box file identifier."),
+        etag: s.optional(s.nonEmptyString("The last observed entity tag for optimistic concurrency.")),
+      },
+      { required: ["fileId"] },
+    ),
+    s.requiredObject("The deletion result.", {
+      deleted: s.boolean("Whether Box accepted the deletion."),
+      fileId: s.nonEmptyString("The deleted Box file identifier."),
+    }),
+    boxProviderScopes.write,
+  ),
+  action(
+    "delete_folder",
+    "Move a Box folder to the trash, optionally including its contents.",
+    s.object(
+      {
+        folderId: s.nonEmptyString("The Box folder identifier."),
+        recursive: s.optional(s.boolean("Whether to delete a non-empty folder recursively.")),
+        etag: s.optional(s.nonEmptyString("The last observed entity tag for optimistic concurrency.")),
+      },
+      { required: ["folderId"] },
+    ),
+    s.requiredObject("The deletion result.", {
+      deleted: s.boolean("Whether Box accepted the deletion."),
+      folderId: s.nonEmptyString("The deleted Box folder identifier."),
+    }),
+    boxProviderScopes.write,
+  ),
+];

--- a/src/providers/box/actions.ts
+++ b/src/providers/box/actions.ts
@@ -281,8 +281,12 @@ export const boxActions: ActionDefinition[] = [
       { required: ["folderId"] },
     ),
     s.requiredObject("The deletion result.", {
-      deleted: s.boolean("Whether Box accepted the deletion."),
+      deleted: s.boolean("Whether Box confirmed that the deletion completed."),
       folderId: s.nonEmptyString("The deleted Box folder identifier."),
+      status: s.stringEnum(["deleted", "in_progress"], {
+        description: "Whether deletion completed or continues asynchronously after a Box timeout.",
+      }),
+      retryAfter: s.nullableString("The Box retry delay when provided, or null when no delay was returned."),
     }),
     boxProviderScopes.write,
   ),

--- a/src/providers/box/definition.ts
+++ b/src/providers/box/definition.ts
@@ -1,0 +1,37 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { boxActions } from "./actions.ts";
+import { boxOAuthScopes } from "./scopes.ts";
+
+const service = "box";
+
+/**
+ * Box provider backed by the Box Content API and a user-provided OAuth app.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Box",
+  description: "Browse and manage files and folders in a Box account.",
+  categories: ["Storage", "Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://account.box.com/api/oauth2/authorize",
+      tokenUrl: "https://api.box.com/oauth2/token",
+      scopes: boxOAuthScopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      clientSetup: {
+        docsUrl: "https://developer.box.com/guides/authentication/oauth2/oauth2-setup/",
+        steps: [
+          "Create a Custom App with OAuth 2.0 in the Box Developer Console.",
+          "Enable read and write access to files and folders for the app.",
+          "Add the callback URL shown by OOMOL Connect to the app's OAuth 2.0 redirect URIs.",
+          "Copy the client ID and client secret into OOMOL Connect.",
+        ],
+      },
+    },
+  ],
+  homepageUrl: "https://www.box.com",
+  actions: boxActions,
+};

--- a/src/providers/box/executors.ts
+++ b/src/providers/box/executors.ts
@@ -208,6 +208,7 @@ async function downloadFile(
       retryAfter
         ? `Box file is not ready for download; retry after ${retryAfter} seconds`
         : "Box file is not ready for download; retry later",
+      retryAfter ? { retryAfter } : undefined,
     );
   }
   if (!response.ok) {
@@ -305,13 +306,24 @@ async function deleteItem(
   const key = resource === "files" ? "fileId" : "folderId";
   const id = requireId(input[key], key);
   const url = new URL(`${boxApiBaseUrl}/${resource}/${encodeURIComponent(id)}`);
-  if (resource === "folders") setQuery(url, "recursive", optionalBoolean(input.recursive));
+  const recursive = resource === "folders" ? optionalBoolean(input.recursive) : undefined;
+  if (resource === "folders") setQuery(url, "recursive", recursive);
   const headers = new Headers();
   const etag = optionalString(input.etag);
   if (etag) headers.set("if-match", etag);
   const response = await boxRequest(url, context, { method: "DELETE", headers });
+  if (resource === "folders" && recursive === true && response.status === 503) {
+    return {
+      deleted: false,
+      folderId: id,
+      status: "in_progress",
+      retryAfter: response.headers.get("retry-after"),
+    };
+  }
   if (!response.ok) throw await boxResponseError(response, `Box ${resource.slice(0, -1)} deletion failed`);
-  return { deleted: true, [key]: id };
+  return resource === "folders"
+    ? { deleted: true, folderId: id, status: "deleted", retryAfter: null }
+    : { deleted: true, fileId: id };
 }
 
 async function boxJsonRequest(

--- a/src/providers/box/executors.ts
+++ b/src/providers/box/executors.ts
@@ -20,6 +20,20 @@ import {
 const boxApiBaseUrl = "https://api.box.com/2.0";
 const boxUploadBaseUrl = "https://upload.box.com/api/2.0";
 const boxSimpleUploadMaxBytes = 50 * 1024 * 1024;
+const boxItemFields = [
+  "id",
+  "type",
+  "name",
+  "etag",
+  "sequence_id",
+  "description",
+  "size",
+  "parent",
+  "path_collection",
+  "shared_link",
+  "created_at",
+  "modified_at",
+].join(",");
 
 type ActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
 
@@ -137,6 +151,7 @@ async function listFolderItems(
   setQuery(url, "limit", optionalNumber(input.limit));
   setQuery(url, "sort", optionalString(input.sort));
   setQuery(url, "direction", optionalString(input.direction));
+  setQuery(url, "fields", boxItemFields);
 
   const payload = await boxJsonRequest(url, context);
   return normalizeItemPage(payload);
@@ -153,6 +168,7 @@ async function search(input: Record<string, unknown>, context: BoxRequestContext
   setQuery(url, "offset", optionalNumber(input.offset));
   setQuery(url, "sort", optionalString(input.sort));
   setQuery(url, "direction", optionalString(input.direction));
+  setQuery(url, "fields", boxItemFields);
 
   const payload = await boxJsonRequest(url, context);
   const page = normalizeItemPage(payload);
@@ -333,10 +349,12 @@ async function boxResponseError(response: Response, fallback: string): Promise<P
   const code = optionalString(record.code);
   const message = optionalString(record.message);
   const suffix = [code, message].filter(Boolean).join(": ");
+  const retryAfter = response.status === 429 || response.status === 503 ? response.headers.get("retry-after") : null;
+  const details = retryAfter ? { ...record, retryAfter } : record;
   return new ProviderRequestError(
     response.status >= 500 ? 502 : response.status,
     suffix ? `${fallback}: ${suffix}` : `${fallback} with HTTP ${response.status}`,
-    record,
+    details,
   );
 }
 

--- a/src/providers/box/executors.ts
+++ b/src/providers/box/executors.ts
@@ -1,0 +1,397 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { ProviderActionHandlers, OAuthProviderContext } from "../provider-runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalNumber,
+  optionalRecord,
+  optionalString,
+  requiredRecord,
+  requiredString,
+} from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import {
+  defineOAuthProviderExecutors,
+  ProviderRequestError,
+  readProviderJsonBody,
+  readTransitFileInput,
+} from "../provider-runtime.ts";
+
+const boxApiBaseUrl = "https://api.box.com/2.0";
+const boxUploadBaseUrl = "https://upload.box.com/api/2.0";
+const boxSimpleUploadMaxBytes = 50 * 1024 * 1024;
+
+type ActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
+
+export const boxActionHandlers: ProviderActionHandlers<"box", ActionHandler> = {
+  get_current_user(_input, context) {
+    return getCurrentUser(context);
+  },
+  get_file(input, context) {
+    return getItem("files", requireId(input.fileId, "fileId"), context);
+  },
+  get_folder(input, context) {
+    return getItem("folders", requireId(input.folderId, "folderId"), context);
+  },
+  list_folder_items(input, context) {
+    return listFolderItems(input, context, false);
+  },
+  list_folder_items_continue(input, context) {
+    return listFolderItems(input, context, true);
+  },
+  search(input, context) {
+    return search(input, context);
+  },
+  download_file(input, context) {
+    return downloadFile(input, context);
+  },
+  create_folder(input, context) {
+    return createFolder(input, context);
+  },
+  upload_file(input, context) {
+    return uploadFile(input, context);
+  },
+  update_file(input, context) {
+    return updateItem("files", input, context);
+  },
+  update_folder(input, context) {
+    return updateItem("folders", input, context);
+  },
+  delete_file(input, context) {
+    return deleteItem("files", input, context);
+  },
+  delete_folder(input, context) {
+    return deleteItem("folders", input, context);
+  },
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors("box", boxActionHandlers);
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher }) {
+    const user = await getCurrentUser({ accessToken: input.accessToken, fetcher });
+    return {
+      profile: {
+        accountId: user.id,
+        displayName: user.name,
+      },
+      metadata: {
+        login: user.login,
+      },
+    };
+  },
+};
+
+interface BoxRequestContext {
+  accessToken: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+interface BoxUser {
+  id: string;
+  type: "user";
+  name: string;
+  login: string;
+  status?: string;
+  spaceAmount?: number;
+  spaceUsed?: number;
+  maxUploadSize?: number;
+}
+
+async function getCurrentUser(context: BoxRequestContext): Promise<BoxUser> {
+  const payload = await boxJsonRequest("/users/me", context);
+  return {
+    id: requiredString(payload.id, "Box user id", invalidResponse),
+    type: "user",
+    name: requiredString(payload.name, "Box user name", invalidResponse),
+    login: requiredString(payload.login, "Box user login", invalidResponse),
+    status: optionalString(payload.status),
+    spaceAmount: optionalNumber(payload.space_amount),
+    spaceUsed: optionalNumber(payload.space_used),
+    maxUploadSize: optionalNumber(payload.max_upload_size),
+  };
+}
+
+async function getItem(
+  resource: "files" | "folders",
+  id: string,
+  context: BoxRequestContext,
+): Promise<{ item: Record<string, unknown> }> {
+  const payload = await boxJsonRequest(`/${resource}/${encodeURIComponent(id)}`, context);
+  return { item: normalizeItem(payload) };
+}
+
+async function listFolderItems(
+  input: Record<string, unknown>,
+  context: BoxRequestContext,
+  continuation: boolean,
+): Promise<Record<string, unknown>> {
+  const folderId = requireId(input.folderId, "folderId");
+  const url = new URL(`${boxApiBaseUrl}/folders/${encodeURIComponent(folderId)}/items`);
+  const marker = optionalString(input.marker);
+  const useMarker = continuation || marker != null || optionalBoolean(input.useMarker) === true;
+  setQuery(url, "usemarker", useMarker ? true : undefined);
+  setQuery(url, "marker", marker);
+  setQuery(url, "offset", useMarker ? undefined : optionalNumber(input.offset));
+  setQuery(url, "limit", optionalNumber(input.limit));
+  setQuery(url, "sort", optionalString(input.sort));
+  setQuery(url, "direction", optionalString(input.direction));
+
+  const payload = await boxJsonRequest(url, context);
+  return normalizeItemPage(payload);
+}
+
+async function search(input: Record<string, unknown>, context: BoxRequestContext): Promise<Record<string, unknown>> {
+  const url = new URL(`${boxApiBaseUrl}/search`);
+  setQuery(url, "query", requiredString(input.query, "query", invalidInput));
+  setQuery(url, "type", optionalString(input.type));
+  setQuery(url, "ancestor_folder_ids", commaSeparated(input.ancestorFolderIds));
+  setQuery(url, "file_extensions", commaSeparated(input.fileExtensions));
+  setQuery(url, "content_types", commaSeparated(input.contentTypes));
+  setQuery(url, "limit", optionalNumber(input.limit));
+  setQuery(url, "offset", optionalNumber(input.offset));
+  setQuery(url, "sort", optionalString(input.sort));
+  setQuery(url, "direction", optionalString(input.direction));
+
+  const payload = await boxJsonRequest(url, context);
+  const page = normalizeItemPage(payload);
+  const offset = optionalNumber(page.offset) ?? 0;
+  const limit = optionalNumber(page.limit) ?? 0;
+  const totalCount = optionalNumber(page.totalCount) ?? 0;
+  return {
+    entries: page.entries,
+    limit,
+    offset,
+    totalCount,
+    nextOffset: offset + limit < totalCount ? offset + limit : null,
+  };
+}
+
+async function downloadFile(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "box download_file requires local transit file storage");
+  }
+
+  const fileId = requireId(input.fileId, "fileId");
+  const { item } = await getItem("files", fileId, context);
+  const name = optionalString(input.fileName) ?? requiredString(item.name, "Box file name", invalidResponse);
+  const reportedSize = optionalNumber(item.sizeBytes);
+  if (reportedSize != null && reportedSize > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(413, `Box download exceeds ${context.transitFiles.maxBytes} bytes`);
+  }
+
+  const response = await boxRequest(`/files/${encodeURIComponent(fileId)}/content`, context);
+  if (response.status === 202) {
+    const retryAfter = response.headers.get("retry-after");
+    throw new ProviderRequestError(
+      503,
+      retryAfter
+        ? `Box file is not ready for download; retry after ${retryAfter} seconds`
+        : "Box file is not ready for download; retry later",
+    );
+  }
+  if (!response.ok) {
+    throw await boxResponseError(response, "Box file download failed");
+  }
+  const mimeType = response.headers.get("content-type") ?? "application/octet-stream";
+  const bytes = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes,
+    fieldName: "Box download",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const file = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  return { item, file };
+}
+
+async function createFolder(
+  input: Record<string, unknown>,
+  context: BoxRequestContext,
+): Promise<{ item: Record<string, unknown> }> {
+  const payload = await boxJsonRequest("/folders", context, {
+    method: "POST",
+    body: JSON.stringify({
+      name: requiredString(input.name, "name", invalidInput),
+      parent: { id: requireId(input.parentFolderId, "parentFolderId") },
+    }),
+  });
+  return { item: normalizeItem(payload) };
+}
+
+async function uploadFile(
+  input: Record<string, unknown>,
+  context: OAuthProviderContext,
+): Promise<{ item: Record<string, unknown> }> {
+  const source = await readTransitFileInput(input.file, context);
+  if (source.sizeBytes > boxSimpleUploadMaxBytes) {
+    throw new ProviderRequestError(413, "box upload_file only supports files up to 50 MB");
+  }
+
+  const attributes: Record<string, unknown> = {
+    name: requiredString(input.name, "name", invalidInput),
+    parent: { id: requireId(input.parentFolderId, "parentFolderId") },
+  };
+  const contentCreatedAt = optionalString(input.contentCreatedAt);
+  const contentModifiedAt = optionalString(input.contentModifiedAt);
+  if (contentCreatedAt) attributes.content_created_at = contentCreatedAt;
+  if (contentModifiedAt) attributes.content_modified_at = contentModifiedAt;
+
+  const body = new FormData();
+  body.append("attributes", JSON.stringify(attributes));
+  body.append("file", source.file, source.name);
+  const payload = await boxJsonRequest(new URL(`${boxUploadBaseUrl}/files/content`), context, {
+    method: "POST",
+    body,
+  });
+  const entries = readObjectArray(payload.entries);
+  const item = entries[0];
+  if (!item) throw invalidResponse("Box upload response did not include a file");
+  return { item: normalizeItem(item) };
+}
+
+async function updateItem(
+  resource: "files" | "folders",
+  input: Record<string, unknown>,
+  context: BoxRequestContext,
+): Promise<{ item: Record<string, unknown> }> {
+  const key = resource === "files" ? "fileId" : "folderId";
+  const id = requireId(input[key], key);
+  const body: Record<string, unknown> = {};
+  const name = optionalString(input.name);
+  const description = typeof input.description === "string" ? input.description : undefined;
+  const parentFolderId = optionalString(input.parentFolderId);
+  if (name) body.name = name;
+  if (description != null) body.description = description;
+  if (parentFolderId) body.parent = { id: parentFolderId };
+  if (Object.keys(body).length === 0) {
+    throw new ProviderRequestError(400, `box ${key === "fileId" ? "update_file" : "update_folder"} requires a change`);
+  }
+
+  const headers = new Headers();
+  const etag = optionalString(input.etag);
+  if (etag) headers.set("if-match", etag);
+  const payload = await boxJsonRequest(`/${resource}/${encodeURIComponent(id)}`, context, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { item: normalizeItem(payload) };
+}
+
+async function deleteItem(
+  resource: "files" | "folders",
+  input: Record<string, unknown>,
+  context: BoxRequestContext,
+): Promise<Record<string, unknown>> {
+  const key = resource === "files" ? "fileId" : "folderId";
+  const id = requireId(input[key], key);
+  const url = new URL(`${boxApiBaseUrl}/${resource}/${encodeURIComponent(id)}`);
+  if (resource === "folders") setQuery(url, "recursive", optionalBoolean(input.recursive));
+  const headers = new Headers();
+  const etag = optionalString(input.etag);
+  if (etag) headers.set("if-match", etag);
+  const response = await boxRequest(url, context, { method: "DELETE", headers });
+  if (!response.ok) throw await boxResponseError(response, `Box ${resource.slice(0, -1)} deletion failed`);
+  return { deleted: true, [key]: id };
+}
+
+async function boxJsonRequest(
+  path: string | URL,
+  context: BoxRequestContext,
+  init: RequestInit = {},
+): Promise<Record<string, unknown>> {
+  const response = await boxRequest(path, context, init);
+  if (!response.ok) throw await boxResponseError(response, "Box request failed");
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: {},
+    invalidJsonMessage: "Box returned invalid JSON",
+  });
+  return requiredRecord(payload, "Box response", invalidResponse);
+}
+
+function boxRequest(path: string | URL, context: BoxRequestContext, init: RequestInit = {}): Promise<Response> {
+  const url = typeof path === "string" ? `${boxApiBaseUrl}${path}` : path;
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${context.accessToken}`);
+  headers.set("accept", "application/json");
+  if (init.body != null && typeof init.body === "string" && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  return context.fetcher(url, { ...init, headers, signal: context.signal });
+}
+
+async function boxResponseError(response: Response, fallback: string): Promise<ProviderRequestError> {
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: {},
+    invalidJsonMessage: `${fallback} with HTTP ${response.status}`,
+    invalidJsonFallback: () => ({}),
+  });
+  const record = optionalRecord(payload) ?? {};
+  const code = optionalString(record.code);
+  const message = optionalString(record.message);
+  const suffix = [code, message].filter(Boolean).join(": ");
+  return new ProviderRequestError(
+    response.status >= 500 ? 502 : response.status,
+    suffix ? `${fallback}: ${suffix}` : `${fallback} with HTTP ${response.status}`,
+    record,
+  );
+}
+
+function normalizeItem(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...payload,
+    id: requiredString(payload.id, "Box item id", invalidResponse),
+    type: requiredString(payload.type, "Box item type", invalidResponse),
+    name: requiredString(payload.name, "Box item name", invalidResponse),
+    etag: optionalString(payload.etag) ?? null,
+    sequenceId: optionalString(payload.sequence_id) ?? null,
+    description: typeof payload.description === "string" ? payload.description : null,
+    sizeBytes: optionalNumber(payload.size) ?? null,
+    parent: optionalRecord(payload.parent) ?? null,
+    pathCollection: optionalRecord(payload.path_collection) ?? null,
+    sharedLink: optionalRecord(payload.shared_link) ?? null,
+    createdAt: optionalString(payload.created_at) ?? null,
+    modifiedAt: optionalString(payload.modified_at) ?? null,
+  };
+}
+
+function normalizeItemPage(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    entries: readObjectArray(payload.entries).map(normalizeItem),
+    limit: optionalNumber(payload.limit) ?? 0,
+    offset: optionalNumber(payload.offset),
+    totalCount: optionalNumber(payload.total_count),
+    nextMarker: optionalString(payload.next_marker) ?? null,
+    previousMarker: optionalString(payload.prev_marker) ?? null,
+  };
+}
+
+function readObjectArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item, index) => requiredRecord(item, `Box entries[${index}]`, invalidResponse));
+}
+
+function commaSeparated(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.map((item) => optionalString(item)).filter((item): item is string => item != null);
+  return values.length > 0 ? values.join(",") : undefined;
+}
+
+function setQuery(url: URL, name: string, value: string | number | boolean | undefined): void {
+  if (value != null) url.searchParams.set(name, String(value));
+}
+
+function requireId(value: unknown, name: string): string {
+  return requiredString(value, name, invalidInput);
+}
+
+function invalidInput(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}
+
+function invalidResponse(message: string): ProviderRequestError {
+  return new ProviderRequestError(502, message);
+}

--- a/src/providers/box/scopes.ts
+++ b/src/providers/box/scopes.ts
@@ -1,0 +1,6 @@
+export const boxProviderScopes = {
+  read: "root_readonly",
+  write: "root_readwrite",
+};
+
+export const boxOAuthScopes: string[] = [boxProviderScopes.read, boxProviderScopes.write];


### PR DESCRIPTION
## Summary

- add a native Box OAuth 2.0 provider for issue #419
- implement current-user, file/folder metadata, marker and offset listing, search, upload/download, create, update, and delete actions
- use transit storage for binary content and the shared guarded provider fetch for all Box egress
- add Box OAuth app setup guidance and credential validation

## Upstream validation

- checked the current Box Content API 2024.0 reference for every endpoint and request shape
- probed the OAuth token, current-user, folder-listing, search, and multipart upload endpoints against Box; each accepted the documented route/encoding and reached the expected authentication boundary
- modeled Box search with offset pagination and folder continuation with marker pagination

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (148 files passed, 1 skipped; 1350 tests passed, 4 skipped)
- `git diff --check`

Closes #419