### PR TITLE
fix(runtime): handle JSON media types case-insensitively

### DIFF
--- a/src/server/api/http-utils.ts
+++ b/src/server/api/http-utils.ts
@@ -22,7 +22,7 @@ export type JsonRequestBody = {
  */
 export async function readJsonBody(context: Context, maxBytes?: number): Promise<JsonRequestBody> {
   const contentType = context.req.header("content-type") ?? "";
-  if (contentType.split(";", 1)[0]?.trim().toLowerCase() !== "application/json") {
+  if (!contentType.toLowerCase().includes("application/json")) {
     return {};
   }
 

--- a/src/server/api/http-utils.ts
+++ b/src/server/api/http-utils.ts
@@ -22,7 +22,7 @@ export type JsonRequestBody = {
  */
 export async function readJsonBody(context: Context, maxBytes?: number): Promise<JsonRequestBody> {
   const contentType = context.req.header("content-type") ?? "";
-  if (!contentType.includes("application/json")) {
+  if (contentType.split(";", 1)[0]?.trim().toLowerCase() !== "application/json") {
     return {};
   }
 

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -507,6 +507,31 @@ describe("ConnectServer", () => {
     });
   });
 
+  it("accepts case-insensitive JSON media types when disconnecting a named connection", async () => {
+    const app = createTestServer([apiKeyProvider]).createApp();
+    for (const [connectionName, apiKey] of [
+      ["default", "default-key"],
+      ["work", "work-key"],
+    ]) {
+      await app.request("/api/connections/example", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ authType: "api_key", connectionName, values: { apiKey } }),
+      });
+    }
+
+    const response = await app.request("/api/connections/example", {
+      method: "DELETE",
+      headers: { "content-type": "Application/JSON; Charset=UTF-8" },
+      body: JSON.stringify({ connectionName: "work" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ connectionName: "work", configured: false });
+    const connections = (await (await app.request("/api/connections")).json()) as Array<{ connectionName: string }>;
+    expect(connections.map((connection) => connection.connectionName)).toEqual(["default"]);
+  });
+
   it("rejects JSON request bodies that are not objects", async () => {
     const app = createTestServer([
       {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -904,7 +904,7 @@ export class ConnectServer {
   }
 
   private async disconnect(context: Context, service: string): Promise<Response> {
-    const body = context.req.header("content-type")?.includes("application/json") ? await readJsonBody(context) : {};
+    const body = await readJsonBody(context);
     const connectionName = readConnectionName(context, body);
     const logContext: ConnectionLogContext = {
       operation: "disconnect",


### PR DESCRIPTION
## Summary

- compare the JSON media type case-insensitively before parsing request bodies
- ignore media type parameters while preserving the existing non-JSON behavior
- route connection deletion through the shared JSON body reader

## Problem

HTTP media type type and subtype tokens are case-insensitive. A valid request such as `Content-Type: Application/JSON; Charset=UTF-8` was treated as non-JSON because the runtime used a case-sensitive substring check.

For `DELETE /api/connections/:service`, an external client that supplied `connectionName` only in that JSON body could therefore have the body ignored. The missing name then normalized to `default`, so the wrong connection was disconnected. The Web Console uses a query parameter and is not affected, but the server explicitly accepts the body selector.

## Fix

Normalize only the type/subtype portion of Content-Type in `readJsonBody`, compare it exactly with `application/json`, and remove the duplicate route-level check from the disconnect handler. This keeps one owner for JSON body detection.

The regression test creates `default` and `work`, disconnects `work` with a mixed-case JSON media type, and verifies that only `default` remains.

## Verification

- `npm run fix-check`
- `npm test` — 155 test files passed, 1 skipped; 1460 tests passed, 4 skipped
- focused regression test confirmed the previous behavior disconnected `default` before the fix