### PR TITLE
feat: add Indeed provider

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -169,12 +169,8 @@ export type OAuth2AuthDefinition = {
   };
   /** Extra static authorization URL parameters, such as Google `access_type=offline`. */
   authorizationParams?: Record<string, string>;
-  /** Provider callback query parameters forwarded to token exchange and, when requested, token refresh. */
-  callbackParameters?: Array<{
-    name: string;
-    tokenRequestField?: string;
-    includeInRefresh?: boolean;
-  }>;
+  /** Provider callback query parameters forwarded to token exchange and later token refresh. */
+  tokenRequestCallbackParameters?: string[];
   /** Provider-specific OAuth authorization request field names. */
   authorizationRequestFields?: {
     clientId?: string | false;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -169,6 +169,12 @@ export type OAuth2AuthDefinition = {
   };
   /** Extra static authorization URL parameters, such as Google `access_type=offline`. */
   authorizationParams?: Record<string, string>;
+  /** Provider callback query parameters forwarded to token exchange and, when requested, token refresh. */
+  callbackParameters?: Array<{
+    name: string;
+    tokenRequestField?: string;
+    includeInRefresh?: boolean;
+  }>;
   /** Provider-specific OAuth authorization request field names. */
   authorizationRequestFields?: {
     clientId?: string | false;

--- a/src/oauth/oauth-credential-refresh-service.test.ts
+++ b/src/oauth/oauth-credential-refresh-service.test.ts
@@ -150,4 +150,19 @@ describe("OAuthCredentialRefreshService", () => {
     expect(refreshed.refreshToken).toBe("refresh-token");
     expect(refreshed.providerSecret).toEqual(credential.providerSecret);
   });
+
+  it("forwards stored provider parameters during refresh", async () => {
+    const fetcher = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ access_token: "new-access-token" }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+    const credential = {
+      ...expiredCredential({ expires_in: 3600 }),
+      providerSecret: { oauthRefreshParameters: { employer: "employer-id" } },
+    };
+
+    await new OAuthCredentialRefreshService(clientConfigs).refresh("example", credential);
+
+    expect(String(fetcher.mock.calls[0]?.[1]?.body)).toContain("employer=employer-id");
+  });
 });

--- a/src/oauth/oauth-credential-refresh-service.ts
+++ b/src/oauth/oauth-credential-refresh-service.ts
@@ -2,6 +2,7 @@ import type { ResolvedCredential } from "../core/types.ts";
 import type { OAuthClientConfigService } from "./oauth-client-config-service.ts";
 
 import { ConnectionError } from "../connection-service.ts";
+import { optionalRecord, stringRecord } from "../core/cast.ts";
 import { readOAuthClientConfigMetadata } from "./oauth-client-config-service.ts";
 import { expiresAtFromLifetime, requestRefreshToken } from "./oauth-token.ts";
 
@@ -74,11 +75,8 @@ export class OAuthCredentialRefreshService implements IOAuthCredentialRefresher 
 function readOAuthRefreshParameters(
   providerSecret: Record<string, unknown> | undefined,
 ): Record<string, string> | undefined {
-  const value = providerSecret?.oauthRefreshParameters;
-  if (typeof value !== "object" || value == null || Array.isArray(value)) return undefined;
-  const fields: Record<string, string> = {};
-  for (const [key, fieldValue] of Object.entries(value)) {
-    if (typeof fieldValue === "string") fields[key] = fieldValue;
-  }
+  const value = optionalRecord(providerSecret?.oauthRefreshParameters);
+  if (!value) return undefined;
+  const fields = stringRecord(value);
   return Object.keys(fields).length > 0 ? fields : undefined;
 }

--- a/src/oauth/oauth-credential-refresh-service.ts
+++ b/src/oauth/oauth-credential-refresh-service.ts
@@ -38,6 +38,7 @@ export class OAuthCredentialRefreshService implements IOAuthCredentialRefresher 
         clientSecret: config.clientSecret,
         responseEnvelope: auth.tokenResponseEnvelope,
         refreshToken: value,
