### PR TITLE
fix(feishu): decode Base record matrices

### DIFF
--- a/src/providers/feishu/shared/base-runtime.test.ts
+++ b/src/providers/feishu/shared/base-runtime.test.ts
@@ -1,0 +1,88 @@
+import type { FeishuJsonRequest } from "./client.ts";
+
+import { describe, expect, it } from "vitest";
+import { createFeishuBaseActionHandlers } from "./base-runtime.ts";
+
+const recordMatrix = {
+  fields: ["Name", "Status"],
+  field_id_list: ["fld_name", "fld_status"],
+  record_id_list: ["rec_1", "rec_2"],
+  data: [
+    ["Alice", "Done"],
+    ["Bob", null],
+  ],
+  total: 2,
+  has_more: false,
+};
+
+const expectedRecords = [
+  {
+    record_id: "rec_1",
+    fields: { Name: "Alice", Status: "Done" },
+  },
+  {
+    record_id: "rec_2",
+    fields: { Name: "Bob", Status: null },
+  },
+];
+
+describe("Feishu Base record responses", () => {
+  it("decodes record matrices returned by list and search", async () => {
+    const request: FeishuJsonRequest = async () => recordMatrix;
+    const handlers = createFeishuBaseActionHandlers(request);
+    const input = {
+      appToken: "base_1",
+      tableId: "tbl_1",
+      keyword: "Alice",
+      searchFields: ["Name"],
+      offset: 0,
+      limit: 2,
+    };
+
+    await expect(handlers.list_base_records(input)).resolves.toEqual({
+      items: expectedRecords,
+      offset: 0,
+      limit: 2,
+      total: 2,
+      hasMore: false,
+    });
+    await expect(handlers.search_base_records(input)).resolves.toEqual({
+      items: expectedRecords,
+      offset: 0,
+      limit: 2,
+      total: 2,
+      hasMore: false,
+    });
+  });
+
+  it("decodes the record matrix returned by batch get", async () => {
+    const request: FeishuJsonRequest = async () => ({
+      fields: recordMatrix.fields,
+      field_id_list: recordMatrix.field_id_list,
+      record_id_list: ["rec_1"],
+      data: [["Alice", "Done"]],
+    });
+    const handlers = createFeishuBaseActionHandlers(request);
+
+    await expect(
+      handlers.get_base_record({
+        appToken: "base_1",
+        tableId: "tbl_1",
+        recordId: "rec_1",
+      }),
+    ).resolves.toEqual({ record: expectedRecords[0] });
+  });
+
+  it("rejects inconsistent record matrices", async () => {
+    const request: FeishuJsonRequest = async () => ({
+      fields: ["Name"],
+      record_id_list: ["rec_1"],
+      data: [],
+    });
+    const handlers = createFeishuBaseActionHandlers(request);
+
+    await expect(handlers.list_base_records({ appToken: "base_1", tableId: "tbl_1" })).rejects.toThrow(
+      "record_id_list and data lengths differ",
+    );
+  });
+});

--- a/src/providers/feishu/shared/base-runtime.test.ts
+++ b/src/providers/feishu/shared/base-runtime.test.ts
@@ -1,6 +1,7 @@
 import type { FeishuJsonRequest } from "./client.ts";
 
 import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../../provider-runtime.ts";
 import { createFeishuBaseActionHandlers } from "./base-runtime.ts";
 
 const recordMatrix = {
@@ -26,43 +27,112 @@ const expectedRecords = [
   },
 ];
 
