### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ Run OpenConnector from a prebuilt image on GitHub Packages (GHCR): `ghcr.io/oomo
 
 See [docs/docker-ghcr.md](docs/docker-ghcr.md) for tags, pulling, and running.
 
+## RepoCloud Deployment
+
+Deploy OpenConnector to the cloud with one click on RepoCloud with competitive pricing and no
+infrastructure setup required.
+
+See [RepoCloud](https://repocloud.io/details/Open%20Connector/) for one-click cloud deployment.
+
 ## Build a Desktop Agent with Wanta
 
 OpenConnector and [Wanta](https://github.com/oomol-lab/wanta) are two open-source projects for AI


### PR DESCRIPTION
Add a RepoCloud Deployment section to the README, matching the existing text-link style used by the Fly.io, Cloudflare, and Docker GHCR deployment sections.

 - Adds `## RepoCloud Deployment` section after Docker Image (GHCR) and before Build a Desktop Agent with Wanta
 - Button links to https://repocloud.io/details/Open%20Connector/