+        extraFields: readOAuthRefreshParameters(credential.providerSecret),
         tokenRequestFields: auth.tokenRequestFields,
         tokenEndpointAuthMethod: auth.tokenEndpointAuthMethod,
         tokenRequestFormat: auth.tokenRequestFormat,
@@ -68,4 +69,16 @@ export class OAuthCredentialRefreshService implements IOAuthCredentialRefresher 
       },
     };
   }
+}
+
+function readOAuthRefreshParameters(
+  providerSecret: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  const value = providerSecret?.oauthRefreshParameters;
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return undefined;
+  const fields: Record<string, string> = {};
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (typeof fieldValue === "string") fields[key] = fieldValue;
+  }
+  return Object.keys(fields).length > 0 ? fields : undefined;
 }

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -77,7 +77,7 @@ const callbackParameterOAuthProvider: ProviderDefinition = {
       tokenUrl: "https://example.com/oauth/token",
       scopes: ["read"],
       tokenEndpointAuthMethod: "client_secret_post",
-      callbackParameters: [{ name: "employer", includeInRefresh: true }],
+      tokenRequestCallbackParameters: ["employer"],
     },
   ],
 };

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -67,6 +67,21 @@ const pkceOAuthProvider: ProviderDefinition = {
   ],
 };
 
