### PR TITLE
fix(providers): close credential validator egress gaps

### DIFF
--- a/src/providers/coupang/runtime.ts
+++ b/src/providers/coupang/runtime.ts
@@ -39,7 +39,7 @@ interface ValidationResult {
 
 export async function validateCoupangCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch,
 ): Promise<ValidationResult> {
   const credential = readCoupangCredential(input);
   await requestCoupangJson({

--- a/src/providers/faktoora/runtime.ts
+++ b/src/providers/faktoora/runtime.ts
@@ -111,7 +111,7 @@ export const faktooraActionHandlers: ProviderActionHandlers<"faktoora", Faktoora
 
 export async function validateFaktooraCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch,
 ): Promise<FaktooraCredentialCheck> {
   const apiKey = requiredString(input.apiKey, "apiKey", (message) => new ProviderRequestError(400, message));
   await requestFaktooraJson({

--- a/src/providers/helpdesk/runtime.ts
+++ b/src/providers/helpdesk/runtime.ts
@@ -59,7 +59,7 @@ export const helpdeskActionHandlers: ProviderActionHandlers<"helpdesk", Helpdesk
 
 export async function validateHelpdeskCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch,
 ): Promise<HelpdeskCredentialCheck> {
   const apiKey = requiredString(input.apiKey, "apiKey", (message) => new ProviderRequestError(400, message));
   const accountId = requireHelpdeskAccountId(input);

--- a/src/providers/invoice_ninja/executors.test.ts
+++ b/src/providers/invoice_ninja/executors.test.ts
@@ -37,4 +37,21 @@ describe("Invoice Ninja credential validation", () => {
     ).rejects.toThrow("instanceUrl must not target private or reserved IP addresses");
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("forwards the caller abort signal to the validation request", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      init?.signal?.throwIfAborted();
+      return Response.json({ data: { id: "company-1" } });
+    });
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "invoice-token", values: { instanceUrl: "https://10.0.0.5" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal: AbortSignal.abort() },
+      ),
+    ).rejects.toThrow("Invoice Ninja request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
 });

--- a/src/providers/invoice_ninja/executors.test.ts
+++ b/src/providers/invoice_ninja/executors.test.ts
@@ -54,4 +54,24 @@ describe("Invoice Ninja credential validation", () => {
     ).rejects.toThrow("Invoice Ninja request timed out");
     expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
+
+  it("maps a caller abort reason to the timeout error", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    // A caller that aborts with its own reason makes fetch reject with that
+    // reason object, whose name is not "AbortError".
+    const signal = AbortSignal.abort(new Error("cancelled by caller"));
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return Response.json({ data: { id: "company-1" } });
+    });
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "invoice-token", values: { instanceUrl: "https://10.0.0.5" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal },
+      ),
+    ).rejects.toThrow("Invoice Ninja request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.reason).toBe(signal.reason);
+  });
 });

--- a/src/providers/invoice_ninja/executors.ts
+++ b/src/providers/invoice_ninja/executors.ts
@@ -8,6 +8,7 @@ interface InvoiceNinjaContext {
   apiKey: string;
   apiBaseUrl: string;
   fetcher: typeof fetch;
+  signal?: AbortSignal;
 }
 
 const handlers: Record<string, (input: Record<string, unknown>, context: InvoiceNinjaContext) => Promise<unknown>> =
@@ -16,7 +17,12 @@ const handlers: Record<string, (input: Record<string, unknown>, context: Invoice
       name,
       (input: Record<string, unknown>, context: InvoiceNinjaContext) =>
         handler(
-          { apiKey: context.apiKey, providerMetadata: { apiBaseUrl: context.apiBaseUrl }, input },
+          {
+            apiKey: context.apiKey,
+            providerMetadata: { apiBaseUrl: context.apiBaseUrl },
+            input,
+            signal: context.signal,
+          },
           context.fetcher,
         ),
     ]),
@@ -29,13 +35,13 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireApiKeyCredential(context, "invoice_ninja");
     const urls = normalizeInvoiceNinjaUrls(credential.values.instanceUrl);
