### PR TITLE
feat(github): expose workflow job logs

### DIFF
--- a/src/providers/github/actions.ts
+++ b/src/providers/github/actions.ts
@@ -74,6 +74,7 @@ const githubRequiredInputFields: Record<string, string[]> = {
   list_workflow_runs: ["owner", "repo"],
   get_workflow_run: ["owner", "repo", "runId"],
   list_workflow_run_jobs: ["owner", "repo", "runId"],
+  get_workflow_job_logs: ["owner", "repo", "jobId"],
   rerun_workflow: ["owner", "repo", "runId"],
   list_releases: ["owner", "repo"],
   create_release: ["owner", "repo", "tagName"],
@@ -1449,6 +1450,22 @@ export const githubActions: ActionDefinition[] = [
     outputSchema: s.object({
       total_count: s.integer(),
       jobs: s.array(githubWorkflowJobSchema),
+    }),
+  }),
+  action({
+    name: "get_workflow_job_logs",
+    description: "Get the tail of the plain-text logs for a completed GitHub Actions workflow job.",
+    requiredScopes: githubRepoScopes,
+    inputSchema: s.object({
+      owner: nonEmptyString,
+      repo: nonEmptyString,
+      jobId: s.integer({ minimum: 1 }),
+    }),
+    outputSchema: s.object({
+      logs: s.string({ description: "The complete log text or its trailing 256 KiB when truncated." }),
+      sizeBytes: s.integer({ description: "The total size of the downloaded log in bytes." }),
+      returnedBytes: s.integer({ description: "The number of source log bytes represented by logs." }),
+      truncated: s.boolean({ description: "Whether logs omits bytes from the beginning of the job log." }),
     }),
   }),
   action({

--- a/src/providers/github/executors.ts
+++ b/src/providers/github/executors.ts
@@ -32,6 +32,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<GitHubAction
     return {
       accessToken: credential.accessToken,
       fetcher,
+      signal: context.signal,
     };
   },
 });

--- a/src/providers/github/runtime-pull-request.ts
+++ b/src/providers/github/runtime-pull-request.ts
@@ -14,6 +14,7 @@ import {
   githubHeaders,
   githubRequestJson,
   githubRequestNoContent,
+  githubRequestTextTail,
   mapReviewComment,
   normalizeGitHubError,
   normalizeRequestedReviewersResponse,
@@ -295,6 +296,10 @@ export const pullRequestActionHandlers: ProviderActionHandlerSubset<"github", Gi
 
   list_workflow_run_jobs(input, { accessToken, fetcher }) {
     return listWorkflowRunJobs(input, accessToken, fetcher);
+  },
+
+  get_workflow_job_logs(input, { accessToken, fetcher, signal }) {
+    return getWorkflowJobLogs(input, accessToken, fetcher, signal);
   },
 
   rerun_workflow(input, { accessToken, fetcher }) {
@@ -670,6 +675,30 @@ async function listWorkflowRunJobs(input: Record<string, unknown>, accessToken: 
   return {
     total_count: Number(response.total_count ?? 0),
     jobs: Array.isArray(response.jobs) ? (response.jobs as Record<string, unknown>[]) : [],
+  };
+}
+
+const workflowJobLogTailMaxBytes = 256 * 1024;
+
+async function getWorkflowJobLogs(
+  input: Record<string, unknown>,
+  accessToken: string,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+) {
+  const result = await githubRequestTextTail({
+    path: `/repos/${encodeURIComponent(String(input.owner))}/${encodeURIComponent(String(input.repo))}/actions/jobs/${String(input.jobId)}/logs`,
+    accessToken,
+    fetcher,
+    maxBytes: workflowJobLogTailMaxBytes,
+    signal,
+  });
+
+  return {
+    logs: result.text,
+    sizeBytes: result.sizeBytes,
+    returnedBytes: result.returnedBytes,
+    truncated: result.truncated,
   };
 }
 

--- a/src/providers/github/runtime-shared.test.ts
+++ b/src/providers/github/runtime-shared.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { githubRequestTextTail } from "./runtime-shared.ts";
+
+describe("GitHub text responses", () => {
+  it("returns complete text below the tail limit", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => chunkedTextResponse(["hello ", "world"]));
+
+    const result = await githubRequestTextTail({
+      path: "/repos/oomol/test/actions/jobs/1/logs",
+      accessToken: "secret",
+      fetcher,
+      maxBytes: 32,
+    });
+
+    expect(result).toEqual({
+      text: "hello world",
+      sizeBytes: 11,
+      returnedBytes: 11,
+      truncated: false,
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.com/repos/oomol/test/actions/jobs/1/logs",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer secret" }),
+      }),
+    );
+  });
+
+  it("retains the trailing bytes across response chunks", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => chunkedTextResponse(["abc", "def", "ghi"]));
+
+    const result = await githubRequestTextTail({
+      path: "/logs",
+      accessToken: "secret",
+      fetcher,
+      maxBytes: 5,
+    });
+
+    expect(result).toEqual({
+      text: "efghi",
+      sizeBytes: 9,
+      returnedBytes: 5,
+      truncated: true,
+    });
+  });
+
+  it("drops an incomplete UTF-8 character at the beginning of a truncated tail", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => chunkedTextResponse(["a😀bc"]));
+
+    const result = await githubRequestTextTail({
+      path: "/logs",
+      accessToken: "secret",
+      fetcher,
+      maxBytes: 5,
+    });
+
+    expect(result).toEqual({
+      text: "bc",
+      sizeBytes: 7,
+      returnedBytes: 2,
+      truncated: true,
+    });
+  });
+
+  it("normalizes GitHub errors instead of returning their body as logs", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json({ message: "Not Found" }, { status: 404 }));
+
+    await expect(
+      githubRequestTextTail({
+        path: "/logs",
+        accessToken: "secret",
+        fetcher,
+        maxBytes: 5,
+      }),
+    ).rejects.toMatchObject({ status: 404, message: "Not Found" });
+  });
+});
+
+function chunkedTextResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/plain" } },
+  );
+}