+const callbackParameterOAuthProvider: ProviderDefinition = {
+  ...oauthProvider,
+  service: "callback_parameter",
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://example.com/oauth/authorize",
+      tokenUrl: "https://example.com/oauth/token",
+      scopes: ["read"],
+      tokenEndpointAuthMethod: "client_secret_post",
+      callbackParameters: [{ name: "employer", includeInRefresh: true }],
+    },
+  ],
+};
+
 const customOAuthProvider: ProviderDefinition = {
   ...oauthProvider,
   service: "custom_oauth",
@@ -572,6 +587,34 @@ describe("OAuthFlowService", () => {
     });
     expect(tokenBody).toBeInstanceOf(URLSearchParams);
     expect((tokenBody as URLSearchParams).get("code_verifier")).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("forwards allowlisted callback parameters and stores refresh parameters", async () => {
+    const services = createServices([callbackParameterOAuthProvider]);
+    await services.clientConfigs.upsertConfig({
+      service: "callback_parameter",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    const fetcher = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ access_token: "access-token", refresh_token: "refresh-token", token_type: "Bearer" }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+
+    const started = await services.flow.startAuthorization({ service: "callback_parameter" });
+    await services.flow.completeAuthorization({
+      state: started.state,
+      code: "code",
+      callbackParameters: { employer: "employer-id", untrusted: "ignored" },
+    });
+
+    const tokenBody = fetcher.mock.calls[0]?.[1]?.body;
+    expect(tokenBody).toBeInstanceOf(URLSearchParams);
+    expect(String(tokenBody)).toContain("employer=employer-id");
+    expect(String(tokenBody)).not.toContain("untrusted");
+    await expect(services.connections.getCredential("callback_parameter")).resolves.toMatchObject({
+      providerSecret: { oauthRefreshParameters: { employer: "employer-id" } },
+    });
   });
 
   it("accepts token responses that use token instead of access_token", async () => {

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -161,10 +161,10 @@ export class OAuthFlowService {
       tokenEndpointAuthMethod: auth.tokenEndpointAuthMethod,
       tokenRequestFormat: auth.tokenRequestFormat,
       tokenUrl: this.clientConfigs.resolveEndpointUrl(pending.service, auth.tokenUrl, config),
-      extraFields: createTokenExtraFields(pending, auth, input.callbackParameters),
+      extraFields: createTokenExtraFields(pending, auth.tokenRequestCallbackParameters, input.callbackParameters),
       createError: (message) => new OAuthFlowError("oauth_token_exchange_failed", message),
     });
-    const refreshParameters = readCallbackParameters(auth, input.callbackParameters, true);
+    const refreshParameters = readCallbackParameters(auth.tokenRequestCallbackParameters, input.callbackParameters);
     const oauthCredential = {
       ...tokenResponse,
       providerSecret:
@@ -215,24 +215,22 @@ function setAuthorizationParam(
 
 function createTokenExtraFields(
   state: OAuthAuthorizationState,
-  auth: ReturnType<OAuthClientConfigService["getOAuthDefinition"]>,
+  parameterNames: readonly string[] | undefined,
   callbackParameters: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
-  const fields = readCallbackParameters(auth, callbackParameters, false);
+  const fields = readCallbackParameters(parameterNames, callbackParameters);
   if (state.pkceCodeVerifier) fields.code_verifier = state.pkceCodeVerifier;
   return Object.keys(fields).length > 0 ? fields : undefined;
 }
 
 function readCallbackParameters(
-  auth: ReturnType<OAuthClientConfigService["getOAuthDefinition"]>,
+  parameterNames: readonly string[] | undefined,
   values: Record<string, string> | undefined,
-  refreshOnly: boolean,
 ): Record<string, string> {
   const fields: Record<string, string> = {};
-  for (const parameter of auth.callbackParameters ?? []) {
-    if (refreshOnly && !parameter.includeInRefresh) continue;
-    const value = values?.[parameter.name];
-    if (value) fields[parameter.tokenRequestField ?? parameter.name] = value;
+  for (const name of parameterNames ?? []) {
+    const value = values?.[name];
+    if (value) fields[name] = value;
   }
   return fields;
 }

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -26,6 +26,7 @@ export interface OAuthAuthorizationStartInput {
 export interface OAuthAuthorizationCompleteInput {
   state: string;
   code: string;
+  callbackParameters?: Record<string, string>;
   signal?: AbortSignal;
 }
 
@@ -160,11 +161,14 @@ export class OAuthFlowService {
       tokenEndpointAuthMethod: auth.tokenEndpointAuthMethod,
       tokenRequestFormat: auth.tokenRequestFormat,
       tokenUrl: this.clientConfigs.resolveEndpointUrl(pending.service, auth.tokenUrl, config),
-      extraFields: createTokenExtraFields(pending),
+      extraFields: createTokenExtraFields(pending, auth, input.callbackParameters),
       createError: (message) => new OAuthFlowError("oauth_token_exchange_failed", message),
     });
+    const refreshParameters = readCallbackParameters(auth, input.callbackParameters, true);
     const oauthCredential = {
       ...tokenResponse,
+      providerSecret:
+        Object.keys(refreshParameters).length > 0 ? { oauthRefreshParameters: refreshParameters } : undefined,
       metadata: {
         ...tokenResponse.metadata,
         oauthClientId: config.clientId,
@@ -209,14 +213,28 @@ function setAuthorizationParam(
   }
 }
 
-function createTokenExtraFields(state: OAuthAuthorizationState): Record<string, string> | undefined {
-  if (!state.pkceCodeVerifier) {
-    return undefined;
-  }
+function createTokenExtraFields(
+  state: OAuthAuthorizationState,
+  auth: ReturnType<OAuthClientConfigService["getOAuthDefinition"]>,
+  callbackParameters: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const fields = readCallbackParameters(auth, callbackParameters, false);
+  if (state.pkceCodeVerifier) fields.code_verifier = state.pkceCodeVerifier;
+  return Object.keys(fields).length > 0 ? fields : undefined;
+}
 
-  return {
-    code_verifier: state.pkceCodeVerifier,
-  };
+function readCallbackParameters(
+  auth: ReturnType<OAuthClientConfigService["getOAuthDefinition"]>,
+  values: Record<string, string> | undefined,
+  refreshOnly: boolean,
+): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const parameter of auth.callbackParameters ?? []) {
+    if (refreshOnly && !parameter.includeInRefresh) continue;
+    const value = values?.[parameter.name];
+    if (value) fields[parameter.tokenRequestField ?? parameter.name] = value;
+  }
+  return fields;
 }
 
 function isExpiredOAuthState(state: OAuthAuthorizationState, maxAgeMs: number): boolean {

--- a/src/oauth/oauth-token.ts
+++ b/src/oauth/oauth-token.ts
@@ -31,6 +31,7 @@ interface AuthorizationCodeTokenRequest extends OAuthTokenRequestOptions {
 
 interface RefreshTokenRequest extends OAuthTokenRequestOptions {
   refreshToken: string;
+  extraFields?: Record<string, string>;
   createError: OAuthTokenErrorFactory;
 }
 
@@ -275,7 +276,10 @@ function createRefreshTokenFields(input: RefreshTokenRequest): Record<string, st
     "refresh_token",
     input.refreshToken,
   );
-  return fields;
+  return {
+    ...fields,
+    ...(input.extraFields ?? {}),
+  };
 }
 
 function setMappedField(

--- a/src/providers/indeed/actions.ts
+++ b/src/providers/indeed/actions.ts
@@ -1,0 +1,135 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "indeed";
+const readScopes = ["employer_access", "employer.hosted_job"];
+
+const graphQlErrorSchema = s.object(
+  {
+    message: s.nonEmptyString("Indeed GraphQL error message."),
+    path: s.optional(s.array(s.unknown("GraphQL response path segment."))),
+    extensions: s.optional(s.object({}, { additionalProperties: true })),
+  },
+  { additionalProperties: true },
+);
+
+const graphQlOutputSchema = s.object({
+  data: s.optional(s.nullable(s.object({}, { additionalProperties: true }))),
+  errors: s.optional(s.array(graphQlErrorSchema)),
+});
+
+const jobFieldsSchema: JsonSchema = s.object(
+  {
+    id: s.nonEmptyString("Indeed EmployerJob IRI."),
+    jobData: s.optional(s.nullable(s.object({}, { additionalProperties: true }))),
+    roleData: s.optional(s.nullable(s.object({}, { additionalProperties: true }))),
+    managementUrls: s.optional(s.nullable(s.object({}, { additionalProperties: true }))),
+  },
+  { additionalProperties: true },
+);
+
+export const indeedActions: readonly ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_current_user",
+    description: "Get the Indeed user and associated employers represented by the OAuth access token.",
+    requiredScopes: ["email", "employer_access"],
+    providerPermissions: ["email", "employer_access"],
+    inputSchema: s.object({}),
+    outputSchema: s.object(
+      {
+        sub: s.nonEmptyString("Indeed user account ID."),
+        email: s.optional(s.email("Email address when the email scope was granted.")),
+        email_verified: s.optional(s.boolean("Whether Indeed verified the email address.")),
+        employers: s.optional(
+          s.array(
+            s.object({
+              id: s.nonEmptyString("Indeed employer ID."),
+              name: s.nonEmptyString("Indeed employer name."),
+            }),
+          ),
+        ),
+      },
+      { additionalProperties: true },
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "execute_graphql",
+    description: "Execute an approved Indeed Partner GraphQL query or mutation and return its data and errors.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({
+      query: s.nonWhitespaceString("GraphQL document to execute."),
+      variables: s.optional(s.object({}, { additionalProperties: true })),
+      operationName: s.optional(s.nonEmptyString("Operation name when the document contains multiple operations.")),
+    }),
+    outputSchema: graphQlOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "find_employer_jobs",
+    description: "List jobs for the employer represented by the OAuth token, with filters and cursor pagination.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({
+      legacySourceId: s.optional(s.nonEmptyString("Sponsored Jobs API source ID filter.")),
+      jobFeedTypes: s.optional(s.array(s.nonEmptyString("Indeed JobFeedType enum value."), { maxItems: 2 })),
+      includeMultiLocationJobs: s.optional(s.boolean("Whether to include multi-location jobs.")),
+      jobRequisitionIds: s.optional(s.array(s.nonEmptyString("ATS requisition ID filter."))),
+      first: s.optional(s.integer("Maximum jobs to return.", { minimum: 1, maximum: 1000, default: 10 })),
+      before: s.optional(s.nonEmptyString("Cursor for backward pagination.")),
+      after: s.optional(s.nonEmptyString("Cursor for forward pagination.")),
+    }),
+    outputSchema: s.object({
+      employerJobs: s.array(jobFieldsSchema),
+      estimatedTotalResultsCount: s.nonNegativeInteger("Estimated total number of matching jobs."),
+      pageInfo: s.object({
+        endCursor: s.nullableString("Cursor for the next page."),
+        hasNextPage: s.boolean("Whether a next page exists."),
+        hasPreviousPage: s.boolean("Whether a previous page exists."),
+        startCursor: s.nullableString("Cursor for the previous page."),
+      }),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "get_job",
+    description: "Get one Indeed employer job by its EmployerJob IRI.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({ id: s.nonEmptyString("EmployerJob IRI returned by Indeed.") }),
+    outputSchema: s.object({ job: s.nullable(jobFieldsSchema) }),
+  }),
+  defineProviderAction(service, {
+    name: "get_jobs",
+    description: "Get multiple Indeed employer jobs by their EmployerJob IRIs.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({ ids: s.array(s.nonEmptyString("EmployerJob IRI returned by Indeed."), { minItems: 1 }) }),
+    outputSchema: s.object({ jobs: s.array(s.nullable(jobFieldsSchema)) }),
+  }),
+  defineProviderAction(service, {
+    name: "update_sourced_job_postings",
+    description: "Update supported fields on one sourced Indeed job posting.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({
+      update: s.object(
+        {
+          sourcedPostingId: s.nonEmptyString("Sourced posting UUID or EmployerJob IRI."),
+          metadata: s.optional(s.object({}, { additionalProperties: true })),
+          body: s.optional(s.object({}, { additionalProperties: true })),
+        },
+        { optional: ["metadata", "body"] },
+      ),
+    }),
+    outputSchema: graphQlOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "clear_sourced_job_posting_updates",
+    description: "Clear updates previously applied to one sourced Indeed job posting.",
+    requiredScopes: readScopes,
+    providerPermissions: readScopes,
+    inputSchema: s.object({ sourcedPostingId: s.nonEmptyString("Sourced posting UUID or EmployerJob IRI.") }),
+    outputSchema: graphQlOutputSchema,
+  }),
+];

--- a/src/providers/indeed/definition.ts
+++ b/src/providers/indeed/definition.ts
@@ -18,7 +18,7 @@ export const provider: ProviderDefinition = {
       tokenEndpointAuthMethod: "client_secret_post",
       pkce: { method: "S256" },
       authorizationParams: { prompt: "select_employer" },
-      callbackParameters: [{ name: "employer", includeInRefresh: true }],
+      tokenRequestCallbackParameters: ["employer"],
       clientSetup: {
         docsUrl: "https://docs.indeed.com/authentication/auth-3-legged-oauth",
         steps: [

--- a/src/providers/indeed/definition.ts
+++ b/src/providers/indeed/definition.ts
@@ -1,0 +1,34 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { indeedActions } from "./actions.ts";
+
+const scopes = ["email", "offline_access", "employer_access", "employer.hosted_job"];
+
+export const provider: ProviderDefinition = {
+  service: "indeed",
+  displayName: "Indeed",
+  categories: ["Human Resources"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://secure.indeed.com/oauth/v2/authorize",
+      tokenUrl: "https://apis.indeed.com/oauth/v2/tokens",
+      scopes,
+      tokenEndpointAuthMethod: "client_secret_post",
+      pkce: { method: "S256" },
+      authorizationParams: { prompt: "select_employer" },
+      callbackParameters: [{ name: "employer", includeInRefresh: true }],
+      clientSetup: {
+        docsUrl: "https://docs.indeed.com/authentication/auth-3-legged-oauth",
+        steps: [
+          "Become an Indeed partner and register an application in Partner Console.",
+          "Add the callback URL shown here to the application's registered redirect URLs.",
+          "Request approval for the employer and hosted-job scopes used by these actions.",
+        ],
+      },
+    },
+  ],
+  homepageUrl: "https://www.indeed.com",
+  actions: indeedActions,
+};

--- a/src/providers/indeed/executors.ts
+++ b/src/providers/indeed/executors.ts
@@ -1,0 +1,187 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderActionHandlers } from "../provider-runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredRecord,
+  requiredString,
+  requiredStringArray,
+} from "../../core/cast.ts";
+import { defineOAuthProviderExecutors, ProviderRequestError, readProviderJson } from "../provider-runtime.ts";
+
+const service = "indeed";
+const graphQlUrl = "https://apis.indeed.com/graphql";
+const userInfoUrl = "https://secure.indeed.com/v2/api/userinfo";
+
+type IndeedActionHandler = (input: Record<string, unknown>, context: OAuthProviderContext) => Promise<unknown>;
+
+const jobSelection = `
+  id
+  jobData {
+    title
+    dateCreated
+    company
+    externalJobPageUrl
+    datePostedOnIndeed
+    salary { period maximumMinor minimumMinor currency maximumMajor minimumMajor basePaySpecified }
+    jobLocation { countryCode city postalCode fullAddress }
+    externalPostingMetadata { jobPostingId jobRequisitionId campaignCategories trackingUrls rawInputLocation isIntegratedJob }
+  }
+  roleData { title company description { text } metaData { dateCreated isExternalIntegratedJob } }
+  managementUrls { viewJob }
+`;
+
+const actionHandlers: ProviderActionHandlers<"indeed", IndeedActionHandler> = {
+  get_current_user(_input, context) {
+    return requestUserInfo(context);
+  },
+  execute_graphql(input, context) {
+    return requestGraphQl(
+      {
+        query: requiredString(input.query, "query", badInput),
+        variables: optionalRecord(input.variables),
+        operationName: optionalString(input.operationName),
+      },
+      context,
+    );
+  },
+  async find_employer_jobs(input, context) {
+    const filters = {
+      legacySourceId: optionalString(input.legacySourceId),
+      jobFeedType: optionalStringArray(input.jobFeedTypes),
+      includeMultiLocationJobs: optionalBoolean(input.includeMultiLocationJobs),
+      jobRequisitionId: optionalStringArray(input.jobRequisitionIds),
+    };
+    const payload = await requestGraphQl(
+      {
+        query: `query FindEmployerJobs($input: FindEmployerJobsPartnerInput, $first: Int!, $before: String, $after: String) {
+          findEmployerJobsPartner(input: $input, first: $first, before: $before, after: $after) {
+            employerJobs { ${jobSelection} }
+            estimatedTotalResultsCount
+            pageInfo { endCursor hasNextPage hasPreviousPage startCursor }
+          }
+        }`,
+        variables: {
+          input: { filters },
+          first: optionalInteger(input.first) ?? 10,
+          before: optionalString(input.before),
+          after: optionalString(input.after),
+        },
+      },
+      context,
+    );
+    return readGraphQlField(payload, "findEmployerJobsPartner");
+  },
+  async get_job(input, context) {
+    const payload = await requestGraphQl(
+      {
+        query: `query GetEmployerJob($id: ID!) { node(id: $id) { ... on EmployerJob { ${jobSelection} } } }`,
+        variables: { id: requiredString(input.id, "id", badInput) },
+      },
+      context,
+    );
+    return { job: readGraphQlData(payload).node ?? null };
+  },
+  async get_jobs(input, context) {
+    const payload = await requestGraphQl(
+      {
+        query: `query GetEmployerJobs($ids: [ID!]!) { nodes(ids: $ids) { ... on EmployerJob { ${jobSelection} } } }`,
+        variables: { ids: requiredStringArray(input.ids, "ids", badInput) },
+      },
+      context,
+    );
+    return { jobs: readGraphQlData(payload).nodes ?? [] };
+  },
+  update_sourced_job_postings(input, context) {
+    const update = requiredRecord(input.update, "update", badInput);
+    return requestGraphQl(
+      {
+        query: `mutation UpdateSourcedJobPostings($input: UpdateSourcedJobPostingsInput!) {
+          jobsIngest { updateSourcedJobPostings(input: $input) { results { jobPosting { sourcedPostingId employerJobId } } } }
+        }`,
+        variables: { input: { updates: [update] } },
+      },
+      context,
+    );
+  },
+  clear_sourced_job_posting_updates(input, context) {
+    return requestGraphQl(
+      {
+        query: `mutation ClearSourcedJobPostingUpdates($input: ClearSourcedJobPostingUpdatesInput!) {
+          jobsIngest { clearSourcedJobPostingUpdates(input: $input) { results { jobPosting { sourcedPostingId employerJobId } } } }
+        }`,
+        variables: {
+          input: {
+            updates: [{ sourcedPostingId: requiredString(input.sourcedPostingId, "sourcedPostingId", badInput) }],
+          },
+        },
+      },
+      context,
+    );
+  },
+};
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, actionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const user = await requestUserInfo({ accessToken: input.accessToken, fetcher, signal });
+    const accountId = optionalString(user.sub) ?? "indeed:user";
+    const email = optionalString(user.email);
+    return {
+      profile: { accountId, displayName: email ?? `Indeed User ${accountId}` },
+      metadata: { currentUser: user },
+    };
+  },
+};
+
+interface GraphQlRequest {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+}
+
+async function requestGraphQl(input: GraphQlRequest, context: OAuthProviderContext): Promise<Record<string, unknown>> {
+  const response = await context.fetcher(graphQlUrl, {
+    method: "POST",
+    headers: {
+      authorization: `${context.tokenType ?? "Bearer"} ${context.accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(input),
+    signal: context.signal,
+  });
+  return readProviderJson<Record<string, unknown>>(response, "Indeed GraphQL");
+}
+
+async function requestUserInfo(
+  context: Pick<OAuthProviderContext, "accessToken" | "fetcher" | "signal">,
+): Promise<Record<string, unknown>> {
+  const response = await context.fetcher(userInfoUrl, {
+    headers: { authorization: `Bearer ${context.accessToken}` },
+    signal: context.signal,
+  });
+  return readProviderJson<Record<string, unknown>>(response, "Indeed user info");
+}
+
+function readGraphQlData(payload: Record<string, unknown>): Record<string, unknown> {
+  const data = optionalRecord(payload.data);
+  if (data) return data;
+  throw new ProviderRequestError(502, "Indeed GraphQL response did not contain data", payload.errors);
+}
+
+function readGraphQlField(payload: Record<string, unknown>, field: string): unknown {
+  const value = readGraphQlData(payload)[field];
+  if (value !== undefined) return value;
+  throw new ProviderRequestError(502, `Indeed GraphQL response did not contain ${field}`, payload.errors);
+}
+
+function badInput(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -1043,6 +1043,7 @@ export class ConnectServer {
         await this.options.oauthFlow.completeAuthorization({
           state,
           code,
+          callbackParameters: Object.fromEntries(new URL(context.req.url).searchParams),
           signal: context.req.raw.signal,
         })
       ).service;


### PR DESCRIPTION
## Summary

- add an OAuth-backed Indeed provider with current-user, GraphQL, employer job lookup, and sourced-job update actions
- support allowlisted OAuth callback parameters so Indeed employer selection is forwarded to token exchange and refresh
- preserve structured GraphQL data and errors and validate credentials through Indeed userinfo

Closes #420

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (148 passed, 1 skipped; 1352 tests passed, 4 skipped)
- probed the official GraphQL and userinfo endpoints without credentials and confirmed their unauthenticated HTTP behavior

A live authenticated Indeed Partner request was not run because no Partner application credentials were available.