### PR TITLE
refactor(providers): share isAbortLikeError, compactObject and encodePathSegment

### DIFF
--- a/src/providers/addressfinder/executors.ts
+++ b/src/providers/addressfinder/executors.ts
@@ -4,6 +4,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -391,11 +392,4 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
     throw new ProviderRequestError(502, `${label} is not a JSON object`);
   }
   return record;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/affinity/runtime.ts
+++ b/src/providers/affinity/runtime.ts
@@ -3,7 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { compactObject, nullableString, optionalRecord, optionalString } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const affinityApiBaseUrl = "https://api.affinity.co";
 export const affinityValidationPath = "/v2/auth/whoami";
@@ -763,13 +763,4 @@ function readOptionalPositiveIntegerArray(value: unknown, fieldName: string) {
   }
 
   return value.map((item, index) => readPositiveInteger(item, `${fieldName}[${index}]`));
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "name" in error &&
-    (error as { name?: unknown }).name === "AbortError"
-  );
 }

--- a/src/providers/aliyun_sts/runtime.ts
+++ b/src/providers/aliyun_sts/runtime.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomBytes } from "node:crypto";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const aliyunStsEndpoint = "https://sts.aliyuncs.com/";
 export const aliyunStsApiVersion = "2015-04-01";
@@ -194,8 +194,4 @@ function requireStsField(value: string | undefined, field: string): string {
     throw new ProviderRequestError(502, `aliyun_sts response missing ${field}`);
   }
   return value;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/alpaca/runtime.ts
+++ b/src/providers/alpaca/runtime.ts
@@ -2,7 +2,7 @@ import type { CredentialValidationResult, ResolvedCredential } from "../../core/
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 import { readAlpacaGrantedScopes } from "./scopes.ts";
 
 const paperTradingBaseUrl = "https://paper-api.alpaca.markets";
@@ -735,8 +735,4 @@ function readEnvironment(value: unknown, fallback?: Environment): Environment {
   }
 
   throw new ProviderRequestError(400, "environment must be paper or live");
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/api_sports/executors.ts
+++ b/src/providers/api_sports/executors.ts
@@ -4,6 +4,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -874,8 +875,4 @@ function validateInjuriesInput(input: Record<string, unknown>): void {
 
 function readUnexpectedMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : "api_sports request failed";
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/apiverve/executors.ts
+++ b/src/providers/apiverve/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const service = "apiverve";
 const apiverveApiBaseUrl = "https://api.apiverve.com";
@@ -537,8 +542,4 @@ function readNullableNumber(value: unknown): number | null {
 
 function readNullableBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/apollo/executors.ts
+++ b/src/providers/apollo/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const service = "apollo";
 const apolloApiBaseUrl = "https://api.apollo.io";
@@ -384,8 +389,4 @@ function asStringList(value: unknown): string[] | undefined {
 
   const normalized = value.map((item) => optionalString(item)).filter((item): item is string => !!item);
   return normalized.length > 0 ? normalized : undefined;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/bettercontact/runtime.ts
+++ b/src/providers/bettercontact/runtime.ts
@@ -185,7 +185,7 @@ async function requestBettercontactJson(
       throw error;
     }
 
-    if (timeout.didTimeout() || isAbortLikeError(error) || isTimeoutLikeError(error)) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "BetterContact request timed out");
     }
 
@@ -412,8 +412,4 @@ function requireInputString(value: unknown, fieldName: string): string {
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return resolved;
-}
-
-function isTimeoutLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
 }

--- a/src/providers/bidsketch/runtime.ts
+++ b/src/providers/bidsketch/runtime.ts
@@ -151,7 +151,7 @@ async function requestBidsketchJson(input: {
       throw error;
     }
 
-    if (timeout.didTimeout() || isAbortLikeError(error) || isTimeoutLikeError(error)) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "BidSketch request timed out");
     }
 
@@ -303,8 +303,4 @@ function readRequiredPositiveInteger(value: unknown, fieldName: string): number 
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return parsed;
-}
-
-function isTimeoutLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
 }

--- a/src/providers/big_data_cloud/runtime.ts
+++ b/src/providers/big_data_cloud/runtime.ts
@@ -121,7 +121,7 @@ async function requestBigDataCloudJson(input: {
     });
     payload = await readBigDataCloudPayload(response);
   } catch (error) {
-    if (isAbortLikeError(error) || isTimeoutLikeError(error)) {
+    if (isAbortLikeError(error)) {
       throw new ProviderRequestError(504, error instanceof Error ? error.message : "BigDataCloud request timed out");
     }
 
@@ -204,8 +204,4 @@ function mapBigDataCloudError(
   }
 
   return new ProviderRequestError(status || 500, normalizedMessage, payload);
-}
-
-function isTimeoutLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
 }

--- a/src/providers/bigpicture_io/runtime.ts
+++ b/src/providers/bigpicture_io/runtime.ts
@@ -115,7 +115,7 @@ async function requestBigpictureJson(input: {
     });
     payload = await readBigpicturePayload(response);
   } catch (error) {
-    if (timeout.didTimeout() || isAbortLikeError(error) || isTimeoutLikeError(error)) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "BigPicture.io request timed out");
     }
 
@@ -224,8 +224,4 @@ function readRequiredString(value: unknown, fieldName: string): string {
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return value.trim();
-}
-
-function isTimeoutLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
 }

--- a/src/providers/bitbucket/http.ts
+++ b/src/providers/bitbucket/http.ts
@@ -1,4 +1,9 @@
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const bitbucketRequestTimeoutMs = 30_000;
 const bitbucketMaxResponseBytes = 10 * 1024 * 1024;
@@ -75,11 +80,4 @@ async function readLimitedText(response: Response) {
 
 function responseTooLargeError() {
   return new ProviderRequestError(502, "bitbucket response is too large");
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    (error instanceof Error && error.name === "AbortError") ||
-    (typeof DOMException !== "undefined" && error instanceof DOMException && error.name === "AbortError")
-  );
 }

