### PR TITLE
feat(cubox): add save URL provider

### DIFF
--- a/src/providers/cubox/actions.ts
+++ b/src/providers/cubox/actions.ts
@@ -1,0 +1,32 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "cubox";
+
+export const cuboxActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "save_url",
+    description: "Save a web page to Cubox for queued parsing and snapshot processing.",
+    inputSchema: s.object(
+      "The web page and optional metadata to save to Cubox.",
+      {
+        url: s.url("The web page URL to save."),
+        title: s.nonEmptyString("Optional title for the saved page."),
+        description: s.nonEmptyString("Optional description for the saved page."),
+        tags: s.stringArray("Optional Cubox tags to apply to the saved page.", {
+          itemDescription: "A Cubox tag.",
+        }),
+        folder: s.nonEmptyString("Optional Cubox folder name for the saved page."),
+      },
+      { optional: ["title", "description", "tags", "folder"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        queued: s.boolean("Whether Cubox accepted the page for queued parsing and snapshot processing."),
+      },
+      "The Cubox save result.",
+    ),
+  }),
+];

--- a/src/providers/cubox/definition.ts
+++ b/src/providers/cubox/definition.ts
@@ -1,0 +1,32 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { cuboxActions } from "./actions.ts";
+
+const service = "cubox";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Cubox",
+  description: "Save web pages to Cubox for later reading and processing.",
+  categories: ["Productivity"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "apiUrl",
+          label: "API URL",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "https://cubox.pro/...",
+          description:
+            "The personal API URL copied from Cubox under Preferences > Extensions and Automation > API Extension. Keep this URL secret: https://help.cubox.pro/save/89d3/.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://cubox.pro",
+  actions: cuboxActions,
+};

--- a/src/providers/cubox/executors.test.ts
+++ b/src/providers/cubox/executors.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { cuboxActionHandlers, normalizeCuboxApiUrl } from "./executors.ts";
+
+describe("normalizeCuboxApiUrl", () => {
+  it("accepts the official Cubox API Extension URL shape", () => {
+    expect(normalizeCuboxApiUrl("https://cubox.pro/c/api/save/example-token")).toBe(
+      "https://cubox.pro/c/api/save/example-token",
+    );
+  });
+
+  it("rejects non-Cubox origins and unsupported paths", () => {
+    expect(() => normalizeCuboxApiUrl("https://example.com/c/api/save/example-token")).toThrow(
+      "must use https://cubox.pro",
+    );
+    expect(() => normalizeCuboxApiUrl("https://cubox.pro/c/api/read/example-token")).toThrow(
+      "must be a Cubox API Extension save URL",
+    );
+    expect(() => normalizeCuboxApiUrl("https://cubox.pro/c/api/save/example-token?next=https://example.com")).toThrow(
+      "must be a Cubox API Extension save URL",
+    );
+  });
+});
+
+describe("Cubox actions", () => {
+  it("saves a URL with optional metadata and normalizes the successful response", async () => {
+    const apiUrl = "https://cubox.pro/c/api/save/example-token";
+    const fetcher: typeof fetch = async (input, init) => {
+      expect(input.toString()).toBe(apiUrl);
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("content-type")).toBe("application/json");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        type: "url",
+        content: "https://example.com/article",
+        title: "Example article",
+        description: "Saved from OpenConnector",
+        tags: ["reading", "open-connector"],
+        folder: "Inbox",
+      });
+      return Response.json({ code: 200, message: "", data: null });
+    };
+
+    await expect(
+      cuboxActionHandlers.save_url(
+        {
+          url: "https://example.com/article",
+          title: "Example article",
+          description: "Saved from OpenConnector",
+          tags: ["reading", "open-connector"],
+          folder: "Inbox",
+        },
+        { apiUrl, fetcher },
+      ),
+    ).resolves.toEqual({ queued: true });
+  });
+});