--- a/src/providers/github/runtime-shared.ts
+++ b/src/providers/github/runtime-shared.ts
@@ -11,6 +11,7 @@ export const githubUserAgent = "oomol-connect";
 export type GitHubActionContext = {
   accessToken: string;
   fetcher: typeof fetch;
+  signal?: AbortSignal;
 };
 
 export type GitHubActionHandler = (input: Record<string, unknown>, context: GitHubActionContext) => Promise<unknown>;
@@ -30,6 +31,21 @@ interface GitHubNoContentRequest {
   body?: Record<string, unknown>;
   accessToken: string;
   fetcher: typeof fetch;
+}
+
+interface GitHubTextTailRequest {
+  path: string;
+  accessToken: string;
+  fetcher: typeof fetch;
+  maxBytes: number;
+  signal?: AbortSignal;
+}
+
+export interface GitHubTextTail {
+  text: string;
+  sizeBytes: number;
+  returnedBytes: number;
+  truncated: boolean;
 }
 
 export async function githubRequestJson<T>(input: GitHubJsonRequest): Promise<T> {
@@ -60,6 +76,49 @@ export async function githubRequestNoContent(input: GitHubNoContentRequest): Pro
     const payload = await readJsonResponse(response);
     throw normalizeGitHubError(response, payload, "github api request failed");
   }
+}
+
+/** Download a GitHub text response while retaining only its trailing bytes. */
+export async function githubRequestTextTail(input: GitHubTextTailRequest): Promise<GitHubTextTail> {
+  const response = await input.fetcher(buildGitHubUrl(input.path), {
+    headers: githubHeaders(input.accessToken, false),
+    signal: input.signal,
+  });
+  if (!response.ok) {
+    const payload = await readJsonResponse(response);
+    throw normalizeGitHubError(response, payload, "github api request failed");
+  }
+
+  const tail = new Uint8Array(input.maxBytes);
+  const reader = response.body?.getReader();
+  let sizeBytes = 0;
+  let writeOffset = 0;
+  if (reader) {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        sizeBytes += value.byteLength;
+        writeOffset = writeTailBytes(tail, writeOffset, value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  const truncated = sizeBytes > input.maxBytes;
+  const retainedSize = Math.min(sizeBytes, input.maxBytes);
+  const retained = readTailBytes(tail, writeOffset, retainedSize, truncated);
+  const utf8Start = truncated ? skipUtf8ContinuationBytes(retained) : 0;
+  const returnedBytes = retained.byteLength - utf8Start;
+  return {
+    text: new TextDecoder().decode(retained.subarray(utf8Start)),
+    sizeBytes,
+    returnedBytes,
+    truncated,
+  };
 }
 
 export function buildGitHubUrl(path: string, query?: Record<string, string | number | boolean | undefined>): string {
@@ -156,6 +215,38 @@ function isRateLimited(response: Response, payload: unknown): boolean {
 
   const message = readGitHubErrorMessage(payload)?.toLowerCase() ?? "";
   return message.includes("rate limit");
+}
+
+function writeTailBytes(tail: Uint8Array, writeOffset: number, value: Uint8Array): number {
+  if (value.byteLength >= tail.byteLength) {
+    tail.set(value.subarray(value.byteLength - tail.byteLength));
+    return 0;
+  }
+
+  const firstLength = Math.min(value.byteLength, tail.byteLength - writeOffset);
+  tail.set(value.subarray(0, firstLength), writeOffset);
+  tail.set(value.subarray(firstLength), 0);
+  return (writeOffset + value.byteLength) % tail.byteLength;
+}
+
+function readTailBytes(tail: Uint8Array, writeOffset: number, size: number, wrapped: boolean): Uint8Array {
+  if (!wrapped) {
+    return tail.slice(0, size);
+  }
+
+  const value = new Uint8Array(size);
+  const firstLength = tail.byteLength - writeOffset;
+  value.set(tail.subarray(writeOffset), 0);
+  value.set(tail.subarray(0, writeOffset), firstLength);
+  return value;
+}
+
+function skipUtf8ContinuationBytes(value: Uint8Array): number {
+  let offset = 0;
+  while (offset < value.byteLength && (value[offset]! & 0xc0) === 0x80) {
+    offset++;
+  }
+  return offset;
 }
 
 export function decodeGitHubContent(contentBase64: string, encoding?: string): string | null {


### PR DESCRIPTION
## Summary

- add `github.get_workflow_job_logs` for completed workflow jobs
- retain the trailing 256 KiB with total size and truncation metadata
- stream the response with bounded memory and preserve UTF-8 boundaries
- propagate request cancellation and normalize GitHub API errors

Closes #432

## Verification

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (1498 passed, 4 skipped)