-    return { apiKey: credential.apiKey, apiBaseUrl: urls.apiBaseUrl, fetcher };
+    return { apiKey: credential.apiKey, apiBaseUrl: urls.apiBaseUrl, fetcher, signal: context.signal };
   },
 });
 
 export const credentialValidators: CredentialValidators = {
-  apiKey(input, { fetcher }) {
+  apiKey(input, { fetcher, signal }) {
     const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
-    return validateInvoiceNinjaCredential({ apiKey: input.apiKey, ...input.values }, guardedFetcher);
+    return validateInvoiceNinjaCredential({ apiKey: input.apiKey, ...input.values }, guardedFetcher, signal);
   },
 };

--- a/src/providers/invoice_ninja/runtime.ts
+++ b/src/providers/invoice_ninja/runtime.ts
@@ -13,6 +13,7 @@ interface InvoiceNinjaInput {
   apiKey: string;
   providerMetadata: Record<string, unknown>;
   input: Record<string, unknown>;
+  signal?: AbortSignal;
 }
 type Handler = (input: InvoiceNinjaInput, fetcher: typeof fetch) => Promise<unknown>;
 
@@ -135,6 +136,7 @@ export const invoiceNinjaActionHandlers: Record<string, Handler> = {
 export async function validateInvoiceNinjaCredential(
   input: Record<string, string>,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const apiKey = input.apiKey?.trim();
   if (!apiKey) throw new ProviderRequestError(400, "apiKey is required");
@@ -146,6 +148,7 @@ export async function validateInvoiceNinjaCredential(
     method: "POST",
     phase: "validate",
     fetcher,
+    signal,
   });
   const company = unwrapEntity(payload, "company");
   const companyId = optionalString(company.id)?.trim();
@@ -207,6 +210,7 @@ async function request(
     path,
     fetcher,
     phase: "execute",
+    signal: input.signal,
     ...options,
   });
 }
@@ -221,8 +225,9 @@ async function requestJson(input: {
   query?: Record<string, unknown>;
   body?: Record<string, unknown>;
   notFound?: boolean;
+  signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(undefined, 30_000);
+  const timeout = createProviderTimeout(input.signal, 30_000);
   const url = new URL(`${input.apiBaseUrl}${input.path}`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));

--- a/src/providers/invoice_ninja/runtime.ts
+++ b/src/providers/invoice_ninja/runtime.ts
@@ -2,7 +2,12 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortSignalError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const defaultInstanceUrl = "https://invoicing.co";
 const apiPath = "/api/v1";
@@ -252,7 +257,7 @@ async function requestJson(input: {
     return payload;
   } catch (error) {
     if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || (error instanceof Error && error.name === "AbortError")) {
+    if (timeout.didTimeout() || isAbortSignalError(timeout.signal, error)) {
       throw new ProviderRequestError(504, "Invoice Ninja request timed out");
     }
     throw new ProviderRequestError(

--- a/src/providers/kobotoolbox/executors.test.ts
+++ b/src/providers/kobotoolbox/executors.test.ts
@@ -55,6 +55,26 @@ describe("KoboToolbox credential validation", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
+  it("maps a caller abort reason to the timeout error", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    // A caller that aborts with its own reason makes fetch reject with that
+    // reason object, whose name is not "AbortError".
+    const signal = AbortSignal.abort(new Error("cancelled by caller"));
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return Response.json({ username: "alice" });
+    });
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "kobo-token", values: { baseUrl: "https://10.0.0.5" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal },
+      ),
+    ).rejects.toThrow("KoboToolbox request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.reason).toBe(signal.reason);
+  });
+
   it("rejects reserved metadata targets even with the deployment opt-in", async () => {
     setPrivateNetworkAccessAllowed(true);
 

--- a/src/providers/kobotoolbox/executors.test.ts
+++ b/src/providers/kobotoolbox/executors.test.ts
@@ -34,8 +34,25 @@ describe("KoboToolbox credential validation", () => {
         { apiKey: "kobo-token", values: { baseUrl: "https://10.0.0.5" } },
         { fetcher: createProviderFetch({ fetch: fetchMock }) },
       ),
-    ).rejects.toThrow("request URL must not target private or reserved IP addresses");
+    ).rejects.toThrow("baseUrl must not target private or reserved IP addresses");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards the caller abort signal to the validation request", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      init?.signal?.throwIfAborted();
+      return Response.json({ username: "alice" });
+    });
+
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "kobo-token", values: { baseUrl: "https://10.0.0.5" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal: AbortSignal.abort() },
+      ),
+    ).rejects.toThrow("KoboToolbox request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it("rejects reserved metadata targets even with the deployment opt-in", async () => {
@@ -48,7 +65,7 @@ describe("KoboToolbox credential validation", () => {
         { apiKey: "kobo-token", values: { baseUrl: "https://169.254.169.254" } },
         { fetcher: createProviderFetch({ fetch: fetchMock }) },
       ),
-    ).rejects.toThrow("request URL must not target private or reserved IP addresses");
+    ).rejects.toThrow("baseUrl must not target private or reserved IP addresses");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/providers/kobotoolbox/executors.ts
+++ b/src/providers/kobotoolbox/executors.ts
@@ -20,12 +20,21 @@ interface Context {
   apiKey: string;
   baseUrl: string;
   fetcher: typeof fetch;
+  signal?: AbortSignal;
 }
 const handlers = Object.fromEntries(
   Object.entries(koboToolboxActionHandlers).map(([name, handler]) => [
     name,
     (input: Record<string, unknown>, context: Context) =>
-      handler({ apiKey: context.apiKey, input, providerMetadata: { baseUrl: context.baseUrl } }, context.fetcher),
+      handler(
+        {
+          apiKey: context.apiKey,
+          input,
+          providerMetadata: { baseUrl: context.baseUrl },
+          signal: context.signal,
+        },
+        context.fetcher,
+      ),
   ]),
 );
 
