### PR TITLE
ci: bump star-history-action to v1.0.6

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -34,4 +34,4 @@ jobs:
       # third-party action holds contents:write and pushes to the repo, so its
       # supply chain must not be silently updatable.
       - name: Render and commit star history
-        uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4
+        uses: narayann7/star-history-action@12543ab7352b91fb7c5eb0c4fbb39772baa0c168 # v1.0.6


### PR DESCRIPTION
Bumps the pinned `star-history-action` SHA from v1.0.4 to v1.0.6. The new release fixes legend and title text overflowing in viewers that substitute a wider font, and stops `setup-node` v5+ from failing the caller on implicit dependency caching. Inputs and outputs are unchanged, and upstream bumped `RENDER_VERSION`, so the next scheduled run re-renders and commits the chart once even with flat stars.
