### PR TITLE
fix(oauth): prune expired authorization states

### DIFF
--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -490,6 +490,35 @@ describe("OAuthFlowService", () => {
     });
   });
 
+  it("removes expired OAuth authorization states before starting a new flow", async () => {
+    const services = createServices([oauthProvider], { stateMaxAgeMs: 1_000 });
+    await services.clientConfigs.upsertConfig({
+      service: "example",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      extra: {
+        tenant: "default",
+      },
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.001Z"));
+    await services.states.set({
+      service: "example",
+      state: "expired",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    await services.states.set({
+      service: "example",
+      state: "current",
+      createdAt: "2026-01-01T00:00:00.001Z",
+    });
+
+    await services.flow.startAuthorization({ service: "example" });
+
+    await expect(services.states.take("expired")).resolves.toBeUndefined();
+    await expect(services.states.take("current")).resolves.toMatchObject({ state: "current" });
+  });
+
   it("rejects malformed OAuth authorization state timestamps", async () => {
     const services = createServices([oauthProvider]);
     await services.clientConfigs.upsertConfig({
@@ -875,6 +904,12 @@ class MemoryOAuthClientConfigStore implements IOAuthClientConfigStore {
 
 class MemoryOAuthStateStore implements IOAuthStateStore {
   private readonly states = new Map<string, OAuthAuthorizationState>();
+
+  async deleteCreatedBefore(cutoff: string): Promise<void> {
+    for (const [state, value] of this.states) {
+      if (value.createdAt < cutoff) this.states.delete(state);
+    }
+  }
 
   async set(state: OAuthAuthorizationState): Promise<void> {
     this.states.set(state.state, state);

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -55,6 +55,7 @@ export interface OAuthFlowServiceOptions {
  * Storage contract for pending OAuth authorization states.
  */
 export interface IOAuthStateStore {
+  deleteCreatedBefore(cutoff: string): Promise<void>;
   set(state: OAuthAuthorizationState): Promise<void>;
   take(state: string): Promise<OAuthAuthorizationState | undefined>;
 }
@@ -90,13 +91,15 @@ export class OAuthFlowService {
       throw new OAuthFlowError("oauth_client_config_required", `Configure an OAuth client for ${service} first.`);
     }
 
+    const now = new Date();
     const state = crypto.randomUUID();
     const pkceCodeVerifier = auth.pkce ? createPkceCodeVerifier() : undefined;
+    await this.states.deleteCreatedBefore(new Date(now.getTime() - this.stateMaxAgeMs).toISOString());
     await this.states.set({
       service,
       connectionName,
       state,
-      createdAt: new Date().toISOString(),
+      createdAt: now.toISOString(),
       pkceCodeVerifier,
       clientConfig: input.clientConfig ? config : undefined,
     });

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3883,6 +3883,12 @@ class MemoryOAuthClientConfigStore implements IOAuthClientConfigStore {
 class MemoryOAuthStateStore implements IOAuthStateStore {
   private readonly states = new Map<string, OAuthAuthorizationState>();
 
+  async deleteCreatedBefore(cutoff: string): Promise<void> {
+    for (const [state, value] of this.states) {
+      if (value.createdAt < cutoff) this.states.delete(state);
+    }
+  }
+
   async set(state: OAuthAuthorizationState): Promise<void> {
     this.states.set(state.state, state);
   }

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -135,6 +135,25 @@ describe("D1RuntimeDatabase", () => {
     await expect(database.oauthStateStore.take("state-1")).resolves.toBeUndefined();
   });
 
+  it("deletes OAuth states created before a cutoff", async () => {
+    const database = new D1RuntimeDatabase(new SqliteD1Database());
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "expired",
+      createdAt: "2026-06-30T00:00:00.000Z",
+    });
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "current",
+      createdAt: "2026-06-30T00:00:01.000Z",
+    });
+
+    await database.oauthStateStore.deleteCreatedBefore("2026-06-30T00:00:01.000Z");
+
+    await expect(database.oauthStateStore.take("expired")).resolves.toBeUndefined();
+    await expect(database.oauthStateStore.take("current")).resolves.toMatchObject({ state: "current" });
+  });
+
   it("stores OAuth state through the secret codec", async () => {
     const d1 = new SqliteD1Database();
     const database = new D1RuntimeDatabase(d1, {

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -256,6 +256,10 @@ export class D1OAuthStateStore implements IOAuthStateStore {
     this.secretCodec = secretCodec;
   }
 
+  async deleteCreatedBefore(cutoff: string): Promise<void> {
+    await this.database.prepare("delete from oauth_states where created_at < ?").bind(cutoff).run();
+  }
+
   async set(state: OAuthAuthorizationState): Promise<void> {
     await this.database
       .prepare(

--- a/src/server/storage/postgres-runtime-store.test.ts
+++ b/src/server/storage/postgres-runtime-store.test.ts
@@ -127,6 +127,24 @@ describe("PostgresRuntimeDatabase with PGlite", () => {
     await expect(database.oauthStateStore.take("state-1")).resolves.toBeUndefined();
   });
 
+  it("deletes OAuth states created before a cutoff", async () => {
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "expired",
+      createdAt: "2026-06-30T00:00:00.000Z",
+    });
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "current",
+      createdAt: "2026-06-30T00:00:01.000Z",
+    });
+
+    await database.oauthStateStore.deleteCreatedBefore("2026-06-30T00:00:01.000Z");
+
+    await expect(database.oauthStateStore.take("expired")).resolves.toBeUndefined();
+    await expect(database.oauthStateStore.take("current")).resolves.toMatchObject({ state: "current" });
+  });
+
   it("preserves connection identity and rejects stale revisions", async () => {
     const created = await database.connectionStore.set("github", "default", githubCredential("github-token"));
     const updated = await database.connectionStore.set("github", "default", githubCredential("updated-token"));

--- a/src/server/storage/postgres-runtime-store.ts
+++ b/src/server/storage/postgres-runtime-store.ts
@@ -375,6 +375,10 @@ class PostgresOAuthStateStore implements IOAuthStateStore {
     this.secretCodec = secretCodec;
   }
 
+  async deleteCreatedBefore(cutoff: string): Promise<void> {
+    await this.pool.query("delete from oauth_states where created_at < $1", [cutoff]);
+  }
+
   async set(state: OAuthAuthorizationState): Promise<void> {
     await this.pool.query(
       `

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -160,6 +160,26 @@ describe("SqliteRuntimeDatabase", () => {
     second.close();
   });
 
+  it("deletes OAuth states created before a cutoff", async () => {
+    const database = new SqliteRuntimeDatabase(await createDatabasePath());
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "expired",
+      createdAt: "2026-06-30T00:00:00.000Z",
+    });
+    await database.oauthStateStore.set({
+      service: "gmail",
+      state: "current",
+      createdAt: "2026-06-30T00:00:01.000Z",
+    });
+
+    await database.oauthStateStore.deleteCreatedBefore("2026-06-30T00:00:01.000Z");
+
+    await expect(database.oauthStateStore.take("expired")).resolves.toBeUndefined();
+    await expect(database.oauthStateStore.take("current")).resolves.toMatchObject({ state: "current" });
+    database.close();
+  });
+
   it("preserves connection identity and rejects stale credential revisions", async () => {
     const database = new SqliteRuntimeDatabase(await createDatabasePath());
     const credential = {

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -348,6 +348,10 @@ export class SqliteOAuthStateStore implements IOAuthStateStore {
     this.secretCodec = secretCodec;
   }
 
+  async deleteCreatedBefore(cutoff: string): Promise<void> {
+    this.database.prepare("delete from oauth_states where created_at < ?").run(cutoff);
+  }
+
   async set(state: OAuthAuthorizationState): Promise<void> {
     this.database
       .prepare(


### PR DESCRIPTION
## Summary

- prune expired pending OAuth states before starting each new authorization flow
- use the existing `stateMaxAgeMs` value as the single source of truth for the cutoff
- implement the same deletion contract for SQLite, D1, and PostgreSQL

## Problem

Pending OAuth state is consumed only when the callback reaches `completeAuthorization`. If a user denies authorization, closes the browser, or never returns, the row is never taken. The runtime rejects that state after `stateMaxAgeMs`, but the expired row remains in `oauth_states` indefinitely.

This is observable on current main: a SQLite state with `createdAt: 2000-01-01T00:00:00.000Z` remains readable after closing and reopening the runtime database. Pending state may also contain a PKCE verifier or encrypted connection-scoped OAuth client configuration, so expired records should not accumulate.

## Fix

Before writing a new pending state, `OAuthFlowService` computes the expiration cutoff from the same timestamp used for the new state and asks the store to delete rows created before it. SQLite, D1, and PostgreSQL each implement this as one indexed-table delete query over `created_at`.

Cleanup is deliberately request-driven. It needs no scheduler and works in both long-lived Node runtimes and Cloudflare Workers. If OAuth activity stops, the final recent states may remain, but future authorization activity cannot grow the table without first pruning expired rows.

## Tests

- OAuth flow test proves expired states are removed while the exact cutoff boundary remains valid
- SQLite, D1, and PostgreSQL store tests cover the same deletion contract
- `npm run fix-check`
- `npm test` — 155 test files passed, 1 skipped; 1463 tests passed, 4 skipped