--- a/src/providers/bunnycdn/runtime.ts
+++ b/src/providers/bunnycdn/runtime.ts
@@ -3,7 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { isAbortLikeError, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const bunnyApiBaseUrl = "https://api.bunny.net";
 const validationPath = "/pullzone";
@@ -279,8 +279,4 @@ function requiredPullZoneId(value: unknown): number {
     throw new ProviderRequestError(400, "pullZoneId must be a positive integer");
   }
   return pullZoneId;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/businessmap/runtime.ts
+++ b/src/providers/businessmap/runtime.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const businessmapDefaultRequestTimeoutMs = 30_000;
 const businessmapValidationPath = "/workspaces";
@@ -439,8 +444,4 @@ function requirePositiveInteger(value: unknown, fieldName: string): number {
     throw new ProviderRequestError(400, `${fieldName} must be a positive integer`);
   }
   return parsed;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/central_station_crm/runtime.ts
+++ b/src/providers/central_station_crm/runtime.ts
@@ -5,6 +5,7 @@ import { compactObject, optionalInteger, optionalRecord, optionalString } from "
 import {
   createProviderTimeout,
   getProviderActionHandler,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
 } from "../provider-runtime.ts";
@@ -719,13 +720,6 @@ function asNullableInteger(value: unknown) {
     return null;
   }
   return optionalInteger(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.message.includes("aborted")))