+const tableRecordsPath = "/base/v3/bases/base_1/tables/tbl_1/records";
+
+interface RecordedCall {
+  readonly method: string;
+  readonly path: string;
+  readonly body: unknown;
+}
+
+function recordingRequest(response: Record<string, unknown>) {
+  const calls: RecordedCall[] = [];
+  const request: FeishuJsonRequest = async (input) => {
+    calls.push({ method: input.method ?? "GET", path: input.path, body: input.body });
+    return response;
+  };
+  return { calls, handlers: createFeishuBaseActionHandlers(request) };
+}
+
 describe("Feishu Base record responses", () => {
   it("decodes record matrices returned by list and search", async () => {
-    const request: FeishuJsonRequest = async () => recordMatrix;
-    const handlers = createFeishuBaseActionHandlers(request);
-    const input = {
+    const { calls, handlers } = recordingRequest(recordMatrix);
+    const listInput = {
       appToken: "base_1",
       tableId: "tbl_1",
-      keyword: "Alice",
-      searchFields: ["Name"],
       offset: 0,
       limit: 2,
     };
+    const searchInput = { ...listInput, keyword: "Alice", searchFields: ["Name"] };
 
-    await expect(handlers.list_base_records(input)).resolves.toEqual({
+    await expect(handlers.list_base_records(listInput)).resolves.toEqual({
       items: expectedRecords,
       offset: 0,
       limit: 2,
       total: 2,
       hasMore: false,
     });
-    await expect(handlers.search_base_records(input)).resolves.toEqual({
+    await expect(handlers.search_base_records(searchInput)).resolves.toEqual({
       items: expectedRecords,
       offset: 0,
       limit: 2,
       total: 2,
+      hasMore: false,
+    });
+    expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      `GET ${tableRecordsPath}`,
+      `POST ${tableRecordsPath}/search`,
+    ]);
+  });
+
+  it("accepts the legacy record list shapes", async () => {
+    const legacyRecords = [{ record_id: "rec_9", fields: { Name: "Z" } }];
+    for (const response of [{ records: legacyRecords }, { items: legacyRecords }]) {
+      const { handlers } = recordingRequest(response);
+
+      await expect(handlers.list_base_records({ appToken: "base_1", tableId: "tbl_1" })).resolves.toEqual({
+        items: legacyRecords,
+        offset: 0,
+        limit: 100,
+        total: 1,
+        hasMore: false,
+      });
+    }
+  });
+
+  it("returns an empty page for an empty record matrix", async () => {
+    const { handlers } = recordingRequest({
+      fields: ["Name"],
+      record_id_list: [],
+      data: [],
+      has_more: false,
+    });
+
+    await expect(handlers.list_base_records({ appToken: "base_1", tableId: "tbl_1" })).resolves.toEqual({
+      items: [],
+      offset: 0,
+      limit: 100,
+      total: 0,
       hasMore: false,
     });
   });
 
+  it("derives the total from the offset when the matrix reports more pages", async () => {
+    const { handlers } = recordingRequest({
+      fields: ["Name"],
+      record_id_list: ["rec_1"],
+      data: [["Alice"]],
+      has_more: true,
+    });
+
+    await expect(
+      handlers.list_base_records({ appToken: "base_1", tableId: "tbl_1", offset: 10, limit: 50 }),
+    ).resolves.toEqual({
+      items: [{ record_id: "rec_1", fields: { Name: "Alice" } }],
+      offset: 10,
+      limit: 50,
+      total: 11,
+      hasMore: true,
+    });
+  });
+
   it("decodes the record matrix returned by batch get", async () => {
-    const request: FeishuJsonRequest = async () => ({
+    const { calls, handlers } = recordingRequest({
       fields: recordMatrix.fields,
       field_id_list: recordMatrix.field_id_list,
       record_id_list: ["rec_1"],
       data: [["Alice", "Done"]],
     });
-    const handlers = createFeishuBaseActionHandlers(request);
 
     await expect(
       handlers.get_base_record({
@@ -71,15 +141,70 @@ describe("Feishu Base record responses", () => {
         recordId: "rec_1",
       }),
     ).resolves.toEqual({ record: expectedRecords[0] });
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${tableRecordsPath}/batch_get`,
+        body: { record_id_list: ["rec_1"] },
+      },
+    ]);
+  });
+
+  it("rejects a record listed in record_not_found", async () => {
+    const { handlers } = recordingRequest({
+      fields: ["Name", "Note"],
+      record_id_list: ["rec_missing"],
+      data: [[null, null]],
+      record_not_found: ["rec_missing"],
+      has_more: false,
+    });
+
+    const missing = handlers.get_base_record({
+      appToken: "base_1",
+      tableId: "tbl_1",
+      recordId: "rec_missing",
+    });
+    await expect(missing).rejects.toBeInstanceOf(ProviderRequestError);
+    await expect(missing).rejects.toMatchObject({ status: 404 });
+    await expect(missing).rejects.toThrow("Base record rec_missing was not found");
+  });
+
+  it("picks the requested record out of a partially found batch", async () => {
+    const { handlers } = recordingRequest({
+      fields: ["Name"],
+      record_id_list: ["rec_1", "rec_missing"],
+      data: [["Alice"], [null]],
+      record_not_found: ["rec_missing"],
+      has_more: false,
+    });
+
+    await expect(
+      handlers.get_base_record({ appToken: "base_1", tableId: "tbl_1", recordId: "rec_1" }),
+    ).resolves.toEqual({ record: { record_id: "rec_1", fields: { Name: "Alice" } } });
+    await expect(
+      handlers.get_base_record({ appToken: "base_1", tableId: "tbl_1", recordId: "rec_missing" }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("rejects a batch get that returns a different record", async () => {
+    const { handlers } = recordingRequest({
+      fields: ["Name"],
+      record_id_list: ["rec_other"],
+      data: [["Alice"]],
+      has_more: false,
+    });
+
+    await expect(handlers.get_base_record({ appToken: "base_1", tableId: "tbl_1", recordId: "rec_1" })).rejects.toThrow(
+      "Base record rec_1 was not returned",
+    );
   });
 
   it("rejects inconsistent record matrices", async () => {
-    const request: FeishuJsonRequest = async () => ({
+    const { handlers } = recordingRequest({
       fields: ["Name"],
       record_id_list: ["rec_1"],
       data: [],
     });
-    const handlers = createFeishuBaseActionHandlers(request);
 
     await expect(handlers.list_base_records({ appToken: "base_1", tableId: "tbl_1" })).rejects.toThrow(
       "record_id_list and data lengths differ",

--- a/src/providers/feishu/shared/base-runtime.ts
+++ b/src/providers/feishu/shared/base-runtime.ts
@@ -433,7 +433,7 @@ async function listRecords(request: FeishuJsonRequest, input: Record<string, unk
     }),
     "Base record list",
   );
-  return normalizePage(data, ["records", "items"], offset, limit);
+  return normalizeRecordPage(data, offset, limit);
 }
 
 async function searchRecords(request: FeishuJsonRequest, input: Record<string, unknown>) {
@@ -457,7 +457,7 @@ async function searchRecords(request: FeishuJsonRequest, input: Record<string, u
     }),
     "Base record search",
   );
-  return normalizePage(data, ["records", "items"], offset, limit);
+  return normalizeRecordPage(data, offset, limit);
 }
 
 async function getRecord(request: FeishuJsonRequest, input: Record<string, unknown>) {
@@ -475,7 +475,7 @@ async function getRecord(request: FeishuJsonRequest, input: Record<string, unkno
     }),
     "Base record batch get",
   );
-  const record = extractItems(data, ["records", "items"])[0];
+  const record = extractRecords(data)[0];
   if (!record || !optionalObject(record)) {
     throw invalidResponse(`Base record ${recordId} was not returned`);
   }
@@ -506,7 +506,14 @@ async function deleteRecords(request: FeishuJsonRequest, input: Record<string, u
 }
 
 function normalizePage(data: Record<string, unknown>, itemKeys: readonly string[], offset: number, limit: number) {
-  const items = extractItems(data, itemKeys);
+  return pageFromItems(data, extractItems(data, itemKeys), offset, limit);
+}
+
+function normalizeRecordPage(data: Record<string, unknown>, offset: number, limit: number) {
+  return pageFromItems(data, extractRecords(data), offset, limit);
+}
+
+function pageFromItems(data: Record<string, unknown>, items: unknown[], offset: number, limit: number) {
   const reportedTotal = optionalNumber(data.total);
   const total = reportedTotal ?? offset + items.length;
   const hasMore =
@@ -514,6 +521,41 @@ function normalizePage(data: Record<string, unknown>, itemKeys: readonly string[
     optionalBoolean(data.hasMore) ??
     (reportedTotal !== undefined ? offset + items.length < reportedTotal : items.length === limit);
   return { items, offset, limit, total, hasMore };
+}
+
+function extractRecords(data: Record<string, unknown>): unknown[] {
+  const items = firstArray(data, ["records", "items"]);
+  if (items) {
+    return items;
+  }
+
+  const matrixKeys = ["record_id_list", "fields", "data"];
+  if (!matrixKeys.some((key) => Object.hasOwn(data, key))) {
+    return [];
+  }
+
+  const recordIds = requireResponseStringArray(data.record_id_list, "record_id_list");
+  const fields = requireResponseStringArray(data.fields, "fields");
+  const rows = data.data;
+  if (!Array.isArray(rows)) {
+    throw invalidResponse("data must be an array of record rows");
+  }
+  if (recordIds.length !== rows.length) {
+    throw invalidResponse(`record_id_list and data lengths differ (${recordIds.length} and ${rows.length})`);
+  }
+
+  return rows.map((value, rowIndex) => {
+    if (!Array.isArray(value)) {
+      throw invalidResponse(`data row ${rowIndex + 1} must be an array`);
+    }
+    if (value.length !== fields.length) {
+      throw invalidResponse(`data row ${rowIndex + 1} has ${value.length} cells but fields has ${fields.length}`);
+    }
+    return {
+      record_id: recordIds[rowIndex],
+      fields: Object.fromEntries(fields.map((field, fieldIndex) => [field, value[fieldIndex]])),
+    };
+  });
 }
 
 function extractItems(data: Record<string, unknown>, keys: readonly string[]) {
@@ -585,6 +627,13 @@ function requireStringArray(value: unknown, fieldName: string) {
     return items as string[];
   }
   throw new ProviderRequestError(400, `${fieldName} must contain non-empty strings`);
+}
+
+function requireResponseStringArray(value: unknown, fieldName: string): string[] {
+  if (Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0)) {
+    return value;
+  }
+  throw invalidResponse(`${fieldName} must contain non-empty strings`);
 }
 
 function optionalStringArray(value: unknown) {

--- a/src/providers/feishu/shared/base-runtime.ts
+++ b/src/providers/feishu/shared/base-runtime.ts
@@ -475,11 +475,24 @@ async function getRecord(request: FeishuJsonRequest, input: Record<string, unkno
     }),
     "Base record batch get",
   );
-  const record = extractRecords(data)[0];
-  if (!record || !optionalObject(record)) {
+  if (optionalStringArray(data.record_not_found)?.includes(recordId)) {
+    throw new ProviderRequestError(404, `Base record ${recordId} was not found`);
+  }
+  const record = findRecord(extractRecords(data), recordId);
+  if (!record) {
     throw invalidResponse(`Base record ${recordId} was not returned`);
   }
   return { record };
+}
+
+function findRecord(records: readonly unknown[], recordId: string) {
+  for (const entry of records) {
+    const record = optionalObject(entry);
+    if (record && record.record_id === recordId) {
+      return record;
+    }
+  }
+  return undefined;
 }
 
 async function writeRecord(


### PR DESCRIPTION
## Summary

- decode Feishu Base v3 parallel record arrays into record objects
- apply the decoder to list, search, and batch-get reads while preserving records/items compatibility
- reject inconsistent matrix shapes instead of silently returning an empty page

## Why

Base v3 record reads return fields, record_id_list, and data as parallel arrays. The runtime only read top-level records or items, so list and search returned empty pages and get_base_record reported that the requested record was not returned.

The normalized records now match the shape returned by single-record writes: record_id plus a fields object.

## Tests

- npm run fix-check
- npm test (152 files passed, 1 skipped; 1411 tests passed, 4 skipped)

No existing issue was found for this bug.