@@ -39,16 +48,18 @@ export const executors: ProviderExecutors = defineProviderExecutors<Context>({
       apiKey: credential.apiKey,
       baseUrl: normalizeKoboToolboxBaseUrl(credential.values.baseUrl ?? credential.metadata.baseUrl),
       fetcher,
+      signal: context.signal,
     };
   },
 });
 
 export const credentialValidators: CredentialValidators = {
-  async apiKey(input, { fetcher }) {
+  async apiKey(input, { fetcher, signal }) {
     const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
     const result = await validateKoboToolboxCredential(
       { apiKey: input.apiKey, baseUrl: String(input.values.baseUrl ?? "") },
       guardedFetcher,
+      signal,
     );
     return {
       profile: { accountId: result.providerAccountId ?? "kobotoolbox", displayName: result.accountLabel },

--- a/src/providers/kobotoolbox/runtime.test.ts
+++ b/src/providers/kobotoolbox/runtime.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { normalizeKoboToolboxBaseUrl } from "./runtime.ts";
+
+afterEach(() => setPrivateNetworkAccessAllowed(false));
+
+describe("normalizeKoboToolboxBaseUrl", () => {
+  it("allows a public host and drops the trailing slash", () => {
+    expect(normalizeKoboToolboxBaseUrl("https://kf.kobotoolbox.org/")).toBe("https://kf.kobotoolbox.org");
+  });
+
+  it("allows private instances only with the deployment opt-in", () => {
+    expect(() => normalizeKoboToolboxBaseUrl("https://10.0.0.5")).toThrow("private or reserved IP addresses");
+
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(normalizeKoboToolboxBaseUrl("https://10.0.0.5")).toBe("https://10.0.0.5");
+  });
+
+  it("rejects reserved metadata and IPv6 targets even with the deployment opt-in", () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    expect(() => normalizeKoboToolboxBaseUrl("https://169.254.169.254")).toThrow("private or reserved IP addresses");
+    expect(() => normalizeKoboToolboxBaseUrl("https://[::ffff:169.254.169.254]/")).toThrow("IPv6");
+    expect(() => normalizeKoboToolboxBaseUrl("https://metadata.google.internal")).toThrow("cloud metadata hosts");
+  });
+
+  it("keeps requiring https and a server root URL without a path", () => {
+    expect(() => normalizeKoboToolboxBaseUrl("http://kf.kobotoolbox.org")).toThrow("baseUrl must use https");
+    expect(() => normalizeKoboToolboxBaseUrl("https://kf.kobotoolbox.org/api/v2")).toThrow(
+      "baseUrl must be the KoboToolbox server root URL without a path",
+    );
+    expect(() => normalizeKoboToolboxBaseUrl("")).toThrow("baseUrl is required");
+  });
+});

--- a/src/providers/kobotoolbox/runtime.ts
+++ b/src/providers/kobotoolbox/runtime.ts
@@ -7,12 +7,14 @@ import {
   pickOptionalInteger,
   pickOptionalString,
 } from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 interface ApiKeyProviderActionInput {
   apiKey: string;
   input: Record<string, unknown>;
   providerMetadata: Record<string, unknown>;
+  signal?: AbortSignal;
 }
 interface ProviderProxyFetchInput {
   fetcher: typeof fetch;
@@ -210,6 +212,7 @@ export const koboToolboxActionHandlers: Record<string, Handler> = {
 export async function validateKoboToolboxCredential(
   input: Record<string, string>,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<ValidateCredentialResult> {
   const apiKey = requireApiKey(input);
   const baseUrl = normalizeKoboToolboxBaseUrl(input.baseUrl);
@@ -220,6 +223,7 @@ export async function validateKoboToolboxCredential(
       path: "/me/",
       phase: "validate",
       fetcher,
+      signal,
     }),
     "current user profile",
   );
@@ -237,16 +241,18 @@ export async function validateKoboToolboxCredential(
   };
 }
 
-export function normalizeKoboToolboxBaseUrl(value: unknown): string {
+export function normalizeKoboToolboxBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
   if (typeof value !== "string" || !value.trim()) {
     throw new ProviderRequestError(400, "baseUrl is required");
   }
-  let url: URL;
-  try {
-    url = new URL(value.trim());
-  } catch {
-    throw new ProviderRequestError(400, "baseUrl must be a valid http(s) URL");
-  }
+  const url = assertPublicHttpUrl(value.trim(), {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
   if (url.protocol !== "https:") {
     throw new ProviderRequestError(400, "baseUrl must use https");
   }
@@ -276,8 +282,9 @@ export async function requestKoboToolboxJson(input: {
   query?: Record<string, unknown>;
   body?: unknown;
   notFound?: boolean;
+  signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(undefined, 30_000);
+  const timeout = createProviderTimeout(input.signal, 30_000);
   const url = new URL(input.path, `${normalizeKoboToolboxBaseUrl(input.baseUrl)}/`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
@@ -331,6 +338,7 @@ function requestForAction(
     path,
     fetcher,
     phase: "execute",
+    signal: input.signal,
     ...options,
   });
 }

--- a/src/providers/kobotoolbox/runtime.ts
+++ b/src/providers/kobotoolbox/runtime.ts
@@ -8,7 +8,12 @@ import {
   pickOptionalString,
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortSignalError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 interface ApiKeyProviderActionInput {
   apiKey: string;
@@ -309,7 +314,7 @@ export async function requestKoboToolboxJson(input: {
     return payload;
   } catch (error) {
     if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || (error instanceof Error && error.name === "AbortError")) {
+    if (timeout.didTimeout() || isAbortSignalError(timeout.signal, error)) {
       throw new ProviderRequestError(504, "KoboToolbox request timed out");
     }
     throw new ProviderRequestError(

--- a/src/providers/mautic/executors.test.ts
+++ b/src/providers/mautic/executors.test.ts
@@ -37,4 +37,21 @@ describe("Mautic credential validation", () => {
     ).rejects.toThrow("baseUrl must not target private or reserved IP addresses");
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("forwards the caller abort signal to the validation request", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      init?.signal?.throwIfAborted();
+      return Response.json({ user: { id: 1, username: "admin" } });
+    });
+
+    await expect(
+      credentialValidators.customCredential!(
+        { values: { baseUrl: "https://10.0.0.5", username: "admin", password: "secret" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal: AbortSignal.abort() },
+      ),
+    ).rejects.toThrow("Mautic request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
 });

--- a/src/providers/mautic/executors.test.ts
+++ b/src/providers/mautic/executors.test.ts
@@ -54,4 +54,24 @@ describe("Mautic credential validation", () => {
     ).rejects.toThrow("Mautic request timed out");
     expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
+
+  it("maps a caller abort reason to the timeout error", async () => {
+    setPrivateNetworkAccessAllowed(true);
+
+    // A caller that aborts with its own reason makes fetch reject with that
+    // reason object, whose name is not "AbortError".
+    const signal = AbortSignal.abort(new Error("cancelled by caller"));
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) throw init.signal.reason;
+      return Response.json({ user: { id: 1, username: "admin" } });
+    });
+
+    await expect(
+      credentialValidators.customCredential!(
+        { values: { baseUrl: "https://10.0.0.5", username: "admin", password: "secret" } },
+        { fetcher: createProviderFetch({ fetch: fetchMock }), signal },
+      ),
+    ).rejects.toThrow("Mautic request timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.reason).toBe(signal.reason);
+  });
 });

--- a/src/providers/mautic/executors.ts
+++ b/src/providers/mautic/executors.ts
@@ -7,6 +7,7 @@ import { mauticActionHandlers, normalizeMauticBaseUrl, validateMauticCredential 
 interface MauticContext {
   values: Record<string, string>;
   fetcher: typeof fetch;
+  signal?: AbortSignal;
 }
 
 const handlers: Record<string, (input: Record<string, unknown>, context: MauticContext) => Promise<unknown>> =
@@ -22,6 +23,7 @@ const handlers: Record<string, (input: Record<string, unknown>, context: MauticC
             password: context.values.password ?? "",
           },
           context.fetcher,
+          context.signal,
         ),
     ]),
   );
@@ -32,13 +34,13 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   allowPrivateNetwork: isPrivateNetworkAccessAllowed,
   async createContext(context: ExecutionContext, fetcher: typeof fetch) {
     const credential = await requireCustomCredential(context, "mautic");
-    return { values: credential.values, fetcher };
+    return { values: credential.values, fetcher, signal: context.signal };
   },
 });
 
 export const credentialValidators: CredentialValidators = {
-  customCredential(input, { fetcher }) {
+  customCredential(input, { fetcher, signal }) {
     const guardedFetcher = createProviderFetch({ fetch: fetcher, allowPrivateNetwork: isPrivateNetworkAccessAllowed });
-    return validateMauticCredential(input.values, guardedFetcher);
+    return validateMauticCredential(input.values, guardedFetcher, signal);
   },
 };

--- a/src/providers/mautic/runtime.ts
+++ b/src/providers/mautic/runtime.ts
@@ -3,7 +3,12 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import { Buffer } from "node:buffer";
 import { compactObject, optionalInteger, optionalRecord, optionalString, positiveInteger } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortSignalError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 type MauticCredential = {
   baseUrl: string;
@@ -19,22 +24,25 @@ type MauticRequest = {
   method?: "DELETE" | "GET" | "PATCH" | "POST";
   query?: Record<string, unknown>;
   jsonBody?: Record<string, unknown>;
+  signal?: AbortSignal;
 };
 
 type MauticActionHandler = (
   input: Record<string, unknown>,
   credential: MauticCredential,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ) => Promise<unknown>;
 
 const mauticRequestTimeoutMs = 30_000;
 const mauticMaxResponseBytes = 10 * 1024 * 1024;
 
 export const mauticActionHandlers: Record<string, MauticActionHandler> = {
-  async list_contacts(input, credential, fetcher) {
+  async list_contacts(input, credential, fetcher, signal) {
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: "contacts",
       phase: "execute",
       query: buildListQuery(input),
@@ -46,21 +54,23 @@ export const mauticActionHandlers: Record<string, MauticActionHandler> = {
     };
   },
 
-  async get_contact(input, credential, fetcher) {
+  async get_contact(input, credential, fetcher, signal) {
     const contactId = readEntityId(input.contactId, "contactId");
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: `contacts/${contactId}`,
       phase: "execute",
     });
     return { contact: requireResponseObject(readObjectValue(payload, "contact"), "contact") };
   },
 
-  async create_contact(input, credential, fetcher) {
+  async create_contact(input, credential, fetcher, signal) {
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: "contacts/new",
       phase: "execute",
       method: "POST",
@@ -69,11 +79,12 @@ export const mauticActionHandlers: Record<string, MauticActionHandler> = {
     return { contact: requireResponseObject(readObjectValue(payload, "contact"), "contact") };
   },
 
-  async update_contact(input, credential, fetcher) {
+  async update_contact(input, credential, fetcher, signal) {
     const contactId = readEntityId(input.contactId, "contactId");
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: `contacts/${contactId}/edit`,
       phase: "execute",
       method: "PATCH",
@@ -82,11 +93,12 @@ export const mauticActionHandlers: Record<string, MauticActionHandler> = {
     return { contact: requireResponseObject(readObjectValue(payload, "contact"), "contact") };
   },
 
-  async delete_contact(input, credential, fetcher) {
+  async delete_contact(input, credential, fetcher, signal) {
     const contactId = readEntityId(input.contactId, "contactId");
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: `contacts/${contactId}/delete`,
       phase: "execute",
       method: "DELETE",
@@ -94,10 +106,11 @@ export const mauticActionHandlers: Record<string, MauticActionHandler> = {
     return { contact: requireResponseObject(readObjectValue(payload, "contact"), "contact") };
   },
 
-  async list_segments(input, credential, fetcher) {
+  async list_segments(input, credential, fetcher, signal) {
     const payload = await requestMauticJson({
       credential,
       fetcher,
+      signal,
       path: "segments",
       phase: "execute",
       query: buildListQuery(input),
@@ -109,23 +122,25 @@ export const mauticActionHandlers: Record<string, MauticActionHandler> = {
     };
   },
 
-  async add_contact_to_segment(input, credential, fetcher) {
-    return changeSegmentMembership(input, credential, fetcher, "add");
+  async add_contact_to_segment(input, credential, fetcher, signal) {
+    return changeSegmentMembership(input, credential, fetcher, "add", signal);
   },
 
-  async remove_contact_from_segment(input, credential, fetcher) {
-    return changeSegmentMembership(input, credential, fetcher, "remove");
+  async remove_contact_from_segment(input, credential, fetcher, signal) {
+    return changeSegmentMembership(input, credential, fetcher, "remove", signal);
   },
 };
 
 export async function validateMauticCredential(
   input: Record<string, string>,
   fetcher: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<CredentialValidationResult> {
   const credential = buildMauticCredential(input);
   const payload = await requestMauticJson({
     credential,
     fetcher,
+    signal,
     path: "users/self",
     phase: "validate",
   });
@@ -234,12 +249,14 @@ async function changeSegmentMembership(
   credential: MauticCredential,
   fetcher: typeof fetch,
   operation: "add" | "remove",
+  signal?: AbortSignal,
 ) {
   const segmentId = readEntityId(input.segmentId, "segmentId");
   const contactId = readEntityId(input.contactId, "contactId");
   const payload = await requestMauticJson({
     credential,
     fetcher,
+    signal,
     path: `segments/${segmentId}/contact/${contactId}/${operation}`,
     phase: "execute",
     method: "POST",
@@ -258,7 +275,7 @@ async function requestMauticJson(input: MauticRequest): Promise<Record<string, u
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(undefined, mauticRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal, mauticRequestTimeoutMs);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",
@@ -291,7 +308,7 @@ async function requestMauticJson(input: MauticRequest): Promise<Record<string, u
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeout.didTimeout()) {
+    if (timeout.didTimeout() || isAbortSignalError(timeout.signal, error)) {
       throw new ProviderRequestError(504, "Mautic request timed out");
     }
     throw new ProviderRequestError(

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   defineOAuthProviderExecutors,
   defineProviderExecutors,
   defineProviderProxy,
+  isAbortSignalError,
   mapProviderActionSources,
   providerFetch,
   ProviderRequestError,
@@ -159,6 +160,21 @@ describe("createProviderTimeout", () => {
     } finally {
       timeout.cleanup();
     }
+  });
+});
+
+describe("isAbortSignalError", () => {
+  it("accepts both AbortError rejections and the signal's own abort reason", () => {
+    expect(isAbortSignalError(AbortSignal.abort(), new DOMException("aborted", "AbortError"))).toBe(true);
+
+    const cancelled = AbortSignal.abort(new Error("cancelled"));
+    expect(isAbortSignalError(cancelled, cancelled.reason)).toBe(true);
+  });
+
+  it("rejects errors that did not come from the aborted signal", () => {
+    const pending = new AbortController().signal;
+    expect(isAbortSignalError(pending, new DOMException("aborted", "AbortError"))).toBe(false);
+    expect(isAbortSignalError(AbortSignal.abort(new Error("cancelled")), new Error("connection reset"))).toBe(false);
   });
 });
 

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -660,10 +660,11 @@ export function isAbortLikeError(error: unknown): boolean {
 }
 
 /**
- * Return whether an error came from a specific aborted signal.
+ * Return whether an error came from a specific aborted signal, counting the
+ * signal's own abort reason regardless of the name it carries.
  */
 export function isAbortSignalError(signal: AbortSignal | undefined, error: unknown): boolean {
-  return signal?.aborted === true && isAbortLikeError(error);
+  return signal?.aborted === true && (isAbortLikeError(error) || error === signal.reason);
 }
 
 /**

--- a/src/providers/walmart_marketplace/runtime.ts
+++ b/src/providers/walmart_marketplace/runtime.ts
@@ -36,7 +36,7 @@ interface ValidationResult {
 
 export async function validateWalmartMarketplaceCredential(
   input: Record<string, string>,
-  fetcher: typeof fetch = fetch,
+  fetcher: typeof fetch,
 ): Promise<ValidationResult> {
   const credential = readCredential(input);
   await exchangeAccessToken(credential, fetcher, "validate");


### PR DESCRIPTION
Follow-ups from reviewing #439. That PR made the Invoice Ninja, KoboToolbox and Mautic credential validators honour the private-network opt-in, and the review turned up three adjacent gaps in the same area that were out of its scope.

`validateCoupangCredential`, `validateFaktooraCredential`, `validateHelpdeskCredential` and `validateWalmartMarketplaceCredential` still declared `fetcher: typeof fetch = fetch`, so a caller that forgot the argument would silently egress through the global fetch and bypass the SSRF guard. Every caller already passes the guarded fetcher, so the default is simply removed and the parameter is required, which is what the other validators do.

`normalizeKoboToolboxBaseUrl` was the only self-hosted base URL normalizer that never called `assertPublicHttpUrl`. Private, reserved and cloud-metadata hosts were still blocked, but only by the guarded fetch at request time, so they surfaced as a 502 provider error instead of the 400 `baseUrl` validation error that Invoice Ninja and Mautic return. It now routes through `assertPublicHttpUrl` with the deployment opt-in, keeping the existing https-only and root-path-only rules, and _src/providers/kobotoolbox/runtime.test.ts_ covers the default deny, the opt-in, and the reserved targets that stay blocked.

The request helpers in all three providers called `createProviderTimeout(undefined, ...)`, so cancelling a connection create or an action run could not abort the in-flight request and only the fixed 30 second timeout applied. The caller signal is now threaded through both the validator and the action context the way Dokploy does it, and Mautic reports a caller abort as a 504 timeout like the other two instead of wrapping it into a 502 provider failure.

Refs #439