-  );
 }
 
 function readApiKey(value: unknown): string {

--- a/src/providers/check/executors.ts
+++ b/src/providers/check/executors.ts
@@ -17,6 +17,7 @@ import {
 import {
   defineProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -277,8 +278,4 @@ function resolveApiBaseUrl(environment: CheckEnvironment): string {
 
 function providerError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/checkly/executors.ts
+++ b/src/providers/checkly/executors.ts
@@ -4,6 +4,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { optionalBoolean, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -256,8 +257,4 @@ function resolveAccountId(value: unknown): string {
 
 function providerError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/cincopa/executors.ts
+++ b/src/providers/cincopa/executors.ts
@@ -9,7 +9,12 @@ import {
   requiredRecord,
   requiredString,
 } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "cincopa";
 const apiBaseUrl = "https://api.cincopa.com/v2";
@@ -268,8 +273,4 @@ function joinStringArray(value: unknown): string | undefined {
 
 function providerError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, `Cincopa returned invalid ${message}`);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/circle/executors.ts
+++ b/src/providers/circle/executors.ts
@@ -9,7 +9,12 @@ import {
   optionalString,
   requiredRecord,
 } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "circle";
 const apiBaseUrl = "https://app.circle.so/api/admin/v2";
@@ -349,8 +354,4 @@ function optionalIntegerListString(value: unknown): string | undefined {
 
 function providerError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/clinicalkey/runtime.ts
+++ b/src/providers/clinicalkey/runtime.ts
@@ -1,7 +1,12 @@
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const clinicalKeyApiBaseUrl = "https://api.elsevier.com/sushi/r51";
 const clinicalKeyPlatformCode = "ck";
@@ -299,10 +304,6 @@ function readRequiredString(value: unknown, fieldName: string) {
 
 function readOptionalString(value: unknown) {
   return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function providerInputError(message: string): ProviderRequestError {

--- a/src/providers/crossref/runtime.ts
+++ b/src/providers/crossref/runtime.ts
@@ -880,10 +880,6 @@ function numberToString(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
 }
 
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
-}
-
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
 }
@@ -897,4 +893,9 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";

--- a/src/providers/datacite/runtime.ts
+++ b/src/providers/datacite/runtime.ts
@@ -224,13 +224,14 @@ function readOptionalBooleanString(value: unknown) {
   return typeof value === "boolean" ? String(value) : undefined;
 }
 
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
-}
-
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
 }
 import { Buffer } from "node:buffer";
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";

--- a/src/providers/deepgram/runtime.ts
+++ b/src/providers/deepgram/runtime.ts
@@ -9,7 +9,13 @@ import {
   compactObject,
   optionalBoolean,
 } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { encodePathSegment } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const deepgramApiBaseUrl = "https://api.deepgram.com/v1";
 const deepgramDefaultRequestTimeoutMs = 30_000;
@@ -467,17 +473,4 @@ function readNullableBoolean(value: unknown) {
   }
   const parsed = optionalBoolean(value);
   return parsed ?? null;
-}
-
-function encodePathSegment(value: string) {
-  return encodeURIComponent(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  const name = "name" in error ? String(error.name) : "";
-  return name === "AbortError" || name === "TimeoutError";
 }

--- a/src/providers/dialmycalls/runtime.ts
+++ b/src/providers/dialmycalls/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { DialMyCallsActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface DialmycallsCredentialCheck {
   providerAccountId?: string;
@@ -372,8 +377,4 @@ function requireObject(value: unknown, context: string): Record<string, unknown>
     throw new ProviderRequestError(502, `${context} must be an object`);
   }
   return object;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/doppler_marketing_automation/runtime.ts
+++ b/src/providers/doppler_marketing_automation/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { DopplerMarketingAutomationActionName } from "./actions.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface DopplerMarketingAutomationCredentialCheck {
   providerAccountId?: string;
@@ -500,8 +505,4 @@ function readNullableString(value: unknown) {
 
 function readNullableBoolean(value: unknown) {
   return typeof value === "boolean" ? value : null;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/elasticsearch/executors.ts
+++ b/src/providers/elasticsearch/executors.ts
@@ -9,7 +9,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { assertPublicHttpUrl, encodePathSegment, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderFetch,
   createProviderProxyUrl,
@@ -564,10 +564,6 @@ function buildBasicAuthHeader(username: string, password: string) {
 
 function buildApiKeyAuthHeader(apiKey: string) {
   return `ApiKey ${apiKey}`;
-}
-
-function encodePathSegment(value: string) {
-  return encodeURIComponent(value);
 }
 
 async function readElasticsearchPayload(response: Response) {

--- a/src/providers/embase/runtime.ts
+++ b/src/providers/embase/runtime.ts
@@ -1,7 +1,12 @@
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const embaseApiBaseUrl = "https://api.elsevier.com/content/embase";
 const embaseDefaultRequestTimeoutMs = 30_000;
@@ -334,10 +339,6 @@ function readRequiredString(value: unknown, fieldName: string) {
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return value.trim();
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function providerInputError(message: string): ProviderRequestError {

--- a/src/providers/europe_pmc/request.ts
+++ b/src/providers/europe_pmc/request.ts
@@ -1,5 +1,10 @@
 import { optionalRecord, optionalString } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 export const europePmcApiBaseUrl = "https://www.ebi.ac.uk/europepmc/webservices/rest";
 export const europePmcAnnotationsApiBaseUrl = "https://www.ebi.ac.uk/europepmc/annotations_api";
@@ -157,8 +162,4 @@ function extractErrorMessage(body: string) {
 
 function readOptionalString(value: unknown) {
   return optionalString(value)?.trim() || undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/feishu/shared/approval-runtime.ts
+++ b/src/providers/feishu/shared/approval-runtime.ts
@@ -1,5 +1,6 @@
 import type { FeishuJsonRequest, FeishuQueryValue } from "./client.ts";
 
+import { compactObject } from "../../../core/cast.ts";
 import { ProviderRequestError } from "../../provider-runtime.ts";
 
 interface FeishuApprovalActionHandler {
@@ -234,16 +235,6 @@ function mapEnum<T>(value: unknown, values: Readonly<Record<string, T>>, fieldNa
     throw new ProviderRequestError(400, `${fieldName} has an unsupported value`);
   }
   return mapped;
-}
-
-function compactObject(value: Record<string, unknown>) {
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (item !== undefined) {
-      result[key] = item;
-    }
-  }
-  return result;
 }
 
 function compactQuery(value: Record<string, unknown>) {

--- a/src/providers/feishu/shared/base-advanced-runtime.ts
+++ b/src/providers/feishu/shared/base-advanced-runtime.ts
@@ -1,5 +1,6 @@
 import type { FeishuJsonRequest, FeishuQueryValue } from "./client.ts";
 
+import { compactObject } from "../../../core/cast.ts";
 import { ProviderRequestError } from "../../provider-runtime.ts";
 
 interface FeishuBaseAdvancedActionHandler {
@@ -398,16 +399,6 @@ function uniqueStrings(value: unknown, fieldName: string) {
   }
   const items = value.map((item) => requireString(item, fieldName));
   return [...new Set(items)];
-}
-
-function compactObject(value: Record<string, unknown>) {
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (item !== undefined) {
-      result[key] = item;
-    }
-  }
-  return result;
 }
 
 function compactQuery(value: Record<string, unknown> | undefined) {

--- a/src/providers/feishu/shared/base-runtime.ts
+++ b/src/providers/feishu/shared/base-runtime.ts
@@ -1,5 +1,6 @@
 import type { FeishuJsonRequest } from "./client.ts";
 
+import { compactObject } from "../../../core/cast.ts";
 import { ProviderRequestError } from "../../provider-runtime.ts";
 
 interface FeishuBaseActionHandler {
@@ -607,16 +608,6 @@ function tablePath(appToken: unknown, tableId: unknown) {
 
 function segment(value: unknown) {
   return encodeURIComponent(requireString(value, "path identifier"));
-}
-
-function compactObject(value: Record<string, unknown>) {
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (item !== undefined) {
-      result[key] = item;
-    }
-  }
-  return result;
 }
 
 function serializeJson(value: unknown) {

--- a/src/providers/feishu/shared/domain-media-runtime.ts
+++ b/src/providers/feishu/shared/domain-media-runtime.ts
@@ -2,7 +2,7 @@ import type { TransitFileWriter } from "../../../core/types.ts";
 import type { FeishuJsonRequest } from "./client.ts";
 import type { DownloadedFeishuSource } from "./media.ts";
 
-import { optionalRecord } from "../../../core/cast.ts";
+import { compactObject, optionalRecord } from "../../../core/cast.ts";
 import { createProviderFetch, ProviderRequestError } from "../../provider-runtime.ts";
 import { requestFeishuMultipart, withFeishuRawResponse } from "./client.ts";
 import {
@@ -947,16 +947,6 @@ function isPositiveIntegerString(value: string) {
     }
   }
   return true;
-}
-
-function compactObject(input: Record<string, unknown>) {
-  const output: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(input)) {
-    if (value !== undefined) {
-      output[key] = value;
-    }
-  }
-  return output;
 }
 
 function requireObject(value: unknown, fieldName: string) {

--- a/src/providers/feishu/shared/sheets-advanced-runtime.ts
+++ b/src/providers/feishu/shared/sheets-advanced-runtime.ts
@@ -1,5 +1,6 @@
 import type { FeishuJsonRequest } from "./client.ts";
 
+import { compactObject } from "../../../core/cast.ts";
 import { ProviderRequestError } from "../../provider-runtime.ts";
 
 interface FeishuSheetsAdvancedActionHandler {
@@ -466,16 +467,6 @@ function parseCell(value: string) {
     column = column * 26 + character.charCodeAt(0) - 64;
   }
   return { row, column };
-}
-
-function compactObject(value: Record<string, unknown>) {
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (item !== undefined) {
-      result[key] = item;
-    }
-  }
-  return result;
 }
 
 function requireObject(value: unknown, fieldName: string) {

--- a/src/providers/feishu/shared/sheets-runtime.ts
+++ b/src/providers/feishu/shared/sheets-runtime.ts
@@ -1,5 +1,6 @@
 import type { FeishuJsonRequest } from "./client.ts";
 
+import { compactObject } from "../../../core/cast.ts";
 import { ProviderRequestError } from "../../provider-runtime.ts";
 
 interface FeishuSheetsActionHandler {
@@ -760,16 +761,6 @@ function stringifyCellValue(value: unknown) {
   } else {
     return JSON.stringify(value);
   }
-}
-
-function compactObject(value: Record<string, unknown>) {
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (item !== undefined) {
-      result[key] = item;
-    }
-  }
-  return result;
 }
 
 function segment(value: string) {

--- a/src/providers/fidel_api/executors.ts
+++ b/src/providers/fidel_api/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "fidel_api";
 const fidelApiBaseUrl = "https://api.fidel.uk/v1";
@@ -585,8 +590,4 @@ function createFidelRequestSignal(parent?: AbortSignal): FidelApiRequestSignal {
       parent?.removeEventListener("abort", abortFromParent);
     },
   };
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/fireberry/runtime.ts
+++ b/src/providers/fireberry/runtime.ts
@@ -3,7 +3,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalNumber, optionalRecord, requiredRecord, requiredString } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const fireberryApiBaseUrl = "https://api.fireberry.com";
 export const fireberryDefaultRequestTimeoutMs = 30_000;
@@ -410,8 +410,4 @@ function hashToken(apiKey: string) {
 
 function isRecordObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/fly/runtime.ts
+++ b/src/providers/fly/runtime.ts
@@ -3,7 +3,7 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import { encodePathSegment, jsonObject } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const flyApiBaseUrl = "https://api.machines.dev/v1/";
 const flyValidationPath = "tokens/current";
@@ -334,8 +334,4 @@ function requiredActionString(value: unknown, fieldName: string): string {
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return result;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/formbricks/executors.ts
+++ b/src/providers/formbricks/executors.ts
@@ -6,6 +6,7 @@ import { compactObject, optionalInteger, optionalRecord, optionalString } from "
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
 } from "../provider-runtime.ts";
@@ -448,10 +449,6 @@ function nullableProviderString(value: unknown): string | null {
     return null;
   }
   return typeof value === "string" ? value : null;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({

--- a/src/providers/formspree/executors.ts
+++ b/src/providers/formspree/executors.ts
@@ -4,6 +4,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -270,8 +271,4 @@ function extractErrorMessage(payload: unknown): string | undefined {
   return record
     ? (optionalString(record.message) ?? optionalString(record.error) ?? optionalString(record.detail))
     : undefined;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/freshdesk/executors.ts
+++ b/src/providers/freshdesk/executors.ts
@@ -11,6 +11,7 @@ import { compactObject, optionalInteger, optionalRecord, optionalString } from "
 import {
   defineProviderProxy,
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -370,10 +371,6 @@ function isFreshdeskSubdomain(value: string): boolean {
 
 function buildFreshdeskAuthorizationHeader(apiKey: string): string {
   return `Basic ${Buffer.from(`${apiKey}:X`).toString("base64")}`;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
 }
 
 function trimTrailingSlash(value: string): string {

--- a/src/providers/freshservice/executors.ts
+++ b/src/providers/freshservice/executors.ts
@@ -11,6 +11,7 @@ import { compactObject, optionalInteger, optionalRecord, optionalString } from "
 import {
   defineProviderProxy,
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -565,10 +566,6 @@ function readOptionalStringArray(value: unknown): string[] | undefined {
     .map((item) => optionalString(item))
     .filter((item): item is string => item !== undefined && item.length > 0);
   return result.length > 0 ? result : undefined;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
 }
 
 function trimTrailingSlash(value: string): string {

--- a/src/providers/front/executors.ts
+++ b/src/providers/front/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "front";
 const frontApiBaseUrl = "https://api2.frontapp.com";
@@ -245,10 +250,6 @@ async function frontFetch(
       error,
     );
   }
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 async function readFrontPayload(response: Response): Promise<unknown> {

--- a/src/providers/gatherup/runtime.ts
+++ b/src/providers/gatherup/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 export interface GatherupContext {
   apiKey: string;
@@ -198,11 +203,4 @@ function invalidCredential(message: string): ProviderRequestError {
 
 function readOptionalFlag(value: unknown) {
   return typeof value === "boolean" ? (value ? 1 : 0) : undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/geckoboard/executors.ts
+++ b/src/providers/geckoboard/executors.ts
@@ -4,7 +4,12 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { compactJson, jsonObject } from "../../core/request.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "geckoboard";
 const geckoboardApiBaseUrl = "https://api.geckoboard.com";
@@ -254,8 +259,4 @@ function readResponseObject(value: unknown, fieldName: string): Record<string, u
     throw new ProviderRequestError(502, `Geckoboard response is missing ${fieldName}`, value);
   }
   return record;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/gemini/runtime.ts
+++ b/src/providers/gemini/runtime.ts
@@ -2,7 +2,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
 import { jsonObject, readBoundedResponseBytes } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const geminiApiBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
 export const geminiDefaultTextModel = "gemini-2.5-flash";
@@ -698,10 +698,6 @@ function shouldSendGeminiApiKey(url: string): boolean {
 
 function isGoogleHost(hostname: string): boolean {
   return hostname === "googleapis.com" || hostname.endsWith(".googleapis.com");
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 async function createTransitDownloadableFile(

--- a/src/providers/getnote/runtime.ts
+++ b/src/providers/getnote/runtime.ts
@@ -9,7 +9,7 @@ import {
   optionalString,
   requiredRecord,
 } from "../../core/cast.ts";
-import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { isAbortLikeError, providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const getnoteBaseUrl = "https://openapi.biji.com";
 const getnoteRequestTimeoutMs = 30_000;
@@ -771,8 +771,4 @@ function readFirstObjectField(input: Record<string, unknown>, keys: string[]) {
 
 function toRecord(value: unknown): Record<string, unknown> {
   return requiredRecord(value, "Getnote response object", (message) => new ProviderRequestError(502, message));
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/getresponse/runtime.ts
+++ b/src/providers/getresponse/runtime.ts
@@ -1,7 +1,12 @@
 import type { CredentialValidationResult } from "../../core/types.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const getresponseRetailApiBaseUrl = "https://api.getresponse.com/v3";
 export const getresponseMaxApiBaseUrls = [
@@ -810,8 +815,4 @@ function optionalBooleanLike(value: unknown) {
   if (value === "true") return true;
   if (value === "false") return false;
   return null;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/googlesheets/runtime-shared.ts
+++ b/src/providers/googlesheets/runtime-shared.ts
@@ -13,7 +13,7 @@ import {
   requiredRecord,
   stringArray,
 } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export {
   compactObject,
@@ -316,8 +316,4 @@ function columnIndexToLetters(columnIndex: number): string {
     current = Math.floor((current - 1) / 26);
   }
   return letters;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/grafana/runtime.ts
+++ b/src/providers/grafana/runtime.ts
@@ -2,7 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { assertPublicHttpUrl, encodePathSegment, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -683,8 +683,4 @@ function requireObject(value: unknown, fieldName: string): Record<string, unknow
     throw new ProviderRequestError(400, `${fieldName} object is required`);
   }
   return object;
-}
-
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
 }

--- a/src/providers/grafana_cloud/runtime.ts
+++ b/src/providers/grafana_cloud/runtime.ts
@@ -2,6 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -286,8 +287,4 @@ function requireTrimmedString(value: unknown, fieldName: string): string {
     throw new ProviderRequestError(400, `${fieldName} is required`);
   }
   return trimmed;
-}
-
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
 }

--- a/src/providers/gumloop/executors.ts
+++ b/src/providers/gumloop/executors.ts
@@ -11,6 +11,7 @@ import {
 } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -458,8 +459,4 @@ function providerInputError(message: string): ProviderRequestError {
 
 function providerOutputError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/gumroad/executors.ts
+++ b/src/providers/gumroad/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "gumroad";
 const gumroadApiBaseUrl = "https://api.gumroad.com/v2";
@@ -290,8 +295,4 @@ function mapGumroadError(
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/habitica/executors.ts
+++ b/src/providers/habitica/executors.ts
@@ -17,6 +17,7 @@ import {
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
   providerUserAgent,
@@ -668,8 +669,4 @@ function providerInputError(message: string): ProviderRequestError {
 
 function providerOutputError(message: string): ProviderRequestError {
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.message.toLowerCase().includes("abort"));
 }

--- a/src/providers/hackerrank_work/executors.ts
+++ b/src/providers/hackerrank_work/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalIntegerLike, optionalRecord, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "hackerrank_work";
 const hackerrankWorkApiBaseUrl = "https://www.hackerrank.com/x/api/v3";
@@ -298,13 +303,4 @@ function readString(value: unknown): string | undefined {
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    String((error as { name?: unknown }).name) === "AbortError"
-  );
 }

--- a/src/providers/harmonic_ai/executors.ts
+++ b/src/providers/harmonic_ai/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, stringRecord } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "harmonic_ai";
 const harmonicAiApiBaseUrl = "https://api.harmonic.ai";
@@ -275,13 +280,4 @@ function numberQueryValue(value: unknown): number | undefined {
 
 function stringArrayQueryValue(value: unknown): string[] | undefined {
   return Array.isArray(value) ? value.map((item) => String(item)) : undefined;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    String((error as { name?: unknown }).name) === "AbortError"
-  );
 }

--- a/src/providers/harvest/executors.ts
+++ b/src/providers/harvest/executors.ts
@@ -12,6 +12,7 @@ import {
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
   providerUserAgent,
@@ -910,13 +911,4 @@ function assertDateRange(input: Record<string, unknown>): void {
   if (from && to && from > to) {
     throw new ProviderRequestError(400, "to must be on or after from.");
   }
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    String((error as { name?: unknown }).name) === "AbortError"
-  );
 }

--- a/src/providers/haveibeenpwned/executors.ts
+++ b/src/providers/haveibeenpwned/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "haveibeenpwned";
 const haveibeenpwnedApiBaseUrl = "https://haveibeenpwned.com/api/v3";
@@ -457,13 +462,4 @@ function stringifyOptionalBoolean(value: unknown): string | undefined {
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    String((error as { name?: unknown }).name) === "AbortError"
-  );
 }

--- a/src/providers/headout/executors.ts
+++ b/src/providers/headout/executors.ts
@@ -12,6 +12,7 @@ import {
 } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -798,14 +799,4 @@ function readStringArrayOrNull(value: unknown): string[] | null {
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    (String((error as { name?: unknown }).name) === "AbortError" ||
-      String((error as { name?: unknown }).name) === "TimeoutError")
-  );
 }

--- a/src/providers/healthchecks_io/executors.ts
+++ b/src/providers/healthchecks_io/executors.ts
@@ -13,6 +13,7 @@ import {
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
 } from "../provider-runtime.ts";
@@ -403,16 +404,6 @@ function assertUpdateCheckInput(input: Record<string, unknown>): void {
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === "object" &&
-    "name" in error &&
-    (String((error as { name?: unknown }).name) === "AbortError" ||
-      String((error as { name?: unknown }).name) === "TimeoutError")
-  );
 }
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({

--- a/src/providers/heartbeat/executors.ts
+++ b/src/providers/heartbeat/executors.ts
@@ -7,6 +7,7 @@ import {
   createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
@@ -235,11 +236,4 @@ function requireResourceObject(payload: unknown, label: string): Record<string, 
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/helpdesk/runtime.ts
+++ b/src/providers/helpdesk/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { HelpdeskActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface HelpdeskCredentialCheck {
   providerAccountId?: string;
@@ -495,11 +500,4 @@ function requireOkAcknowledgement(value: unknown) {
   if (typeof value !== "string" || value.trim() !== "OK") {
     throw new ProviderRequestError(502, "HelpDesk acknowledgement response must be OK");
   }
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/infolobby/runtime.ts
+++ b/src/providers/infolobby/runtime.ts
@@ -1,6 +1,6 @@
 import type { InfolobbyActionName } from "./actions.ts";
 
-import { requiredString } from "../../core/cast.ts";
+import { compactObject, requiredString } from "../../core/cast.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface InfolobbyCredentialCheck {
@@ -244,8 +244,4 @@ function optionalRecord(value: unknown) {
 
 function readOptionalString(value: unknown) {
   return typeof value === "string" && value ? value : undefined;
-}
-
-function compactObject(value: Record<string, unknown>) {
-  return Object.fromEntries(Object.entries(value).filter((entry) => entry[1] !== undefined));
 }

--- a/src/providers/instabot/runtime.ts
+++ b/src/providers/instabot/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { InstabotActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface InstabotCredentialCheck {
   providerAccountId?: string;
@@ -334,8 +339,4 @@ function requireObject(value: unknown, message: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return optionalRecord(value) !== undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/jazzhr/runtime.ts
+++ b/src/providers/jazzhr/runtime.ts
@@ -3,6 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
 import {
   createProviderTimeout,
   isAbortLikeError,
@@ -319,8 +320,4 @@ function stringifyOptional(value: unknown): string | undefined {
 function stringifyPathValue(value: unknown): string {
   if (typeof value === "boolean") return value ? "true" : "false";
   return String(value);
-}
-
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
 }

--- a/src/providers/lightfield/executors.ts
+++ b/src/providers/lightfield/executors.ts
@@ -3,6 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalString, requiredString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
 import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const service = "lightfield";
@@ -344,10 +345,6 @@ function readNumberProperty(payload: Record<string, unknown>, key: string, label
     throw new ProviderRequestError(502, `Invalid ${label}.`, payload);
   }
   return value;
-}
-
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
 }
 
 function invalidInputError(message: string): ProviderRequestError {

--- a/src/providers/mailgun/runtime.ts
+++ b/src/providers/mailgun/runtime.ts
@@ -10,6 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
 import {
   defineProviderExecutors,
   providerUserAgent,
@@ -657,8 +658,4 @@ function appendPrefixedRecord(form: FormData, prefix: string, value: unknown): v
     }
     form.append(`${prefix}${key}`, typeof child === "string" ? child : JSON.stringify(child));
   }
-}
-
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
 }

--- a/src/providers/metaso/runtime.ts
+++ b/src/providers/metaso/runtime.ts
@@ -4,7 +4,7 @@ import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.t
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const metasoApiBaseUrl = "https://metaso.cn/api/v1";
 
@@ -381,8 +381,4 @@ function readPositiveInteger(value: unknown, fieldName: string): number | undefi
 
 function requiredInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/more_trees/runtime.ts
+++ b/src/providers/more_trees/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { MoreTreesActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface MoreTreesCredentialCheck {
   providerAccountId?: string;
@@ -328,11 +333,4 @@ function resolveStoredAccountCode(providerMetadata: Record<string, unknown> | un
 function readOptionalTrimmedString(value: unknown) {
   const text = optionalString(value)?.trim();
   return text || undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    (error instanceof DOMException && error.name === "AbortError") ||
-    (error instanceof Error && error.name === "AbortError")
-  );
 }

--- a/src/providers/neutrino/runtime.ts
+++ b/src/providers/neutrino/runtime.ts
@@ -4,7 +4,7 @@ import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.
 import type { NeutrinoActionName } from "./actions.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import { isAbortLikeError, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const neutrinoApiBaseUrl = "https://neutrinoapi.net";
 
@@ -237,11 +237,4 @@ function isNeutrinoRateLimitError(apiErrorCode: number | undefined): boolean {
 
 function invalidInput(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/next_dns/executors.ts
+++ b/src/providers/next_dns/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "next_dns";
 const nextDnsApiBaseUrl = "https://api.nextdns.io";
@@ -282,8 +287,4 @@ function mapNextDnsError(
 
 function readInputString(value: unknown, fieldName: string): string {
   return requiredString(value, fieldName, (message) => new ProviderRequestError(400, message));
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }

--- a/src/providers/partner_stack_partner/runtime.ts
+++ b/src/providers/partner_stack_partner/runtime.ts
@@ -10,7 +10,12 @@ import {
   requiredRecord,
   requiredString,
 } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export const partnerStackPartnerApiBaseUrl = "https://api.partnerstack.com/api/v2/";
 const partnerStackPartnerValidationPath = "/api/v2/marketplace/programs";
@@ -278,13 +283,6 @@ function createPartnerStackTransportError(error: unknown) {
       ? `PartnerStack Partner request failed: ${error.message}`
       : "PartnerStack Partner request failed";
   return new ProviderRequestError(502, message);
-}
-
-function isAbortLikeError(error: unknown) {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return error.name === "AbortError" || error.name === "TimeoutError";
 }
 
 function extractErrorMessage(payload: unknown): string | undefined {

--- a/src/providers/productive/runtime.ts
+++ b/src/providers/productive/runtime.ts
@@ -6,6 +6,7 @@ import { compactObject, optionalNumber, optionalRecord, optionalString } from ".
 import {
   defineProviderExecutors,
   getProviderActionHandler,
+  isAbortLikeError,
   providerFetch,
   ProviderRequestError,
   providerUserAgent,
@@ -564,10 +565,6 @@ function nullableOutputString(value: unknown) {
 
 function readOptionalNumber(value: unknown) {
   return optionalNumber(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 function readRequiredApiKey(apiKey: unknown) {

--- a/src/providers/productlane/runtime.ts
+++ b/src/providers/productlane/runtime.ts
@@ -2,6 +2,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProductlaneActionName } from "./actions.ts";
 
 import { requiredString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export interface ProductlaneCredentialCheck {
@@ -322,10 +323,6 @@ function readErrorMessage(payload: unknown) {
 function omitId(input: Record<string, unknown>) {
   const { id: _id, ...body } = input;
   return body;
-}
-
-function encodePathSegment(value: unknown) {
-  return encodeURIComponent(String(value));
 }
 
 function readObject(value: unknown) {

--- a/src/providers/prospeo/runtime.ts
+++ b/src/providers/prospeo/runtime.ts
@@ -7,6 +7,7 @@ import { compactObject, optionalRecord, optionalString, requiredString } from ".
 import {
   defineApiKeyProviderExecutors,
   getProviderActionHandler,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
 } from "../provider-runtime.ts";
@@ -532,11 +533,4 @@ function readFirstObject(input: Record<string, unknown>, keys: string[]) {
 function readNonEmptyString(value: unknown) {
   const text = optionalString(value);
   return text || undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   defineOAuthProviderExecutors,
   defineProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   isAbortSignalError,
   mapProviderActionSources,
   providerFetch,
@@ -160,6 +161,28 @@ describe("createProviderTimeout", () => {
     } finally {
       timeout.cleanup();
     }
+  });
+});
+
+describe("isAbortLikeError", () => {
+  it("accepts AbortError and the TimeoutError raised by AbortSignal.timeout()", () => {
+    expect(isAbortLikeError(new DOMException("aborted", "AbortError"))).toBe(true);
+    expect(isAbortLikeError(new DOMException("timed out", "TimeoutError"))).toBe(true);
+    expect(isAbortLikeError(AbortSignal.abort().reason)).toBe(true);
+  });
+
+  it("recognizes the reason an AbortSignal.timeout() signal aborts with", async () => {
+    const signal = AbortSignal.timeout(1);
+    await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
+    expect((signal.reason as Error).name).toBe("TimeoutError");
+    expect(isAbortLikeError(signal.reason)).toBe(true);
+  });
+
+  it("rejects other errors and non-error values", () => {
+    expect(isAbortLikeError(new Error("connection reset"))).toBe(false);
+    expect(isAbortLikeError(new TypeError("fetch failed"))).toBe(false);
+    expect(isAbortLikeError({ name: "AbortError" })).toBe(false);
+    expect(isAbortLikeError(undefined)).toBe(false);
   });
 });
 

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -640,10 +640,12 @@ export function createProviderTimeout(parentSignal: AbortSignal | undefined, tim
 }
 
 /**
- * Return whether a caught error represents a fetch abort.
+ * Return whether a caught error represents a fetch abort: the `AbortError`
+ * raised by an aborted controller or the `TimeoutError` raised by
+ * `AbortSignal.timeout()`.
  */
 export function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 /**

--- a/src/providers/reducto/executors.ts
+++ b/src/providers/reducto/executors.ts
@@ -3,7 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { defineApiKeyProviderExecutors, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
+import {
+  defineApiKeyProviderExecutors,
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
 
 const service = "reducto";
 const reductoApiBaseUrl = "https://platform.reducto.ai";
@@ -280,10 +285,4 @@ function readRequiredDocumentUrl(input: Record<string, unknown>): string {
 
 function readOptionalTrimmedString(value: unknown): string | undefined {
   return optionalString(value);
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof DOMException
-    ? error.name === "AbortError"
-    : error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/semantic_scholar/executors.ts
+++ b/src/providers/semantic_scholar/executors.ts
@@ -12,6 +12,7 @@ import {
   createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   mapProviderActionSources,
   providerProxyEndpointPrefixes,
   ProviderRequestError,
@@ -574,10 +575,6 @@ function readStringList(value: unknown) {
   }
 
   return value.map((item) => readRequiredString(item, "id"));
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof DOMException && error.name === "AbortError";
 }
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({

--- a/src/providers/semrush/executors.ts
+++ b/src/providers/semrush/executors.ts
@@ -5,6 +5,7 @@ import { compactObject, optionalIntegerLike, optionalRawString } from "../../cor
 import {
   createProviderTimeout,
   defineProviderExecutors,
+  isAbortLikeError,
   mapProviderActionSources,
   providerUserAgent,
   ProviderRequestError,
@@ -274,8 +275,4 @@ function readOptionalString(value: unknown) {
 function stringifyOptionalInteger(value: unknown) {
   const integer = optionalIntegerLike(value, "integer");
   return integer === undefined ? undefined : String(integer);
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/telegram/executors.ts
+++ b/src/providers/telegram/executors.ts
@@ -12,6 +12,7 @@ import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   requireApiKeyCredential,
 } from "../provider-runtime.ts";
@@ -1368,8 +1369,4 @@ function assertValidTelegramBotToken(botToken: string): void {
   if (botToken.length === 0 || /[/?#\s]/u.test(botToken)) {
     throw new ProviderRequestError(400, "telegram bot token is malformed");
   }
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/tikhub/endpoint-catalog.ts
+++ b/src/providers/tikhub/endpoint-catalog.ts
@@ -6,7 +6,7 @@ import type {
 } from "./endpoint-types.ts";
 
 import { createHash } from "node:crypto";
-import { createProviderTimeout } from "../provider-runtime.ts";
+import { createProviderTimeout, isAbortLikeError } from "../provider-runtime.ts";
 import { cancelResponseBody, readBoundedResponseText } from "./bounded-response.ts";
 import { parseTikHubEndpointDocument } from "./endpoint-document.ts";
 import { parseTikHubLlmsIndex, tikhubDocsIndexUrl } from "./endpoint-index.ts";
@@ -543,11 +543,4 @@ function sha256Hex(value: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/tikhub/runtime.ts
+++ b/src/providers/tikhub/runtime.ts
@@ -8,7 +8,7 @@ import {
   optionalString as asOptionalString,
   requiredString,
 } from "../../core/cast.ts";
-import { createProviderTimeout, providerUserAgent } from "../provider-runtime.ts";
+import { createProviderTimeout, isAbortLikeError, providerUserAgent } from "../provider-runtime.ts";
 import { BoundedResponseTooLargeError, readBoundedResponseText } from "./bounded-response.ts";
 import { discoverTikHubEndpoints } from "./endpoint-catalog.ts";
 import {
@@ -781,11 +781,4 @@ function asRecordOrEmpty(value: unknown, fieldName: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isAbortLikeError(error: unknown) {
-  return (
-    error instanceof DOMException ||
-    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-  );
 }

--- a/src/providers/vida/runtime.ts
+++ b/src/providers/vida/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { VidaActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  createProviderTimeout,
+  isAbortLikeError,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 export interface VidaCredentialCheck {
   providerAccountId?: string;
@@ -260,8 +265,4 @@ function readOptionalString(value: unknown) {
 
 function readOptionalNumberString(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
-}
-
-function isAbortLikeError(error: unknown) {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/workpath/executors.ts
+++ b/src/providers/workpath/executors.ts
@@ -210,7 +210,7 @@ async function workpathRequest(
       throw error;
     }
 
-    if (timeout.didTimeout() || isAbortLikeError(error) || isTimeoutLikeError(error)) {
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
       throw new ProviderRequestError(
         504,
         `Workpath ${input.path} request timed out after ${Math.ceil(workpathDefaultRequestTimeoutMs / 1000)} seconds`,
@@ -324,8 +324,4 @@ function extractWorkpathErrorMessage(payload: unknown): string | undefined {
 
 function providerInputError(message: string): ProviderRequestError {
   return new ProviderRequestError(400, message);
-}
-
-function isTimeoutLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
 }


### PR DESCRIPTION
Collapses three provider-local helper families onto their shared owners. This is the first of the provider-level convergence PRs that follow #441; each one lands separately because they touch hundreds of files and, unlike #441, a few of them are wire-visible.

## What changes

- `isAbortLikeError` in `provider-runtime.ts` now also accepts the `TimeoutError` that `AbortSignal.timeout()` aborts with (`error instanceof Error && (name === "AbortError" || name === "TimeoutError")`). Three tests pin it, including one that awaits a real `AbortSignal.timeout(1)` abort.
- 63 provider files that declared their own `isAbortLikeError` (19 textual variants: byte-identical, AbortError-only, `instanceof DOMException`, duck-typed on `"name" in error`, any-DOMException, message matching) now import the shared one. Five providers that OR-ed a local `isTimeoutLikeError` into the same branch (bettercontact, bidsketch, big_data_cloud, bigpicture_io, workpath) drop the now-redundant term and function.
- 7 local `compactObject` copies (six `feishu/shared/*-runtime.ts`, infolobby) are replaced by `core/cast.ts`'s. `getnote` keeps its own: it also drops `null`, `""` and `[]`, and its bodies are fed by `readStringArray`, so the shared helper would start sending `tags: []` on note updates.
- 8 local `encodePathSegment` copies (grafana, grafana_cloud, jazzhr, lightfield, mailgun, deepgram, elasticsearch, productlane) are replaced by `core/request.ts`'s. Kept on purpose: biorxiv_medrxiv (rejects `.`/`..`, a path-traversal guard), everhour (restores `%3A` to `:`), faraday / firehydrant / freepik / replicate (validate-and-throw readers).

Net -242 lines across 84 files.

## Wire-visible changes

Only providers that build their request signal with `AbortSignal.timeout()` and whose deleted predicate matched `AbortError` alone change behavior. For them the "timed out" branch was unreachable (Node and workerd both reject with a `TimeoutError`), so a timeout surfaced as the generic 502 branch. It now surfaces as the branch the provider wrote for it. `error.code` stays `provider_error` in every case; only `details.status` and the message move.

| provider | old outcome on timeout | new outcome |
|---|---|---|
| affinity | 502 `Affinity request failed: The operation was aborted due to timeout` | 504 `Affinity request timed out` |
| apiverve | 502 `APIVerve request failed: ...` | 504 `APIVerve request timed out` |
| apollo | 502 `The operation was aborted due to timeout` | 502 `apollo <path> request timed out after 30 seconds` (message only) |
| check | 502 `Check request failed: ...` | 504 `Check request timed out` |
| checkly | 502 `checkly request failed: ...` | 504 `checkly request timed out` |
| cincopa | 502 `Cincopa request failed: ...` | 504 `Cincopa request timed out` |
| circle | 502 `Circle request failed: ...` | 504 `Circle request timed out` |
| fireberry | 502 `fireberry request failed: ...` | 504 `fireberry request timed out` |
| freshdesk | 502 `Freshdesk request failed: ...` (details = error) | 504 `Freshdesk request timed out after 30 seconds` |
| freshservice | 502 `Freshservice request failed: ...` (details = error) | 504 `Freshservice request timed out after 30 seconds` |
| getnote | 502 `Getnote request failed: ...` | 504 `Getnote request timed out` |
| gumloop | 502 `Gumloop request failed: ...` | 504 `Gumloop request timed out` |
| gumroad | 502 `Gumroad request failed: ...` | 504 `Gumroad request timed out` |
| hackerrank_work | 502 `hackerrank_work request failed: ...` | 504 `hackerrank_work request timed out` |
| harvest (2 sites) | 502 `harvest request failed: ...` / `harvest account discovery failed: ...` | 504 `harvest request timed out` / `harvest account discovery timed out` |
| haveibeenpwned | 502 `Have I Been Pwned request failed: ...` | 504 `Have I Been Pwned request timed out` |

Everything else is byte-identical on `/v1`:

- The ~350 providers that already imported the shared helper only ever see `AbortError`: `createProviderTimeout` aborts with no reason, the only parent signal is `context.req.raw.signal`, and `oauth-token.ts` catches its own `TimeoutError`. Computed the file-level intersection of shared-helper importers and `AbortSignal.timeout` users: every hit is in this diff.
- 12 converted providers using `AbortSignal.timeout()` already accepted `TimeoutError` (by name, or in habitica's case by matching the "aborted" message), so they do not change.
- The 8 any-DOMException predicates and the 2 message matchers narrow to `{AbortError, TimeoutError}`; probed undici 7.25 and miniflare for every other failure mode reachable from those try blocks (ECONNREFUSED, reset, `terminated`, malformed chunked bodies, invalid JSON, body already read, client disconnect via `@hono/node-server`): all are `TypeError` / `SyntaxError` / a string reason, classified the same way before and after.

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1552 tests), `npm run build --workspace web`, `git diff --check`: green.
- `npm run generate:catalog`: all 1451 `catalog/apps/*.json` byte-identical to `origin/main` (sha256 compared).
- Residue sweep: the only remaining local `isAbortLikeError` / `compactObject` / `encodePathSegment` declarations are the 7 kept on purpose above; the 2 remaining `isTimeoutLikeError` declarers (taxjar, ossinsight) do not import the shared helper and are untouched.
- `oxlint` with `no-unused-vars` forced on over all changed files: no import went dead when the local helpers were removed.

## Not in this PR

The other provider-level convergences from the same audit (shared error factories, `createProviderTimeout` default, request wrapper, cast helper aliases, dead exports, `ApiKeyActionRequest`, SigV4, hand-written proxies) each get their own PR.