--- a/src/providers/cubox/executors.test.ts
+++ b/src/providers/cubox/executors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { cuboxActionHandlers, normalizeCuboxApiUrl } from "./executors.ts";
+import { credentialValidators, cuboxActionHandlers, normalizeCuboxApiUrl } from "./executors.ts";
 
 describe("normalizeCuboxApiUrl", () => {
   it("accepts the official Cubox API Extension URL shape", () => {
@@ -18,6 +18,20 @@ describe("normalizeCuboxApiUrl", () => {
     expect(() => normalizeCuboxApiUrl("https://cubox.pro/c/api/save/example-token?next=https://example.com")).toThrow(
       "must be a Cubox API Extension save URL",
     );
+  });
+});
+
+describe("Cubox credentials", () => {
+  it("rejects invalid API URLs before storing the credential", async () => {
+    const fetcher = vi.fn(async () => Response.json({}));
+
+    await expect(
+      credentialValidators.customCredential!(
+        { values: { apiUrl: "https://example.com/c/api/save/example-token" } },
+        { fetcher },
+      ),
+    ).rejects.toThrow("must use https://cubox.pro");
+    expect(fetcher).not.toHaveBeenCalled();
   });
 });
 

--- a/src/providers/cubox/executors.test.ts
+++ b/src/providers/cubox/executors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { cuboxActionHandlers, normalizeCuboxApiUrl } from "./executors.ts";
 
 describe("normalizeCuboxApiUrl", () => {
@@ -22,6 +22,18 @@ describe("normalizeCuboxApiUrl", () => {
 });
 
 describe("Cubox actions", () => {
+  it("rejects cloud metadata URLs before calling Cubox", async () => {
+    const fetcher = vi.fn(async () => Response.json({ code: 200 }));
+
+    await expect(
+      cuboxActionHandlers.save_url(
+        { url: "http://169.254.169.254/latest/meta-data" },
+        { apiUrl: "https://cubox.pro/c/api/save/example-token", fetcher },
+      ),
+    ).rejects.toThrow("url must not target private or reserved IP addresses");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("saves a URL with optional metadata and normalizes the successful response", async () => {
     const apiUrl = "https://cubox.pro/c/api/save/example-token";
     const fetcher: typeof fetch = async (input, init) => {

--- a/src/providers/cubox/executors.ts
+++ b/src/providers/cubox/executors.ts
@@ -33,6 +33,10 @@ type CuboxActionHandler = ProviderRuntimeHandler<CuboxContext>;
 
 export const cuboxActionHandlers: ProviderActionHandlers<typeof service, CuboxActionHandler> = {
   async save_url(input, context) {
+    const contentUrl = assertPublicHttpUrl(requiredString(input.url, "url", providerInputError), {
+      fieldName: "url",
+      createError: providerInputError,
+    });
     const response = await context.fetcher(context.apiUrl, {
       method: "POST",
       headers: {
@@ -43,7 +47,7 @@ export const cuboxActionHandlers: ProviderActionHandlers<typeof service, CuboxAc
       body: JSON.stringify(
         compactObject({
           type: "url",
-          content: requiredString(input.url, "url", providerInputError),
+          content: contentUrl.toString(),
           title: optionalString(input.title),
           description: optionalString(input.description),
           tags: optionalStringArray(input.tags),

--- a/src/providers/cubox/executors.ts
+++ b/src/providers/cubox/executors.ts
@@ -1,4 +1,4 @@
-import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
 import type { ProviderActionHandlers, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import {
@@ -89,6 +89,12 @@ export const executors: ProviderExecutors = defineProviderExecutors<CuboxContext
   },
   fallbackMessage: "Cubox request failed.",
 });
+
+export const credentialValidators: CredentialValidators = {
+  async customCredential(input) {
+    normalizeCuboxApiUrl(requiredString(input.values.apiUrl, "apiUrl", providerInputError));
+  },
+};
 
 /** Normalize and restrict the secret Cubox API URL before provider egress. */
 export function normalizeCuboxApiUrl(value: string): string {

--- a/src/providers/cubox/executors.ts
+++ b/src/providers/cubox/executors.ts
@@ -1,0 +1,114 @@
+import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { ProviderActionHandlers, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import {
+  compactObject,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  requiredString,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import {
+  defineProviderExecutors,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+  requireCustomCredential,
+} from "../provider-runtime.ts";
+
+const service = "cubox";
+const cuboxApiHost = "cubox.pro";
+const cuboxSavePathPattern = /^\/c\/api\/save\/[^/]+\/?$/u;
+const cuboxSuccessCode = 200;
+
+interface CuboxContext {
+  apiUrl: string;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+type CuboxActionHandler = ProviderRuntimeHandler<CuboxContext>;
+
+export const cuboxActionHandlers: ProviderActionHandlers<typeof service, CuboxActionHandler> = {
+  async save_url(input, context) {
+    const response = await context.fetcher(context.apiUrl, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        "user-agent": providerUserAgent,
+      },
+      body: JSON.stringify(
+        compactObject({
+          type: "url",
+          content: requiredString(input.url, "url", providerInputError),
+          title: optionalString(input.title),
+          description: optionalString(input.description),
+          tags: optionalStringArray(input.tags),
+          folder: optionalString(input.folder),
+        }),
+      ),
+      signal: context.signal,
+    });
+
+    const payload = optionalRecord(
+      await readProviderJsonBody(response, {
+        emptyBody: {},
+        invalidJsonMessage: "Cubox returned an invalid JSON response.",
+        maxBytes: 64 * 1024,
+      }),
+    );
+    const code = optionalInteger(payload?.code);
+    if (!response.ok) {
+      throw new ProviderRequestError(response.status, `Cubox request failed with HTTP ${response.status}.`);
+    }
+    if (code !== cuboxSuccessCode) {
+      throw new ProviderRequestError(502, "Cubox did not accept the page.");
+    }
+
+    return { queued: true };
+  },
+};
+
+export const executors: ProviderExecutors = defineProviderExecutors<CuboxContext>({
+  service,
+  handlers: cuboxActionHandlers,
+  async createContext(context: ExecutionContext, fetcher: ProviderFetch): Promise<CuboxContext> {
+    const credential = await requireCustomCredential(context, service);
+    return {
+      apiUrl: normalizeCuboxApiUrl(requiredString(credential.values.apiUrl, "apiUrl", providerInputError)),
+      fetcher,
+      signal: context.signal,
+    };
+  },
+  fallbackMessage: "Cubox request failed.",
+});
+
+/** Normalize and restrict the secret Cubox API URL before provider egress. */
+export function normalizeCuboxApiUrl(value: string): string {
+  const url = assertPublicHttpUrl(value, {
+    fieldName: "apiUrl",
+    createError: providerInputError,
+  });
+
+  if (url.protocol !== "https:") {
+    throw providerInputError("apiUrl must use https");
+  }
+  if (url.hostname !== cuboxApiHost || url.port !== "") {
+    throw providerInputError(`apiUrl must use https://${cuboxApiHost}`);
+  }
+  if (url.username || url.password) {
+    throw providerInputError("apiUrl must not include URL credentials");
+  }
+  if (!cuboxSavePathPattern.test(url.pathname) || url.search || url.hash) {
+    throw providerInputError("apiUrl must be a Cubox API Extension save URL");
+  }
+
+  return url.toString();
+}
+
+function providerInputError(message: string): ProviderRequestError {
+  return new ProviderRequestError(400, message);
+}


### PR DESCRIPTION
## Summary

- add a locally executable Cubox provider using a custom API URL credential
- expose `cubox.save_url` with URL, title, description, tags, and folder inputs
- validate the Cubox API Extension URL and route requests through the guarded provider fetch
- normalize successful queued saves to `{ queued: true }`

## Testing

- `npx oxfmt --check src/providers/cubox`
- `npx oxlint src/providers/cubox`
- `npm test -- src/providers/cubox/executors.test.ts` (3 tests passed)
- `npm run typecheck`
- manual end-to-end test: OpenConnector returned `queued: true` and the saved page appeared in Cubox
