### PR TITLE
refactor(providers): default createProviderTimeout to 30 seconds

### DIFF
--- a/src/providers/17track/runtime.ts
+++ b/src/providers/17track/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const seventeenTrackApiBaseUrl = "https://api.17track.net/track/v2.4";
-const seventeenTrackRequestTimeoutMs = 30_000;
 const seventeenTrackMaxResponseBytes = 1_048_576;
 
 export const seventeenTrackActionHandlers: ProviderActionHandlers<
@@ -66,7 +65,7 @@ async function requestSeventeenTrack(
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">,
   phase: "validate" | "execute",
 ) {
-  const timeout = createProviderTimeout(context.signal, seventeenTrackRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(`${seventeenTrackApiBaseUrl}/${path}`, {
       method: "POST",

--- a/src/providers/7_shifts/runtime.ts
+++ b/src/providers/7_shifts/runtime.ts
@@ -24,8 +24,6 @@ export interface SevenShiftsContext extends ApiKeyProviderContext {
 
 export const sevenShiftsApiBaseUrl = "https://api.7shifts.com";
 
-const sevenShiftsDefaultRequestTimeoutMs = 30_000;
-
 type SevenShiftsRequestPhase = "validate" | "execute";
 type SevenShiftsEntityKind = "company" | "location" | "department" | "role" | "user";
 type SevenShiftsActionHandler = (input: Record<string, unknown>, context: SevenShiftsContext) => Promise<unknown>;
@@ -181,7 +179,7 @@ export async function validateSevenShiftsCredential(
 }
 
 async function requestSevenShiftsJson(options: SevenShiftsRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.signal, sevenShiftsDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
 
   try {
     const response = await options.fetcher(buildSevenShiftsUrl(options.path, options.query), {

--- a/src/providers/accredible_certificates/executors.ts
+++ b/src/providers/accredible_certificates/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "accredible_certificates";
 const accredibleCertificatesApiBaseUrl = "https://api.accredible.com/";
-const accredibleCertificatesDefaultRequestTimeoutMs = 30_000;
 
 type AccredibleCertificatesRequestPhase = "validate" | "execute";
 type AccredibleCertificatesMethod = "GET" | "POST" | "DELETE";
@@ -280,7 +279,7 @@ async function requestAccredibleCertificatesJson(input: {
   signal?: AbortSignal;
   phase: AccredibleCertificatesRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, accredibleCertificatesDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const method = input.method ?? "GET";
 
   let response: Response;

--- a/src/providers/active_trail/executors.ts
+++ b/src/providers/active_trail/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "active_trail";
 const activeTrailApiBaseUrl = "https://webapi.mymarketing.co.il/api";
-const activeTrailDefaultRequestTimeoutMs = 30_000;
 
 type ActiveTrailPhase = "validate" | "execute";
 type ActiveTrailMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -234,7 +233,7 @@ async function requestActiveTrailJson(input: {
   body?: Record<string, unknown>;
   phase: ActiveTrailPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, activeTrailDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/acuity_scheduling/runtime.ts
+++ b/src/providers/acuity_scheduling/runtime.ts
@@ -18,7 +18,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const acuitySchedulingApiBaseUrl = "https://acuityscheduling.com/api/v1";
-const acuitySchedulingRequestTimeoutMs = 30_000;
 
 type AcuitySchedulingCredential = {
   userId: string;
@@ -277,7 +276,7 @@ async function requestAcuityScheduling(input: {
   query?: Record<string, AcuitySchedulingQueryValue>;
   body?: unknown;
 }) {
-  const timeoutHandle = createProviderTimeout(input.signal, acuitySchedulingRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.signal);
   const headers = new Headers({
     accept: "application/json",
     authorization: `Basic ${Buffer.from(`${input.credential.userId}:${input.credential.apiKey}`).toString("base64")}`,

--- a/src/providers/adafruit_io/executors.ts
+++ b/src/providers/adafruit_io/executors.ts
@@ -28,7 +28,6 @@ import {
 
 const service = "adafruit_io";
 const adafruitIoApiBaseUrl = "https://io.adafruit.com/api/v2";
-const adafruitIoDefaultRequestTimeoutMs = 30_000;
 
 type AdafruitIoPhase = "validate" | "execute";
 
@@ -253,7 +252,7 @@ async function requestAdafruitIoJson(input: {
   phase: AdafruitIoPhase;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, adafruitIoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/aerisweather/runtime.ts
+++ b/src/providers/aerisweather/runtime.ts
@@ -23,8 +23,6 @@ import {
 
 export const aerisweatherApiBaseUrl = "https://data.api.xweather.com";
 
-const aerisweatherRequestTimeoutMs = 30_000;
-
 type AerisWeatherRequestPhase = "validate" | "execute";
 type AerisWeatherQueryValue = string | number | undefined;
 
@@ -138,7 +136,7 @@ async function requestAerisWeatherJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, aerisweatherRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       headers: {

--- a/src/providers/aimfox/executors.ts
+++ b/src/providers/aimfox/executors.ts
@@ -21,7 +21,6 @@ import {
 } from "../provider-runtime.ts";
 
 const aimfoxApiBaseUrl = "https://api.aimfox.com/api/v2";
-const aimfoxDefaultRequestTimeoutMs = 30_000;
 const leadSearchBodyKeys = [
   "keywords",
   "current_companies",
@@ -277,7 +276,7 @@ async function requestAimfoxJson(input: {
     init.body = JSON.stringify(input.body);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, aimfoxDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       ...init,

--- a/src/providers/airbrake/executors.ts
+++ b/src/providers/airbrake/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "airbrake";
 const airbrakeApiBaseUrl = "https://api.airbrake.io";
-const airbrakeRequestTimeoutMs = 30_000;
 
 type AirbrakeRequestPhase = "validate" | "execute";
 type AirbrakeQueryValue = string | number | boolean | undefined;
@@ -253,7 +252,7 @@ function requestAirbrakeForAction(
 }
 
 async function requestAirbrake(input: AirbrakeRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, airbrakeRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildAirbrakeUrl(input.path, input.apiKey, input.query ?? {}), {
       method: input.method ?? "GET",

--- a/src/providers/aircall/runtime.ts
+++ b/src/providers/aircall/runtime.ts
@@ -9,7 +9,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 export const aircallApiBaseUrl = "https://api.aircall.io";
 const aircallRequestBaseUrl = "https://api.aircall.io/";
 const aircallValidationPath = "/v1/ping";
-const aircallDefaultTimeoutMs = 30_000;
 
 type AircallRequestPhase = "validate" | "execute";
 
@@ -178,7 +177,7 @@ async function requestAircallJson(context: AircallActionContext, input: AircallR
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, aircallDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/altiria/executors.ts
+++ b/src/providers/altiria/executors.ts
@@ -22,7 +22,6 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "altiria";
-const altiriaRequestTimeoutMs = 30_000;
 const altiriaMaxResponseBytes = 10 * 1024 * 1024;
 const altiriaRestPath = "/api/rest";
 
@@ -299,7 +298,7 @@ async function requestAltiria(input: AltiriaRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, altiriaRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const fetcher = createProviderFetch({ fetch: input.fetcher });
 
   try {

--- a/src/providers/ambivo/executors.ts
+++ b/src/providers/ambivo/executors.ts
@@ -16,7 +16,6 @@ import {
 const service = "ambivo";
 const ambivoApiBaseUrl = "https://fapi.ambivo.com";
 const ambivoValidationPath = "/crm/leads";
-const ambivoRequestTimeoutMs = 30_000;
 const ambivoMaxResponseBytes = 10 * 1024 * 1024;
 
 interface AmbivoRequestOptions {
@@ -244,7 +243,7 @@ async function requestAmbivoJson(options: AmbivoRequestOptions) {
     headers["content-type"] = "application/json";
   }
 
-  const timeout = createProviderTimeout(options.signal, ambivoRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   try {
     const response = await options.fetcher(url, {
       method: options.method ?? "GET",

--- a/src/providers/amilia/runtime.ts
+++ b/src/providers/amilia/runtime.ts
@@ -22,7 +22,6 @@ import {
 export const amiliaApiOrigin = "https://app.amilia.com";
 
 const amiliaJwtHelpUrl = "https://app.amilia.com/apidocs/Index.html#authentication";
-const amiliaRequestTimeoutMs = 30_000;
 
 type AmiliaRequestPhase = "validate" | "execute";
 type AmiliaQueryValue = string | number | boolean | undefined;
@@ -177,7 +176,7 @@ async function requestAmiliaJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, amiliaRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       headers: {

--- a/src/providers/amplitude/runtime.ts
+++ b/src/providers/amplitude/runtime.ts
@@ -15,7 +15,6 @@ export const amplitudeApiBaseUrl = "https://amplitude.com";
 export const amplitudeEuApiBaseUrl = "https://analytics.eu.amplitude.com";
 
 const amplitudeValidationPath = "/api/2/events/list";
-const amplitudeDefaultTimeoutMs = 30_000;
 
 export interface AmplitudeActionContext {
   apiKeyId: string;
@@ -166,7 +165,7 @@ async function requestAmplitudeJson(input: AmplitudeRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, amplitudeDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url.toString(), {

--- a/src/providers/anrok/executors.ts
+++ b/src/providers/anrok/executors.ts
@@ -16,7 +16,6 @@ import {
 const anrokApiBaseUrl = "https://api.anrok.com";
 const anrokCredentialHelpUrl = "https://app.anrok.com/-/api-keys";
 const anrokValidationPath = "/v1/seller/productTaxCategories/list";
-const anrokDefaultRequestTimeoutMs = 30_000;
 
 type AnrokPhase = "validate" | "execute";
 type AnrokActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -133,7 +132,7 @@ async function requestAnrokJson(input: {
   phase: AnrokPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, anrokDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildAnrokUrl(input.path), {

--- a/src/providers/anysearch/runtime.ts
+++ b/src/providers/anysearch/runtime.ts
@@ -27,7 +27,6 @@ type AnySearchContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "sign
 
 export const anySearchApiBaseUrl = "https://api.anysearch.com";
 const anySearchMcpEndpoint = anySearchApiBaseUrl + "/mcp";
-const anySearchRequestTimeoutMs = 30_000;
 const anySearchClientHeader = "connector/1.0.0";
 const authenticatedQuotaResponse = Symbol("authenticatedQuotaResponse");
 const credentialErrorSymbols = new Set([
@@ -197,7 +196,7 @@ async function requestAnySearchJson(
   phase: AnySearchRequestPhase,
   extraHeaders: Record<string, string> = {},
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, anySearchRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(url, {

--- a/src/providers/api_void/executors.ts
+++ b/src/providers/api_void/executors.ts
@@ -17,7 +17,6 @@ import {
 
 const service = "api_void";
 const apiVoidApiBaseUrl = "https://api.apivoid.com";
-const apiVoidRequestTimeoutMs = 30_000;
 
 type ApiVoidRequestPhase = "validate" | "execute";
 
@@ -155,7 +154,7 @@ function requestApiVoidForAction(
 }
 
 async function requestApiVoid(input: ApiVoidRequestInput): Promise<ApiVoidActionOutput> {
-  const timeout = createProviderTimeout(input.context.signal, apiVoidRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/arcgis_online/executors.ts
+++ b/src/providers/arcgis_online/executors.ts
@@ -16,7 +16,6 @@ import {
 const service = "arcgis_online";
 const arcgisOnlineApiBaseUrl = "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer";
 const arcgisOnlineValidationPath = "/suggest";
-const arcgisOnlineRequestTimeoutMs = 30_000;
 
 type ArcgisOnlineQueryValue = string | number | boolean | undefined;
 type ArcgisOnlineActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -120,7 +119,7 @@ async function requestArcgisOnline(input: {
   query: Record<string, ArcgisOnlineQueryValue>;
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, arcgisOnlineRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildArcgisOnlineUrl(input.path, input.query, input.context.apiKey), {
       method: "GET",

--- a/src/providers/atlas_so/executors.ts
+++ b/src/providers/atlas_so/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "atlas_so";
 const atlasSoApiBaseUrl = "https://api.atlas.so";
-const atlasSoDefaultRequestTimeoutMs = 30_000;
 
 type AtlasSoPhase = "validate" | "execute";
 type AtlasSoMethod = "GET" | "POST";
@@ -227,7 +226,7 @@ async function requestAtlasSoJson(input: {
   query?: Record<string, AtlasSoQueryValue>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, atlasSoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildAtlasSoUrl(input.path, input.query), {

--- a/src/providers/bazhuayu/executors.ts
+++ b/src/providers/bazhuayu/executors.ts
@@ -34,7 +34,6 @@ import {
 } from "./runtime.ts";
 
 const service = "bazhuayu";
-const requestTimeoutMs = 30_000;
 
 const handlers: ProviderActionHandlers<
   "bazhuayu",
@@ -115,7 +114,7 @@ async function fetchProxy(
       headers.set("content-type", "application/json");
     }
   }
-  const timeout = createProviderTimeout(parentSignal, requestTimeoutMs);
+  const timeout = createProviderTimeout(parentSignal);
   try {
     return await providerFetch(url, { ...init, signal: timeout.signal });
   } finally {

--- a/src/providers/bazhuayu/runtime.ts
+++ b/src/providers/bazhuayu/runtime.ts
@@ -12,7 +12,6 @@ import {
 export const bazhuayuApiBaseUrl = "https://openapi.bazhuayu.com";
 export const bazhuayuApiDocsUrl = "https://openapi.bazhuayu.com/zh-CN/";
 
-const requestTimeoutMs = 30_000;
 export const maximumBazhuayuResponseBytes: number = 10 * 1024 * 1024;
 const tokenRefreshLeewayMs = 60_000;
 const maximumTokenCacheEntries = 1_024;
@@ -443,7 +442,7 @@ async function requestJson(
   phase: "validate" | "execute",
   signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(url, { ...init, signal: timeout.signal });
     const payload = await readProviderJsonBody(response, {

--- a/src/providers/beamer/runtime.ts
+++ b/src/providers/beamer/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const beamerApiBaseUrl = "https://api.getbeamer.com/v0";
-const beamerTimeoutMs = 30_000;
 
 type BeamerPhase = "validate" | "execute";
 type BeamerActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -215,7 +214,7 @@ async function requestBeamerJson(
   context: BeamerContext,
   phase: BeamerPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, beamerTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(url, {

--- a/src/providers/beebole/executors.ts
+++ b/src/providers/beebole/executors.ts
@@ -22,7 +22,6 @@ const service = "beebole";
 const beeboleApiBaseUrl = "https://app.beebole.com";
 const beeboleGraphqlPath = "/graphql";
 const beeboleGraphqlEndpoint = `${beeboleApiBaseUrl}${beeboleGraphqlPath}`;
-const beeboleRequestTimeoutMs = 30_000;
 
 type BeeboleRequestPhase = "validate" | "execute";
 
@@ -96,7 +95,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestBeeboleGraphql(input: BeeboleGraphqlRequestOptions): Promise<BeeboleGraphqlPayload> {
-  const timeout = createProviderTimeout(input.context.signal, beeboleRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(beeboleGraphqlEndpoint, {
       method: "POST",

--- a/src/providers/beeminder/runtime.ts
+++ b/src/providers/beeminder/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const beeminderApiBaseUrl = "https://www.beeminder.com/api/v1";
-const beeminderDefaultRequestTimeoutMs = 30_000;
 
 type BeeminderPhase = "validate" | "execute";
 type BeeminderContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -187,7 +186,7 @@ async function requestBeeminderJson(input: {
   context: BeeminderContext;
   phase: BeeminderPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, beeminderDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const body = input.form ? buildBeeminderForm(input.context.apiKey, input.form) : undefined;
 
   try {

--- a/src/providers/benchmark_email/runtime.ts
+++ b/src/providers/benchmark_email/runtime.ts
@@ -11,7 +11,6 @@ import {
   providerUserAgent,
 } from "../provider-runtime.ts";
 
-const benchmarkEmailDefaultRequestTimeoutMs = 30_000;
 const benchmarkEmailValidationMethod = "clientGetProfileDetails";
 
 type BenchmarkEmailRequestPhase = "validate" | "execute";
@@ -119,7 +118,7 @@ async function requestBenchmarkEmailJson(input: {
   phase: BenchmarkEmailRequestPhase;
   query?: Record<string, string | undefined>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, benchmarkEmailDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(

--- a/src/providers/benzinga/runtime.ts
+++ b/src/providers/benzinga/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const benzingaApiBaseUrl = "https://api.benzinga.com";
-const benzingaDefaultRequestTimeoutMs = 30_000;
 
 type BenzingaPhase = "validate" | "execute";
 type BenzingaContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -116,7 +115,7 @@ async function requestBenzingaJson(input: {
   params: Record<string, string | undefined>;
   phase: BenzingaPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, benzingaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildBenzingaUrl(input.path, input.context.apiKey, input.params), {

--- a/src/providers/bettercontact/runtime.ts
+++ b/src/providers/bettercontact/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const bettercontactApiBaseUrl = "https://app.bettercontact.rocks/api/v2";
-const bettercontactDefaultRequestTimeoutMs = 30_000;
 
 type BettercontactMode = "validate" | "execute";
 type BettercontactActionHandler = ProviderRuntimeHandler<BettercontactContext>;
@@ -159,7 +158,7 @@ async function requestBettercontactJson(
   input: BettercontactRequestInput,
   context: BettercontactContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, bettercontactDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildBettercontactUrl(input, context.apiKey), {

--- a/src/providers/bidsketch/runtime.ts
+++ b/src/providers/bidsketch/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const bidsketchApiBaseUrl: string = "https://bidsketch.com/api/v1";
-const bidsketchRequestTimeoutMs = 30_000;
 const bidsketchValidationPath = "/proposals/stats.json";
 
 type BidsketchPhase = "validate" | "execute";
@@ -131,7 +130,7 @@ async function requestBidsketchJson(input: {
   phase: BidsketchPhase;
   query?: Record<string, number | undefined>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, bidsketchRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildBidsketchUrl(input.path, input.query), {

--- a/src/providers/bigmailer/runtime.ts
+++ b/src/providers/bigmailer/runtime.ts
@@ -11,7 +11,6 @@ import {
 
 export const bigmailerApiBaseUrl: string = "https://api.bigmailer.io";
 
-const bigmailerDefaultRequestTimeoutMs = 30_000;
 const bigmailerValidationEndpoint = "/v1/brands";
 
 type BigmailerRequestPhase = "validate" | "execute";
@@ -293,7 +292,7 @@ async function requestBigmailerJson(input: {
   query?: Record<string, string | number | boolean | undefined>;
   body?: Record<string, unknown>;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, bigmailerDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildBigmailerUrl(input.path, input.query), {

--- a/src/providers/bigml/runtime.ts
+++ b/src/providers/bigml/runtime.ts
@@ -33,7 +33,6 @@ interface BigmlStatus {
 }
 
 export const bigmlApiBaseUrl = "https://bigml.io/andromeda";
-const timeoutMs = 30_000;
 export const bigmlActionHandlers: ProviderActionHandlers<"bigml", ProviderRuntimeHandler<BigmlContext>> = {
   async list_models(input, context) {
     const payload = await request("/model", "GET", buildListQuery(input), undefined, context, "execute");
@@ -137,7 +136,7 @@ async function request(
   context: BigmlContext,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const url = new URL(path.startsWith("/") ? path.slice(1) : path, `${bigmlApiBaseUrl}/`);
     url.searchParams.set("username", context.username);

--- a/src/providers/bigpicture_io/runtime.ts
+++ b/src/providers/bigpicture_io/runtime.ts
@@ -15,7 +15,6 @@ const bigpictureIpApiBaseUrl = "https://ip.bigpicture.io";
 const bigpictureCompanyFindPath = "/v1/companies/find";
 const bigpictureIpLookupPath = "/v2/companies/ip";
 const bigpictureValidationIp = "204.4.143.118";
-const bigpictureRequestTimeoutMs = 30_000;
 
 type BigpictureRequestPhase = "validate" | "execute";
 type BigpictureActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -99,7 +98,7 @@ async function requestBigpictureJson(input: {
   phase: BigpictureRequestPhase;
   allowAccepted: boolean;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, bigpictureRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   let response: Response;
   let payload: unknown;

--- a/src/providers/bird/runtime.ts
+++ b/src/providers/bird/runtime.ts
@@ -6,7 +6,6 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const birdApiBaseUrl: string = "https://api.bird.com";
-const birdRequestTimeoutMs = 30_000;
 
 type BirdRequestPhase = "validate" | "execute";
 type BirdRequestMethod = "GET" | "POST" | "PATCH" | "DELETE";
@@ -374,7 +373,7 @@ async function birdRequest(
     url.searchParams.append(key, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, birdRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/bitbucket/http.ts
+++ b/src/providers/bitbucket/http.ts
@@ -5,7 +5,6 @@ import {
   providerUserAgent,
 } from "../provider-runtime.ts";
 
-const bitbucketRequestTimeoutMs = 30_000;
 const bitbucketMaxResponseBytes = 10 * 1024 * 1024;
 
 export async function fetchBitbucketText(
@@ -13,7 +12,7 @@ export async function fetchBitbucketText(
   input: string | URL,
   init: RequestInit,
 ): Promise<{ response: Response; text: string }> {
-  const timeout = createProviderTimeout(init.signal ?? undefined, bitbucketRequestTimeoutMs);
+  const timeout = createProviderTimeout(init.signal ?? undefined);
   try {
     const headers = new Headers(init.headers);
     headers.set("user-agent", providerUserAgent);

--- a/src/providers/bitrise/runtime.ts
+++ b/src/providers/bitrise/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const bitriseApiBaseUrl = "https://api.bitrise.io/v0.1";
 
-const bitriseDefaultRequestTimeoutMs = 30_000;
-
 interface BitriseActionHandler {
   (input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<unknown>;
 }
@@ -189,7 +187,7 @@ async function bitriseFetch(input: BitriseRequestInput) {
     url.search = input.query.toString();
   }
 
-  const timeout = createProviderTimeout(input.signal, bitriseDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/blaze_meter_performance/shared-runtime.ts
+++ b/src/providers/blaze_meter_performance/shared-runtime.ts
@@ -20,7 +20,6 @@ export const blazeMeterApiBaseUrl = "https://a.blazemeter.com/api/v4";
 export const blazeMeterValidationPath = "/user";
 
 const blazeMeterRequestBaseUrl = "https://a.blazemeter.com/api/v4/";
-const blazeMeterDefaultTimeoutMs = 30_000;
 const blazeMeterFetch = createProviderFetch({ skipDnsValidation: true });
 
 export type BlazeMeterPhase = "validate" | "execute";
@@ -192,7 +191,7 @@ async function requestBlazeMeter(
     appendBlazeMeterQueryValue(url, key, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, blazeMeterDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url.toString(), {
       method: input.method ?? "GET",

--- a/src/providers/bluesky/runtime.ts
+++ b/src/providers/bluesky/runtime.ts
@@ -12,7 +12,6 @@ export interface BlueskyContext extends ApiKeyProviderContext {
 
 export const blueskyApiBaseUrl = "https://bsky.social";
 
-const blueskyDefaultRequestTimeoutMs = 30_000;
 const createSessionPath = "/xrpc/com.atproto.server.createSession";
 
 export type BlueskyRequestPhase = "validate" | "execute";
@@ -238,7 +237,7 @@ function buildTextPostRecord(input: Record<string, unknown>): Record<string, unk
 
 async function requestBlueskyJson(options: BlueskyRequestOptions): Promise<unknown> {
   const url = buildBlueskyUrl(options.path, options.query);
-  const timeout = createProviderTimeout(options.signal, blueskyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   try {
     let response: Response;
     try {

--- a/src/providers/boldsign/runtime.ts
+++ b/src/providers/boldsign/runtime.ts
@@ -33,7 +33,6 @@ interface BoldSignRequestInput extends BoldSignActionContext {
 
 type BoldSignActionHandler = (input: Record<string, unknown>, context: BoldSignActionContext) => Promise<unknown>;
 
-const boldSignRequestTimeoutMs = 30_000;
 const boldSignCreditsPath = "/v1/plan/apiCreditsCount";
 
 const boldSignApiBaseUrlByRegion: Record<BoldSignRegion, string> = {
@@ -223,7 +222,7 @@ function buildSendFromTemplateBody(input: Record<string, unknown>) {
 }
 
 async function requestBoldSignJson(input: BoldSignRequestInput) {
-  const timeout = createProviderTimeout(input.signal, boldSignRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const url = new URL(input.path, `${input.apiBaseUrl}/`);
     appendQuery(url, input.query);

--- a/src/providers/booqable/runtime.ts
+++ b/src/providers/booqable/runtime.ts
@@ -28,8 +28,6 @@ interface BooqableRequestInput {
   notFoundAsInvalidInput?: boolean;
 }
 
-const booqableRequestTimeoutMs = 30_000;
-
 export const booqableActionHandlers: ProviderActionHandlers<"booqable", ProviderRuntimeHandler<BooqableContext>> = {
   async get_current_company(input, context) {
     return normalizeSingleResponse(
@@ -234,7 +232,7 @@ function readSearchBody(input: Record<string, unknown>): JsonObject {
 }
 
 async function requestBooqableJson(input: BooqableRequestInput): Promise<JsonObject> {
-  const timeout = createProviderTimeout(input.context.signal, booqableRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildBooqableUrl(input.context.companySlug, input.path, input.query), {
       method: input.method,

--- a/src/providers/bot_star/executors.ts
+++ b/src/providers/bot_star/executors.ts
@@ -16,7 +16,6 @@ const service = "bot_star";
 const botStarApiBaseUrl = "https://apis.botstar.com/v1";
 const botStarRequestBaseUrl = "https://apis.botstar.com/v1/";
 const botStarValidationPath = "/bots/";
-const botStarDefaultTimeoutMs = 30_000;
 
 type BotStarPhase = "validate" | "execute";
 type BotStarQueryValue = boolean | number | string | undefined;
@@ -280,7 +279,7 @@ async function botStarRequest(input: BotStarRequestInput): Promise<unknown> {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, botStarDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/botpress/runtime.ts
+++ b/src/providers/botpress/runtime.ts
@@ -31,7 +31,6 @@ export const botpressApiBaseUrl = "https://api.botpress.cloud/v1/admin";
 
 const botpressRequestBaseUrl = "https://api.botpress.cloud/v1/admin/";
 const botpressValidationPath = "/bots";
-const botpressDefaultTimeoutMs = 30_000;
 
 export const botpressActionHandlers: ProviderActionHandlers<"botpress", ProviderRuntimeHandler<BotpressContext>> = {
   async list_workspaces(input, context) {
@@ -104,7 +103,7 @@ async function botpressRequest(input: BotpressRequestInput): Promise<unknown> {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, botpressDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/braze/executors.ts
+++ b/src/providers/braze/executors.ts
@@ -22,7 +22,6 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "braze";
-const brazeRequestTimeoutMs = 30_000;
 const brazeCredentialHelpUrl = "https://www.braze.com/docs/api/basics";
 
 type BrazeRequestPhase = "validate" | "execute";
@@ -202,7 +201,7 @@ async function requestBrazeJson(input: {
   query?: Array<[string, unknown]>;
   phase: BrazeRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, brazeRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
 

--- a/src/providers/breathe/executors.ts
+++ b/src/providers/breathe/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "breathe";
 const breatheApiBaseUrl = "https://api.breathehr.com/v1";
-const breatheDefaultRequestTimeoutMs = 30_000;
 
 type BreathePhase = "validate" | "execute";
 type BreatheActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -136,7 +135,7 @@ async function requestBreatheJson(input: {
   params: Record<string, string | undefined>;
   phase: BreathePhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, breatheDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
 

--- a/src/providers/breezy_hr/executors.ts
+++ b/src/providers/breezy_hr/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "breezy_hr";
 const breezyHrApiBaseUrl = "https://api.breezy.hr/v3";
-const breezyHrRequestTimeoutMs = 30_000;
 const breezyHrMaxResponseBytes = 10 * 1024 * 1024;
 
 type BreezyHrPhase = "validate" | "execute";
@@ -209,7 +208,7 @@ async function requestBreezyHrJson(input: BreezyHrRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, breezyHrRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/brex/runtime.ts
+++ b/src/providers/brex/runtime.ts
@@ -7,7 +7,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 export const brexApiBaseUrl = "https://api.brex.com";
 const brexValidationPath = "/v2/users/me";
-const brexDefaultRequestTimeoutMs = 30_000;
 
 type BrexRequestPhase = "validate" | "execute";
 type BrexActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -247,7 +246,7 @@ export async function validateBrexCredential(
 }
 
 async function requestBrexJson(input: BrexRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, brexDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const url = new URL(input.path.startsWith("/") ? input.path.slice(1) : input.path, `${brexApiBaseUrl}/`);
     if (input.query) {

--- a/src/providers/bright_data/runtime.ts
+++ b/src/providers/bright_data/runtime.ts
@@ -14,7 +14,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 export const brightDataApiBaseUrl = "https://api.brightdata.com";
 const brightDataStatusPath = "/status";
-const brightDataRequestTimeoutMs = 30_000;
 
 type BrightDataRequestPhase = "validate" | "execute";
 type BrightDataQueryValue = string | number | boolean | undefined;
@@ -204,7 +203,7 @@ async function getSnapshotParts(input: Record<string, unknown>, context: BrightD
 }
 
 async function requestBrightDataJson(input: BrightDataRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, brightDataRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(input.path, brightDataApiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/bug_herd/runtime.ts
+++ b/src/providers/bug_herd/runtime.ts
@@ -13,7 +13,6 @@ import {
 } from "../provider-runtime.ts";
 
 const bugHerdApiBaseUrl = "https://www.bugherd.com";
-const bugHerdRequestTimeoutMs = 30_000;
 
 type BugHerdPhase = "validate" | "execute";
 type BugHerdQuery = Record<string, string | number | boolean | undefined>;
@@ -285,7 +284,7 @@ async function requestBugHerdJson(input: {
   signal?: AbortSignal;
   notFoundAsInvalidInput?: boolean;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, bugHerdRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildBugHerdUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/bugsnag/runtime.ts
+++ b/src/providers/bugsnag/runtime.ts
@@ -13,7 +13,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const bugsnagApiBaseUrl: string = "https://api.bugsnag.com";
-const bugsnagDefaultRequestTimeoutMs = 30_000;
 
 type BugsnagQueryValue = string | number | boolean | undefined;
 type BugsnagRequestPhase = "validate" | "execute";
@@ -238,7 +237,7 @@ async function requestBugsnagJson(input: {
   phase: BugsnagRequestPhase;
   notFoundAsInvalidInput?: boolean;
 }): Promise<BugsnagJsonResponse> {
-  const timeout = createProviderTimeout(input.signal, bugsnagDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(input.path, bugsnagApiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/builder_io/runtime.ts
+++ b/src/providers/builder_io/runtime.ts
@@ -12,7 +12,6 @@ import {
 export const builderIoWriteApiBaseUrl = "https://builder.io";
 
 const builderIoApiBaseUrl = "https://cdn.builder.io";
-const builderIoDefaultRequestTimeoutMs = 30_000;
 
 type BuilderIoActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -159,7 +158,7 @@ async function requestBuilderIoJson(input: {
     headers["content-type"] = "application/json";
   }
 
-  const timeout = createProviderTimeout(input.context.signal, builderIoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(input.url, {
       method: input.method,

--- a/src/providers/buildium/runtime.ts
+++ b/src/providers/buildium/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 export const buildiumApiBaseUrl: string = "https://api.buildium.com";
 const rentalsPath = "/v1/rentals";
-const buildiumDefaultRequestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 type BuildiumActionHandler = ProviderRuntimeHandler<BuildiumActionContext>;
@@ -135,7 +134,7 @@ async function buildiumRequestJson(input: {
   phase: RequestPhase;
   searchParams?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, buildiumDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = new URL(input.path, buildiumApiBaseUrl);
   for (const [key, value] of input.searchParams ?? []) {
     url.searchParams.set(key, value);

--- a/src/providers/buildkite/runtime.ts
+++ b/src/providers/buildkite/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const buildkiteApiBaseUrl = "https://api.buildkite.com/v2";
-const buildkiteDefaultRequestTimeoutMs = 30_000;
 
 type BuildkiteRequestPhase = "validate" | "execute";
 type BuildkiteQueryValue = string | number | boolean | undefined;
@@ -397,7 +396,7 @@ async function buildkiteFetch(input: {
     body = JSON.stringify(input.body);
   }
 
-  const timeout = createProviderTimeout(input.signal, buildkiteDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/builtwith/runtime.ts
+++ b/src/providers/builtwith/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const builtwithApiBaseUrl = "https://api.builtwith.com";
 const builtwithValidationPath = "/whoamiv1/api.json";
-const builtwithDefaultRequestTimeoutMs = 30_000;
 
 type BuiltwithActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -166,7 +165,7 @@ async function builtwithRequest(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, builtwithDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildBuiltwithUrl(input, context.apiKey), {

--- a/src/providers/calendarific/executors.ts
+++ b/src/providers/calendarific/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "calendarific";
 const calendarificApiBaseUrl = "https://calendarific.com/api/v2";
-const requestTimeoutMs = 30_000;
 
 type CalendarificPhase = "validate" | "execute";
 type CalendarificActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -115,7 +114,7 @@ async function requestCalendarificJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: CalendarificPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildCalendarificUrl(input.path, input.context.apiKey, input.params), {

--- a/src/providers/callrail/executors.ts
+++ b/src/providers/callrail/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "callrail";
 const callrailApiBaseUrl = "https://api.callrail.com";
-const requestTimeoutMs = 30_000;
 
 type CallrailRequestPhase = "validate" | "execute";
 type CallrailActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -154,7 +153,7 @@ async function requestCallrailJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(url, {

--- a/src/providers/capsule_crm/executors.ts
+++ b/src/providers/capsule_crm/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "capsule_crm";
 const capsuleCrmApiBaseUrl = "https://api.capsulecrm.com/api/v2";
-const requestTimeoutMs = 30_000;
 
 type CapsuleCrmActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -214,7 +213,7 @@ async function requestJsonWithHeaders(input: CapsuleCrmRequestInput) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
 
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/captainbi/runtime.ts
+++ b/src/providers/captainbi/runtime.ts
@@ -14,7 +14,6 @@ import {
 
 export const captainBiApiBaseUrl: string = "https://openapi.captainbi.com";
 export const captainBiTokenUrl: string = `${captainBiApiBaseUrl}/oauth2/token`;
-const captainBiRequestTimeoutMs = 30_000;
 const defaultPage = 1;
 const defaultRows = 100;
 
@@ -322,7 +321,7 @@ async function fetchCaptainBiResponse(input: {
   init: RequestInit;
   operation: string;
 }) {
-  const timeout = createProviderTimeout(undefined, captainBiRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     return await input.fetcher(input.url, { ...input.init, signal: timeout.signal });
   } catch (error) {

--- a/src/providers/cartes/runtime.ts
+++ b/src/providers/cartes/runtime.ts
@@ -22,7 +22,6 @@ import {
 export const cartesApiBaseUrl = "https://cartes.io/api";
 
 const cartesRequestBaseUrl = `${cartesApiBaseUrl}/`;
-const cartesDefaultTimeoutMs = 30_000;
 
 type CartesActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 type CartesQueryValue = string | number | boolean | readonly (string | number)[] | undefined;
@@ -276,7 +275,7 @@ async function cartesRequest(
   appendQuery(url, options.query);
 
   const method = options.method ?? "GET";
-  const timeoutHandle = createProviderTimeout(context.signal, cartesDefaultTimeoutMs);
+  const timeoutHandle = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/castingwords/runtime.ts
+++ b/src/providers/castingwords/runtime.ts
@@ -23,7 +23,6 @@ import {
 
 export const castingwordsApiBaseUrl = "https://castingwords.com/store/API4";
 
-const castingwordsRequestTimeoutMs = 30_000;
 const castingwordsRunningStatuses = new Set([
   "Audio Processing",
   "Awaiting Edit",
@@ -177,7 +176,7 @@ async function requestCastingwords(input: {
         })
       : undefined;
 
-  const timeout = createProviderTimeout(input.context.signal, castingwordsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   try {
     response = await input.context.fetcher(url, {

--- a/src/providers/censys/runtime.ts
+++ b/src/providers/censys/runtime.ts
@@ -10,7 +10,6 @@ type CensysRequestPhase = "validate" | "execute";
 type CensysQueryValue = string | undefined;
 
 export const censysApiBaseUrl = "https://api.platform.censys.io/v3";
-const censysDefaultRequestTimeoutMs = 30_000;
 
 export const censysActionHandlers: ProviderActionHandlers<"censys", CensysActionHandler> = {
   async get_host(input, context) {
@@ -107,7 +106,7 @@ async function requestCensysJson(
 ): Promise<Record<string, unknown>> {
   let response: Response;
   let payload: unknown;
-  const timeoutSignal = createProviderTimeout(signal, censysDefaultRequestTimeoutMs);
+  const timeoutSignal = createProviderTimeout(signal);
 
   try {
     response = await fetcher(buildCensysUrl(input), {

--- a/src/providers/central_station_crm/runtime.ts
+++ b/src/providers/central_station_crm/runtime.ts
@@ -16,7 +16,6 @@ const centralStationCrmHostSuffix = ".centralstationcrm.net";
 const centralStationCrmApiPath = "/api";
 const centralStationCrmValidationEndpoint = "/check_connection";
 const centralStationCrmUserEndpoint = "/user";
-const centralStationCrmDefaultRequestTimeoutMs = 30_000;
 
 type CentralStationCrmPhase = "validate" | "execute";
 type CentralStationCrmEntity = "person" | "company" | "deal";
@@ -408,7 +407,7 @@ async function deleteRecord(input: { input: CentralStationCrmActionInput; fetche
 }
 
 async function requestCentralStationCrmJson(input: CentralStationCrmRequestInput) {
-  const timeoutHandle = createProviderTimeout(input.signal, centralStationCrmDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildCentralStationCrmUrl(input.apiBaseUrl, input.path, input.query), {

--- a/src/providers/certn/runtime.ts
+++ b/src/providers/certn/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const certnValidationPath = "/api/public/cases/";
-const certnDefaultRequestTimeoutMs = 30_000;
 
 export const certnRegions = {
   ca: {
@@ -224,7 +223,7 @@ async function requestCertn(input: {
     url.searchParams.append(key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, certnDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     return await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/chargeblast/executors.ts
+++ b/src/providers/chargeblast/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "chargeblast";
 const chargeblastApiBaseUrl = "https://api.chargeblast.com";
-const defaultRequestTimeoutMs = 30_000;
 const maxNonJsonErrorMessageLength = 300;
 const chargeblastMaxResponseBytes = 10 * 1024 * 1024;
 
@@ -211,7 +210,7 @@ async function requestChargeblastJson(
   context: ApiKeyProviderContext,
   phase: ChargeblastPhase,
 ) {
-  const timeoutHandle = createProviderTimeout(context.signal, defaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(new URL(path, chargeblastApiBaseUrl), {

--- a/src/providers/chat_api_for_whatsapp/runtime.ts
+++ b/src/providers/chat_api_for_whatsapp/runtime.ts
@@ -24,8 +24,6 @@ import {
 
 export const chatApiForWhatsappApiOrigin = "https://api.chat-api.com";
 
-const chatApiForWhatsappRequestTimeoutMs = 30_000;
-
 type ChatApiForWhatsappPhase = "validate" | "execute";
 
 export interface ChatApiForWhatsappContext {
@@ -233,7 +231,7 @@ async function requestChatApiForWhatsapp(input: {
   query?: Record<string, unknown>;
   body?: Record<string, unknown>;
 }): Promise<ChatApiForWhatsappResponse> {
-  const timeout = createProviderTimeout(input.context.signal, chatApiForWhatsappRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = new URL(
     input.path.startsWith("/") ? input.path.slice(1) : input.path,
     resolveChatApiForWhatsappBaseUrl(input.context.instanceId),

--- a/src/providers/chatarmin/executors.ts
+++ b/src/providers/chatarmin/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "chatarmin";
 const chatarminApiBaseUrl = "https://api.chatarmin.com/api/public";
-const chatarminDefaultRequestTimeoutMs = 30_000;
 
 type ChatarminRequestPhase = "validate" | "execute";
 type ChatarminMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -277,7 +276,7 @@ async function chatarminRequestJson(
   context: ChatarminContext,
   phase: ChatarminRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, chatarminDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildChatarminUrl(input.path, input.query), {

--- a/src/providers/chorus/executors.ts
+++ b/src/providers/chorus/executors.ts
@@ -14,7 +14,6 @@ import {
 const service = "chorus";
 const chorusApiBaseUrl = "https://chorus.ai";
 const chorusValidationPath = "/api/v1/users/me";
-const chorusDefaultRequestTimeoutMs = 30_000;
 
 type ChorusPhase = "validate" | "execute";
 type ChorusAcceptHeader = "application/json" | "application/vnd.api+json";
@@ -160,7 +159,7 @@ async function requestChorusJson(input: {
   context: ChorusContext;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, chorusDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildChorusUrl(input.path, input.query), {

--- a/src/providers/cin7_core/executors.ts
+++ b/src/providers/cin7_core/executors.ts
@@ -27,7 +27,6 @@ const service = "cin7_core";
 const cin7CoreApiBaseUrl = "https://inventory.dearsystems.com/ExternalApi/v2/";
 const cin7CoreFetch = createProviderFetch({ skipDnsValidation: true });
 const cin7CoreValidationPath = "/me";
-const cin7CoreDefaultRequestTimeoutMs = 30_000;
 
 type Cin7CorePhase = "validate" | "execute";
 
@@ -257,7 +256,7 @@ async function requestCin7CoreJson(input: {
   phase: Cin7CorePhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, cin7CoreDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildCin7CoreUrl(input), {

--- a/src/providers/cisco_meraki/runtime.ts
+++ b/src/providers/cisco_meraki/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const ciscoMerakiApiBaseUrl = "https://api.meraki.com/api/v1";
 
-const ciscoMerakiRequestTimeoutMs = 30_000;
-
 type CiscoMerakiRequestPhase = "validate" | "execute";
 
 interface CiscoMerakiRequest {
@@ -171,7 +169,7 @@ async function requestCiscoMerakiResponse(
     url.searchParams.append(key, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, ciscoMerakiRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     return await context.fetcher(url, {
       headers: {

--- a/src/providers/clari_copilot/executors.ts
+++ b/src/providers/clari_copilot/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "clari_copilot";
 const clariCopilotApiBaseUrl = "https://rest-api.copilot.clari.com";
 const clariCopilotValidationPath = "/users";
-const clariCopilotRequestTimeoutMs = 30_000;
 
 type ClariCopilotPhase = "validate" | "execute";
 
@@ -138,7 +137,7 @@ async function requestClariCopilotJson(input: {
   context: ClariCopilotContext;
   phase: ClariCopilotPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, clariCopilotRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildClariCopilotUrl(input.path, input.query), {

--- a/src/providers/clickhouse/runtime.ts
+++ b/src/providers/clickhouse/runtime.ts
@@ -11,7 +11,6 @@ import {
   ProviderRequestError,
 } from "../provider-runtime.ts";
 
-const clickhouseDefaultRequestTimeoutMs = 30_000;
 const clickhouseDefaultDatabase = "default";
 const clickhouseValidationQuery = "SELECT currentDatabase() AS database, version() AS version";
 
@@ -358,7 +357,7 @@ async function ensureDatabaseExists(database: string, context: ClickhouseActionC
 }
 
 async function requestClickhouseJson(input: ClickhouseRequestInput): Promise<ClickhouseJsonPayload> {
-  const timeout = createProviderTimeout(input.context.signal, clickhouseDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = new URL(input.context.baseUrl);
   url.searchParams.set("default_format", "JSON");
   url.searchParams.set("database", input.database ?? input.context.defaultDatabase);

--- a/src/providers/clickmeeting/runtime.ts
+++ b/src/providers/clickmeeting/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const clickMeetingApiBaseUrl = "https://api.clickmeeting.com/v1";
 
-const clickMeetingDefaultRequestTimeoutMs = 30_000;
-
 type ClickMeetingPhase = "validate" | "execute";
 type ClickMeetingActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -352,7 +350,7 @@ async function requestClickMeetingJson(
   context: ClickMeetingRequestContext,
   phase: ClickMeetingPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, clickMeetingDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildClickMeetingUrl(input.path, input.query), {

--- a/src/providers/clicksend/runtime.ts
+++ b/src/providers/clicksend/runtime.ts
@@ -14,7 +14,6 @@ export const clicksendApiBaseUrl = "https://rest.clicksend.com/v3";
 
 const clicksendRequestBaseUrl = "https://rest.clicksend.com/v3/";
 const clicksendValidationPath = "/account";
-const clicksendDefaultTimeoutMs = 30_000;
 
 type ClicksendPhase = "validate" | "execute";
 type ClicksendActionHandler = (input: Record<string, unknown>, context: ClicksendActionContext) => Promise<unknown>;
@@ -202,7 +201,7 @@ async function requestClicksendJson(input: ClicksendRequestInput): Promise<Recor
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, clicksendDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/clinicalkey/runtime.ts
+++ b/src/providers/clinicalkey/runtime.ts
@@ -12,8 +12,6 @@ import {
 const clinicalKeyApiBaseUrl = "https://api.elsevier.com/sushi/r51";
 const clinicalKeyPlatformCode = "ck";
 
-const clinicalKeyRequestTimeoutMs = 30_000;
-
 type ClinicalKeyRequestPhase = "validate" | "execute";
 type ClinicalKeyCredentials = {
   apiKey: string;
@@ -143,7 +141,7 @@ async function requestClinicalKeyJson(input: {
   fetcher: typeof fetch;
   phase: ClinicalKeyRequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, clinicalKeyRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildClinicalKeyUrl(input.path, input.query, input.credentials), {

--- a/src/providers/close/runtime.ts
+++ b/src/providers/close/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const closeApiBaseUrl = "https://api.close.com/api/v1";
-export const closeDefaultRequestTimeoutMs = 30_000;
 
 type CloseActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 type CloseQueryValue = string | number | undefined;
@@ -387,7 +386,7 @@ async function closeRequest(
     url.searchParams.set(key, String(value));
   }
 
-  const timeout = createProviderTimeout(signal, closeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   let response: Response;
   try {
     response = await fetcher(url, {

--- a/src/providers/cochrane/runtime.ts
+++ b/src/providers/cochrane/runtime.ts
@@ -4,8 +4,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 const cochraneApiBaseUrl = "https://archie.cochrane.org";
 
-const requestTimeoutMs = 30_000;
-
 interface CochraneCredential {
   authMethod: "basic" | "bearer";
   username?: string;
@@ -141,7 +139,7 @@ async function requestCochraneJson(input: CochraneRequestInput) {
 }
 
 async function requestCochrane(input: CochraneRequestInput) {
-  const timeoutHandle = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   const headers = new Headers({
     accept: input.phase == "validate" ? "application/xml;charset=utf-8" : "application/json",
     "user-agent": providerUserAgent,

--- a/src/providers/cockroach_labs/runtime.ts
+++ b/src/providers/cockroach_labs/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 export const cockroachLabsApiBaseUrl = "https://cockroachlabs.cloud";
 const cockroachLabsApiVersion = "2024-09-16";
-const cockroachLabsDefaultRequestTimeoutMs = 30_000;
 
 interface CockroachLabsCredentialInput {
   apiKey: string;
@@ -204,7 +203,7 @@ async function requestCockroachLabsJson(input: {
   phase: CockroachLabsRequestPhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, cockroachLabsDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildCockroachLabsUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/codegen/executors.ts
+++ b/src/providers/codegen/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "codegen";
 const codegenApiBaseUrl = "https://api.codegen.com";
 const codegenValidationPath = "/v1/users/me";
-const codegenDefaultRequestTimeoutMs = 30_000;
 
 type CodegenPhase = "validate" | "execute";
 type CodegenActionContext = ApiKeyProviderContext & {
@@ -222,7 +221,7 @@ async function requestCodegenJson(input: {
   phase: CodegenPhase;
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, codegenDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(new URL(input.path, codegenApiBaseUrl), {

--- a/src/providers/coderpad/runtime.ts
+++ b/src/providers/coderpad/runtime.ts
@@ -3,7 +3,6 @@ import { jsonObject } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const coderpadApiBaseUrl = "https://app.coderpad.io";
-const coderpadRequestTimeoutMs = 30_000;
 
 type CoderpadRequestPhase = "validate" | "execute";
 
@@ -134,7 +133,7 @@ function buildPaginationQuery(input: Record<string, unknown>) {
 }
 
 async function requestCoderpadJson(input: CoderpadRequestInput): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(undefined, coderpadRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   const url = new URL(input.path, coderpadApiBaseUrl);
   for (const [name, value] of Object.entries(input.query ?? {})) {
     if (value != null) url.searchParams.set(name, String(value));

--- a/src/providers/coinmarketcal/executors.ts
+++ b/src/providers/coinmarketcal/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "coinmarketcal";
 const coinmarketcalApiBaseUrl = "https://developers.coinmarketcal.com/v1";
-const requestTimeoutMs = 30_000;
 
 type CoinmarketcalActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -98,7 +97,7 @@ async function requestCoinmarketcalJson(
   context: ApiKeyProviderContext,
   mode: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildCoinmarketcalUrl(path, query), {
       method: "GET",

--- a/src/providers/college_football_data/executors.ts
+++ b/src/providers/college_football_data/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "college_football_data";
 const collegeFootballDataApiBaseUrl = "https://api.collegefootballdata.com";
-const collegeFootballDataDefaultRequestTimeoutMs = 30_000;
 
 type CollegeFootballDataPhase = "validate" | "execute";
 type CollegeFootballDataContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -118,7 +117,7 @@ async function requestCollegeFootballDataJson(
   context: CollegeFootballDataContext,
   phase: CollegeFootballDataPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, collegeFootballDataDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildCollegeFootballDataUrl(path, query), {

--- a/src/providers/commpeak/executors.ts
+++ b/src/providers/commpeak/executors.ts
@@ -22,7 +22,6 @@ import {
 
 const service = "commpeak";
 const commpeakTextPeakBaseUrl = "https://gw.commpeak.com/textpeak";
-const commpeakRequestTimeoutMs = 30_000;
 const commpeakMaxResponseBytes = 10 * 1024 * 1024;
 
 type CommpeakActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -289,7 +288,7 @@ async function commpeakRequestJson(
   fetcher: typeof fetch,
   options: CommpeakRequestOptions = {},
 ) {
-  const timeout = createProviderTimeout(options.signal, commpeakRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   try {
     const response = await fetcher(url, { ...init, signal: timeout.signal });
     const payload = await readCommpeakPayload(response);

--- a/src/providers/companycam/executors.ts
+++ b/src/providers/companycam/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "companycam";
 const companycamApiBaseUrl = "https://api.companycam.com/v2";
 const companycamApiOrigin = "https://api.companycam.com";
-const companycamDefaultRequestTimeoutMs = 30_000;
 
 type CompanycamRequestPhase = "validate" | "execute";
 type CompanycamContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -228,7 +227,7 @@ async function requestCompanycamJson(input: CompanycamRequest): Promise<unknown>
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, companycamDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/concord/executors.ts
+++ b/src/providers/concord/executors.ts
@@ -24,7 +24,6 @@ import {
 
 const service = "concord";
 const concordApiBaseUrl = "https://api.concordnow.com/api/rest/1";
-const concordRequestTimeoutMs = 30_000;
 
 type ConcordPhase = "validate" | "execute";
 type ConcordActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -132,7 +131,7 @@ async function requestConcordJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ConcordPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, concordRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(`${concordApiBaseUrl}${path}`, {
       headers: {

--- a/src/providers/confluent/runtime.ts
+++ b/src/providers/confluent/runtime.ts
@@ -5,7 +5,6 @@ import { compactObject, optionalInteger, optionalRecord, optionalString, require
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const confluentApiBaseUrl = "https://api.confluent.cloud";
-const timeoutMs = 30_000;
 
 export interface ConfluentContext {
   apiKeyId: string;
@@ -158,7 +157,7 @@ export async function requestConfluentJson(context: ConfluentContext, input: Req
   const url = new URL(input.path, `${confluentApiBaseUrl}/`);
   for (const [key, value] of Object.entries(input.query ?? {}))
     if (value !== undefined) url.searchParams.set(key, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/consensus/executors.ts
+++ b/src/providers/consensus/executors.ts
@@ -60,7 +60,7 @@ async function search(
   for (const [name, value] of Object.entries(input)) {
     if (value != null) url.searchParams.set(name, Array.isArray(value) ? value.join(",") : String(value));
   }
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: { accept: "application/json", "user-agent": providerUserAgent, "x-api-key": context.apiKey },

--- a/src/providers/contentful_graphql/executors.ts
+++ b/src/providers/contentful_graphql/executors.ts
@@ -24,7 +24,6 @@ const contentfulGraphqlGlobalApiBaseUrl = "https://graphql.contentful.com";
 const contentfulGraphqlEuApiBaseUrl = "https://graphql.eu.contentful.com";
 const contentfulGraphqlDefaultEnvironmentId = "master";
 const contentfulGraphqlDefaultRegion = "global";
-const contentfulGraphqlDefaultTimeoutMs = 30_000;
 
 type ContentfulGraphqlRegion = "global" | "eu";
 type ContentfulGraphqlPhase = "validate" | "execute";
@@ -181,7 +180,7 @@ async function requestContentfulGraphql(input: {
   region: ContentfulGraphqlRegion;
   signal?: AbortSignal;
 }): Promise<ContentfulGraphqlResponse> {
-  const timeout = createProviderTimeout(input.signal, contentfulGraphqlDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/contentstack_content_delivery/runtime.ts
+++ b/src/providers/contentstack_content_delivery/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const contentstackContentDeliveryApiBaseUrl = "https://cdn.contentstack.io/v3";
 const contentstackContentDeliveryRequestBaseUrl = `${contentstackContentDeliveryApiBaseUrl}/`;
-const contentstackContentDeliveryDefaultTimeoutMs = 30_000;
 
 type ContentstackPhase = "validate" | "execute";
 
@@ -270,7 +269,7 @@ async function requestContentstackJson(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, contentstackContentDeliveryDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildContentstackUrl(input.path, input.query, input.arrayQuery), {
       method: "GET",

--- a/src/providers/contentstack_content_management/runtime.ts
+++ b/src/providers/contentstack_content_management/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const contentstackContentManagementApiBaseUrl = "https://api.contentstack.io/v3";
 const contentstackContentManagementRequestBaseUrl = `${contentstackContentManagementApiBaseUrl}/`;
-const contentstackContentManagementDefaultTimeoutMs = 30_000;
 
 type ContentstackPhase = "validate" | "execute";
 
@@ -273,7 +272,7 @@ async function requestContentstackJson(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, contentstackContentManagementDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildContentstackUrl(input.path, input.query), {
       method: input.method ?? "GET",

--- a/src/providers/context7/runtime.ts
+++ b/src/providers/context7/runtime.ts
@@ -16,8 +16,6 @@ import {
 export const context7ApiBaseUrl = "https://context7.com/api";
 export const context7ValidationEndpoint = "/v2/libs/search";
 
-const context7DefaultRequestTimeoutMs = 30_000;
-
 type Context7RequestPhase = "validate" | "execute";
 
 export async function validateContext7Credential(input: {
@@ -97,7 +95,7 @@ async function requestContext7Json(input: {
   setSearchParams(url, input.query);
 
   input.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.signal, context7DefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/control_d/executors.ts
+++ b/src/providers/control_d/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "control_d";
 const apiBaseUrl = "https://api.controld.com";
-const defaultRequestTimeoutMs = 30_000;
 
 type ControlDRequestPhase = "validate" | "execute";
 
@@ -247,7 +246,7 @@ async function requestControlD(input: {
 
   let response: Response;
   let payload: unknown;
-  const timeout = createProviderTimeout(input.context.signal, defaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     response = await input.context.fetcher(new URL(input.path, apiBaseUrl), {
       method: input.method ?? "GET",

--- a/src/providers/courier/runtime.ts
+++ b/src/providers/courier/runtime.ts
@@ -19,7 +19,6 @@ import {
 
 export const courierApiBaseUrl = "https://api.courier.com";
 
-const courierDefaultRequestTimeoutMs = 30_000;
 const courierValidationPath = "/lists";
 
 type CourierRequestPhase = "validate" | "execute";
@@ -268,7 +267,7 @@ export async function validateCourierCredential(
 }
 
 async function requestCourierJson(input: CourierRequestInput): Promise<CourierResponse> {
-  const timeout = createProviderTimeout(input.context.signal, courierDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/cratedb_cloud/executors.ts
+++ b/src/providers/cratedb_cloud/executors.ts
@@ -22,7 +22,6 @@ const service = "cratedb_cloud";
 const cratedbCloudApiBaseUrl = "https://console.cratedb.cloud";
 const cratedbCloudRequestBaseUrl = `${cratedbCloudApiBaseUrl}/`;
 const cratedbCloudValidationPath = "/api/v2/users/me/";
-const cratedbCloudDefaultTimeoutMs = 30_000;
 const cratedbCloudMaxResponseBytes = 10 * 1024 * 1024;
 
 type CratedbCloudRequestPhase = "validate" | "execute";
@@ -224,7 +223,7 @@ async function requestCratedbCloudJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, cratedbCloudDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/credit_repair_cloud/executors.ts
+++ b/src/providers/credit_repair_cloud/executors.ts
@@ -22,7 +22,6 @@ import {
 const service = "credit_repair_cloud";
 const creditRepairCloudApiBaseUrl = "https://app.creditrepaircloud.com/api";
 const validationRecordId = "MQ==";
-const creditRepairCloudRequestTimeoutMs = 30_000;
 const creditRepairCloudMaxResponseBytes = 10 * 1024 * 1024;
 
 interface CreditRepairCloudActionSpec {
@@ -207,7 +206,7 @@ async function requestCreditRepairCloud(context: CreditRepairCloudRequestContext
   const body = new URLSearchParams();
   body.set("xmlData", xmlData);
 
-  const timeout = createProviderTimeout(context.signal, creditRepairCloudRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "POST",

--- a/src/providers/cronitor/executors.ts
+++ b/src/providers/cronitor/executors.ts
@@ -28,7 +28,6 @@ import {
 const service = "cronitor";
 const cronitorApiBaseUrl = "https://cronitor.io/api";
 const cronitorApiVersion = "2025-11-28";
-const cronitorDefaultRequestTimeoutMs = 30_000;
 
 const cronitorFetch = createProviderFetch({ skipDnsValidation: true });
 
@@ -151,7 +150,7 @@ async function requestCronitorJson(input: {
   method?: CronitorMethod;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, cronitorDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildCronitorUrl(input.path), {
       method: input.method ?? "GET",

--- a/src/providers/cronly/runtime.ts
+++ b/src/providers/cronly/runtime.ts
@@ -118,7 +118,7 @@ interface CronlyRequestInput {
   body?: Record<string, unknown>;
 }
 async function requestCronlyJson(input: CronlyRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, 30_000);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const path = input.path.startsWith("/") ? input.path.slice(1) : input.path;
     const response = await input.context.fetcher(new URL(path, `${cronlyApiBaseUrl}/`), {

--- a/src/providers/crossref/runtime.ts
+++ b/src/providers/crossref/runtime.ts
@@ -1,6 +1,5 @@
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 const crossrefApiBaseUrl = "https://api.crossref.org/v1";
-const crossrefRequestTimeoutMs = 30_000;
 const crossrefMaxResponseBytes = 4 * 1024 * 1024;
 const crossrefCursorPrefix = "crossref_cursor_v1.";
 
@@ -281,7 +280,7 @@ async function requestCrossref(input: {
   apiKey?: string;
   phase?: "execute" | "validate";
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, crossrefRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const headers = new Headers({

--- a/src/providers/crunchbase/executors.ts
+++ b/src/providers/crunchbase/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "crunchbase";
 const crunchbaseApiBaseUrl = "https://api.crunchbase.com/v4";
-const crunchbaseRequestTimeoutMs = 30_000;
 
 type CrunchbasePhase = "validate" | "execute";
 type CrunchbaseActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -156,7 +155,7 @@ async function requestCrunchbaseJson(input: {
     appendQueryValue(url, key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, crunchbaseRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url.toString(), {
       method: input.method ?? "GET",

--- a/src/providers/customerio/runtime.ts
+++ b/src/providers/customerio/runtime.ts
@@ -22,8 +22,6 @@ import {
 export const customerioTrackApiBaseUrl = "https://track.customer.io";
 export const customerioTrackEuApiBaseUrl = "https://track-eu.customer.io";
 
-const customerioDefaultRequestTimeoutMs = 30_000;
-
 type CustomerioPhase = "validate" | "execute";
 
 export interface CustomerioCredentialContext {
@@ -184,7 +182,7 @@ async function customerioRequest(input: {
   phase: CustomerioPhase;
   parseResponse?: boolean;
 }): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(input.context.signal, customerioDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.context.signal);
   const headers: Record<string, string> = {
     accept: "application/json",
     authorization: buildCustomerioAuthorization(input.context.siteId, input.context.apiKey),

--- a/src/providers/daily/executors.ts
+++ b/src/providers/daily/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "daily";
 const dailyApiBaseUrl = "https://api.daily.co/v1";
-const requestTimeoutMs = 30_000;
 
 type DailyRequestPhase = "validate" | "execute";
 
@@ -188,7 +187,7 @@ async function dailyRequestObject(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/dart/runtime.ts
+++ b/src/providers/dart/runtime.ts
@@ -15,7 +15,6 @@ export const dartApiBaseUrl = "https://app.dartai.com/api/v0/public";
 
 type DartRequestPhase = "validate" | "execute";
 
-const dartDefaultRequestTimeoutMs = 30_000;
 const listTaskQueryKeys = [
   "title",
   "ids",
@@ -179,7 +178,7 @@ async function requestDart(input: {
   }
 
   input.context.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.context.signal, dartDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   init.signal = timeout.signal;
   try {
     const response = await input.context.fetcher(url, init);

--- a/src/providers/data247/runtime.ts
+++ b/src/providers/data247/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 const data247ApiBaseUrl = "https://api.data247.com/v3.0";
-const data247DefaultRequestTimeoutMs = 30_000;
 
 type Data247ApiCode = "B" | "CT" | "VP" | "DC" | "AG";
 type Data247Phase = "validate" | "execute";
@@ -150,7 +149,7 @@ async function requestData247Json(input: Data247RequestInput): Promise<unknown> 
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, data247DefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/databox/runtime.ts
+++ b/src/providers/databox/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 const databoxApiBaseUrl = "https://api.databox.com";
 const validateKeyPath = "/v1/auth/validate-key";
-const databoxDefaultRequestTimeoutMs = 30_000;
 
 type DataboxPhase = "validate" | "execute";
 type DataboxMethod = "GET" | "POST" | "DELETE";
@@ -122,7 +121,7 @@ async function databoxRequestJson(input: {
   phase: DataboxPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, databoxDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/datacite/runtime.ts
+++ b/src/providers/datacite/runtime.ts
@@ -1,5 +1,4 @@
 const dataciteApiBaseUrl = "https://api.datacite.org";
-const dataciteRequestTimeoutMs = 30_000;
 
 type DatacitePhase = "validate" | "execute";
 
@@ -95,7 +94,7 @@ function buildListParams(input: Record<string, unknown>): Record<string, string 
 }
 
 async function requestDataciteJson(input: DataciteRequestInput) {
-  const timeoutHandle = createProviderTimeout(undefined, dataciteRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   const url = new URL(input.path, `${dataciteApiBaseUrl}/`);
   for (const [name, value] of Object.entries(input.params)) {
     if (value !== undefined) {

--- a/src/providers/datascope/runtime.ts
+++ b/src/providers/datascope/runtime.ts
@@ -12,7 +12,6 @@ import {
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 const datascopeApiBaseUrl = "https://www.mydatascope.com/api/external/";
-const datascopeDefaultRequestTimeoutMs = 30_000;
 
 type DatascopeRequestPhase = "validate" | "execute";
 type DatascopeQueryValue = string | number | boolean | undefined;
@@ -241,7 +240,7 @@ async function requestDatascopeJson(input: {
     body = JSON.stringify(input.json);
   }
 
-  const timeoutHandle = createProviderTimeout(undefined, datascopeDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   let response: Response;
   try {

--- a/src/providers/daytona/executors.ts
+++ b/src/providers/daytona/executors.ts
@@ -11,7 +11,6 @@ import {
 
 const service = "daytona";
 const daytonaApiBaseUrl = "https://app.daytona.io/api";
-const requestTimeoutMs = 30_000;
 type RequestPhase = "validate" | "execute";
 
 export const executors: ProviderExecutors = defineApiKeyProviderExecutors(
@@ -129,7 +128,7 @@ async function requestDaytona(input: {
     if (Array.isArray(value)) value.forEach((item) => url.searchParams.append(name, String(item)));
     else url.searchParams.set(name, String(value));
   }
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/dealnews/executors.ts
+++ b/src/providers/dealnews/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "dealnews";
 const dealNewsBaseUrl = "https://www.dealnews.com";
-const dealNewsRequestTimeoutMs = 30_000;
 const rssParser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: "",
@@ -56,7 +55,7 @@ export const executors: ProviderExecutors = defineProviderExecutors<DealNewsCont
 });
 
 async function requestFeed(url: URL, context: DealNewsContext): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, dealNewsRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: {

--- a/src/providers/deepgram/runtime.ts
+++ b/src/providers/deepgram/runtime.ts
@@ -18,7 +18,6 @@ import {
 } from "../provider-runtime.ts";
 
 const deepgramApiBaseUrl = "https://api.deepgram.com/v1";
-const deepgramDefaultRequestTimeoutMs = 30_000;
 
 type DeepgramPhase = "validate" | "execute";
 type DeepgramActionHandler = (
@@ -166,7 +165,7 @@ async function requestDeepgramJson(input: {
   fetcher: typeof fetch;
   phase: DeepgramPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, deepgramDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildDeepgramUrl(input), {

--- a/src/providers/deepl/runtime.ts
+++ b/src/providers/deepl/runtime.ts
@@ -8,7 +8,6 @@ export const deeplApiFreeBaseUrl = "https://api-free.deepl.com";
 export const deeplTranslatePath = "/v2/translate";
 export const deeplLanguagesPath = "/v2/languages";
 export const deeplUsagePath = "/v2/usage";
-export const deeplDefaultRequestTimeoutMs = 30_000;
 
 type DeeplRequestMode = "validate" | "execute";
 type DeeplLanguageType = "source" | "target";
@@ -143,7 +142,7 @@ async function requestDeepl(apiKey: string, input: DeeplRequestInput, fetcher: t
     headers.set("content-type", "application/json");
   }
 
-  const timeout = createProviderTimeout(undefined, deeplDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
 
   let response: Response;
   try {

--- a/src/providers/delighted/runtime.ts
+++ b/src/providers/delighted/runtime.ts
@@ -21,7 +21,6 @@ import {
 
 export const delightedApiBaseUrl = "https://api.delighted.com/v1";
 const delightedValidationPath = "/metrics.json";
-const delightedDefaultRequestTimeoutMs = 30_000;
 
 type DelightedQueryValue = string | number | boolean | Array<string | number | boolean> | undefined;
 type DelightedActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -265,7 +264,7 @@ function requestContext(
 }
 
 async function requestDelightedJson(input: DelightedRequestOptions): Promise<DelightedResponse> {
-  const timeout = createProviderTimeout(input.signal, delightedDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const url = new URL(`${delightedApiBaseUrl}${input.path}`);
     appendQuery(url, input.query);

--- a/src/providers/demio/executors.ts
+++ b/src/providers/demio/executors.ts
@@ -19,7 +19,6 @@ import {
 
 const service = "demio";
 const demioApiBaseUrl = "https://my.demio.com/api/v1";
-const demioRequestTimeoutMs = 30_000;
 const demioMaxResponseBytes = 10 * 1024 * 1024;
 
 type DemioRequestPhase = "validate" | "execute";
@@ -173,7 +172,7 @@ async function requestDemioJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, demioRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/desktime/runtime.ts
+++ b/src/providers/desktime/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 const desktimeApiBaseUrl = "https://desktime.com/api/v2/json";
-const desktimeDefaultRequestTimeoutMs = 30_000;
 
 type DeskTimePhase = "validate" | "execute";
 type DeskTimeHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -142,7 +141,7 @@ async function requestDeskTimeJson(input: {
   context: ApiKeyProviderContext;
   phase: DeskTimePhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, desktimeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   try {
     response = await input.context.fetcher(buildDeskTimeUrl(input.path, input.apiKey, input.params), {

--- a/src/providers/detrack/executors.ts
+++ b/src/providers/detrack/executors.ts
@@ -18,7 +18,6 @@ import {
 } from "../provider-runtime.ts";
 
 const detrackApiBaseUrl = "https://app.detrack.com/api/v2";
-const detrackRequestTimeoutMs = 30_000;
 const detrackMaxResponseBytes = 10 * 1024 * 1024;
 
 type DetrackRequestPhase = "validate" | "execute";
@@ -393,7 +392,7 @@ async function detrackRequest(input: DetrackRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, detrackRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/dialmycalls/runtime.ts
+++ b/src/providers/dialmycalls/runtime.ts
@@ -26,8 +26,6 @@ interface ApiKeyProviderActionInput {
 
 export const dialMyCallsApiBaseUrl = "https://api.dialmycalls.com/2.0";
 
-const dialMyCallsDefaultRequestTimeoutMs = 30_000;
-
 type DialMyCallsPhase = "validate" | "execute";
 type DialMyCallsMethod = "GET" | "POST" | "PUT" | "DELETE";
 type DialMyCallsActionHandler = (
@@ -204,7 +202,7 @@ async function requestDialMyCallsJson(input: {
   body?: Record<string, unknown>;
   range?: string;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, dialMyCallsDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildDialMyCallsUrl(input.path), {

--- a/src/providers/dialpad_wfm/runtime.ts
+++ b/src/providers/dialpad_wfm/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 const dialpadWfmApiBaseUrl = "https://api.teamsurfboard.com/api/v1";
-const dialpadWfmRequestTimeoutMs = 30_000;
 const validationScheduleQuery = {
   start: "2024-06-25T00:00:00.000Z",
   end: "2024-06-25T00:01:00.000Z",
@@ -89,7 +88,7 @@ export async function validateDialpadWfmCredential(
 }
 
 async function requestDialpadWfmJson(input: DialpadWfmRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, dialpadWfmRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   try {
     response = await input.context.fetcher(buildDialpadWfmUrl(input), {

--- a/src/providers/diffy/runtime.ts
+++ b/src/providers/diffy/runtime.ts
@@ -4,7 +4,6 @@ import { optionalInteger, optionalRecord, optionalString } from "../../core/cast
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const diffyApiBaseUrl = "https://app.diffy.website/api/";
-const timeoutMs = 30_000;
 interface DiffyContext {
   apiKey: string;
   fetcher: typeof fetch;
@@ -89,7 +88,7 @@ async function requestDiffyJson(
   token?: string,
   init: RequestInit = {},
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const headers = new Headers(init.headers);
     headers.set("accept", "application/json");

--- a/src/providers/digistore24/executors.ts
+++ b/src/providers/digistore24/executors.ts
@@ -42,7 +42,6 @@ interface Digistore24RequestInput {
 }
 
 const digistore24ApiBaseUrl = "https://www.digistore24.com/api/call";
-const digistore24RequestTimeoutMs = 30_000;
 const digistore24MaxResponseBytes = 10 * 1024 * 1024;
 
 export const digistore24ActionHandlers: ProviderActionHandlers<"digistore24", Digistore24ActionHandler> = {
@@ -278,7 +277,7 @@ async function digistore24Request(
 ) {
   let response: Response;
   let payload: unknown;
-  const timeout = createProviderTimeout(signal, digistore24RequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
 
   try {
     response = await fetcher(buildDigistore24Url(input), {

--- a/src/providers/digital_ocean/executors.ts
+++ b/src/providers/digital_ocean/executors.ts
@@ -22,7 +22,6 @@ import {
 
 const service = "digital_ocean";
 const digitalOceanApiBaseUrl = "https://api.digitalocean.com/v2";
-const requestTimeoutMs = 30_000;
 
 interface DigitalOceanContext {
   apiKey: string;
@@ -251,7 +250,7 @@ async function digitalOceanFetch(input: {
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const headers = jsonObject({
       accept: "application/json",

--- a/src/providers/dingtalk_bot/executors.ts
+++ b/src/providers/dingtalk_bot/executors.ts
@@ -28,7 +28,6 @@ import {
 const service = "dingtalk_bot";
 const apiBaseUrl = "https://oapi.dingtalk.com";
 const webhookPath = "/robot/send";
-const requestTimeoutMs = 30_000;
 const validationProbePayload = { msgtype: "__validation_probe__" };
 const validationSuccessCodes = new Set([40035, 400105]);
 
@@ -220,7 +219,7 @@ async function requestDingtalkBot(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<DingtalkBotRequestResult> {
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildWebhookUrl(input.accessToken, input.signingSecret), {
       method: "POST",

--- a/src/providers/discolike/runtime.ts
+++ b/src/providers/discolike/runtime.ts
@@ -20,8 +20,6 @@ import {
 
 export const discolikeApiBaseUrl = "https://api.discolike.com/v1";
 
-const discolikeDefaultRequestTimeoutMs = 30_000;
-
 type DiscolikePhase = "validate" | "execute";
 type DiscolikeQueryValue = string | number | boolean | readonly string[] | undefined;
 type DiscolikeContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -163,7 +161,7 @@ async function requestDiscolikeJson(input: {
   context: DiscolikeContext;
   phase: DiscolikePhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, discolikeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildDiscolikeUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/dns_filter/executors.ts
+++ b/src/providers/dns_filter/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "dns_filter";
 const dnsFilterApiBaseUrl = "https://api.dnsfilter.com";
-const dnsFilterRequestTimeoutMs = 30_000;
 
 type DnsFilterRequestPhase = "validate" | "execute";
 type DnsFilterActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -221,7 +220,7 @@ async function dnsFilterFetch(input: {
     url.search = input.query.toString();
   }
 
-  const timeout = createProviderTimeout(input.signal, dnsFilterRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(url, {
       method: "GET",

--- a/src/providers/docsbot_ai/runtime.ts
+++ b/src/providers/docsbot_ai/runtime.ts
@@ -22,8 +22,6 @@ import {
 export const docsbotAiAdminBaseUrl = "https://docsbot.ai/api";
 export const docsbotAiApiBaseUrl = "https://api.docsbot.ai";
 
-const docsbotAiDefaultRequestTimeoutMs = 30_000;
-
 type DocsbotAiPhase = "validate" | "execute";
 type DocsbotAiContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type DocsbotAiActionHandler = (input: Record<string, unknown>, context: DocsbotAiContext) => Promise<unknown>;
@@ -159,7 +157,7 @@ async function requestDocsbotAiJson(input: {
   body?: Record<string, unknown>;
   phase: DocsbotAiPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, docsbotAiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       authorization: `Bearer ${input.context.apiKey}`,

--- a/src/providers/document360/executors.ts
+++ b/src/providers/document360/executors.ts
@@ -23,7 +23,6 @@ import {
 
 const service = "document360";
 const apiBaseUrl = "https://apihub.document360.io";
-const requestTimeoutMs = 30_000;
 
 interface Document360Context {
   apiKey: string;
@@ -155,7 +154,7 @@ async function requestJson(input: {
   phase: Phase;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/doppler_marketing_automation/runtime.ts
+++ b/src/providers/doppler_marketing_automation/runtime.ts
@@ -26,8 +26,6 @@ interface ApiKeyProviderActionInput {
 
 export const dopplerMarketingAutomationApiBaseUrl = "https://restapi.fromdoppler.com";
 
-const requestTimeoutMs = 30_000;
-
 type RequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | undefined;
 
@@ -236,7 +234,7 @@ export async function executeDopplerMarketingAutomationAction(
 }
 
 async function requestDopplerMarketingJson(input: DopplerMarketingRequest) {
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   const url = buildDopplerMarketingUrl(input.path, input.query);
   const method = input.method ?? "GET";
 

--- a/src/providers/dropcontact/runtime.ts
+++ b/src/providers/dropcontact/runtime.ts
@@ -7,7 +7,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 export const dropcontactApiBaseUrl = "https://api.dropcontact.com";
 
-const requestTimeoutMs = 30_000;
 const textContactFields = [
   "email",
   "first_name",
@@ -99,7 +98,7 @@ async function requestDropcontactJson(
     url.searchParams.set(name, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method,

--- a/src/providers/dynatrace/runtime.ts
+++ b/src/providers/dynatrace/runtime.ts
@@ -33,7 +33,6 @@ interface DynatraceRequestOptions {
   query?: Record<string, string | number | undefined>;
 }
 
-const dynatraceDefaultRequestTimeoutMs = 30_000;
 const dynatraceCredentialHelpUrl =
   "https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/access-tokens";
 const validationChecks: DynatraceValidationCheck[] = [
@@ -192,7 +191,7 @@ async function requestDynatraceJson(options: DynatraceRequestOptions): Promise<u
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(options.signal, dynatraceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   try {
     const response = await options.fetcher(url, {
       method: "GET",

--- a/src/providers/e2b/runtime.ts
+++ b/src/providers/e2b/runtime.ts
@@ -19,7 +19,6 @@ import {
 
 export const e2bApiBaseUrl = "https://api.e2b.app";
 
-const e2bDefaultRequestTimeoutMs = 30_000;
 const e2bValidationPath = "/v2/sandboxes";
 
 type E2bRequestPhase = "validate" | "execute";
@@ -176,7 +175,7 @@ async function requestE2bSandboxArray(input: E2bRequestOptions): Promise<Array<R
 }
 
 async function requestE2bJson(input: E2bRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, e2bDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildE2bUrl(input.path, input.query), {
       method: input.method ?? "GET",

--- a/src/providers/easypost/runtime.ts
+++ b/src/providers/easypost/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const easypostApiBaseUrl = "https://api.easypost.com/v2";
 
-const easypostDefaultRequestTimeoutMs = 30_000;
-
 type EasypostPhase = "validate" | "execute";
 type EasypostContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type EasypostActionHandler = (input: Record<string, unknown>, context: EasypostContext) => Promise<unknown>;
@@ -132,7 +130,7 @@ async function requestEasypost(request: EasypostRequest): Promise<unknown> {
     }
   }
 
-  const timeout = createProviderTimeout(request.context.signal, easypostDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(request.context.signal);
   try {
     const response = await request.context.fetcher(url.toString(), {
       method: request.method,

--- a/src/providers/emailable/runtime.ts
+++ b/src/providers/emailable/runtime.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const emailableApiBaseUrl = "https://api.emailable.com";
-const emailableDefaultRequestTimeoutMs = 30_000;
 
 type EmailableRequestPhase = "validate" | "execute";
 type EmailableActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -203,7 +202,7 @@ async function requestEmailableJson(
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, emailableDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const hasJsonBody = input.body !== undefined;
     const response = await input.fetcher(url, {

--- a/src/providers/emaillistverify/runtime.ts
+++ b/src/providers/emaillistverify/runtime.ts
@@ -15,7 +15,6 @@ import {
 
 const emailListVerifyApiBaseUrl = "https://apps.emaillistverify.com";
 const emailListVerifyApiKeyRejectedStatus = "error_credit";
-const emailListVerifyDefaultRequestTimeoutMs = 30_000;
 
 type EmailListVerifyRequestPhase = "validate" | "execute";
 type EmailListVerifyResponseType = "auto" | "binary";
@@ -327,7 +326,7 @@ async function requestEmailListVerifyApi(
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, emailListVerifyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/embase/runtime.ts
+++ b/src/providers/embase/runtime.ts
@@ -10,7 +10,6 @@ import {
 } from "../provider-runtime.ts";
 
 const embaseApiBaseUrl = "https://api.elsevier.com/content/embase";
-const embaseDefaultRequestTimeoutMs = 30_000;
 
 type EmbasePhase = "validate" | "execute";
 interface EmbaseCredentials {
@@ -113,7 +112,7 @@ async function requestEmbaseJson(input: {
   fetcher: typeof fetch;
   phase: EmbasePhase;
 }): Promise<EmbaseResponse> {
-  const timeoutHandle = createProviderTimeout(undefined, embaseDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildEmbaseUrl(input.path, input.params), {

--- a/src/providers/emelia/executors.ts
+++ b/src/providers/emelia/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "emelia";
 const emeliaApiBaseUrl = "https://api.emelia.io";
-const emeliaRequestTimeoutMs = 30_000;
 
 type EmeliaRequestPhase = "validate" | "execute";
 
@@ -136,7 +135,7 @@ async function requestEmeliaJson(
     url.searchParams.append(key, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, emeliaRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method,

--- a/src/providers/encodian/runtime.ts
+++ b/src/providers/encodian/runtime.ts
@@ -19,7 +19,6 @@ import {
 
 const encodianDefaultApiBaseUrl = "https://api.apps-encodian.com";
 const encodianCreateGuidPath = "/api/v1/Utility/CreateGuid";
-const encodianRequestTimeoutMs = 30_000;
 
 type EncodianPhase = "validate" | "execute";
 
@@ -197,7 +196,7 @@ async function requestEncodianJson(input: {
   phase: EncodianPhase;
 }): Promise<unknown> {
   const url = new URL(input.path, input.context.apiBaseUrl);
-  const timeout = createProviderTimeout(input.context.signal, encodianRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
 

--- a/src/providers/energy_performance_certificates/runtime.ts
+++ b/src/providers/energy_performance_certificates/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const energyPerformanceCertificatesApiBaseUrl = "https://api.get-energy-performance-data.communities.gov.uk";
-const requestTimeoutMs = 30_000;
 
 type EnergyPerformanceCertificatesPhase = "validate" | "execute";
 type SearchFamily = "domestic" | "non-domestic" | "display";
@@ -127,7 +126,7 @@ async function requestJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/envoy/runtime.ts
+++ b/src/providers/envoy/runtime.ts
@@ -23,8 +23,6 @@ import {
 
 export const envoyApiBaseUrl = "https://api.envoy.com";
 
-const envoyDefaultRequestTimeoutMs = 30_000;
-
 interface EnvoyRequestInput {
   path: string;
   apiKey: string;
@@ -242,7 +240,7 @@ async function requestEnvoy(input: EnvoyRequestInput): Promise<Record<string, un
   let response: Response;
   let rawBody: string;
   input.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.signal, envoyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/eodhd_apis/executors.ts
+++ b/src/providers/eodhd_apis/executors.ts
@@ -16,7 +16,6 @@ type EodhdApisActionHandler = (input: Record<string, unknown>, context: ApiKeyPr
 
 const service = "eodhd_apis";
 const eodhdApisApiBaseUrl = "https://eodhd.com/api";
-const eodhdApisDefaultRequestTimeoutMs = 30_000;
 
 const eodhdApisActionHandlers: ProviderActionHandlers<"eodhd_apis", EodhdApisActionHandler> = {
   search_instruments(input, context) {
@@ -236,7 +235,7 @@ async function eodhdApisGet(
   fetcher: typeof fetch,
   signal?: AbortSignal,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(signal, eodhdApisDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
 
   let response: Response;
   try {

--- a/src/providers/evenium/runtime.ts
+++ b/src/providers/evenium/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 const eveniumApiBaseUrl = "https://evenium.com";
 const eveniumValidationPath = "/api/1/events";
-const eveniumDefaultTimeoutMs = 30_000;
 
 type EveniumRequestMode = "validate" | "execute";
 type EveniumContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -172,7 +171,7 @@ async function requestEveniumObject(
 }
 
 async function requestEveniumJson(options: EveniumRequestOptions, context: EveniumContext): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, eveniumDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const url = new URL(options.path, eveniumApiBaseUrl);
     for (const [key, value] of Object.entries(options.query ?? {})) {

--- a/src/providers/everhour/runtime.ts
+++ b/src/providers/everhour/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const everhourApiBaseUrl = "https://api.everhour.com";
 const everhourValidationPath = "/users/me";
-const everhourDefaultRequestTimeoutMs = 30_000;
 
 type EverhourRequestPhase = "validate" | "execute";
 type EverhourMethod = "GET" | "POST" | "DELETE";
@@ -236,7 +235,7 @@ async function requestEverhourJson(input: EverhourRequestInput, context: Everhou
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, everhourDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url.toString(), {

--- a/src/providers/eversign/runtime.ts
+++ b/src/providers/eversign/runtime.ts
@@ -22,8 +22,6 @@ import {
 export const eversignApiBaseUrl = "https://api.eversign.com";
 export const eversignValidationPath = "/business";
 
-const eversignRequestTimeoutMs = 30_000;
-
 type EversignPhase = "validate" | "execute";
 
 interface EversignCredentialSummary {
@@ -254,7 +252,7 @@ async function requestEversignJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, eversignRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/evervault/runtime.ts
+++ b/src/providers/evervault/runtime.ts
@@ -75,7 +75,7 @@ async function request(
   context: EvervaultContext,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path, evervaultApiBaseUrl), {
       method: "POST",

--- a/src/providers/expofp/runtime.ts
+++ b/src/providers/expofp/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const expofpApiBaseUrl = "https://app.expofp.com/api/v1";
-const expofpDefaultRequestTimeoutMs = 30_000;
 
 type ExpofpPhase = "validate" | "execute";
 type ExpofpActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -141,7 +140,7 @@ async function requestExpofpJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ExpofpPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, expofpDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path.replace(/^\//, ""), `${expofpApiBaseUrl}/`), {
       method: "POST",

--- a/src/providers/fairing/executors.ts
+++ b/src/providers/fairing/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "fairing";
 const fairingApiBaseUrl = "https://app.fairing.co/api";
-const fairingRequestTimeoutMs = 30_000;
 
 type FairingPhase = "validate" | "execute";
 type FairingActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -100,7 +99,7 @@ async function requestFairingJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, fairingRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/feishu/shared/client.ts
+++ b/src/providers/feishu/shared/client.ts
@@ -58,7 +58,6 @@ interface FeishuEnvelope {
 }
 
 const feishuOpenBaseUrl = "https://open.feishu.cn/open-apis";
-const feishuRequestTimeoutMs = 30_000;
 const feishuRateLimitedErrorCodes = new Set([11232, 11233, 11247, 230020, 230047, 99991400, 1000004, 1000005]);
 const feishuCredentialExpiredErrorCodes = new Set([
   4001, 10005, 10012, 10013, 10014, 10015, 20002, 20005, 20013, 20014, 99991543, 99991661, 99991663, 99991664, 99991665,
@@ -71,7 +70,7 @@ export function createFeishuJsonRequest(input: CreateFeishuJsonRequestInput): Fe
     const url = new URL(`${feishuOpenBaseUrl}${request.path}`);
     appendQuery(url, request.query);
 
-    const timeout = createProviderTimeout(input.signal, feishuRequestTimeoutMs);
+    const timeout = createProviderTimeout(input.signal);
     try {
       const response = await input.fetcher(url, {
         method: request.method ?? "GET",
@@ -111,7 +110,7 @@ export function createFeishuJsonRequest(input: CreateFeishuJsonRequestInput): Fe
 }
 
 export async function requestFeishuMultipart(input: FeishuMultipartRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, feishuRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(`${feishuOpenBaseUrl}${input.path}`, {
       method: "POST",
@@ -154,7 +153,7 @@ export async function withFeishuRawResponse<T>(
 ): Promise<T> {
   const url = new URL(`${feishuOpenBaseUrl}${input.path}`);
   appendQuery(url, input.query);
-  const timeout = createProviderTimeout(input.signal, feishuRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       headers: {

--- a/src/providers/feishu/shared/media.ts
+++ b/src/providers/feishu/shared/media.ts
@@ -49,7 +49,6 @@ export async function readFeishuSourceBytes(
   return requireInMemoryFeishuSource(source).slice(start, end);
 }
 
-const requestTimeoutMs = 30_000;
 const defaultMaxBytes = 30 * 1024 * 1024;
 const maximumBufferedSourceBytes = 100 * 1024 * 1024;
 
@@ -106,7 +105,7 @@ export async function downloadFeishuSource(
   const canonicalUrl = input.sourceUrl;
   const guardedFetcher = createProviderFetch({ fetch: fetcher });
   const maxBytes = Math.min(input.maxBytes ?? defaultMaxBytes, maximumBufferedSourceBytes);
-  const timeout = createProviderTimeout(signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await guardedFetcher(canonicalUrl, {
       headers: { "user-agent": providerUserAgent },

--- a/src/providers/fiber_ai/runtime.ts
+++ b/src/providers/fiber_ai/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const fiberAiApiBaseUrl = "https://api.fiber.ai";
-const fiberAiRequestTimeoutMs = 30_000;
 const getOrgCreditsPath = "/v1/get-org-credits";
 const getRateLimitsPath = "/v1/rate-limits";
 
@@ -130,7 +129,7 @@ async function fiberAiGetJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, fiberAiRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/flagsmith/executors.ts
+++ b/src/providers/flagsmith/executors.ts
@@ -22,7 +22,6 @@ import {
 export const flagsmithApiBaseUrl = "https://edge.api.flagsmith.com/api/v1";
 const service = "flagsmith";
 const flagsmithValidationPath = "/flags/";
-const flagsmithDefaultRequestTimeoutMs = 30_000;
 
 type FlagsmithRequestPhase = "validate" | "execute";
 type FlagsmithActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -139,7 +138,7 @@ async function requestFlagsmithJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: FlagsmithRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, flagsmithDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers = new Headers({
       accept: "application/json",

--- a/src/providers/flexmail/executors.ts
+++ b/src/providers/flexmail/executors.ts
@@ -21,7 +21,6 @@ import {
 const service = "flexmail";
 const flexmailApiBaseUrl = "https://api.flexmail.eu";
 
-const flexmailDefaultRequestTimeoutMs = 30_000;
 const flexmailMaxResponseBytes = 10 * 1024 * 1024;
 const supportedLanguageSet = new Set([
   "nl",
@@ -423,7 +422,7 @@ async function flexmailRequest(input: FlexmailRequestInput) {
 }
 
 async function flexmailRawRequest(input: FlexmailRequestInput) {
-  const timeoutHandle = createProviderTimeout(input.context.signal, flexmailDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.context.signal);
   const headers: Record<string, string> = {
     accept: "application/hal+json, application/json",
     authorization: buildFlexmailAuthorization(input.context.accountId, input.context.personalAccessToken),

--- a/src/providers/fomo/runtime.ts
+++ b/src/providers/fomo/runtime.ts
@@ -11,7 +11,6 @@ import {
 
 const fomoApiBaseUrl = "https://api.fomo.com/api/v1";
 const fomoEventsPath = "/applications/me/events";
-const fomoRequestTimeoutMs = 30_000;
 
 type FomoRequestMode = "validate" | "execute";
 type FomoEventPayload = Record<string, unknown>;
@@ -156,7 +155,7 @@ async function requestFomoJson(
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, fomoRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await fetcher(url, {
       method: input.method,

--- a/src/providers/formaloo/executors.ts
+++ b/src/providers/formaloo/executors.ts
@@ -10,7 +10,6 @@ import {
 
 const service = "formaloo";
 const formalooApiBaseUrl = "https://api.formaloo.me/v3.0";
-const formalooRequestTimeoutMs = 30_000;
 interface FormalooCredentials {
   apiKey: string;
   apiSecret: string;
@@ -148,7 +147,7 @@ async function requestFormaloo(input: FormalooRequestInput): Promise<unknown> {
   const token = await obtainAuthorizationToken(input.credentials, input.fetcher, input.phase);
   const url = new URL(`${formalooApiBaseUrl}${input.path}`);
   appendQuery(url, input.query);
-  const timeout = createProviderTimeout(undefined, formalooRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",
@@ -178,7 +177,7 @@ async function obtainAuthorizationToken(
   fetcher: typeof fetch,
   phase: "validate" | "execute",
 ) {
-  const timeout = createProviderTimeout(undefined, formalooRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await fetcher(`${formalooApiBaseUrl}/oauth2/authorization-token/`, {
       method: "POST",

--- a/src/providers/formstack/runtime.ts
+++ b/src/providers/formstack/runtime.ts
@@ -5,7 +5,6 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const formstackApiBaseUrl = "https://www.formstack.com/api/v2025";
-const requestTimeoutMs = 30_000;
 
 export type FormstackRequestPhase = "validate" | "execute" | "trigger";
 
@@ -228,7 +227,7 @@ async function requestFormstack(options: {
   for (const [key, value] of Object.entries(options.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await options.fetcher(url, {
       method: options.method,

--- a/src/providers/freepik/executors.ts
+++ b/src/providers/freepik/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "freepik";
 const freepikApiBaseUrl = "https://api.magnific.com";
 const freepikResourcesPath = "/v1/resources";
-const freepikRequestTimeoutMs = 30_000;
 
 type FreepikPhase = "validate" | "execute";
 type FreepikActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -174,7 +173,7 @@ async function requestFreepikJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, freepikRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/freshsales/runtime.ts
+++ b/src/providers/freshsales/runtime.ts
@@ -11,7 +11,6 @@ import {
 
 const freshsalesValidationPath = "/api/contacts/filters";
 const freshsalesDefaultPageSize = 25;
-const freshsalesDefaultRequestTimeoutMs = 30_000;
 
 type FreshsalesRequestPhase = "validate" | "execute";
 type FreshsalesMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -185,7 +184,7 @@ export function resolveFreshsalesBaseUrl(values: Record<string, string>, metadat
 }
 
 async function requestFreshsalesJson(input: FreshsalesRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, freshsalesDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildFreshsalesUrl(input), {
       method: input.method,

--- a/src/providers/freshstatus/runtime.ts
+++ b/src/providers/freshstatus/runtime.ts
@@ -9,7 +9,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const freshstatusApiBaseUrl = "https://public-api.freshstatus.io/api/v1/";
-const requestTimeoutMs = 30_000;
 
 interface FreshstatusCredential {
   apiKey: string;
@@ -208,7 +207,7 @@ function mapDisplayOptions(value: unknown, mapping: Record<string, string>): Rec
 }
 
 async function requestFreshstatus(input: FreshstatusRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(new URL(input.path, freshstatusApiBaseUrl), {
       method: input.method ?? "GET",

--- a/src/providers/full_contact/executors.ts
+++ b/src/providers/full_contact/executors.ts
@@ -27,7 +27,6 @@ import {
 
 const fullContactApiBaseUrl = "https://api.fullcontact.com/v3";
 
-const fullContactDefaultRequestTimeoutMs = 30_000;
 const fullContactMaxResponseBytes = 10 * 1024 * 1024;
 
 type FullContactMode = "validate" | "execute";
@@ -185,7 +184,7 @@ async function requestFullContactJson(
   },
   context: FullContactRequestContext,
 ) {
-  const timeoutHandle = createProviderTimeout(context.signal, fullContactDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(new URL(input.endpoint, `${fullContactApiBaseUrl}/`), {

--- a/src/providers/fullenrich/executors.ts
+++ b/src/providers/fullenrich/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "fullenrich";
 const fullenrichApiBaseUrl = "https://app.fullenrich.com/api/v2";
-const fullenrichRequestTimeoutMs = 30_000;
 
 type FullenrichPhase = "validate" | "execute";
 type FullenrichActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -145,7 +144,7 @@ function validateCompanyLookupInput(input: Record<string, unknown>): void {
 }
 
 async function requestFullenrichJson(options: FullenrichRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.context.signal, fullenrichRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/gagelist/executors.ts
+++ b/src/providers/gagelist/executors.ts
@@ -27,7 +27,6 @@ const service = "gagelist";
 const gagelistApiBaseUrl = "https://gagelist.net/GageList/api";
 const gagelistTokenUrl = "https://gagelist.net/api/token";
 
-const gagelistRequestTimeoutMs = 30_000;
 const gagelistMaxResponseBytes = 10 * 1024 * 1024;
 const gagelistFetch = createProviderFetch({ skipDnsValidation: true });
 
@@ -488,7 +487,7 @@ async function fetchGagelistResponse(input: {
   readonly operation: string;
   readonly signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(input.signal, gagelistRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(input.url, { ...input.init, signal: timeout.signal });
   } catch (error) {

--- a/src/providers/gainsight_nxt/executors.ts
+++ b/src/providers/gainsight_nxt/executors.ts
@@ -20,7 +20,6 @@ import {
   requireApiKeyCredential,
 } from "../provider-runtime.ts";
 
-const gainsightNxtRequestTimeoutMs = 30_000;
 const gainsightNxtMaxResponseBytes = 10 * 1024 * 1024;
 const companyPath = "/v1/data/objects/Company";
 const companyQueryPath = "/v1/data/objects/query/Company";
@@ -158,7 +157,7 @@ async function requestGainsightJson(input: {
   signal?: AbortSignal;
   url?: URL;
 }) {
-  const timeout = createProviderTimeout(input.signal, gainsightNxtRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = input.url ?? buildGainsightUrl(input.baseUrl, input.path ?? "");
 
   try {

--- a/src/providers/gatherup/runtime.ts
+++ b/src/providers/gatherup/runtime.ts
@@ -21,8 +21,6 @@ export const gatherupApiBaseUrl = "https://app.gatherup.com/api/v2";
 export const gatherupCredentialHelpUrl =
   "https://help.gatherup.com/s/article/GatherUp-API-Client-ID-Private-Key-and-Bearer-Token";
 
-const gatherupDefaultRequestTimeoutMs = 30_000;
-
 type GatherupRequestPhase = "validate" | "execute";
 type GatherupQueryValue = string | number | boolean | undefined;
 interface GatherupRequestInput {
@@ -115,7 +113,7 @@ export async function validateGatherupCredential(
 }
 
 async function requestGatherupJson(input: GatherupRequestInput) {
-  const timeout = createProviderTimeout(input.signal, gatherupDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildGatherupUrl(input), {

--- a/src/providers/genpage/runtime.ts
+++ b/src/providers/genpage/runtime.ts
@@ -83,7 +83,7 @@ async function request(input: RequestInput): Promise<unknown> {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, Array.isArray(value) ? value.join(",") : String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal, 30_000);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/getresponse/runtime.ts
+++ b/src/providers/getresponse/runtime.ts
@@ -14,7 +14,6 @@ export const getresponseMaxApiBaseUrls = [
   "https://api3.getresponse360.pl/v3",
 ] as const;
 
-const getresponseRequestTimeoutMs = 30_000;
 const getresponseCredentialHelpUrl = "https://app.getresponse.com/api";
 
 type GetresponseRequestPhase = "validate" | "execute";
@@ -330,7 +329,7 @@ async function requestGetresponseJson(input: {
   query?: Record<string, GetresponseQueryValue>;
   body?: Record<string, unknown>;
 }): Promise<GetresponseRequestResult> {
-  const timeout = createProviderTimeout(undefined, getresponseRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   const url = buildGetresponseUrl(input.connection.apiBaseUrl, input.path, input.query);
   const method = input.method ?? "GET";
   const headers = new Headers({

--- a/src/providers/gift_up/runtime.ts
+++ b/src/providers/gift_up/runtime.ts
@@ -20,7 +20,6 @@ import {
 
 export const giftUpApiBaseUrl = "https://api.giftup.app";
 
-const giftUpDefaultRequestTimeoutMs = 30_000;
 const giftUpValidationEndpoint = "/company";
 
 type GiftUpRequestPhase = "validate" | "execute";
@@ -370,7 +369,7 @@ async function requestGiftUpJson(input: {
   query?: Record<string, GiftUpQueryValue>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, giftUpDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildGiftUpUrl(input.path, input.query), {

--- a/src/providers/gosquared/executors.ts
+++ b/src/providers/gosquared/executors.ts
@@ -23,7 +23,6 @@ import {
 
 const service = "gosquared";
 const gosquaredApiBaseUrl = "https://api.gosquared.com";
-const gosquaredDefaultRequestTimeoutMs = 30_000;
 const gosquaredTokenInfoPath = "/auth/v1/tokeninfo";
 
 interface GosquaredActionContext {
@@ -180,7 +179,7 @@ async function requestGosquaredReport(
 }
 
 async function requestGosquaredJson(options: GosquaredRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.signal, gosquaredDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
 
   try {
     const response = await options.fetcher(buildGosquaredUrl(options), {

--- a/src/providers/govee/executors.ts
+++ b/src/providers/govee/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "govee";
 const goveeApiBaseUrl = "https://openapi.api.govee.com";
-const goveeRequestTimeoutMs = 30_000;
 
 type GoveeRequestPhase = "validate" | "execute";
 
@@ -172,7 +171,7 @@ function buildDevicePayload(input: Record<string, unknown>): Record<string, unkn
 }
 
 async function requestGovee(input: GoveeRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, goveeRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/gptzero/executors.ts
+++ b/src/providers/gptzero/executors.ts
@@ -29,7 +29,6 @@ import {
 const service = "gptzero";
 const gptzeroApiBaseUrl = "https://api.gptzero.me";
 const gptzeroPredictTextPath = "/v2/predict/text";
-const gptzeroDefaultRequestTimeoutMs = 30_000;
 const gptzeroValidationDocument = "This is a GPTZero API key validation request.";
 
 type GptzeroRequestPhase = "validate" | "execute";
@@ -92,7 +91,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestGptzeroJson(input: GptzeroJsonRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, gptzeroDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(new URL(gptzeroPredictTextPath, gptzeroApiBaseUrl), {
       method: "POST",

--- a/src/providers/grafana/runtime.ts
+++ b/src/providers/grafana/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const defaultNamespace = "default";
-const grafanaDefaultRequestTimeoutMs = 30_000;
 const folderParentAnnotation = "grafana.app/folder";
 const grafanaDefaultApiVersion = "v1";
 const grafanaApiVersionCacheMaxEntries = 256;
@@ -414,7 +413,7 @@ async function grafanaRequestJson(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, grafanaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: request.method,

--- a/src/providers/grafana_cloud/runtime.ts
+++ b/src/providers/grafana_cloud/runtime.ts
@@ -138,7 +138,7 @@ async function requestGrafanaCloud(
   url: URL,
   phase: GrafanaCloudRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/granola/runtime.ts
+++ b/src/providers/granola/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const granolaApiBaseUrl = "https://public-api.granola.ai";
 
-const granolaRequestTimeoutMs = 30_000;
-
 type GranolaActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 type GranolaRequestMode = "validate" | "execute";
 
@@ -114,7 +112,7 @@ async function requestGranola(
   url: URL,
   mode: GranolaRequestMode,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, granolaRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url.toString(), {

--- a/src/providers/gtmetrix/runtime.ts
+++ b/src/providers/gtmetrix/runtime.ts
@@ -23,7 +23,6 @@ import {
 
 const gtmetrixApiBaseUrl = "https://gtmetrix.com/api/2.0";
 const gtmetrixJsonMediaType = "application/vnd.api+json";
-const gtmetrixDefaultRequestTimeoutMs = 30_000;
 
 type GtmetrixRequestPhase = "validate" | "execute";
 type GtmetrixQueryValue = string | number | boolean | readonly string[] | readonly number[] | undefined;
@@ -347,7 +346,7 @@ async function requestGtmetrixJson(input: GtmetrixRequestInput): Promise<{
 }
 
 async function fetchGtmetrix(input: GtmetrixRequestInput): Promise<Response> {
-  const timeout = createProviderTimeout(input.signal, gtmetrixDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(normalizePath(input.path), `${gtmetrixApiBaseUrl}/`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value === undefined) continue;

--- a/src/providers/happy_scribe/runtime.ts
+++ b/src/providers/happy_scribe/runtime.ts
@@ -17,7 +17,6 @@ interface ApiKeyProviderActionInput {
 }
 
 const happyScribeApiBaseUrl = "https://www.happyscribe.com/api/v1";
-const requestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 type ActionHandler = (input: Record<string, unknown>, fetcher: typeof fetch, apiKey: string) => Promise<unknown>;
@@ -236,7 +235,7 @@ async function requestHappyScribe(input: {
   fetcher: typeof fetch;
   phase: RequestPhase;
 }) {
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(buildUrl(input.path, input.params), {
       method: input.method,

--- a/src/providers/heartbeat/executors.ts
+++ b/src/providers/heartbeat/executors.ts
@@ -16,7 +16,6 @@ import {
 
 const service = "heartbeat";
 const apiBaseUrl = "https://api.heartbeat.chat/v0";
-const requestTimeoutMs = 30_000;
 const credentialHelpUrl = "https://help.heartbeat.chat/hc/en-us/articles/33257714954001-Heartbeat-API";
 
 type HeartbeatRequestPhase = "validate" | "execute";
@@ -158,7 +157,7 @@ async function requestHeartbeatJson(input: {
       url.searchParams.set(name, value);
     }
   }
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(url, {

--- a/src/providers/helpdesk/runtime.ts
+++ b/src/providers/helpdesk/runtime.ts
@@ -25,7 +25,6 @@ interface ApiKeyProviderActionInput {
 }
 
 export const helpdeskApiBaseUrl = "https://api.helpdesk.com";
-const helpdeskRequestTimeoutMs = 30_000;
 const helpdeskValidationEndpoint = "/v1/licenses";
 
 type HelpdeskRequestPhase = "validate" | "execute";
@@ -368,7 +367,7 @@ async function requestHelpdesk(input: {
   query?: URLSearchParams;
   body?: Record<string, unknown>;
 }) {
-  const timeout = createProviderTimeout(undefined, helpdeskRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   const url = new URL(input.path, helpdeskApiBaseUrl);
   if (input.query) {
     url.search = input.query.toString();

--- a/src/providers/helpscout/runtime.ts
+++ b/src/providers/helpscout/runtime.ts
@@ -1,8 +1,6 @@
 import { compactObject, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
-const helpscoutRequestTimeoutMs = 30_000;
-
 interface HelpscoutActionContext {
   accessToken: string;
   fetcher: typeof fetch;
@@ -402,7 +400,7 @@ async function requestHelpscout(options: HelpscoutRequestOptions) {
     headers.set("content-type", "application/json");
   }
 
-  const timeoutHandle = createProviderTimeout(undefined, helpscoutRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   try {
     const response = await options.fetcher(url, {
       method: options.method ?? "GET",

--- a/src/providers/heyreach/runtime.ts
+++ b/src/providers/heyreach/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 const heyreachApiBaseUrl = "https://api.heyreach.io/api/public";
-const heyreachDefaultRequestTimeoutMs = 30_000;
 
 type HeyreachPhase = "validate" | "execute";
 
@@ -209,7 +208,7 @@ export async function validateHeyreachCredential(
 }
 
 async function requestHeyreachJson(input: HeyreachRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, heyreachDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildHeyreachUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/higgsfield_ai/runtime.ts
+++ b/src/providers/higgsfield_ai/runtime.ts
@@ -17,7 +17,6 @@ const higgsfieldAiValidationPath = `/requests/${higgsfieldAiValidationRequestId}
 const higgsfieldAiValidationNotFoundStatus = "request_not_found";
 const higgsfieldAiDefaultImageModelId = "higgsfield-ai/soul/standard";
 const higgsfieldAiDefaultVideoModelId = "higgsfield-ai/dop/standard";
-const higgsfieldAiRequestTimeoutMs = 30_000;
 
 type HiggsfieldAiRequestPhase = "validate" | "execute";
 
@@ -150,7 +149,7 @@ async function requestHiggsfieldAiJson(input: HiggsfieldAiRequestInput): Promise
 }
 
 async function requestHiggsfieldAiResponse(input: HiggsfieldAiRequestInput): Promise<Response> {
-  const timeout = createProviderTimeout(input.context.signal, higgsfieldAiRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     return await input.context.fetcher(buildHiggsfieldAiUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/high_level/runtime.ts
+++ b/src/providers/high_level/runtime.ts
@@ -15,7 +15,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 const highLevelApiBaseUrl = "https://services.leadconnectorhq.com";
 const highLevelApiVersion = "2021-07-28";
-const highLevelDefaultRequestTimeoutMs = 30_000;
 
 type HighLevelRequestPhase = "validate" | "execute";
 
@@ -151,7 +150,7 @@ export function readHighLevelLocationId(value: unknown): string {
 }
 
 async function requestHighLevelJson(input: HighLevelRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, highLevelDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildHighLevelUrl(input.path), {
       method: input.method,

--- a/src/providers/highergov/runtime.ts
+++ b/src/providers/highergov/runtime.ts
@@ -15,8 +15,6 @@ export const highergovApiBaseUrl = "https://www.highergov.com/api-external/";
 
 type HighergovRequestPhase = "validate" | "execute";
 
-const highergovDefaultRequestTimeoutMs = 30_000;
-
 export const highergovActionHandlers: ProviderActionHandlers<
   "highergov",
   ProviderRuntimeHandler<ApiKeyProviderContext>
@@ -71,7 +69,7 @@ async function requestHighergovList(
   let response: Response;
   let payload: unknown;
   context.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(context.signal, highergovDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/hithink_finance/runtime.ts
+++ b/src/providers/hithink_finance/runtime.ts
@@ -67,7 +67,6 @@ interface HithinkFinanceProxyInput {
 }
 export const hithinkFinanceProxyMaxResponseBytes: number = 4 * 1024 * 1024;
 const hithinkFinanceActionMaxResponseBytes = 16 * 1024 * 1024;
-const hithinkFinanceRequestTimeoutMs = 30_000;
 
 export const hithinkFinanceApiBaseUrl = "https://fuyao.aicubes.cn";
 
@@ -610,7 +609,7 @@ async function hithinkFinanceGet(
     url.searchParams.set(key, String(value));
   }
 
-  const timeout = createProviderTimeout(signal, hithinkFinanceRequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   let response: Response;
   try {
     const upstreamResponse = await fetcher(url, {

--- a/src/providers/holded/runtime.ts
+++ b/src/providers/holded/runtime.ts
@@ -10,7 +10,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const holdedApiBaseUrl = "https://api.holded.com/api/v2";
-const holdedDefaultRequestTimeoutMs = 30_000;
 
 type HoldedPhase = "validate" | "execute";
 type HoldedActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -156,7 +155,7 @@ export async function validateHoldedCredential(
 }
 
 async function requestHoldedJson(input: HoldedRequestInput): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(input.context.signal, holdedDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildHoldedUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/home_assistant/runtime.ts
+++ b/src/providers/home_assistant/runtime.ts
@@ -19,8 +19,6 @@ import {
   providerUserAgent,
 } from "../provider-runtime.ts";
 
-const homeAssistantRequestTimeoutMs = 30_000;
-
 export interface HomeAssistantActionContext {
   apiKey: string;
   baseUrl: string;
@@ -276,7 +274,7 @@ export async function requestHomeAssistantText(input: HomeAssistantRequest): Pro
 }
 
 async function requestHomeAssistant(input: HomeAssistantRequest): Promise<Response> {
-  const timeout = createProviderTimeout(input.context.signal, homeAssistantRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildHomeAssistantUrl(input), {
       method: input.method,

--- a/src/providers/honeybadger/runtime.ts
+++ b/src/providers/honeybadger/runtime.ts
@@ -7,7 +7,6 @@ import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "
 export const defaultHoneybadgerApiBaseUrl = "https://api.honeybadger.io";
 export const honeybadgerValidationPath = "/v1/notices";
 
-const honeybadgerRequestTimeoutMs = 30_000;
 const allowedHoneybadgerApiHosts = new Set(["api.honeybadger.io", "eu-api.honeybadger.io"]);
 
 export interface HoneybadgerActionContext extends ApiKeyProviderContext {
@@ -261,7 +260,7 @@ async function requestHoneybadger(input: {
   contentType?: string | null;
   acceptedStatuses?: number[];
 }): Promise<HoneybadgerResponse> {
-  const timeout = createProviderTimeout(input.signal, honeybadgerRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const headers = new Headers();
   headers.set("accept", "application/json");
   headers.set("user-agent", providerUserAgent);

--- a/src/providers/honeycomb/runtime.ts
+++ b/src/providers/honeycomb/runtime.ts
@@ -13,7 +13,6 @@ import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "
 
 export const defaultHoneycombApiBaseUrl = "https://api.honeycomb.io";
 
-const honeycombRequestTimeoutMs = 30_000;
 const allowedHoneycombApiOrigins = new Set([defaultHoneycombApiBaseUrl, "https://api.eu1.honeycomb.io"]);
 
 export interface HoneycombActionContext extends ApiKeyProviderContext {
@@ -211,7 +210,7 @@ async function requestHoneycombJson(input: {
   signal?: AbortSignal;
   phase: HoneycombRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, honeycombRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const headers = new Headers();
   headers.set("accept", "application/json");
   headers.set("user-agent", providerUserAgent);

--- a/src/providers/hookdeck/runtime.ts
+++ b/src/providers/hookdeck/runtime.ts
@@ -9,8 +9,6 @@ export const hookdeckApiVersion = "2025-07-01";
 export const hookdeckApiPrefix: string = `/${hookdeckApiVersion}`;
 export const hookdeckValidationPath = "/sources";
 
-const hookdeckRequestTimeoutMs = 30_000;
-
 type HookdeckActionContext = ApiKeyProviderContext;
 type HookdeckActionHandler = (input: Record<string, unknown>, context: HookdeckActionContext) => Promise<unknown>;
 
@@ -180,7 +178,7 @@ async function hookdeckRequestJson(
   body?: Record<string, unknown>,
   query?: Record<string, unknown>,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, hookdeckRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(buildHookdeckUrl(path, query), {

--- a/src/providers/hoop/runtime.ts
+++ b/src/providers/hoop/runtime.ts
@@ -12,8 +12,6 @@ import {
 export const hoopApiBaseUrl = "https://use.hoop.dev/api";
 export const hoopValidationPath = "/userinfo";
 
-const hoopRequestTimeoutMs = 30_000;
-
 type HoopRequestPhase = "validate" | "execute";
 type HoopActionContext = ApiKeyProviderContext;
 type HoopActionHandler = (input: Record<string, unknown>, context: HoopActionContext) => Promise<unknown>;
@@ -132,7 +130,7 @@ export async function validateHoopCredential(
 }
 
 async function requestHoopJson(input: HoopRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, hoopRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(buildHoopUrl(input.path, input.query), {

--- a/src/providers/hotjar/executors.ts
+++ b/src/providers/hotjar/executors.ts
@@ -25,7 +25,6 @@ import {
 
 const hotjarApiBaseUrl = "https://api.hotjar.io";
 const hotjarTokenUrl = `${hotjarApiBaseUrl}/v1/oauth/token`;
-const hotjarRequestTimeoutMs = 30_000;
 const hotjarMaxResponseBytes = 10 * 1024 * 1024;
 const hotjarFetch = createProviderFetch({ skipDnsValidation: true });
 
@@ -287,7 +286,7 @@ async function fetchHotjarResponse(input: {
   operation: string;
   signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(input.signal, hotjarRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(input.url, { ...input.init, signal: timeout.signal });
   } catch (error) {

--- a/src/providers/hub_planner/executors.ts
+++ b/src/providers/hub_planner/executors.ts
@@ -16,7 +16,6 @@ import {
 const service = "hub_planner";
 const hubPlannerApiBaseUrl = "https://api.hubplanner.com/v1";
 const hubPlannerValidationPath = "/project";
-const hubPlannerRequestTimeoutMs = 30_000;
 const hubPlannerMaxResponseBytes = 10 * 1024 * 1024;
 
 type HubPlannerPhase = "validate" | "execute";
@@ -207,7 +206,7 @@ async function requestHubPlannerJson<T>(input: {
   signal?: AbortSignal;
 }): Promise<T> {
   const url = buildHubPlannerUrl(input.path, input.query);
-  const timeout = createProviderTimeout(input.signal, hubPlannerRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/huggingface/runtime.shared.ts
+++ b/src/providers/huggingface/runtime.shared.ts
@@ -22,8 +22,6 @@ export const huggingfaceChatCompletionsUrl = "https://router.huggingface.co/v1/c
 export const huggingfaceInferenceBaseUrl = "https://router.huggingface.co/hf-inference/models";
 export const huggingfaceDefaultEmbeddingModel = "sentence-transformers/all-MiniLM-L6-v2";
 
-const huggingfaceDefaultRequestTimeoutMs = 30_000;
-
 export interface HuggingfaceActionContext extends BearerProviderContext {
   authType: "oauth2" | "api_key";
 }
@@ -138,7 +136,7 @@ export async function huggingfaceRequestJson<T>(input: HuggingfaceRequestJsonInp
     ),
   );
 
-  const timeout = createProviderTimeout(input.signal, huggingfaceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url.toString(), {

--- a/src/providers/imagekit/runtime.ts
+++ b/src/providers/imagekit/runtime.ts
@@ -7,8 +7,6 @@ import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "
 
 export const imagekitApiBaseUrl = "https://api.imagekit.io";
 
-const imagekitRequestTimeoutMs = 30_000;
-
 type ImagekitRequestPhase = "validate" | "execute";
 
 interface ImagekitActionContext {
@@ -227,7 +225,7 @@ async function imagekitGetJson(input: Omit<ImagekitRequestInput, "method" | "bod
 }
 
 async function imagekitRequest(input: ImagekitRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, imagekitRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(buildImagekitUrl(input.path, input.query), {

--- a/src/providers/incident_io/executors.ts
+++ b/src/providers/incident_io/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "incident_io";
 const incidentIoApiBaseUrl = "https://api.incident.io";
-const requestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 type IncidentIoActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -190,7 +189,7 @@ function buildListIncidentsQuery(input: Record<string, unknown>): Record<string,
 }
 
 async function requestJson(input: IncidentIoRequestInput, context: IncidentIoActionContext): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/influxdb_cloud/runtime.ts
+++ b/src/providers/influxdb_cloud/runtime.ts
@@ -18,8 +18,6 @@ type InfluxdbCloudActionHandler = (
   context: InfluxdbCloudActionContext,
 ) => Promise<unknown>;
 
-const influxdbCloudDefaultRequestTimeoutMs = 30_000;
-
 export interface InfluxdbCloudActionContext {
   apiKey: string;
   apiBaseUrl: string;
@@ -195,7 +193,7 @@ async function requestInfluxdbCloud(input: {
   let response: Response;
   let payload: unknown;
   input.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.signal, influxdbCloudDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/insites/runtime.ts
+++ b/src/providers/insites/runtime.ts
@@ -11,7 +11,6 @@ export interface InsitesCredentialCheck {
 }
 
 export const insitesApiBaseUrl = "https://api.insites.com/api/v1";
-const insitesDefaultRequestTimeoutMs = 30_000;
 
 type InsitesRequestPhase = "validate" | "execute";
 
@@ -164,7 +163,7 @@ async function requestInsites(input: {
     init.body = JSON.stringify(input.body);
   }
 
-  const timeout = createProviderTimeout(undefined, insitesDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   init.signal = timeout.signal;
   try {
     const response = await input.fetcher(url, init);

--- a/src/providers/instabot/runtime.ts
+++ b/src/providers/instabot/runtime.ts
@@ -25,7 +25,6 @@ interface ApiKeyProviderActionInput {
 }
 
 const instabotApiBaseUrl = "https://api.instabot.io/v1";
-const instabotDefaultRequestTimeoutMs = 30_000;
 
 type InstabotPhase = "validate" | "execute";
 type InstabotCredential = {
@@ -197,7 +196,7 @@ async function listUsers(
 }
 
 async function requestInstabotJson(input: InstabotRequestInput) {
-  const timeoutHandle = createProviderTimeout(undefined, instabotDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   try {
     const url = new URL(input.path.replace(/^\//, ""), `${instabotApiBaseUrl}/`);
     for (const [key, value] of Object.entries(input.query ?? {})) {

--- a/src/providers/intercom/runtime.ts
+++ b/src/providers/intercom/runtime.ts
@@ -13,7 +13,6 @@ import { intercomGrantedPermissions } from "./scopes.ts";
 const intercomDefaultApiBaseUrl = "https://api.intercom.io";
 const intercomApiVersion = "2.13";
 const intercomJobsApiVersion = "2.15";
-const intercomRequestTimeoutMs = 30_000;
 
 const intercomRegionBaseUrlByCode: Record<string, string> = {
   US: "https://api.intercom.io",
@@ -556,7 +555,7 @@ async function intercomRequestJson<T>(input: IntercomJsonRequestInput): Promise<
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, intercomRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const headers = new Headers({
       accept: "application/json",

--- a/src/providers/interzoid/executors.ts
+++ b/src/providers/interzoid/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "interzoid";
 const interzoidApiBaseUrl = "https://api.interzoid.com";
-const interzoidDefaultRequestTimeoutMs = 30_000;
 
 type InterzoidPhase = "validate" | "execute";
 type InterzoidContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -190,7 +189,7 @@ async function requestInterzoidJson(
   input: InterzoidRequestInput,
   context: InterzoidContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, interzoidDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildInterzoidUrl(input, context.apiKey), {

--- a/src/providers/intuiface/executors.ts
+++ b/src/providers/intuiface/executors.ts
@@ -14,7 +14,6 @@ import {
 const service = "intuiface";
 const intuifaceApiOrigin = "https://api.intuiface.com";
 const intuifaceWebTriggersBaseUrl = `${intuifaceApiOrigin}/webtriggers/v1`;
-const intuifaceDefaultRequestTimeoutMs = 30_000;
 
 interface IntuifaceRequestInput {
   method: "GET" | "POST";
@@ -103,7 +102,7 @@ async function requestIntuifaceJson(
   context: ApiKeyProviderContext,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, intuifaceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   const url = new URL(`${intuifaceWebTriggersBaseUrl}${input.path}`);
   appendQuery(url, input.query);
 

--- a/src/providers/invoice_ninja/runtime.ts
+++ b/src/providers/invoice_ninja/runtime.ts
@@ -232,7 +232,7 @@ async function requestJson(input: {
   notFound?: boolean;
   signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(input.signal, 30_000);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(`${input.apiBaseUrl}${input.path}`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));

--- a/src/providers/ipgeolocation_io/executors.ts
+++ b/src/providers/ipgeolocation_io/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "ipgeolocation_io";
 const ipgeolocationIoApiBaseUrl = "https://api.ipgeolocation.io";
-const ipgeolocationIoDefaultRequestTimeoutMs = 30_000;
 
 type IpgeolocationIoPhase = "validate" | "execute";
 type IpgeolocationIoActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -124,7 +123,7 @@ async function requestIpgeolocationIoJson(
   },
   context: IpgeolocationIoActionContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, ipgeolocationIoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildIpgeolocationIoUrl(input.path, context.apiKey, input.params), {
       method: "GET",

--- a/src/providers/jazzhr/runtime.ts
+++ b/src/providers/jazzhr/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 const jazzhrApiBaseUrl = "https://api.resumatorapi.com/v1";
-const jazzhrDefaultRequestTimeoutMs = 30_000;
 
 type JazzhrRequestPhase = "validate" | "execute";
 
@@ -206,7 +205,7 @@ async function requestJazzhrJson(input: {
   signal?: AbortSignal;
   phase: JazzhrRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, jazzhrDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildJazzhrUrl(input.apiKey, input.path, input.query), {
       method: "GET",

--- a/src/providers/jigsawstack/runtime.ts
+++ b/src/providers/jigsawstack/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const jigsawstackApiBaseUrl = "https://api.jigsawstack.com";
-const jigsawstackDefaultRequestTimeoutMs = 30_000;
 const jigsawstackValidationPath = "/v1/web/search/suggest";
 const jigsawstackValidationQuery = "oomol";
 
@@ -160,7 +159,7 @@ async function requestJigsawstackJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   request: JigsawstackRequest,
 ): Promise<Record<string, unknown>> {
-  const timeoutHandle = createProviderTimeout(context.signal, jigsawstackDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildJigsawstackUrl(request.path, request.query), {

--- a/src/providers/jina_ai/executors.ts
+++ b/src/providers/jina_ai/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "jina_ai";
 const apiBaseUrl = "https://api.jina.ai";
-const requestTimeoutMs = 30_000;
 
 type JinaAiActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -75,7 +74,7 @@ async function jinaPost(
   path: string,
   mode: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(`${apiBaseUrl}${path}`, {
       method: "POST",

--- a/src/providers/jotform/executors.ts
+++ b/src/providers/jotform/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "jotform";
 const jotformApiBaseUrl = "https://api.jotform.com";
-const jotformRequestTimeoutMs = 30_000;
 
 type JotformRequestPhase = "validate" | "execute";
 type JotformQueryValue = string | number | undefined;
@@ -263,7 +262,7 @@ async function requestJotformEnvelope(input: JotformRequestInput): Promise<Jotfo
     headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
   }
 
-  const timeout = createProviderTimeout(input.signal, jotformRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/jumpseller/runtime.ts
+++ b/src/providers/jumpseller/runtime.ts
@@ -21,8 +21,6 @@ import {
 
 export const jumpsellerApiBaseUrl = "https://api.jumpseller.com/v1/";
 
-const jumpsellerDefaultTimeoutMs = 30_000;
-
 type JumpsellerRequestPhase = "validate" | "execute";
 type JumpsellerResourceKey = "store" | "product" | "order" | "customer" | "category";
 
@@ -365,7 +363,7 @@ async function requestJumpsellerJson(input: JumpsellerRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, jumpsellerDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/juniper_mist/runtime.ts
+++ b/src/providers/juniper_mist/runtime.ts
@@ -26,7 +26,6 @@ const juniperMistAllowedApiOrigins = [
   "https://api.gc5.mist.com",
   "https://api.gc7.mist.com",
 ];
-const juniperMistDefaultRequestTimeoutMs = 30_000;
 
 type JuniperMistPhase = "validate" | "execute";
 type JuniperMistQueryValue = string | number | undefined;
@@ -173,7 +172,7 @@ async function requestJuniperMistJson(input: {
   signal?: AbortSignal;
   phase: JuniperMistPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, juniperMistDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildJuniperMistUrl(input), {

--- a/src/providers/kadoa/runtime.ts
+++ b/src/providers/kadoa/runtime.ts
@@ -12,8 +12,6 @@ export interface KadoaCredentialCheck {
 
 export const kadoaApiBaseUrl = "https://api.kadoa.com";
 
-const kadoaRequestTimeoutMs = 30_000;
-
 type KadoaRequestPhase = "validate" | "execute";
 
 export async function validateKadoaCredential(apiKey: string, fetcher: typeof fetch): Promise<KadoaCredentialCheck> {
@@ -142,7 +140,7 @@ async function requestKadoaObject(input: {
   fetcher: typeof fetch;
   phase: KadoaRequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, kadoaRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildKadoaUrl(input.path, input.query), {

--- a/src/providers/kandji/runtime.ts
+++ b/src/providers/kandji/runtime.ts
@@ -10,8 +10,6 @@ import {
   providerUserAgent,
 } from "../provider-runtime.ts";
 
-const kandjiDefaultRequestTimeoutMs = 30_000;
-
 type KandjiPhase = "validate" | "execute";
 type KandjiActionHandler = (input: Record<string, unknown>, context: KandjiActionContext) => Promise<unknown>;
 
@@ -181,7 +179,7 @@ async function requestKandjiJson(input: {
   phase: KandjiPhase;
   notFoundAsInvalidInput?: boolean;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, kandjiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildKandjiUrl(input.apiUrl, input.path, input.query), {

--- a/src/providers/keeper_scim/runtime.ts
+++ b/src/providers/keeper_scim/runtime.ts
@@ -21,7 +21,6 @@ const keeperScimRegionBaseUrls = {
 
 const defaultKeeperScimRegion = "us";
 const keeperScimConfigPath = "/ServiceProviderConfig";
-const keeperScimRequestTimeoutMs = 30_000;
 
 type KeeperScimRegion = keyof typeof keeperScimRegionBaseUrls;
 type KeeperScimRequestPhase = "validate" | "execute";
@@ -166,7 +165,7 @@ async function requestKeeperScimJson(input: {
 }): Promise<unknown> {
   let response: Response;
   let payload: unknown;
-  const timeout = createProviderTimeout(input.context.signal, keeperScimRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const url = new URL(`${input.context.config.nodeBaseUrl}${input.path}`);
     for (const [key, value] of input.searchParams ?? []) {

--- a/src/providers/keyword/runtime.ts
+++ b/src/providers/keyword/runtime.ts
@@ -12,7 +12,6 @@ import {
 export const keywordApiBaseUrl = "https://app.keyword.com";
 
 const keywordApiPathPrefix = "/api/v2";
-const keywordDefaultRequestTimeoutMs = 30_000;
 
 type KeywordRequestPhase = "validate" | "execute";
 
@@ -107,7 +106,7 @@ async function requestKeywordJson(
     query?: Record<string, string | undefined>;
   },
 ) {
-  const timeout = createProviderTimeout(context.signal, keywordDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildKeywordUrl(request.path, request.query), {

--- a/src/providers/kintone/runtime.ts
+++ b/src/providers/kintone/runtime.ts
@@ -23,7 +23,6 @@ type KintonePhase = "validate" | "execute";
 type KintoneQueryValue = string | number | readonly (string | number)[];
 type KintoneActionHandler = ProviderRuntimeHandler<KintoneActionContext>;
 
-const kintoneRequestTimeoutMs = 30_000;
 const kintoneCredentialHelpUrl =
   "https://kintone.dev/en/docs/common/user-api/overview/user-api-overview/#api-token-authentication";
 
@@ -171,7 +170,7 @@ async function requestKintoneJson(input: {
   query?: Record<string, KintoneQueryValue | undefined>;
   phase: KintonePhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, kintoneRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildKintoneUrl(input.context.apiBaseUrl, input.path, input.query), {
       method: "GET",

--- a/src/providers/kit/runtime.ts
+++ b/src/providers/kit/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const kitApiBaseUrl = "https://api.kit.com/v4";
-const kitDefaultRequestTimeoutMs = 30_000;
 
 type KitPhase = "validate" | "execute";
 type KitMethod = "GET" | "POST" | "PUT";
@@ -220,7 +219,7 @@ async function requestKitJson(input: {
   phase: KitPhase;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, kitDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/klazify/executors.ts
+++ b/src/providers/klazify/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "klazify";
 const klazifyApiBaseUrl = "https://www.klazify.com/api";
-const klazifyDefaultRequestTimeoutMs = 30_000;
 
 type KlazifyPhase = "validate" | "execute";
 type KlazifyActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -243,7 +242,7 @@ async function requestKlazifyJson(input: {
   signal?: AbortSignal;
   phase: KlazifyPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, klazifyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildKlazifyUrl(input.path), {

--- a/src/providers/klicktipp/executors.ts
+++ b/src/providers/klicktipp/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "klicktipp";
 const klicktippApiBaseUrl = "https://api.klicktipp.com";
 const klicktippDocsUrl = "https://developers.klicktipp.com/guides/listbuilding-api";
-const klicktippRequestTimeoutMs = 30_000;
 
 type KlicktippActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type KlicktippActionHandler = (input: Record<string, unknown>, context: KlicktippActionContext) => Promise<unknown>;
@@ -87,7 +86,7 @@ async function requestKlicktippJson(
   body: Record<string, unknown>,
   context: KlicktippActionContext,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, klicktippRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/klipfolio/runtime.ts
+++ b/src/providers/klipfolio/runtime.ts
@@ -10,7 +10,6 @@ import {
 } from "../provider-runtime.ts";
 
 const klipfolioApiBaseUrl = "https://api.klipfolio.com/api/1.0";
-const klipfolioDefaultRequestTimeoutMs = 30_000;
 
 type KlipfolioPhase = "validate" | "execute";
 type KlipfolioAssetKey = "clients" | "dashboards" | "klips" | "datasources";
@@ -135,7 +134,7 @@ async function requestKlipfolioJson(input: {
   signal?: AbortSignal;
   phase: KlipfolioPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, klipfolioDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildKlipfolioUrl(input.path, input.params ?? {}), {

--- a/src/providers/knock/runtime.ts
+++ b/src/providers/knock/runtime.ts
@@ -14,8 +14,6 @@ import {
 
 export const knockApiBaseUrl = "https://api.knock.app/v1";
 
-const requestTimeoutMs = 30_000;
-
 type KnockRequestMode = "validate" | "execute";
 type KnockActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -155,7 +153,7 @@ async function requestKnockJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   mode: KnockRequestMode,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const headers = knockHeaders(context.apiKey);

--- a/src/providers/knowbe4/executors.ts
+++ b/src/providers/knowbe4/executors.ts
@@ -19,7 +19,6 @@ import {
 const service = "knowbe4";
 const knowbe4ReportingValidationPath = "/v1/account";
 const knowbe4DefaultRegion = "us";
-const knowbe4DefaultRequestTimeoutMs = 30_000;
 
 const knowbe4RegionBaseUrls = {
   us: "https://us.api.knowbe4.com",
@@ -204,7 +203,7 @@ async function requestKnowbe4JsonWithResponse(
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, knowbe4DefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/kobotoolbox/runtime.ts
+++ b/src/providers/kobotoolbox/runtime.ts
@@ -289,7 +289,7 @@ export async function requestKoboToolboxJson(input: {
   notFound?: boolean;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, 30_000);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(input.path, `${normalizeKoboToolboxBaseUrl(input.baseUrl)}/`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));

--- a/src/providers/komari/runtime.ts
+++ b/src/providers/komari/runtime.ts
@@ -29,7 +29,6 @@ export interface KomariActionContext {
   signal?: AbortSignal;
 }
 
-const defaultRequestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 const rpcPath = "api/rpc2";
 const rpcErrorStatusByCode = new Map<number, number>([
@@ -321,7 +320,7 @@ async function requestKomariRpc(
   phase: KomariRequestPhase,
 ): Promise<unknown> {
   const url = new URL(rpcPath, `${context.baseUrl}/`);
-  const timeout = createProviderTimeout(context.signal, defaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "POST",

--- a/src/providers/kommo/runtime.ts
+++ b/src/providers/kommo/runtime.ts
@@ -21,7 +21,6 @@ const kommoCredentialHelpUrl = "https://developers.kommo.com/docs/long-lived-tok
 const kommoPrivateIntegrationHelpUrl = "https://developers.kommo.com/docs/private-integration";
 const kommoHostSuffix = ".kommo.com";
 const kommoValidationEndpoint = "/api/v4/account";
-const kommoDefaultRequestTimeoutMs = 30_000;
 
 type KommoPhase = "validate" | "execute";
 type KommoCollection = "leads" | "contacts" | "companies" | "tasks" | "users" | "pipelines";
@@ -291,7 +290,7 @@ async function getRecord<TRecord extends Record<string, unknown>>(input: {
 }
 
 async function requestKommoJson(input: KommoRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, kommoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildKommoUrl(input.apiBaseUrl, input.path, input.query), {

--- a/src/providers/krispcall/runtime.ts
+++ b/src/providers/krispcall/runtime.ts
@@ -25,8 +25,6 @@ import {
 export const krispcallApiBaseUrl = "https://api.krispcall.com";
 export const krispcallTokenUrl = "https://app-login.krispcall.com/api/login/oauth/access_token";
 
-const krispcallRequestTimeoutMs = 30_000;
-
 export interface KrispCallCredential {
   readonly clientId: string;
   readonly clientSecret: string;
@@ -320,7 +318,7 @@ async function fetchKrispCallResponse(input: {
   readonly init: RequestInit;
   readonly operation: string;
 }) {
-  const timeout = createProviderTimeout(input.init.signal ?? undefined, krispcallRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.init.signal ?? undefined);
   try {
     return await input.fetcher(input.url, { ...input.init, signal: timeout.signal });
   } catch (error) {

--- a/src/providers/kustomer/executors.ts
+++ b/src/providers/kustomer/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "kustomer";
 const kustomerApiBaseUrl = "https://api.kustomerapp.com/v1";
-const kustomerDefaultRequestTimeoutMs = 30_000;
 
 type KustomerActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
 type KustomerActionHandler = (input: Record<string, unknown>, context: KustomerActionContext) => Promise<unknown>;
@@ -127,7 +126,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestKustomerJson(input: KustomerRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, kustomerDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const headers: Record<string, string> = {
     accept: "application/json",
     authorization: `Bearer ${input.apiKey}`,

--- a/src/providers/la_growth_machine/executors.ts
+++ b/src/providers/la_growth_machine/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "la_growth_machine";
 const laGrowthMachineApiBaseUrl = "https://apiv2.lagrowthmachine.com/flow";
-const laGrowthMachineRequestTimeoutMs = 30_000;
 
 type JsonObject = Record<string, unknown>;
 type LaGrowthMachineContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -171,7 +170,7 @@ async function requestLaGrowthMachine(request: {
     appendQueryValue(url, key, value);
   }
 
-  const timeout = createProviderTimeout(request.context.signal, laGrowthMachineRequestTimeoutMs);
+  const timeout = createProviderTimeout(request.context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/label_studio/executors.ts
+++ b/src/providers/label_studio/executors.ts
@@ -31,7 +31,6 @@ import {
 
 const service = "label_studio";
 const labelStudioValidationPath = "/api/current-user/whoami";
-const labelStudioDefaultRequestTimeoutMs = 30_000;
 
 type LabelStudioPhase = "validate" | "execute";
 type LabelStudioMethod = "GET" | "POST";
@@ -272,7 +271,7 @@ async function requestLabelStudioJson(input: {
   body?: unknown;
   notFoundAsInvalidInput?: boolean;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, labelStudioDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildLabelStudioUrl(input.baseUrl, input.path, input.query), {

--- a/src/providers/laposta/runtime.ts
+++ b/src/providers/laposta/runtime.ts
@@ -18,8 +18,6 @@ type LapostaActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
 export const lapostaApiBaseUrl = "https://api.laposta.nl";
 
-const lapostaDefaultRequestTimeoutMs = 30_000;
-
 export const lapostaActionHandlers: ProviderActionHandlers<"laposta", LapostaActionHandler> = {
   list_lists(_input, context) {
     return listResources("list", context);
@@ -220,7 +218,7 @@ async function requestLapostaJson(
   }
 
   input.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.signal, lapostaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/leadboxer/runtime.ts
+++ b/src/providers/leadboxer/runtime.ts
@@ -31,7 +31,6 @@ type LeadboxerActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof
 export const leadboxerApiBaseUrl = "https://api.leadboxer.com";
 
 const leadboxerValidationEndpoint = "/v1/management/credits";
-const leadboxerRequestTimeoutMs = 30_000;
 
 const leadboxerActionHandlers: ProviderActionHandlers<"leadboxer", LeadboxerActionHandler> = {
   lookup_ip(input, fetcher) {
@@ -96,7 +95,7 @@ export async function requestLeadboxerJson(input: {
   fetcher: typeof fetch;
   phase: LeadboxerRequestPhase;
 }): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(undefined, leadboxerRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildLeadboxerUrl(input.path, input.query), {

--- a/src/providers/leadmagic/executors.ts
+++ b/src/providers/leadmagic/executors.ts
@@ -28,7 +28,6 @@ import {
 
 const service = "leadmagic";
 const leadmagicApiBaseUrl = "https://api.leadmagic.io/v1";
-const leadmagicDefaultRequestTimeoutMs = 30_000;
 
 type LeadmagicMode = "validate" | "execute";
 type LeadmagicActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -184,7 +183,7 @@ async function requestLeadmagicJson(
   input: LeadmagicRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, leadmagicDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(buildLeadmagicUrl(input.path), {

--- a/src/providers/leexi/executors.ts
+++ b/src/providers/leexi/executors.ts
@@ -37,7 +37,6 @@ const service = "leexi";
 const leexiApiBaseUrl = "https://public-api.leexi.ai/v1";
 const leexiRequestBaseUrl = "https://public-api.leexi.ai/v1/";
 const leexiValidationPath = "/users";
-const leexiDefaultTimeoutMs = 30_000;
 const leexiFetch = createProviderFetch({ skipDnsValidation: true });
 
 type LeexiRequestPhase = "validate" | "execute";
@@ -296,7 +295,7 @@ async function requestLeexiJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, leexiDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   try {
     response = await input.context.fetcher(url, {

--- a/src/providers/leiga/executors.ts
+++ b/src/providers/leiga/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "leiga";
 const leigaApiBaseUrl = "https://app.leiga.com/openapi/api";
-const leigaDefaultRequestTimeoutMs = 30_000;
 
 type LeigaPhase = "validate" | "execute";
 type LeigaActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -177,7 +176,7 @@ async function validateLeigaCredential(context: ApiKeyProviderContext): Promise<
 async function requestLeigaJson(
   input: LeigaRequestInput & { context: ApiKeyProviderContext },
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, leigaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildLeigaUrl(input.path, input.query ?? {}), {

--- a/src/providers/lemlist/executors.ts
+++ b/src/providers/lemlist/executors.ts
@@ -27,7 +27,6 @@ import {
 const service = "lemlist";
 const lemlistApiBaseUrl = "https://api.lemlist.com/api";
 const lemlistValidationPath = "/team";
-const lemlistDefaultRequestTimeoutMs = 30_000;
 const lemlistFetch = createProviderFetch({ skipDnsValidation: true });
 
 type LemlistRequestPhase = "validate" | "execute";
@@ -181,7 +180,7 @@ async function requestLemlistJson(input: {
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(input.context.signal, lemlistDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   let response: Response;
   let payload: unknown;

--- a/src/providers/lemon_squeezy/runtime.ts
+++ b/src/providers/lemon_squeezy/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const lemonSqueezyApiBaseUrl = "https://api.lemonsqueezy.com/v1";
 const lemonSqueezyValidationPath = "/users/me";
-const lemonSqueezyDefaultRequestTimeoutMs = 30_000;
 
 type LemonSqueezyRequestPhase = "validate" | "execute";
 type LemonSqueezyActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -384,7 +383,7 @@ async function requestLemonSqueezy(input: LemonSqueezyRequestInput): Promise<Res
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(input.context.signal, lemonSqueezyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     return await input.context.fetcher(url, {

--- a/src/providers/lessonspace/executors.ts
+++ b/src/providers/lessonspace/executors.ts
@@ -21,7 +21,6 @@ import {
 const service = "lessonspace";
 const lessonspaceApiBaseUrl = "https://api.thelessonspace.com/v2";
 const lessonspaceValidationPath = "/hello/";
-const lessonspaceDefaultRequestTimeoutMs = 30_000;
 
 type LessonspacePhase = "validate" | "execute";
 type LessonspaceActionHandler = (input: Record<string, unknown>, context: LessonspaceContext) => Promise<unknown>;
@@ -247,7 +246,7 @@ function buildLaunchBody(input: Record<string, unknown>): Record<string, unknown
 async function lessonspaceRequestJson(
   input: LessonspaceRequestInput & { context: LessonspaceContext },
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, lessonspaceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/lever/executors.ts
+++ b/src/providers/lever/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "lever";
 const leverApiBaseUrl = "https://api.lever.co/v1";
-const leverDefaultRequestTimeoutMs = 30_000;
 
 type LeverPhase = "validate" | "execute";
 type LeverActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -180,7 +179,7 @@ async function requestLeverJson(input: {
   body?: Record<string, unknown>;
   phase: LeverPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, leverDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const url = new URL(`${leverApiBaseUrl}/${input.path}`);

--- a/src/providers/lexoffice/runtime.ts
+++ b/src/providers/lexoffice/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 const lexofficeApiBaseUrl = "https://api.lexware.io";
 const lexofficeValidationPath = "/v1/profile";
-const lexofficeDefaultRequestTimeoutMs = 30_000;
 
 type LexofficeRequestPhase = "validate" | "execute";
 type LexofficeActionContext = ApiKeyProviderContext;
@@ -208,7 +207,7 @@ export async function validateLexofficeCredential(
 }
 
 async function requestLexofficeJson(input: LexofficeRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, lexofficeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildLexofficeUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/lifx/runtime.ts
+++ b/src/providers/lifx/runtime.ts
@@ -14,8 +14,6 @@ import {
 
 export const lifxApiBaseUrl = "https://api.lifx.com/v1";
 
-const lifxRequestTimeoutMs = 30_000;
-
 type LifxRequestPhase = "validate" | "execute";
 
 interface LifxRequestInput {
@@ -194,7 +192,7 @@ async function requestLifx(input: LifxRequestInput): Promise<unknown> {
 
 async function requestLifxUrl(input: Omit<LifxRequestInput, "path"> & { url: URL }): Promise<unknown> {
   input.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(input.signal, lifxRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/line/runtime.ts
+++ b/src/providers/line/runtime.ts
@@ -12,8 +12,6 @@ export interface LineCredentialCheck {
 
 export const lineApiBaseUrl = "https://api.line.me";
 
-const lineRequestTimeoutMs = 30_000;
-
 type LineRequestPhase = "validate" | "execute";
 
 export async function validateLineCredential(apiKey: string, fetcher: typeof fetch): Promise<LineCredentialCheck> {
@@ -134,7 +132,7 @@ async function requestLineObject(input: {
   fetcher: typeof fetch;
   phase: LineRequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, lineRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const headers = new Headers({

--- a/src/providers/linkly/executors.ts
+++ b/src/providers/linkly/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "linkly";
 const linklyApiBaseUrl = "https://api.linklyhq.com";
-const linklyRequestTimeoutMs = 30_000;
 const linklyApiPrefix = "/api/v1";
 const filterKeys = ["domain", "slug", "utm_campaign", "utm_content", "utm_medium", "utm_source", "utm_term"] as const;
 const linkMutationFields = [
@@ -201,7 +200,7 @@ async function requestLinklyJson(input: {
   query?: LinklyQuery;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, linklyRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildLinklyUrl(input.path, input.query), {

--- a/src/providers/liveagent/executors.ts
+++ b/src/providers/liveagent/executors.ts
@@ -24,7 +24,6 @@ const service = "liveagent";
 const liveagentCredentialHelpUrl = "https://support.liveagent.com/741982-API-key";
 const liveagentValidationPath = "/my_account/_link";
 const liveagentApiPathPrefix = "/api/v3";
-const liveagentDefaultRequestTimeoutMs = 30_000;
 const liveagentMaxResponseBytes = 10 * 1024 * 1024;
 
 type LiveagentMode = "validate" | "execute";
@@ -351,7 +350,7 @@ async function requestLiveagentJson(input: {
   readonly body?: unknown;
   readonly signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(input.signal, liveagentDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildLiveagentUrl(input.apiBaseUrl, input.path, input.query), {

--- a/src/providers/livespace/runtime.ts
+++ b/src/providers/livespace/runtime.ts
@@ -364,7 +364,7 @@ async function postLivespaceForm(
   formData: Record<string, string>,
   credentialPhase: boolean,
 ) {
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/lob/executors.ts
+++ b/src/providers/lob/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "lob";
 const lobApiBaseUrl = "https://api.lob.com/v1";
-const lobDefaultRequestTimeoutMs = 30_000;
 
 type LobActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -169,7 +168,7 @@ async function requestLobJson(input: {
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, lobDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/lodgify/runtime.ts
+++ b/src/providers/lodgify/runtime.ts
@@ -14,7 +14,6 @@ import {
 export const lodgifyApiBaseUrl = "https://api.lodgify.com";
 
 const lodgifyValidationPath = "/v2/properties";
-const lodgifyDefaultRequestTimeoutMs = 30_000;
 
 type LodgifyPhase = "validate" | "execute";
 type LodgifyActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -215,7 +214,7 @@ async function getBooking(input: Record<string, unknown>, context: LodgifyAction
 }
 
 async function requestLodgifyJson(input: LodgifyRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, lodgifyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildLodgifyUrl(input.path, input.query), {

--- a/src/providers/longbridge/runtime.ts
+++ b/src/providers/longbridge/runtime.ts
@@ -26,7 +26,6 @@ import { indexSymbolToCounterId, symbolToCounterId } from "./counter-id.ts";
 import { longbridgeReadonlyActionSpecs, longbridgeScreenerDefaultReturns } from "./readonly-action-specs.ts";
 
 const longbridgeApiBaseUrl = "https://openapi.longbridge.com";
-const longbridgeRequestTimeoutMs = 30_000;
 
 export type LongbridgeHttpMethod = "GET" | "POST" | "PUT" | "DELETE";
 type LongbridgeRequestPhase = "connect" | "execute";
@@ -380,7 +379,7 @@ export async function validateLongbridgeCredential(
 
 export async function requestLongbridgeJson(input: LongbridgeRequestOptions): Promise<unknown> {
   const url = buildLongbridgeUrl(input.path, input.query);
-  const timeout = createProviderTimeout(input.context.signal, longbridgeRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, buildLongbridgeRequestInit(input, timeout.signal));
     const payload = await readLongbridgeJson(response);

--- a/src/providers/loop_returns/runtime.ts
+++ b/src/providers/loop_returns/runtime.ts
@@ -7,8 +7,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 export const loopReturnsApiBaseUrl = "https://api.loopreturns.com/api/v1";
 
-const loopReturnsRequestTimeoutMs = 30_000;
-
 type LoopReturnsRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | undefined;
 type LoopReturnsContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -195,7 +193,7 @@ export async function validateLoopReturnsCredential(
 }
 
 async function requestLoopReturnsJson(options: LoopReturnsRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.signal, loopReturnsRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   const url = new URL(`${loopReturnsApiBaseUrl}${options.path}`);
   appendQuery(url, options.query);
 

--- a/src/providers/magileads/runtime.ts
+++ b/src/providers/magileads/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const magileadsApiBaseUrl = "https://app.api-magileads.net";
-const timeoutMs = 30_000;
 
 const request =
   (
@@ -80,7 +79,7 @@ async function requestMagileads(
   context: ApiKeyProviderContext,
   phase: "execute" | "validate",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path, `${magileadsApiBaseUrl}/`), {
       method,

--- a/src/providers/mailcheck/executors.ts
+++ b/src/providers/mailcheck/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "mailcheck";
 const mailcheckApiBaseUrl = "https://api.usercheck.com";
-const mailcheckDefaultRequestTimeoutMs = 30_000;
 
 type MailcheckRequestPhase = "validate" | "execute";
 type MailcheckActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -154,7 +153,7 @@ async function requestMailcheckJson(input: {
   phase: MailcheckRequestPhase;
 }): Promise<unknown> {
   const url = new URL(input.path, mailcheckApiBaseUrl);
-  const timeout = createProviderTimeout(input.context.signal, mailcheckDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   let response: Response;
   let payload: unknown;

--- a/src/providers/mails_so/runtime.ts
+++ b/src/providers/mails_so/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from "../provider-runtime.ts";
 
 const mailsSoApiBaseUrl = "https://api.mails.so";
-const mailsSoDefaultRequestTimeoutMs = 30_000;
 
 type MailsSoRequestPhase = "validate" | "execute";
 type MailsSoActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -144,7 +143,7 @@ async function requestMailsSoJson(input: {
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, mailsSoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers = new Headers({
       accept: "application/json",

--- a/src/providers/maintainx/runtime.ts
+++ b/src/providers/maintainx/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const maintainxApiBaseUrl = "https://api.getmaintainx.com/v1";
 
-const maintainxDefaultTimeoutMs = 30_000;
-
 type MaintainxRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | readonly (string | number | boolean)[] | undefined;
 type MaintainxActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -255,7 +253,7 @@ export async function validateMaintainxCredential(
 }
 
 async function requestMaintainxJson(options: MaintainxRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.signal, maintainxDefaultTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   const url = new URL(`${maintainxApiBaseUrl}${options.path}`);
   appendQuery(url, options.query);
 

--- a/src/providers/markettime/executors.ts
+++ b/src/providers/markettime/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "markettime";
 const markettimeApiBaseUrl = "https://publicapi.markettime.com";
-const markettimeRequestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 
@@ -124,7 +123,7 @@ async function requestMarkettime(input: MarkettimeRequestInput): Promise<unknown
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value != null) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal, markettimeRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/mautic/runtime.ts
+++ b/src/providers/mautic/runtime.ts
@@ -34,7 +34,6 @@ type MauticActionHandler = (
   signal?: AbortSignal,
 ) => Promise<unknown>;
 
-const mauticRequestTimeoutMs = 30_000;
 const mauticMaxResponseBytes = 10 * 1024 * 1024;
 
 export const mauticActionHandlers: Record<string, MauticActionHandler> = {
@@ -275,7 +274,7 @@ async function requestMauticJson(input: MauticRequest): Promise<Record<string, u
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(input.signal, mauticRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/mediastack/runtime.ts
+++ b/src/providers/mediastack/runtime.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const mediastackApiBaseUrl = "https://api.mediastack.com/v1";
-const mediastackDefaultRequestTimeoutMs = 30_000;
 
 type MediastackPhase = "validate" | "execute";
 type MediastackQueryValue = string | number | undefined;
@@ -125,7 +124,7 @@ async function searchLiveNews(input: Record<string, unknown>, context: Mediastac
 }
 
 async function requestMediastackJson(input: MediastackRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, mediastackDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildMediastackUrl(input.path, input.query, input.apiKey), {

--- a/src/providers/megaventory/runtime.ts
+++ b/src/providers/megaventory/runtime.ts
@@ -5,7 +5,6 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 import { optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 export const megaventoryApiBaseUrl = "https://api.megaventory.com/v2017a";
-const timeoutMs = 30_000;
 const recordAction = "InsertOrUpdateNonEmptyFields";
 const lists: Record<string, { path: string; responseKey: string; outputKey: string }> = {
   list_products: { path: "/Product/ProductGet", responseKey: "mvProducts", outputKey: "products" },
@@ -162,7 +161,7 @@ async function request(
   context: ApiKeyProviderContext,
   phase: "validate" | "execute",
 ) {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(`${megaventoryApiBaseUrl}${path}`, {
       method: "POST",

--- a/src/providers/mem/executors.ts
+++ b/src/providers/mem/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "mem";
 const memApiBaseUrl = "https://api.mem.ai/v2";
-const memRequestTimeoutMs = 30_000;
 const memMaxResponseBytes = 10 * 1024 * 1024;
 
 type MemRequestPhase = "validate" | "execute";
@@ -114,7 +113,7 @@ async function requestMemJson(
   context: MemActionContext,
   phase: MemRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, memRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   const headers = new Headers({
     accept: "application/json",
     authorization: `Bearer ${context.apiKey}`,

--- a/src/providers/memberstack/runtime.ts
+++ b/src/providers/memberstack/runtime.ts
@@ -18,7 +18,6 @@ import {
 } from "../provider-runtime.ts";
 
 const memberstackApiBaseUrl = "https://admin.memberstack.com";
-const memberstackDefaultRequestTimeoutMs = 30_000;
 
 type MemberstackPhase = "validate" | "execute";
 type MemberstackActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -173,7 +172,7 @@ async function requestMemberstackJson(input: {
   emptySuccess?: boolean;
   phase: MemberstackPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, memberstackDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const body = input.body && Object.keys(input.body).length > 0 ? input.body : undefined;

--- a/src/providers/membervault/executors.ts
+++ b/src/providers/membervault/executors.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "membervault";
-const membervaultDefaultTimeoutMs = 30_000;
 const membervaultMaxResponseBytes = 10 * 1024 * 1024;
 const defaultRootDomain = "mvsite.app";
 const legacyRootDomain = "vipmembervault.com";
@@ -158,7 +157,7 @@ async function requestMembervaultJson(
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(context.signal, membervaultDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: { accept: "application/json", "user-agent": providerUserAgent },

--- a/src/providers/meta/executors.ts
+++ b/src/providers/meta/executors.ts
@@ -17,7 +17,6 @@ export const metaGraphApiBaseUrl: string = `https://graph.facebook.com/${metaGra
 const service = "meta";
 const metaValidationPath = "/me";
 const metaMeFields = "id,name";
-const metaDefaultTimeoutMs = 30_000;
 const defaultAdAccountFields = "id,account_id,name,currency,timezone_name,account_status,business_name";
 const defaultCampaignFields = "id,name,status,effective_status,objective,buying_type,created_time,updated_time";
 const defaultInsightFields =
@@ -197,7 +196,7 @@ async function requestMetaJson<T>(input: {
   phase: MetaRequestPhase;
   signal?: AbortSignal;
 }): Promise<T> {
-  const timeout = createProviderTimeout(input.signal, metaDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildMetaUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/metatextai/runtime.ts
+++ b/src/providers/metatextai/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const metatextaiApiBaseUrl = "https://guard-api.metatext.ai";
-const metatextaiDefaultRequestTimeoutMs = 30_000;
 
 type MetatextaiPhase = "validate" | "execute";
 type MetatextaiActionHandler = (input: Record<string, unknown>, context: MetatextaiActionContext) => Promise<unknown>;
@@ -134,7 +133,7 @@ async function metatextaiRequestJson(input: {
   phase: MetatextaiPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, metatextaiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildUrl(input.path), {

--- a/src/providers/mezmo/runtime.ts
+++ b/src/providers/mezmo/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const mezmoApiBaseUrl = "https://api.mezmo.com";
-const mezmoDefaultTimeoutMs = 30_000;
 
 type MezmoPhase = "validate" | "execute";
 type MezmoActionContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -130,7 +129,7 @@ async function requestMezmoJson(input: {
   context: MezmoActionContext;
   phase: MezmoPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, mezmoDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildMezmoUrl(input.path, input.params), {

--- a/src/providers/microsoft_text_translate/runtime.ts
+++ b/src/providers/microsoft_text_translate/runtime.ts
@@ -8,7 +8,6 @@ import {
 
 export const microsoftTextTranslateApiBaseUrl = "https://api.cognitive.microsofttranslator.com";
 export const microsoftTextTranslateApiVersion = "3.0";
-const requestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 
@@ -151,7 +150,7 @@ export async function validateMicrosoftTextTranslateCredential(context: Microsof
 }
 
 async function requestMicrosoftTextTranslate(input: MicrosoftTextTranslateRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const url = new URL(input.path, microsoftTextTranslateApiBaseUrl);
     url.searchParams.set("api-version", microsoftTextTranslateApiVersion);

--- a/src/providers/minerstat/executors.ts
+++ b/src/providers/minerstat/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "minerstat";
 const minerstatApiOrigin = "https://api.minerstat.com";
 const minerstatApiBaseUrl = `${minerstatApiOrigin}/v2`;
-const minerstatRequestTimeoutMs = 30_000;
 
 type MinerstatRequestPhase = "validate" | "execute";
 type MinerstatActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -101,7 +100,7 @@ async function requestMinerstatArray(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, minerstatRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/mintlify/runtime.ts
+++ b/src/providers/mintlify/runtime.ts
@@ -2,7 +2,6 @@ import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const mintlifyApiBaseUrl = "https://api.mintlify.com/v1";
-const mintlifyDefaultRequestTimeoutMs = 30_000;
 type MintlifyRequestPhase = "validate" | "execute";
 
 export async function validateMintlifyCredential(
@@ -69,7 +68,7 @@ async function requestMintlifyJson(input: {
   fetcher: typeof fetch;
   phase: MintlifyRequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, mintlifyDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(new URL(`${mintlifyApiBaseUrl}${input.path}`), {
       method: input.method,

--- a/src/providers/mixmax/executors.ts
+++ b/src/providers/mixmax/executors.ts
@@ -23,7 +23,6 @@ import {
 const service = "mixmax";
 const mixmaxApiBaseUrl = "https://api.mixmax.com";
 const mixmaxValidationPath = "/v1/users/me";
-const mixmaxRequestTimeoutMs = 30_000;
 const mixmaxMaxResponseBytes = 10 * 1024 * 1024;
 
 interface MixmaxContext {
@@ -178,7 +177,7 @@ async function requestMixmaxJson(input: MixmaxRequestOptions, context: MixmaxCon
     }
   }
   const method = input.method ?? "GET";
-  const timeout = createProviderTimeout(context.signal, mixmaxRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method,

--- a/src/providers/mixpanel/executors.ts
+++ b/src/providers/mixpanel/executors.ts
@@ -32,7 +32,6 @@ import {
 const service = "mixpanel";
 const mixpanelDefaultBaseUrl = "https://mixpanel.com";
 const mixpanelDefaultExportBaseUrl = "https://data.mixpanel.com";
-const mixpanelDefaultRequestTimeoutMs = 30_000;
 const mixpanelAllowedHostSuffix = ".mixpanel.com";
 
 type MixpanelPhase = "validate" | "execute";
@@ -555,7 +554,7 @@ async function requestMixpanelText(input: MixpanelRequestInput): Promise<string>
 }
 
 async function requestMixpanel(input: MixpanelRequestInput): Promise<{ text: string; payload: unknown }> {
-  const timeout = createProviderTimeout(input.signal, mixpanelDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const url = buildMixpanelUrl(input.baseUrl, input.path);
     for (const [key, value] of Object.entries(input.query ?? {})) {

--- a/src/providers/moesif/runtime.ts
+++ b/src/providers/moesif/runtime.ts
@@ -21,7 +21,6 @@ import {
 
 export const moesifApiBaseUrl = "https://api.moesif.com/v1";
 
-const moesifDefaultRequestTimeoutMs = 30_000;
 const defaultOrganizationId = "~";
 const defaultAppId = "~";
 const defaultTake = 20;
@@ -174,7 +173,7 @@ export async function validateMoesifCredential(
 }
 
 async function requestMoesifJson(input: MoesifRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, moesifDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(buildMoesifUrl(input.path, input.params, input.repeatedParams), {

--- a/src/providers/momentum_io/executors.ts
+++ b/src/providers/momentum_io/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "momentum_io";
 const momentumIoApiBaseUrl = "https://api.momentum.io";
-const momentumIoDefaultRequestTimeoutMs = 30_000;
 const momentumIoValidationPath = "/v1/users?pageSize=1";
 
 type MomentumIoRequestPhase = "validate" | "execute";
@@ -135,7 +134,7 @@ async function requestMomentumIoJson(
 ): Promise<unknown> {
   let response: Response;
   let payload: unknown;
-  const timeout = createProviderTimeout(context.signal, momentumIoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     response = await context.fetcher(new URL(path, momentumIoApiBaseUrl), {

--- a/src/providers/mongo_db_atlas_administration/executors.ts
+++ b/src/providers/mongo_db_atlas_administration/executors.ts
@@ -31,7 +31,6 @@ const service = "mongo_db_atlas_administration";
 const mongoDbAtlasAdministrationApiBaseUrl = "https://cloud.mongodb.com/api/atlas/v2";
 const atlasFetch = createProviderFetch({ skipDnsValidation: true });
 const atlasAcceptHeader = "application/vnd.atlas.2024-08-05+json";
-const defaultRequestTimeoutMs = 30_000;
 
 type AtlasPhase = "validate" | "execute";
 
@@ -230,7 +229,7 @@ async function requestAtlasJson(input: {
   phase: AtlasPhase;
   query?: Record<string, string | undefined>;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, defaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = buildAtlasUrl(input.path, input.query);
 
   try {

--- a/src/providers/moorcheh/runtime.ts
+++ b/src/providers/moorcheh/runtime.ts
@@ -8,7 +8,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 
 export const moorchehApiBaseUrl = "https://api.moorcheh.ai/v1";
 
-const requestTimeoutMs = 30_000;
 const namespaceNamePattern = /^[A-Za-z0-9_-]+$/u;
 
 type RequestPhase = "validate" | "execute";
@@ -149,7 +148,7 @@ async function requestMoorchehJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: RequestPhase,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/mother_duck/executors.ts
+++ b/src/providers/mother_duck/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "mother_duck";
 const motherDuckApiBaseUrl = "https://api.motherduck.com";
-const motherDuckRequestTimeoutMs = 30_000;
 const motherDuckTokenHelpUrl = "https://app.motherduck.com/settings/tokens";
 
 type MotherDuckMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -183,7 +182,7 @@ async function setUserDucklingConfig(input: Record<string, unknown>, context: Ap
 }
 
 async function requestMotherDuckJson(input: MotherDuckRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, motherDuckRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(new URL(input.path, motherDuckApiBaseUrl), {

--- a/src/providers/motion/executors.ts
+++ b/src/providers/motion/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "motion";
 const motionApiBaseUrl = "https://api.usemotion.com/v1";
-const motionDefaultRequestTimeoutMs = 30_000;
 const taskUpdateFieldNames = [
   "name",
   "workspaceId",
@@ -262,7 +261,7 @@ async function requestMotionJson(input: {
   query?: Record<string, string>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, motionDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildMotionUrl(input.path, input.query), {

--- a/src/providers/moxie/runtime.ts
+++ b/src/providers/moxie/runtime.ts
@@ -17,7 +17,6 @@ export interface MoxieActionContext {
   signal?: AbortSignal;
 }
 
-const timeoutMs = 30_000;
 const maxResponseBytes = 4 * 1024 * 1024;
 const validationPath = "action/pipelineStages/list";
 
@@ -101,7 +100,7 @@ async function requestMoxieJson(input: {
     const text = optionalString(value);
     if (text != null) url.searchParams.set(key, text);
   }
-  const timeout = createProviderTimeout(input.signal, timeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       headers: { accept: "application/json", "user-agent": providerUserAgent, "x-api-key": input.apiKey },

--- a/src/providers/mx/runtime.ts
+++ b/src/providers/mx/runtime.ts
@@ -28,7 +28,6 @@ export const mxApiBaseUrl = "https://api.mx.com";
 const mxRequestBaseUrl = "https://api.mx.com/";
 const mxVersion = "v20250224";
 const mxValidationPath = "/users";
-const mxDefaultTimeoutMs = 30_000;
 
 type MxPhase = "validate" | "execute";
 export interface MxContext {
@@ -174,7 +173,7 @@ async function requestMxJson(input: MxRequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, mxDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/mymind/executors.ts
+++ b/src/providers/mymind/executors.ts
@@ -28,7 +28,6 @@ import {
 
 const service = "mymind";
 const myMindApiBaseUrl = "https://api.mymind.com";
-const requestTimeoutMs = 30_000;
 /** mymind recommends a five-minute lifetime for the JWT signed for each request. */
 const accessTokenTtlSeconds = 300;
 const markdownMediaType = "text/markdown";
@@ -532,7 +531,7 @@ async function send(
   context: MyMindContext,
   phase: RequestPhase,
 ): Promise<{ response: Response; timeout: ReturnType<typeof createProviderTimeout> }> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   const url = new URL(`${myMindApiBaseUrl}${path}`);
   for (const [name, value] of Object.entries(init.query ?? {})) {
     for (const item of Array.isArray(value) ? value : value === undefined ? [] : [value]) {

--- a/src/providers/neetodesk/runtime.ts
+++ b/src/providers/neetodesk/runtime.ts
@@ -13,7 +13,6 @@ import {
 } from "../provider-runtime.ts";
 
 const apiPath = "/api/external/v2";
-const timeoutMs = 30_000;
 
 export interface NeetodeskContext {
   apiKey: string;
@@ -126,7 +125,7 @@ interface NeetodeskRequest {
 async function requestNeetodesk(input: NeetodeskRequest): Promise<unknown> {
   const url = new URL(`${neetodeskBaseUrl(input.context.subdomain)}${input.path}`);
   for (const [name, value] of Object.entries(input.query ?? {})) url.searchParams.set(name, value);
-  const timeout = createProviderTimeout(input.context.signal, timeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/netsuite/runtime.ts
+++ b/src/providers/netsuite/runtime.ts
@@ -24,7 +24,6 @@ import {
 const netsuiteRecordPathPrefix = "/services/rest/record/v1";
 const netsuiteQueryPathPrefix = "/services/rest/query/v1";
 const netsuiteValidationPath = `${netsuiteRecordPathPrefix}/metadata-catalog`;
-const netsuiteRequestTimeoutMs = 30_000;
 
 type NetsuiteMode = "validate" | "execute";
 type NetsuiteActionHandler = ProviderRuntimeHandler<NetsuiteContext>;
@@ -237,7 +236,7 @@ async function requestNetsuiteJson(input: NetsuiteRequestOptions): Promise<unkno
 }
 
 async function requestNetsuiteJsonWithMetadata(input: NetsuiteRequestOptions): Promise<NetsuiteResponsePayload> {
-  const timeout = createProviderTimeout(input.context.signal, netsuiteRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     let response: Response;
     try {

--- a/src/providers/neverbounce/executors.ts
+++ b/src/providers/neverbounce/executors.ts
@@ -20,7 +20,6 @@ import {
 
 const service = "neverbounce";
 const neverbounceApiBaseUrl = "https://api.neverbounce.com/v4.2";
-const neverbounceDefaultRequestTimeoutMs = 30_000;
 
 type NeverBouncePhase = "validate" | "execute";
 type NeverBounceActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -150,7 +149,7 @@ async function requestNeverBounceRaw(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, neverbounceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const headers: Record<string, string> = {
       accept: options.accept,

--- a/src/providers/ngrok/executors.ts
+++ b/src/providers/ngrok/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "ngrok";
 const ngrokApiBaseUrl = "https://api.ngrok.com";
 const ngrokApiVersion = "2";
-const ngrokDefaultRequestTimeoutMs = 30_000;
 const ngrokValidationPath = "/endpoints";
 
 type NgrokRequestPhase = "validate" | "execute";
@@ -124,7 +123,7 @@ async function requestNgrokJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, ngrokDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(url.toString(), {

--- a/src/providers/niftyimages/executors.ts
+++ b/src/providers/niftyimages/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "niftyimages";
 const niftyimagesApiBaseUrl = "https://api.niftyimages.com/v1";
-const niftyimagesRequestTimeoutMs = 30_000;
 const niftyimagesMaxResponseBytes = 10 * 1024 * 1024;
 
 type NiftyimagesRequestPhase = "validate" | "execute";
@@ -158,7 +157,7 @@ async function requestNiftyimagesJson(
   },
   context: NiftyimagesContext,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, niftyimagesRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildNiftyimagesUrl(input.path, input.params), {
       method: "GET",

--- a/src/providers/ninox/executors.ts
+++ b/src/providers/ninox/executors.ts
@@ -14,7 +14,6 @@ import {
 export const ninoxApiBaseUrl = "https://api.ninox.com/v1";
 
 const service = "ninox";
-const ninoxDefaultRequestTimeoutMs = 30_000;
 const ninoxValidationPath = "/teams";
 
 type NinoxPhase = "validate" | "execute";
@@ -319,7 +318,7 @@ async function deleteRecords(input: Record<string, unknown>, context: ApiKeyProv
 }
 
 async function requestNinoxJson(input: NinoxRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, ninoxDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildNinoxUrl(input.path, input.query), {

--- a/src/providers/nocodb/executors.ts
+++ b/src/providers/nocodb/executors.ts
@@ -30,7 +30,6 @@ import {
 
 const service = "nocodb";
 const nocodbValidationPath = "/api/v1/auth/user/me";
-const nocodbRequestTimeoutMs = 30_000;
 
 interface NocodbContext {
   apiKey: string;
@@ -406,7 +405,7 @@ interface NocodbRequestOptions {
 }
 
 async function requestNocodbJson(context: NocodbContext, input: NocodbRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, nocodbRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildNocodbUrl(context.baseUrl, input.path, input.query), {
       method: input.method ?? "GET",

--- a/src/providers/nocrm_io/executors.ts
+++ b/src/providers/nocrm_io/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "nocrm_io";
 const nocrmValidationPath = "/api/v2/ping";
-const nocrmRequestTimeoutMs = 30_000;
 
 interface NocrmContext {
   apiKey: string;
@@ -217,7 +216,7 @@ interface NocrmRequestOptions {
 }
 
 async function requestNocrmJson(context: NocrmContext, input: NocrmRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, nocrmRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildNocrmUrl(context.baseUrl, input.path, input.query), {
       method: input.method ?? "GET",

--- a/src/providers/northbeam/runtime.ts
+++ b/src/providers/northbeam/runtime.ts
@@ -20,8 +20,6 @@ import {
 
 export const northbeamApiBaseUrl = "https://api.northbeam.io/v1";
 
-const northbeamRequestTimeoutMs = 30_000;
-
 type NorthbeamPhase = "validate" | "execute";
 type NorthbeamActionHandler = ProviderRuntimeHandler<NorthbeamContext>;
 
@@ -134,7 +132,7 @@ async function listSpend(input: Record<string, unknown>, context: NorthbeamConte
 }
 
 async function requestNorthbeamJson(options: NorthbeamRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.context.signal, northbeamRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   try {
     let response: Response;
     try {

--- a/src/providers/nozbe_teams/executors.ts
+++ b/src/providers/nozbe_teams/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "nozbe_teams";
 const nozbeTeamsApiBaseUrl = "https://api4.nozbe.com/v1/api";
 const nozbeTeamsValidationPath = "/teams";
-const nozbeTeamsRequestTimeoutMs = 30_000;
 const nozbeTeamsMaxResponseBytes = 10 * 1024 * 1024;
 
 type NozbeRequestPhase = "validate" | "execute";
@@ -178,7 +177,7 @@ async function requestNozbeJson(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, nozbeTeamsRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method,

--- a/src/providers/npm/runtime.ts
+++ b/src/providers/npm/runtime.ts
@@ -37,7 +37,6 @@ interface DownloadPoint {
 
 const downloadPeriodPresets = new Set(["last-day", "last-week", "last-month", "last-year"]);
 const npmMaxResponseBytes = 10 * 1024 * 1024;
-const npmRequestTimeoutMs = 30_000;
 
 export const npmActionHandlers: ProviderActionHandlers<"npm", NpmActionHandler> = {
   async get_current_user(_input, context) {
@@ -288,7 +287,7 @@ async function requestNpmJson(input: {
     headers.set("content-type", "application/json");
   }
 
-  const timeout = createProviderTimeout(input.signal, npmRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(new URL(input.path, input.baseUrl ?? npmRegistryBaseUrl), {
       method: input.method ?? "GET",

--- a/src/providers/nusii_proposals/runtime.ts
+++ b/src/providers/nusii_proposals/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const nusiiProposalsApiBaseUrl = "https://app.nusii.com/api/v2/";
 
-const nusiiProposalsRequestTimeoutMs = 30_000;
-
 type NusiiProposalsRequestPhase = "validate" | "execute";
 type NusiiProposalsMethod = "GET" | "POST" | "PUT";
 type NusiiProposalsContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -299,7 +297,7 @@ async function requestNusiiJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, nusiiProposalsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/nutrient_document_web_services_api/executors.ts
+++ b/src/providers/nutrient_document_web_services_api/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "nutrient_document_web_services_api";
 const nutrientApiBaseUrl = "https://api.nutrient.io";
-const nutrientRequestTimeoutMs = 30_000;
 const nutrientMaxResponseBytes = 10 * 1024 * 1024;
 
 type NutrientRequestPhase = "validate" | "execute";
@@ -136,7 +135,7 @@ async function nutrientJsonRequest(
   },
   context: NutrientContext,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, nutrientRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path, nutrientApiBaseUrl), {
       method: input.method,

--- a/src/providers/nylas/runtime.ts
+++ b/src/providers/nylas/runtime.ts
@@ -30,7 +30,6 @@ interface NylasRequestOptions {
 }
 
 export const nylasApiBaseUrl = "https://api.us.nylas.com/v3";
-const nylasDefaultRequestTimeoutMs = 30_000;
 
 export const nylasActionHandlers: ProviderActionHandlers<"nylas", NylasActionHandler> = {
   async list_grants(input, context) {
@@ -170,7 +169,7 @@ export async function validateNylasCredential(
 }
 
 async function requestNylasJson(options: NylasRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.context.signal, nylasDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   try {
     const response = await options.context.fetcher(buildNylasUrl(options.path, options.params ?? {}), {
       method: "GET",

--- a/src/providers/nyne_ai/executors.ts
+++ b/src/providers/nyne_ai/executors.ts
@@ -22,7 +22,6 @@ import {
 
 const service = "nyne_ai";
 const nyneAiApiBaseUrl = "https://api.nyne.ai";
-const nyneAiRequestTimeoutMs = 30_000;
 
 type NyneAiMode = "validate" | "execute";
 type NyneAiActionHandler = ProviderRuntimeHandler<NyneAiActionContext>;
@@ -277,7 +276,7 @@ async function requestNyneAiJson(
   input: NyneAiRequestInput,
   context: NyneAiActionContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, nyneAiRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildNyneAiUrl(input), {
       method: input.method,

--- a/src/providers/octopus_deploy/executors.ts
+++ b/src/providers/octopus_deploy/executors.ts
@@ -23,7 +23,6 @@ import {
 
 const service = "octopus_deploy";
 const validationPath = "/users/me";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 
 interface OctopusDeployContext {
@@ -229,7 +228,7 @@ async function requestOctopusDeployObject(
 ): Promise<Record<string, unknown>> {
   const url = new URL(path.replace(/^\/+/, ""), `${context.apiBaseUrl}/`);
   appendQuery(url, query);
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/okta/runtime.ts
+++ b/src/providers/okta/runtime.ts
@@ -22,7 +22,6 @@ import {
   ProviderRequestError,
 } from "../provider-runtime.ts";
 
-const oktaRequestTimeoutMs = 30_000;
 export const oktaApiTokenHelpUrl = "https://developer.okta.com/docs/guides/create-an-api-token/main/";
 const oktaLifecycleOperations: Set<string> = new Set([
   "activate",
@@ -380,7 +379,7 @@ async function requestOktaObject(
 }
 
 async function requestOkta(input: OktaRequestInput): Promise<OktaResponse> {
-  const timeout = createProviderTimeout(input.signal, oktaRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildOktaUrl(input), {
       method: input.method,

--- a/src/providers/oncehub/executors.ts
+++ b/src/providers/oncehub/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "oncehub";
 const oncehubApiBaseUrl = "https://api.oncehub.com";
 const oncehubValidationPath = "/test";
-const oncehubRequestTimeoutMs = 30_000;
 
 type OncehubRequestPhase = "validate" | "execute";
 type OncehubActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -132,7 +131,7 @@ async function requestOncehubJson(input: OncehubRequestInput): Promise<unknown> 
 }
 
 async function requestOncehubResponse(input: OncehubRequestInput): Promise<Response> {
-  const timeout = createProviderTimeout(input.context.signal, oncehubRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     return await input.context.fetcher(buildOncehubUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/one_password/executors.ts
+++ b/src/providers/one_password/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "one_password";
 const onePasswordValidationPath = "/v1/vaults";
-const onePasswordRequestTimeoutMs = 30_000;
 
 type OnePasswordPhase = "validate" | "execute";
 type OnePasswordActionHandler = (input: Record<string, unknown>, context: OnePasswordContext) => Promise<unknown>;
@@ -166,7 +165,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestOnePasswordJson(input: OnePasswordRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, onePasswordRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildOnePasswordUrl(input), {
       method: "GET",

--- a/src/providers/one_password_events/runtime.ts
+++ b/src/providers/one_password_events/runtime.ts
@@ -26,8 +26,6 @@ import {
 
 export const onePasswordEventsValidationPath = "/api/v2/auth/introspect";
 
-const onePasswordEventsRequestTimeoutMs = 30_000;
-
 type OnePasswordEventsPhase = "validate" | "execute";
 type OnePasswordEventsActionHandler = ProviderRuntimeHandler<OnePasswordEventsContext>;
 
@@ -191,7 +189,7 @@ async function requestOnePasswordEventsJson(input: {
   phase: OnePasswordEventsPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, onePasswordEventsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(new URL(input.path, `${input.context.baseUrl}/`), {
       method: input.method,

--- a/src/providers/onesignal_rest_api/executors.ts
+++ b/src/providers/onesignal_rest_api/executors.ts
@@ -14,7 +14,6 @@ import {
 const service = "onesignal_rest_api";
 const onesignalRestApiBaseUrl = "https://api.onesignal.com";
 const onesignalValidationPath = "/notifications";
-const onesignalDefaultRequestTimeoutMs = 30_000;
 
 type OneSignalRequestPhase = "validate" | "execute";
 type OneSignalActionHandler = (input: Record<string, unknown>, context: OneSignalContext) => Promise<unknown>;
@@ -146,7 +145,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestOneSignalJson(input: OneSignalRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, onesignalDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const headers = new Headers({

--- a/src/providers/onfleet/runtime.ts
+++ b/src/providers/onfleet/runtime.ts
@@ -10,7 +10,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const onfleetApiBaseUrl = "https://onfleet.com/api/v2";
-const onfleetRequestTimeoutMs = 30_000;
 
 type OnfleetRequestPhase = "validate" | "execute";
 export interface OnfleetActionContext {
@@ -113,7 +112,7 @@ export async function requestOnfleetJson(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, onfleetRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/ongage/runtime.ts
+++ b/src/providers/ongage/runtime.ts
@@ -22,8 +22,6 @@ import {
 
 export const ongageApiBaseUrl = "https://api.ongage.com";
 
-const ongageRequestTimeoutMs = 30_000;
-
 type OngageRequestPhase = "validate" | "execute";
 type OngageRequestMethod = "GET" | "POST" | "PUT";
 type OngageQuery = Record<string, boolean | number | string | undefined>;
@@ -213,7 +211,7 @@ async function changeContactStatus(input: Record<string, unknown>, context: ApiK
 }
 
 async function requestOngage(input: OngageRequestOptions): Promise<OngageResponseEnvelope> {
-  const timeout = createProviderTimeout(input.signal, ongageRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildOngageUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/onlyoffice_docspace/runtime.ts
+++ b/src/providers/onlyoffice_docspace/runtime.ts
@@ -7,8 +7,6 @@ import { objectArray, optionalInteger, optionalRecord, optionalString } from "..
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
-const requestTimeoutMs = 30_000;
-
 export interface OnlyofficeContext {
   apiKey: string;
   portalUrl: string;
@@ -124,7 +122,7 @@ async function request(
 ): Promise<unknown> {
   const url = new URL(path, context.apiBaseUrl);
   for (const [key, value] of Object.entries(query)) if (value !== undefined) url.searchParams.set(key, String(value));
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/openai/executors.ts
+++ b/src/providers/openai/executors.ts
@@ -34,7 +34,6 @@ type OpenAiActionHandler = (input: Record<string, unknown>, context: OpenAiActio
 const service = "openai";
 const openaiApiBaseUrl = "https://api.openai.com/v1";
 const openaiAudioSourceMaxBytes = 25 * 1024 * 1024;
-const openaiAudioSourceFetchTimeoutMs = 30_000;
 
 export const openaiActionHandlers: ProviderActionHandlers<"openai", OpenAiActionHandler> = {
   list_models(_input, context) {
@@ -561,7 +560,7 @@ async function fetchPublicAudioUrl(
   context: Pick<OpenAiActionContext, "fetcher" | "signal">,
 ): Promise<Response> {
   assertPublicAudioUrl(url);
-  const timeout = createProviderTimeout(context.signal, openaiAudioSourceFetchTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, { signal: timeout.signal });

--- a/src/providers/openalex/executors.ts
+++ b/src/providers/openalex/executors.ts
@@ -14,7 +14,6 @@ import {
 import { openalexApiBaseUrl, openalexEntityValues } from "./constants.ts";
 
 const service = "openalex";
-const openalexDefaultRequestTimeoutMs = 30_000;
 const openalexEntities = new Set(openalexEntityValues);
 
 type OpenAlexPhase = "validate" | "execute";
@@ -149,7 +148,7 @@ async function requestOpenAlexJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   phase: OpenAlexPhase;
 }): Promise<Record<string, unknown>> {
-  const timeoutHandle = createProviderTimeout(input.context.signal, openalexDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildOpenAlexUrl(input.path, input.apiKey, input.params), {

--- a/src/providers/openfootball_worldcup/executors.ts
+++ b/src/providers/openfootball_worldcup/executors.ts
@@ -14,7 +14,6 @@ const service = "openfootball_worldcup";
 const openfootballRawBaseUrl = "https://raw.githubusercontent.com/openfootball/worldcup.json/master";
 const openfootballJsdelivrBaseUrl = "https://cdn.jsdelivr.net/gh/openfootball/worldcup.json@master";
 const openfootballEsmBaseUrl = "https://esm.sh/gh/openfootball/worldcup.json@master";
-const defaultRequestTimeoutMs = 30_000;
 
 type DatasetKind = "matches" | "groups" | "teams" | "stadiums" | "squads" | "qualiPlayoffs";
 
@@ -148,7 +147,7 @@ function buildDatasetUrls(season: number, kind: DatasetKind): string[] {
 }
 
 async function requestJson(url: string, context: OpenfootballWorldcupContext, label: string): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, defaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/opengraph_io/executors.ts
+++ b/src/providers/opengraph_io/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "opengraph_io";
 const opengraphIoApiBaseUrl = "https://opengraph.io";
 const opengraphIoValidationTargetUrl = "https://example.com";
-const opengraphIoRequestTimeoutMs = 30_000;
 
 type OpenGraphIoRequestPhase = "validate" | "execute";
 type OpenGraphIoQueryValue = string | number | boolean | undefined;
@@ -191,7 +190,7 @@ async function opengraphIoRequest(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, opengraphIoRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/openstatus/executors.ts
+++ b/src/providers/openstatus/executors.ts
@@ -27,7 +27,6 @@ import {
 const service = "openstatus";
 export const openstatusApiBaseUrl = "https://api.openstatus.dev";
 
-const openstatusRequestTimeoutMs = 30_000;
 const monitorService = "openstatus.monitor.v1.MonitorService";
 
 type OpenstatusRequestPhase = "validate" | "execute";
@@ -321,7 +320,7 @@ async function openstatusFetch(input: {
   body?: Record<string, unknown>;
 }): Promise<Response> {
   const url = new URL(input.path, openstatusApiBaseUrl);
-  const timeout = createProviderTimeout(input.signal, openstatusRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     return await input.fetcher(url, {

--- a/src/providers/opsgenie/runtime.ts
+++ b/src/providers/opsgenie/runtime.ts
@@ -19,8 +19,6 @@ import {
 export const opsgenieUsApiBaseUrl = "https://api.opsgenie.com";
 export const opsgenieEuApiBaseUrl = "https://api.eu.opsgenie.com";
 
-const opsgenieDefaultTimeoutMs = 30_000;
-
 type OpsgenieEnvironment = "us" | "eu";
 type OpsgenieRequestPhase = "validate" | "execute";
 type OpsgenieActionHandler = (input: Record<string, unknown>, context: OpsgenieContext) => Promise<unknown>;
@@ -235,7 +233,7 @@ async function requestOpsgenieJson<T>(input: OpsgenieRequestInput): Promise<T> {
     appendQueryParam(url, key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal, opsgenieDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers = compactObject({
       accept: "application/json",

--- a/src/providers/optimoroute/runtime.ts
+++ b/src/providers/optimoroute/runtime.ts
@@ -13,8 +13,6 @@ import {
 export const optimorouteApiBaseUrl = "https://api.optimoroute.com/v1";
 export const optimorouteValidationPath = "/get_orders";
 
-const optimorouteDefaultRequestTimeoutMs = 30_000;
-
 type OptimoroutePhase = "validate" | "execute";
 type OptimorouteActionContext = ApiKeyProviderContext;
 type OptimorouteActionHandler = (input: Record<string, unknown>, context: OptimorouteActionContext) => Promise<unknown>;
@@ -133,7 +131,7 @@ async function optimorouteRequest(
   const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
   const url = new URL(normalizedPath, `${optimorouteApiBaseUrl}/`);
   url.searchParams.set("key", context.apiKey);
-  const timeout = createProviderTimeout(context.signal, optimorouteDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(url.toString(), {

--- a/src/providers/oracle_cloud/runtime.ts
+++ b/src/providers/oracle_cloud/runtime.ts
@@ -23,7 +23,6 @@ import {
 import { oracleInstanceActions, oracleInstanceAgentMaxWaitSeconds } from "./actions.ts";
 import { parseOracleApiPrivateKey, signOracleApiRequest } from "./request-signer.ts";
 
-const requestTimeoutMs = 30_000;
 const commandWaitMs = oracleInstanceAgentMaxWaitSeconds * 1_000;
 const defaultRealm = "oc1";
 
@@ -623,7 +622,7 @@ export async function requestOracle(input: OracleRequestInput): Promise<OracleRe
   const body = input.body === undefined ? undefined : JSON.stringify(input.body);
   const headers = signOracleApiRequest(input.context, { method, url, body });
   headers.set("user-agent", providerUserAgent);
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   let response: Response;
   let text: string;

--- a/src/providers/ordinal/runtime.ts
+++ b/src/providers/ordinal/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 export const ordinalApiBaseUrl = "https://app.tryordinal.com/api/v1";
 
-const ordinalRequestTimeoutMs = 30_000;
 const ordinalValidationPath = "/workspace";
 
 type OrdinalRequestPhase = "validate" | "execute";
@@ -165,7 +164,7 @@ async function requestOrdinalResponse(input: {
   query?: Record<string, unknown>;
 }): Promise<Response> {
   const apiKey = requiredString(input.context.apiKey, "apiKey", (message) => new ProviderRequestError(401, message));
-  const timeout = createProviderTimeout(input.context.signal, ordinalRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     return await input.context.fetcher(buildOrdinalUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/oura/runtime.ts
+++ b/src/providers/oura/runtime.ts
@@ -28,7 +28,6 @@ import {
 } from "./collections.ts";
 
 const ouraPersonalInfoPath = `${ouraUserCollectionPath}/personal_info`;
-const ouraRequestTimeoutMs = 30_000;
 
 type OuraRequestPhase = "validate" | "execute";
 type OuraActionHandler = ProviderRuntimeHandler<OAuthProviderContext>;
@@ -188,7 +187,7 @@ async function requestOuraObject(input: OuraRequestInput): Promise<Record<string
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(input.signal, ouraRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/owl_protocol/runtime.ts
+++ b/src/providers/owl_protocol/runtime.ts
@@ -21,7 +21,6 @@ import {
 
 export const owlProtocolApiBaseUrl = "https://api.owl.build";
 
-const owlProtocolDefaultRequestTimeoutMs = 30_000;
 const authProbePath = "/api/auth";
 const projectInfoPath = "/api/project/info";
 
@@ -149,7 +148,7 @@ async function requestOwlProtocolJson(input: {
   phase: OwlProtocolRequestPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, owlProtocolDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const apiKey = requiredString(input.context.apiKey, "apiKey", (message) => new ProviderRequestError(401, message));
 
   try {

--- a/src/providers/paperform/executors.ts
+++ b/src/providers/paperform/executors.ts
@@ -260,7 +260,7 @@ async function requestJson(path: string, context: PaperformContext, phase: Paper
 
 async function paperformFetch(path: string, context: PaperformContext): Promise<Response> {
   const url = new URL(path, paperformApiBaseUrl);
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   try {
     return await context.fetcher(url, {
       headers: {

--- a/src/providers/paypal/runtime.ts
+++ b/src/providers/paypal/runtime.ts
@@ -19,8 +19,6 @@ const paypalApiBaseUrls = {
   live: "https://api-m.paypal.com",
 } as const satisfies Record<PayPalEnvironment, string>;
 
-const paypalRequestTimeoutMs = 30_000;
-
 type PayPalRequestPhase = "validate" | "execute";
 
 type PayPalCredentialContext = {
@@ -387,7 +385,7 @@ async function paypalApiRequest(input: PayPalApiRequestInput) {
 }
 
 async function fetchPayPalPayload(fetcher: typeof fetch, url: string | URL, init: RequestInit) {
-  const timeout = createProviderTimeout(undefined, paypalRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await fetcher(url, { ...init, signal: timeout.signal });
     return { response, payload: await readPayPalPayload(response) };

--- a/src/providers/permit_io/runtime.ts
+++ b/src/providers/permit_io/runtime.ts
@@ -204,7 +204,7 @@ function resolveContext(context: PermitIoContext, input: Record<string, unknown>
 }
 
 async function requestPermitIoJson(options: PermitIoRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.signal, 30_000);
+  const timeout = createProviderTimeout(options.signal);
   const url = new URL(options.path, permitIoApiBaseUrl);
   for (const [name, value] of Object.entries(options.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/pi_hole/runtime.ts
+++ b/src/providers/pi_hole/runtime.ts
@@ -25,7 +25,6 @@ import {
   readTransitFileInput,
 } from "../provider-runtime.ts";
 
-const piHoleRequestTimeoutMs = 30_000;
 const defaultPiHoleApiPath = "api";
 const piHoleGravityOutputTailChars = 2_000;
 // Keep in sync with the server-side upload cap (FTL MAXFILESIZE).
@@ -128,7 +127,7 @@ async function performPiHoleRequest(options: PiHoleRequestOptions & { sid: strin
     body = JSON.stringify(options.body);
   }
 
-  const timeout = createProviderTimeout(context.signal, piHoleRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     return await context.fetcher(url, {
       method: options.method,

--- a/src/providers/pinpoint/runtime.ts
+++ b/src/providers/pinpoint/runtime.ts
@@ -21,8 +21,6 @@ interface ValidateCredentialResult {
   providerMetadata: Record<string, unknown>;
 }
 
-const pinpointRequestTimeoutMs = 30_000;
-
 interface PinpointRequestInput {
   apiBaseUrl: string;
   apiKey: string;
@@ -148,7 +146,7 @@ function appendQueryValue(query: URLSearchParams, name: string, value: unknown) 
 }
 
 async function requestPinpoint(input: PinpointRequestInput) {
-  const timeout = createProviderTimeout(undefined, pinpointRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   const guardedFetch = input.fetcher;
   const url = new URL(`${input.apiBaseUrl}${input.path}`);
   if (input.query) url.search = input.query.toString();

--- a/src/providers/planhat/executors.ts
+++ b/src/providers/planhat/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "planhat";
 const apiBaseUrl = "https://api.planhat.com";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 
 type PlanhatPhase = "validate" | "execute";
@@ -179,7 +178,7 @@ async function requestPlanhatJson(request: PlanhatRequest): Promise<unknown> {
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(request.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(request.context.signal);
   try {
     const response = await request.context.fetcher(url, {
       method: request.method,

--- a/src/providers/plasmic/executors.ts
+++ b/src/providers/plasmic/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "plasmic";
 const plasmicDataBaseUrl = "https://data.plasmic.app";
 const plasmicCmsBaseUrl = `${plasmicDataBaseUrl}/api/v1/cms`;
-const plasmicDefaultRequestTimeoutMs = 30_000;
 const plasmicCmsTokenHeaderName = "x-plasmic-api-cms-tokens";
 
 interface PlasmicContext {
@@ -87,7 +86,7 @@ function buildModelReadUrl(cmsId: string, input: Record<string, unknown>, endpoi
 }
 
 async function plasmicGetJson(url: URL, context: PlasmicContext): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, plasmicDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response, payload: unknown;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/poper/executors.ts
+++ b/src/providers/poper/executors.ts
@@ -23,7 +23,6 @@ import {
 
 const service = "poper";
 const baseUrl = "https://api.poper.ai/general/v1";
-const timeoutMs = 30_000;
 
 export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, {
   list_popups(_input, context) {
@@ -86,7 +85,7 @@ async function requestPoper(
   signal?: AbortSignal,
   validation = false,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(signal, timeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(`${baseUrl}${path}`, {
       method: "POST",

--- a/src/providers/postalytics/runtime.ts
+++ b/src/providers/postalytics/runtime.ts
@@ -16,7 +16,6 @@ import {
 export const postalyticsApiBaseUrl = "https://api.postalytics.com/api/v1";
 
 const postalyticsValidationPath = "/account/me";
-const postalyticsRequestTimeoutMs = 30_000;
 
 type PostalyticsRequestPhase = "validate" | "execute";
 
@@ -171,7 +170,7 @@ async function requestPostalyticsJson(input: PostalyticsRequestInput): Promise<u
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal, postalyticsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/postgrid/executors.ts
+++ b/src/providers/postgrid/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "postgrid";
 const postgridApiBaseUrl = "https://api.postgrid.com/print-mail/v1";
-const postgridDefaultRequestTimeoutMs = 30_000;
 
 type PostgridPhase = "validate" | "execute";
 type PostgridActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -173,7 +172,7 @@ async function requestPostgridJson(input: {
   context: ApiKeyProviderContext;
   phase: PostgridPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, postgridDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildPostgridUrl(input.path, input.params ?? {}), {

--- a/src/providers/practitest/runtime.ts
+++ b/src/providers/practitest/runtime.ts
@@ -10,7 +10,6 @@ interface ApiKeyProviderActionInput {
 }
 
 export const practitestApiBaseUrl = "https://api.practitest.com/api/v2";
-const requestTimeoutMs = 30_000;
 
 interface PractitestActionInput extends ApiKeyProviderActionInput {
   actionName: string;
@@ -210,7 +209,7 @@ function buildTestBody(input: Record<string, unknown>, includeSteps: boolean) {
 }
 
 async function requestPractitest(options: PractitestRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   const url = new URL(`${practitestApiBaseUrl}${options.path}`);
   for (const [name, value] of Object.entries(options.query ?? {})) {
     if (value !== undefined) url.searchParams.set(name, String(value));

--- a/src/providers/predis_ai/executors.ts
+++ b/src/providers/predis_ai/executors.ts
@@ -17,7 +17,6 @@ const apiBaseUrl = "https://brain.predis.ai/predis_api/v1";
 const createContentPath = "/create_content/";
 const getPostsPath = "/get_posts/";
 const getTemplatesPath = "/get_templates/";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 const validationBrandId = "__oomol_validation_brand__";
 
@@ -145,7 +144,7 @@ async function requestPredisAi(input: PredisAiRequest): Promise<{ payload: unkno
   for (const [key, value] of input.query ?? []) {
     url.searchParams.append(key, value);
   }
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/pretix/runtime.ts
+++ b/src/providers/pretix/runtime.ts
@@ -26,8 +26,6 @@ export interface PretixActionContext extends PretixCredential {
 
 type PretixActionHandler = (input: Record<string, unknown>, context: PretixActionContext) => Promise<unknown>;
 
-const requestTimeoutMs = 30_000;
-
 export const pretixActionHandlers: ProviderActionHandlers<"pretix", PretixActionHandler> = {
   async list_organizers(input, context) {
     return normalizePage(await requestPretix(context, "/api/v1/organizers/", pickPageQuery(input)), "organizers");
@@ -151,7 +149,7 @@ async function requestPretix(
 ): Promise<unknown> {
   const url = new URL(`${context.baseUrl}${path}`);
   setSearchParams(url, query);
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: {

--- a/src/providers/printavo/runtime.ts
+++ b/src/providers/printavo/runtime.ts
@@ -18,7 +18,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const printavoApiBaseUrl = "https://www.printavo.com/api/v2";
-const printavoDefaultRequestTimeoutMs = 30_000;
 
 export interface PrintavoActionContext {
   token: string;
@@ -400,7 +399,7 @@ async function printavoGraphql(
   context: Pick<PrintavoActionContext, "token" | "email" | "fetcher" | "signal">,
   phase: PrintavoRequestPhase,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, printavoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(printavoApiBaseUrl, {
       method: "POST",

--- a/src/providers/processplan/runtime.ts
+++ b/src/providers/processplan/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const processplanApiBaseUrl = "https://apius0.processplan.com/api/v4";
-const timeoutMs = 30_000;
 
 export const processplanActionHandlers: ProviderActionHandlers<
   "processplan",
@@ -115,7 +114,7 @@ async function requestProcessplan(
 ): Promise<unknown> {
   const url = new URL(`${processplanApiBaseUrl}${path}`);
   for (const [name, value] of Object.entries(options.query ?? {})) url.searchParams.set(name, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: options.method ?? "GET",

--- a/src/providers/promptlayer/runtime.ts
+++ b/src/providers/promptlayer/runtime.ts
@@ -29,7 +29,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const promptLayerApiBaseUrl = "https://api.promptlayer.com";
-const promptLayerDefaultRequestTimeoutMs = 30_000;
 
 type PromptLayerPhase = "validate" | "execute";
 type PromptLayerMethod = "GET" | "POST";
@@ -196,7 +195,7 @@ export async function validatePromptLayerCredential(
 }
 
 async function requestPromptLayerJson(input: PromptLayerRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, promptLayerDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -151,6 +151,27 @@ describe("provider action contracts", () => {
 });
 
 describe("createProviderTimeout", () => {
+  it("times out after 30 seconds unless a budget is passed", () => {
+    vi.useFakeTimers();
+    try {
+      const timeout = createProviderTimeout(undefined);
+      vi.advanceTimersByTime(29_999);
+      expect(timeout.didTimeout()).toBe(false);
+      expect(timeout.signal.aborted).toBe(false);
+      vi.advanceTimersByTime(1);
+      expect(timeout.didTimeout()).toBe(true);
+      expect(timeout.signal.aborted).toBe(true);
+      timeout.cleanup();
+
+      const custom = createProviderTimeout(undefined, 5);
+      vi.advanceTimersByTime(5);
+      expect(custom.didTimeout()).toBe(true);
+      custom.cleanup();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("inherits an already-aborted parent signal", () => {
     const parent = new AbortController();
     parent.abort(new Error("cancelled"));

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -318,6 +318,7 @@ const blockedProxyRequestHeaders = new Set([
 const defaultProviderProxyMaxResponseBytes = 20 * 1024 * 1024;
 const defaultProviderJsonMaxResponseBytes = 20 * 1024 * 1024;
 const defaultProviderErrorMaxResponseBytes = 64 * 1024;
+const defaultProviderRequestTimeoutMs = 30_000;
 
 export function createProviderProxyUrl(baseUrl: string, endpointInput: unknown, queryInput?: unknown): URL {
   const endpoint = normalizeProviderProxyEndpoint(endpointInput);
@@ -630,9 +631,14 @@ async function applyProviderProxyAuth(
 
 /**
  * Return an abort signal that fires when either the parent signal aborts or the
- * provider-local timeout expires.
+ * provider-local timeout expires. The timeout defaults to 30 seconds, the value
+ * almost every provider request uses; pass `timeoutMs` only for endpoints that
+ * genuinely need a different budget.
  */
-export function createProviderTimeout(parentSignal: AbortSignal | undefined, timeoutMs: number): ProviderTimeout {
+export function createProviderTimeout(
+  parentSignal: AbortSignal | undefined,
+  timeoutMs: number = defaultProviderRequestTimeoutMs,
+): ProviderTimeout {
   const controller = new AbortController();
   let timeoutReached = false;
   const timeoutId = setTimeout(() => {

--- a/src/providers/proxiedmail/executors.ts
+++ b/src/providers/proxiedmail/executors.ts
@@ -27,7 +27,6 @@ import {
 
 const service = "proxiedmail";
 const proxiedmailApiBaseUrl = "https://proxiedmail.com/api/v1";
-const proxiedmailRequestTimeoutMs = 30_000;
 
 type ProxiedmailRequestPhase = "validate" | "execute";
 type ProxiedmailMethod = "GET" | "POST" | "PATCH";
@@ -207,7 +206,7 @@ async function requestProxiedmailJson(input: {
   signal?: AbortSignal;
   phase: ProxiedmailRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, proxiedmailRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildProxiedmailUrl(input.path), {
       method: input.method,

--- a/src/providers/prtg_classic/runtime.ts
+++ b/src/providers/prtg_classic/runtime.ts
@@ -15,7 +15,6 @@ import { deviceSortColumns, sensorSortColumns } from "./constants.ts";
 export const prtgClassicTablePath = "/table.json";
 
 const prtgClassicApiPathPrefix = "/api";
-const prtgClassicRequestTimeoutMs = 30_000;
 
 type PrtgClassicRequestMode = "validate" | "execute";
 type QueryValue = string | number | boolean | readonly (string | number | boolean)[] | undefined;
@@ -187,7 +186,7 @@ async function requestPrtgClassicTableJson(options: PrtgClassicRequestOptions): 
   });
   assertPrtgClassicRequestUrl(url);
 
-  const timeout = createProviderTimeout(options.context.signal, prtgClassicRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   try {
     const response = await options.context.fetcher(url, {
       method: "GET",

--- a/src/providers/pubmed/runtime.ts
+++ b/src/providers/pubmed/runtime.ts
@@ -210,7 +210,6 @@ const pubmedSortValues: Record<PubmedSort, string> = {
 };
 const anonymousRequestIntervalMs = 334;
 const apiKeyRequestIntervalMs = 100;
-const pubmedRequestTimeoutMs = 30_000;
 const maximumJsonResponseBytes = 1024 * 1024;
 const maximumXmlResponseBytes = 10 * 1024 * 1024;
 const maximumCachedApiKeyRequestGates = 100;
@@ -665,7 +664,7 @@ async function requestNcbiTextOnce(
   options: NcbiTextRequestOptions,
   context: PubmedActionContext,
 ): Promise<{ response: Response; text: string }> {
-  const timeout = createProviderTimeout(context.signal, pubmedRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       ...options.init,

--- a/src/providers/qdrant/runtime.ts
+++ b/src/providers/qdrant/runtime.ts
@@ -24,7 +24,6 @@ import {
 import { qdrantUuidPattern } from "./actions.ts";
 
 const service = "qdrant";
-const requestTimeoutMs = 30_000;
 const qdrantHostnameSuffix = ".cloud.qdrant.io";
 
 type QdrantRequestPhase = "validate" | "execute";
@@ -201,7 +200,7 @@ async function requestQdrantJson(
   body: object | undefined,
   phase: QdrantRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path, `${context.clusterUrl.origin}/`), {
       method,

--- a/src/providers/qichacha/runtime.ts
+++ b/src/providers/qichacha/runtime.ts
@@ -3,7 +3,6 @@ import { optionalInteger, optionalRecord, optionalString } from "../../core/cast
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const qichachaApiBaseUrl = "https://api.qichacha.com";
-const qichachaRequestTimeoutMs = 30_000;
 const actionPathByName: Record<string, string> = {
   list_company_shareholders: "/ECIPartner/GetList",
   list_company_historical_investments: "/HistoryInvestmentCheck/GetList",
@@ -77,7 +76,7 @@ async function requestQichacha(input: QichachaRequestInput) {
   url.searchParams.set("searchKey", input.searchKey);
   url.searchParams.set("pageIndex", String(input.pageIndex));
   url.searchParams.set("pageSize", String(input.pageSize));
-  const timeoutHandle = createProviderTimeout(undefined, qichachaRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/qingflow/runtime.ts
+++ b/src/providers/qingflow/runtime.ts
@@ -6,7 +6,6 @@ import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "
 export const qingflowApiBaseUrl = "https://api.qingflow.com";
 
 const qingflowValidationPath = "/app";
-const qingflowRequestTimeoutMs = 30_000;
 
 type QingflowRequestPhase = "validate" | "execute";
 type QingflowActionContext = { accessToken: string; fetcher: typeof fetch };
@@ -350,7 +349,7 @@ async function requestQingflowEnvelope(input: QingflowRequestInput) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
 
-  const timeout = createProviderTimeout(undefined, qingflowRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/quipteams/executors.ts
+++ b/src/providers/quipteams/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "quipteams";
 const quipteamsApiBaseUrl = "https://api.quipteams.com";
-const quipteamsRequestTimeoutMs = 30_000;
 
 type QuipteamsRequestPhase = "validate" | "execute";
 type QuipteamsActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -134,7 +133,7 @@ async function requestQuipteamsJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: QuipteamsRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, quipteamsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/radar/executors.ts
+++ b/src/providers/radar/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "radar";
 const radarApiBaseUrl = "https://api.radar.io";
-const radarDefaultRequestTimeoutMs = 30_000;
 const radarValidationPath = "/v1/geocode/ip";
 
 type RadarRequestPhase = "validate" | "execute";
@@ -160,7 +159,7 @@ async function requestRadarJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   phase: RadarRequestPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, radarDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildRadarUrl(input.path, input.query), {

--- a/src/providers/raindrop/executors.ts
+++ b/src/providers/raindrop/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "raindrop";
 const raindropApiBaseUrl = "https://api.raindrop.io/rest/v1";
-const requestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 
@@ -195,7 +194,7 @@ async function requestJson(
   context: RequestContext,
   phase: RequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   const url = new URL(`${raindropApiBaseUrl}${path}`);
   for (const [name, value] of Object.entries(init.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/raisely/runtime.ts
+++ b/src/providers/raisely/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const raiselyApiBaseUrl = "https://api.raisely.com/v3";
 
-const raiselyRequestTimeoutMs = 30_000;
-
 type RaiselyRequestMethod = "GET" | "POST" | "PATCH" | "DELETE";
 type RaiselyActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -258,7 +256,7 @@ async function fetchRaiselyJson(
   init: RequestInit,
 ): Promise<RaiselyJsonResponse> {
   init.signal?.throwIfAborted();
-  const timeout = createProviderTimeout(init.signal ?? undefined, raiselyRequestTimeoutMs);
+  const timeout = createProviderTimeout(init.signal ?? undefined);
   try {
     const response = await fetcher(url, { ...init, signal: timeout.signal });
     return {

--- a/src/providers/referralhero/runtime.ts
+++ b/src/providers/referralhero/runtime.ts
@@ -5,7 +5,6 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 export const referralheroApiBaseUrl = "https://app.referralhero.com/api/v2";
-const timeoutMs = 30_000;
 interface Spec {
   method: string;
   path: string;
@@ -117,7 +116,7 @@ async function request(spec: Spec, context: ApiKeyProviderContext, phase: "valid
   const url = new URL(`${referralheroApiBaseUrl}${spec.path}`);
   for (const [key, value] of Object.entries(spec.query ?? {}))
     if (value !== undefined) url.searchParams.set(key, String(value));
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: spec.method,

--- a/src/providers/referralrock/runtime.ts
+++ b/src/providers/referralrock/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const referralRockApiBaseUrl = "https://api.referralrock.com";
-const timeoutMs = 30_000;
 interface Context {
   publicKey: string;
   privateKey: string;
@@ -68,7 +67,7 @@ export async function validateReferralRockCredential(context: Context): Promise<
 async function request(path: string, query: Record<string, string>, context: Context, phase: "validate" | "execute") {
   const url = new URL(path, referralRockApiBaseUrl);
   for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: {

--- a/src/providers/respond_io/executors.ts
+++ b/src/providers/respond_io/executors.ts
@@ -15,7 +15,6 @@ import {
 
 const service = "respond_io";
 const apiBaseUrl = "https://api.respond.io/v2";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 const mutableContactFields = [
   "firstName",
@@ -220,7 +219,7 @@ async function requestRespondIoJson(input: RespondIoRequest): Promise<unknown> {
       url.searchParams.set(key, String(value));
     }
   }
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/retently/runtime.ts
+++ b/src/providers/retently/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const retentlyApiBaseUrl = "https://app.retently.com";
 
-const retentlyDefaultRequestTimeoutMs = 30_000;
-
 type RetentlyPhase = "validate" | "execute";
 type RetentlyActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -221,7 +219,7 @@ function buildListFeedbackParams(input: Record<string, unknown>): Record<string,
 }
 
 async function requestRetentlyJson(input: RetentlyRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, retentlyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildRetentlyUrl(input.path, input.params, input.attributes), {
       method: input.method,

--- a/src/providers/ritekit/executors.ts
+++ b/src/providers/ritekit/executors.ts
@@ -21,7 +21,6 @@ import {
 
 const service = "ritekit";
 const apiBaseUrl = "https://api.ritekit.com";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 type RiteKitPhase = "validate" | "execute";
 type QueryEntry = [string, unknown];
@@ -137,7 +136,7 @@ async function requestRiteKit(
   for (const [name, value] of query) {
     if (value != null && value !== "") url.searchParams.set(name, String(value));
   }
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/sage_sales_management/runtime.ts
+++ b/src/providers/sage_sales_management/runtime.ts
@@ -32,8 +32,6 @@ type ResourceConfig = {
 
 export const sageSalesManagementApiBaseUrl = "https://api.forcemanager.com/api/v4";
 
-const requestTimeoutMs = 30_000;
-
 const accountsConfig = {
   resourcePath: "accounts",
   listOutputKey: "accounts",
@@ -355,7 +353,7 @@ async function requestSageSalesManagementJsonWithStatus(input: {
   extraHeaders?: Record<string, string>;
   body?: Record<string, unknown>;
 }) {
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildSageSalesManagementUrl(input.path, input.query), {

--- a/src/providers/salesmate/executors.ts
+++ b/src/providers/salesmate/executors.ts
@@ -25,7 +25,6 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "salesmate";
-const salesmateDefaultRequestTimeoutMs = 30_000;
 
 type SalesmatePhase = "validate" | "execute";
 type SalesmateMethod = "GET" | "POST" | "DELETE";
@@ -190,7 +189,7 @@ async function requestSalesmateJson(
   input: SalesmateRequestInput,
   context: SalesmateRequestContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, salesmateDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildSalesmateUrl(input, context.linkName), {
       method: input.method,

--- a/src/providers/satismeter/executors.ts
+++ b/src/providers/satismeter/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "satismeter";
 const satismeterApiBaseUrl = "https://app.satismeter.com/api/v3";
-const satismeterDefaultRequestTimeoutMs = 30_000;
 const satismeterValidationProbeProjectId = "000000000000000000000000";
 const satismeterValidationPath = `/projects/${satismeterValidationProbeProjectId}`;
 
@@ -213,7 +212,7 @@ async function requestSatismeterResponse(input: {
   query?: URLSearchParams;
   mode: SatismeterMode;
 }): Promise<{ httpResponse: Response; payload: unknown }> {
-  const timeout = createProviderTimeout(input.signal, satismeterDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const httpResponse = await satismeterFetch({
       apiKey: input.apiKey,

--- a/src/providers/scopus/runtime.ts
+++ b/src/providers/scopus/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const scopusApiBaseUrl = "https://api.elsevier.com/content";
-const scopusRequestTimeoutMs = 30_000;
 
 type ScopusPhase = "validate" | "execute";
 
@@ -247,7 +246,7 @@ interface ScopusRequest {
 }
 
 async function requestScopusJson(input: ScopusRequest, context: ScopusContext): Promise<ScopusResponse> {
-  const timeout = createProviderTimeout(context.signal, scopusRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildScopusUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/screendesk/runtime.ts
+++ b/src/providers/screendesk/runtime.ts
@@ -7,7 +7,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const screendeskApiBaseUrl = "https://app.screendesk.io/api/v2";
-const requestTimeoutMs = 30_000;
 
 export interface ScreendeskContext {
   apiKey: string;
@@ -90,7 +89,7 @@ export async function validateScreendeskCredential(context: ScreendeskContext): 
 }
 
 async function requestScreendesk(input: ScreendeskRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const relativePath = input.path.startsWith("/") ? input.path.slice(1) : input.path;
     const url = new URL(relativePath, `${screendeskApiBaseUrl}/`);

--- a/src/providers/seatable/runtime.ts
+++ b/src/providers/seatable/runtime.ts
@@ -43,8 +43,6 @@ interface SeaTableRequestOptions {
 
 type SeaTableActionHandler = (input: Record<string, unknown>, context: SeaTableContext) => Promise<unknown>;
 
-const requestTimeoutMs = 30_000;
-
 export const seatableActionHandlers: Record<string, SeaTableActionHandler> = {
   async get_metadata(_input, context) {
     return {
@@ -197,7 +195,7 @@ async function getBaseAccess(
   phase: "execute" | "validate",
   signal?: AbortSignal,
 ): Promise<SeaTableBaseAccess> {
-  const timeout = createProviderTimeout(signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(new URL("api/v2.1/dtable/app-access-token/", serverUrl), {
       headers: requestHeaders(apiToken),
@@ -233,7 +231,7 @@ async function requestBaseJson(
   for (const [key, value] of Object.entries(options.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: options.method ?? "GET",

--- a/src/providers/sellersprite/runtime.ts
+++ b/src/providers/sellersprite/runtime.ts
@@ -16,7 +16,6 @@ import {
 export const sellerSpriteApiBaseUrl = "https://api.sellersprite.com";
 
 const sellerSpriteValidationPath = "/v1/visits";
-const sellerSpriteRequestTimeoutMs = 30_000;
 const sellerSpriteMarketplaces = new Set(["US", "JP", "UK", "DE", "FR", "IT", "ES", "CA", "IN"]);
 const competitorStringFields: readonly string[] = ["brand", "sellerName", "nodeIdPath", "keyword"];
 const researchStringFields: readonly string[] = [
@@ -144,7 +143,7 @@ export function toSellerSpriteExecutionError(error: unknown): ExecutionResult {
 }
 
 async function requestSellerSpriteData(input: SellerSpriteRequest): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, sellerSpriteRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   let response: Response;
   let payload: unknown;
 

--- a/src/providers/semantic_scholar/executors.ts
+++ b/src/providers/semantic_scholar/executors.ts
@@ -24,7 +24,6 @@ const service = "semantic_scholar";
 
 const graphApiBaseUrl = "https://api.semanticscholar.org/graph/v1";
 const recommendationsApiBaseUrl = "https://api.semanticscholar.org/recommendations/v1";
-const semanticScholarDefaultRequestTimeoutMs = 30_000;
 
 type SemanticScholarPhase = "validate" | "execute";
 type SemanticScholarApiFamily = "graph" | "recommendations";
@@ -348,7 +347,7 @@ async function requestSemanticScholarJson(input: {
   fetcher: typeof fetch;
   phase: SemanticScholarPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, semanticScholarDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildSemanticScholarUrl(input), {

--- a/src/providers/semrush/executors.ts
+++ b/src/providers/semrush/executors.ts
@@ -14,7 +14,6 @@ import {
 
 export const semrushApiBaseUrl = "https://api.semrush.com";
 
-const semrushDefaultRequestTimeoutMs = 30_000;
 const semrushEmptyResultPrefix = "ERROR 50 :: NOTHING FOUND";
 
 type SemrushPhase = "validate" | "execute";
@@ -129,7 +128,7 @@ async function requestSemrushReport(input: {
   fetcher: typeof fetch;
   phase: SemrushPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, semrushDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildSemrushUrl(input.apiKey, input.params), {

--- a/src/providers/sensibo/runtime.ts
+++ b/src/providers/sensibo/runtime.ts
@@ -14,7 +14,6 @@ import {
 const service = "sensibo";
 const sensiboApiBaseUrl = "https://home.sensibo.com/api/v2";
 const sensiboValidationPath = "/users/me/pods";
-const sensiboTimeoutMs = 30_000;
 const defaultDeviceFields = "id,name,room,measurements,acState,connectionStatus,productModel";
 
 type SensiboPhase = "validate" | "execute";
@@ -140,7 +139,7 @@ async function requestSensiboJson(input: {
   phase: SensiboPhase;
 }): Promise<unknown> {
   const url = buildSensiboUrl(input.path, input.apiKey, input.query);
-  const timeout = createProviderTimeout(input.context.signal, sensiboTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: input.method,

--- a/src/providers/serply/executors.ts
+++ b/src/providers/serply/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "serply";
 const serplyBaseUrl = "https://api.serply.io";
-const serplyDefaultRequestTimeoutMs = 30_000;
 
 type SerplyPhase = "validate" | "execute";
 
@@ -125,7 +124,7 @@ async function requestSerplyJson(
 ): Promise<unknown> {
   let response: Response;
   let payload: unknown;
-  const timeout = createProviderTimeout(context.signal, serplyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     response = await context.fetcher(buildSerplyUrl(path, query), {

--- a/src/providers/serveravatar/executors.ts
+++ b/src/providers/serveravatar/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "serveravatar";
 const serverAvatarApiBaseUrl = "https://api.serveravatar.com";
-const serverAvatarRequestTimeoutMs = 30_000;
 
 type ServerAvatarRequestPhase = "validate" | "execute";
 type QueryValue = string | number | undefined;
@@ -127,7 +126,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestServerAvatarJson(input: ServerAvatarRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, serverAvatarRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = new URL(input.path, serverAvatarApiBaseUrl);
   appendQuery(url, input.query);
 

--- a/src/providers/sheetdb/runtime.ts
+++ b/src/providers/sheetdb/runtime.ts
@@ -189,7 +189,7 @@ async function deleteRows(input: Record<string, unknown>, context: SheetDbContex
 
 export async function requestSheetDb(input: SheetDbRequestInput): Promise<unknown> {
   const url = buildSheetDbUrl(input.apiId, input.path, input.query);
-  const timeout = createProviderTimeout(input.signal, 30_000);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/sherpa/executors.ts
+++ b/src/providers/sherpa/executors.ts
@@ -116,7 +116,7 @@ async function request(
   fetcher: typeof fetch,
   signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(signal, 30_000);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(`${apiBaseUrl}${path}`, {
       method: "POST",

--- a/src/providers/ship_bob/executors.ts
+++ b/src/providers/ship_bob/executors.ts
@@ -13,7 +13,6 @@ import {
 const service = "ship_bob";
 const shipBobApiBaseUrl = "https://api.shipbob.com";
 const shipBobApiVersionPath = "/2026-01";
-const shipBobRequestTimeoutMs = 30_000;
 
 type ShipBobRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | readonly (string | number | boolean)[] | undefined;
@@ -170,7 +169,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestShipBobJson(options: ShipBobRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.context.signal, shipBobRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   const url = new URL(`${shipBobApiBaseUrl}${shipBobApiVersionPath}${options.path}`);
   appendQuery(url, options.query);
 

--- a/src/providers/shippo/executors.ts
+++ b/src/providers/shippo/executors.ts
@@ -26,7 +26,6 @@ import {
 const service = "shippo";
 const shippoApiBaseUrl = "https://api.goshippo.com";
 const shippoApiVersion = "2018-02-08";
-const shippoDefaultRequestTimeoutMs = 30_000;
 const shippoValidationEndpoint = "/addresses/";
 const shippoFetch = createProviderFetch({ skipDnsValidation: true });
 
@@ -207,7 +206,7 @@ async function requestShippoJson(input: ShippoRequestInput): Promise<unknown> {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, shippoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/shodan/executors.ts
+++ b/src/providers/shodan/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "shodan";
 const shodanApiBaseUrl = "https://api.shodan.io";
-const shodanDefaultRequestTimeoutMs = 30_000;
 const validationEndpoint = "/api-info";
 
 type ShodanPhase = "validate" | "execute";
@@ -134,7 +133,7 @@ async function requestShodanJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ShodanPhase,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, shodanDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildShodanUrl(input, context.apiKey), {
       method: "GET",

--- a/src/providers/shortpixel/runtime.ts
+++ b/src/providers/shortpixel/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 const shortpixelAccountApiBaseUrl = "https://api.shortpixel.com/v2";
 const shortpixelCdnApiBaseUrl = "https://no-cdn.shortpixel.ai";
-const shortpixelDefaultRequestTimeoutMs = 30_000;
 
 type ShortpixelPhase = "validate" | "execute";
 type ShortpixelActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -132,7 +131,7 @@ async function requestShortpixelJson(
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">,
   phase: ShortpixelPhase,
 ) {
-  const timeoutHandle = createProviderTimeout(context.signal, shortpixelDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(context.signal);
 
   try {
     const response = await context.fetcher(input.url, {

--- a/src/providers/shotstack/runtime.ts
+++ b/src/providers/shotstack/runtime.ts
@@ -9,8 +9,6 @@ import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "
 const shotstackApiBaseUrl = "https://api.shotstack.io/edit/v1";
 export const shotstackProxyBaseUrl = "https://api.shotstack.io";
 
-const shotstackRequestTimeoutMs = 30_000;
-
 type ShotstackRequestPhase = "validate" | "execute";
 
 export const shotstackActionHandlers: ProviderActionHandlers<
@@ -128,7 +126,7 @@ async function requestShotstackJson(input: {
   signal?: AbortSignal;
   phase: ShotstackRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, shotstackRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const headers: Record<string, string> = {
     accept: "application/json",
     "x-api-key": input.apiKey,

--- a/src/providers/signaturely/runtime.ts
+++ b/src/providers/signaturely/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const signaturelyApiBaseUrl = "https://api.signaturely.com/api/v1/";
-const timeoutMs = 30_000;
 export const signaturelyActionHandlers: ProviderActionHandlers<
   "signaturely",
   ProviderRuntimeHandler<ApiKeyProviderContext>
@@ -91,7 +90,7 @@ async function request(
   method = "GET",
   body?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(path, signaturelyApiBaseUrl), {
       method,

--- a/src/providers/signpath/runtime.ts
+++ b/src/providers/signpath/runtime.ts
@@ -21,7 +21,6 @@ type SignpathActionHandler = (input: Record<string, unknown>, context: SignpathA
 type SignpathPhase = "validate" | "execute";
 
 export const signpathApiBaseUrl = "https://app.signpath.io/api/v1";
-const signpathDefaultRequestTimeoutMs = 30_000;
 
 export const signpathActionHandlers: ProviderActionHandlers<"signpath", SignpathActionHandler> = {
   async list_signing_policies(input, context) {
@@ -145,7 +144,7 @@ async function requestSignpathJson(
   signal: AbortSignal | undefined,
   phase: SignpathPhase,
 ) {
-  const timeoutSignal = createProviderTimeout(signal, signpathDefaultRequestTimeoutMs);
+  const timeoutSignal = createProviderTimeout(signal);
 
   try {
     const response = await fetcher(buildSignpathUrl(input), {

--- a/src/providers/simplesat/runtime.ts
+++ b/src/providers/simplesat/runtime.ts
@@ -13,7 +13,6 @@ import {
 export const simplesatApiBaseUrl = "https://api.simplesat.io";
 export const simplesatValidationPath = "/api/v1/surveys";
 
-const simplesatDefaultRequestTimeoutMs = 30_000;
 const simplesatCredentialHelpUrl = "https://app.simplesat.io/settings/api-keys/";
 
 type SimplesatRequestPhase = "validate" | "execute";
@@ -226,7 +225,7 @@ export async function validateSimplesatCredential(
 }
 
 async function requestSimplesatJson(input: SimplesatRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, simplesatDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(buildSimplesatUrl(input), {

--- a/src/providers/simplybook_me/executors.ts
+++ b/src/providers/simplybook_me/executors.ts
@@ -14,7 +14,6 @@ import {
 const service = "simplybook_me";
 const simplybookMeApiBaseUrl = "https://user-api.simplybook.me";
 const simplybookMeLoginUrl = `${simplybookMeApiBaseUrl}/login`;
-const simplybookMeDefaultRequestTimeoutMs = 30_000;
 
 interface SimplybookMeContext {
   companyLogin: string;
@@ -152,7 +151,7 @@ function callPublicMethod(context: SimplybookMeContext, method: string, params: 
 }
 
 async function callJsonRpc(input: JsonRpcRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, simplybookMeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(input.url, {
       method: "POST",

--- a/src/providers/skio/runtime.ts
+++ b/src/providers/skio/runtime.ts
@@ -17,7 +17,6 @@ import {
 
 export const skioApiBaseUrl = "https://api.skio.com/public-rest-api-http";
 const validationPath = "/subscriptions";
-const timeoutMs = 30_000;
 
 type SkioPhase = "validate" | "execute";
 type SkioActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -143,7 +142,7 @@ async function requestSkioJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, timeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildSkioUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/skyvern/runtime.ts
+++ b/src/providers/skyvern/runtime.ts
@@ -3,7 +3,6 @@ import { jsonObject } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 export const skyvernApiBaseUrl = "https://api.skyvern.com";
-const skyvernRequestTimeoutMs = 30_000;
 type SkyvernRequestPhase = "validate" | "execute";
 
 export async function validateSkyvernCredential(apiKey: string, fetcher: typeof fetch): Promise<void> {
@@ -188,7 +187,7 @@ async function requestSkyvernJson(input: {
   fetcher: typeof fetch;
   phase: SkyvernRequestPhase;
 }) {
-  const timeout = createProviderTimeout(undefined, skyvernRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(new URL(input.path, skyvernApiBaseUrl), {
       method: input.method,

--- a/src/providers/slack/runtime.ts
+++ b/src/providers/slack/runtime.ts
@@ -17,7 +17,6 @@ import { slackConversationTypes } from "./constants.ts";
 
 const slackApiBaseUrl = "https://slack.com/api";
 const slackFileUrlMaxBytes = 100 * 1024 * 1024;
-const slackFileUrlFetchTimeoutMs = 30_000;
 
 type SlackActionContext = Omit<OAuthProviderContext, "providerSecret" | "tokenType">;
 type SlackOAuthTokenKind = "bot" | "user";
@@ -773,7 +772,7 @@ async function resolveSlackFileContent(
 ): Promise<Uint8Array> {
   const fileUrl = requiredString(input.fileUrl, "fileUrl", (message) => new ProviderRequestError(400, message));
   assertFetchableFileUrl(fileUrl);
-  const timeout = createProviderTimeout(context.signal, slackFileUrlFetchTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(fileUrl, { signal: timeout.signal });
     if (!response.ok) {

--- a/src/providers/sling/executors.ts
+++ b/src/providers/sling/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "sling";
 const slingApiBaseUrl = "https://api.getsling.com/v1";
-const slingRequestTimeoutMs = 30_000;
 
 type SlingPhase = "validate" | "execute";
 type SlingQueryValue = string | number | boolean | readonly (string | number)[];
@@ -142,7 +141,7 @@ async function requestSlingJson(input: {
   phase: SlingPhase;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, slingRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildSlingUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/smartrecruiters/runtime.ts
+++ b/src/providers/smartrecruiters/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const smartrecruitersApiBaseUrl = "https://api.smartrecruiters.com";
 
-const smartrecruitersDefaultTimeoutMs = 30_000;
-
 type SmartRecruitersPhase = "validate" | "execute";
 type SmartRecruitersActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 type SmartRecruitersQuery = Record<string, string | readonly string[] | undefined>;
@@ -117,7 +115,7 @@ async function requestSmartRecruitersJson(
   input: SmartRecruitersRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, smartrecruitersDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildSmartRecruitersUrl(input.path, input.query), {
       method: input.method,

--- a/src/providers/smartsheet/runtime.ts
+++ b/src/providers/smartsheet/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const smartsheetApiBaseUrl = "https://api.smartsheet.com/2.0";
-const smartsheetDefaultRequestTimeoutMs = 30_000;
 const smartsheetIntegrationSource = "AI,OOMOL,oomol-connect";
 
 type SmartsheetPhase = "validate" | "execute";
@@ -163,7 +162,7 @@ async function requestSmartsheetJson(input: {
   phase: SmartsheetPhase;
   body?: unknown;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, smartsheetDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildSmartsheetUrl(input.path, input.params), {
       method: input.method,

--- a/src/providers/smartsuite/runtime.ts
+++ b/src/providers/smartsuite/runtime.ts
@@ -10,7 +10,6 @@ interface ApiKeyProviderActionInput {
 }
 
 export const smartsuiteApiBaseUrl = "https://app.smartsuite.com/api/v1";
-const smartsuiteRequestTimeoutMs = 30_000;
 
 interface SmartsuiteActionInput extends ApiKeyProviderActionInput {
   actionName: string;
@@ -158,7 +157,7 @@ async function requestSmartsuite(input: SmartsuiteRequestInput) {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(undefined, smartsuiteRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/smtp2go/runtime.ts
+++ b/src/providers/smtp2go/runtime.ts
@@ -12,8 +12,6 @@ import {
 
 export const smtp2goApiBaseUrl = "https://api.smtp2go.com/v3";
 
-const smtp2goDefaultRequestTimeoutMs = 30_000;
-
 type Smtp2goPhase = "validate" | "execute";
 type Smtp2goActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -202,7 +200,7 @@ async function requestSmtp2goJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: Smtp2goPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, smtp2goDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildSmtp2goUrl(input.path), {

--- a/src/providers/snipcart/runtime.ts
+++ b/src/providers/snipcart/runtime.ts
@@ -2,7 +2,6 @@ import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 
 const snipcartApiBaseUrl = "https://app.snipcart.com/api";
-const snipcartRequestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 
@@ -107,7 +106,7 @@ async function requestSnipcartJson(input: {
   fetcher: typeof fetch;
   phase: RequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, snipcartRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
   const url = new URL(`${snipcartApiBaseUrl}${input.path}`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/snyk/runtime.ts
+++ b/src/providers/snyk/runtime.ts
@@ -29,7 +29,6 @@ interface RequestInput {
 
 export const snykApiBaseUrl = "https://api.snyk.io/rest";
 const apiVersion = "2024-10-15";
-const timeoutMs = 30_000;
 
 export const snykActionHandlers: ProviderActionHandlers<"snyk", ProviderRuntimeHandler<ApiKeyProviderContext>> = {
   async get_self(_input, context) {
@@ -174,7 +173,7 @@ export async function validateSnykCredential(
 }
 
 async function requestJson(input: RequestInput): Promise<SnykResponse> {
-  const timeout = createProviderTimeout(input.context.signal, timeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const url = buildUrl(input.path, input.query, input.commaArrays);
     const response = await input.context.fetcher(url, {

--- a/src/providers/sonarcloud/runtime.ts
+++ b/src/providers/sonarcloud/runtime.ts
@@ -22,7 +22,6 @@ import {
 } from "../provider-runtime.ts";
 import { sonarCloudAllowedApiBaseUrls, sonarCloudDefaultApiBaseUrl } from "./constants.ts";
 
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 
 type SonarCloudPhase = "validate" | "execute";
@@ -170,7 +169,7 @@ export async function validateSonarCloudCredential(
 }
 
 async function requestSonarCloudJson(input: SonarCloudRequest): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildSonarCloudUrl(input), {
       method: "GET",

--- a/src/providers/sportsdata/runtime.ts
+++ b/src/providers/sportsdata/runtime.ts
@@ -14,7 +14,6 @@ import {
 export const sportsdataApiBaseUrl = "https://api.sportsdata.io";
 
 const apiKeyHeader = "Ocp-Apim-Subscription-Key";
-const requestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 type SportsdataActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -107,7 +106,7 @@ async function requestSportsdata(
   signal: AbortSignal | undefined,
   phase: RequestPhase,
 ): Promise<unknown[]> {
-  const timeout = createProviderTimeout(signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(new URL(path, sportsdataApiBaseUrl), {
       headers: { accept: "application/json", [apiKeyHeader]: apiKey, "user-agent": providerUserAgent },

--- a/src/providers/sslmate_cert_spotter_api/runtime.ts
+++ b/src/providers/sslmate_cert_spotter_api/runtime.ts
@@ -13,8 +13,6 @@ import {
 export const certSpotterMonitoringApiBaseUrl: string = "https://sslmate.com/api/v3/monitoring";
 export const certSpotterCtSearchApiBaseUrl: string = "https://api.certspotter.com/v1";
 
-const certSpotterDefaultRequestTimeoutMs = 30_000;
-
 type CertSpotterRequestPhase = "validate" | "execute";
 type CertSpotterActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -190,7 +188,7 @@ async function requestCertSpotterJson(input: {
   body?: string;
   phase: CertSpotterRequestPhase;
 }): Promise<{ response: Response; payload: unknown }> {
-  const timeout = createProviderTimeout(input.context.signal, certSpotterDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(input.url, {
       method: input.method,

--- a/src/providers/stabilityai/executors.ts
+++ b/src/providers/stabilityai/executors.ts
@@ -17,7 +17,6 @@ const service = "stabilityai";
 const stabilityAiApiBaseUrl = "https://api.stability.ai";
 const stabilityAiValidationPath = "/v1/user/account";
 const stabilityAiTextToAudioPath = "/v2beta/audio/stable-audio-2/text-to-audio";
-const stabilityAiDefaultRequestTimeoutMs = 30_000;
 
 type StabilityAiPhase = "validate" | "execute";
 type StabilityAiActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -199,7 +198,7 @@ async function requestStabilityAiJson(input: StabilityAiRequestInput): Promise<u
 }
 
 async function requestStabilityAiResponse(input: StabilityAiRequestInput): Promise<Response> {
-  const timeout = createProviderTimeout(input.signal, stabilityAiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(new URL(input.path, stabilityAiApiBaseUrl), {
       method: input.method ?? "GET",

--- a/src/providers/stack_ai/executors.ts
+++ b/src/providers/stack_ai/executors.ts
@@ -24,7 +24,6 @@ import {
 
 const service = "stack_ai";
 const stackAiInferenceBaseUrl = "https://stack-inference.com";
-const stackAiRequestTimeoutMs = 30_000;
 
 const stackAiFetch = createProviderFetch({ skipDnsValidation: true });
 
@@ -183,7 +182,7 @@ async function stackAiJsonRequest(
   },
   context: StackAiContext,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, stackAiRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const url = new URL(input.path, stackAiInferenceBaseUrl);
     for (const [key, value] of Object.entries(input.query ?? {})) {

--- a/src/providers/stack_overflow_for_teams/runtime.ts
+++ b/src/providers/stack_overflow_for_teams/runtime.ts
@@ -13,7 +13,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const stackOverflowForTeamsApiBaseUrl = "https://api.stackoverflowteams.com/v3/";
-const requestTimeoutMs = 30_000;
 
 export interface StackOverflowForTeamsContext {
   apiKey: string;
@@ -114,7 +113,7 @@ async function requestPaginated(
 async function requestJson(input: RequestInput): Promise<unknown> {
   const url = new URL(`teams/${encodeURIComponent(input.team)}/${input.path}`, stackOverflowForTeamsApiBaseUrl);
   if (input.query) url.search = input.query.toString();
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       headers: {

--- a/src/providers/stannp/runtime.ts
+++ b/src/providers/stannp/runtime.ts
@@ -16,7 +16,6 @@ export interface StannpActionContext {
 
 type StannpRequestPhase = "validate" | "execute";
 
-const stannpDefaultRequestTimeoutMs = 30_000;
 const stannpBaseUrlByRegion: Record<StannpRegion, string> = {
   eu: "https://api-eu1.stannp.com",
   us: "https://api-us1.stannp.com",
@@ -246,7 +245,7 @@ async function stannpRequest(
   init: RequestInit,
   phase: StannpRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, stannpDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       ...init,

--- a/src/providers/starton/executors.ts
+++ b/src/providers/starton/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "starton";
 const startonApiBaseUrl = "https://api.starton.com";
-const startonDefaultRequestTimeoutMs = 30_000;
 
 type StartonPhase = "validate" | "execute";
 type StartonActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -145,7 +144,7 @@ async function requestStartonJson(input: {
   query?: Record<string, string | boolean | undefined>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, startonDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildStartonUrl(input.path, input.query ?? {}), {
       method: input.method,

--- a/src/providers/statamic/executors.ts
+++ b/src/providers/statamic/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "statamic";
 const statamicApiBaseUrl = "https://statamic.com/api/v1";
-const statamicDefaultRequestTimeoutMs = 30_000;
 
 type StatamicPhase = "validate" | "execute";
 type StatamicActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -113,7 +112,7 @@ async function requestStatamicJson(input: {
   phase: StatamicPhase;
   body?: Record<string, unknown>;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, statamicDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/statista/runtime.ts
+++ b/src/providers/statista/runtime.ts
@@ -13,7 +13,6 @@ import {
 export const statistaApiBaseUrl = "https://api.statista.ai";
 
 const statistaValidationPath = "/v1/search/statistics";
-const statistaDefaultTimeoutMs = 30_000;
 
 type StatistaMode = "validate" | "execute";
 type StatistaQuery = Record<string, string | undefined>;
@@ -120,7 +119,7 @@ async function requestStatistaJson(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, statistaDefaultTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(url, {

--- a/src/providers/statuscake/executors.ts
+++ b/src/providers/statuscake/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "statuscake";
 const statuscakeApiBaseUrl = "https://api.statuscake.com/v1";
-const statuscakeDefaultRequestTimeoutMs = 30_000;
 
 type StatuscakePhase = "validate" | "execute";
 type StatuscakeActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -248,7 +247,7 @@ async function statuscakeFetch(input: {
     url.search = input.query.toString();
   }
 
-  const timeout = createProviderTimeout(input.context.signal, statuscakeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     return await input.context.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/store_leads/executors.ts
+++ b/src/providers/store_leads/executors.ts
@@ -16,7 +16,6 @@ import {
 const service = "store_leads";
 const storeLeadsApiBaseUrl = "https://storeleads.app/json/api/v1/all";
 const storeLeadsValidationPath = "/app";
-const storeLeadsDefaultRequestTimeoutMs = 30_000;
 
 type StoreLeadsPhase = "validate" | "execute";
 type StoreLeadsActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -138,7 +137,7 @@ async function requestStoreLeadsJson(input: {
   phase: StoreLeadsPhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, storeLeadsDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildStoreLeadsUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/storecensus/executors.ts
+++ b/src/providers/storecensus/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "storecensus";
 const storecensusApiBaseUrl = "https://www.storecensus.com/api/v1";
 const storecensusValidationPath = "/app-categories";
-const storecensusDefaultRequestTimeoutMs = 30_000;
 
 type StorecensusPhase = "validate" | "execute";
 type StorecensusActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -115,7 +114,7 @@ async function requestStorecensusJson(input: {
   query?: URLSearchParams;
   body?: unknown;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, storecensusDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/streamtime/runtime.ts
+++ b/src/providers/streamtime/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const streamtimeApiBaseUrl = "https://api.streamtime.net/v2";
 const streamtimeValidationPath = "/organisation";
-const streamtimeRequestTimeoutMs = 30_000;
 
 type StreamtimeMode = "validation" | "execution";
 type StreamtimeMethod = "GET" | "POST" | "PUT";
@@ -161,7 +160,7 @@ async function streamtimeRequest(
   mode: StreamtimeMode,
 ): Promise<unknown> {
   const url = new URL(path.startsWith("/") ? path.slice(1) : path, `${streamtimeApiBaseUrl}/`);
-  const timeout = createProviderTimeout(context.signal, streamtimeRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   let response: Response;
   try {

--- a/src/providers/superchat/runtime.ts
+++ b/src/providers/superchat/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 const superchatApiBaseUrl = "https://api.superchat.com";
 const superchatApiVersionPath = "/v1.0";
-const superchatRequestTimeoutMs = 30_000;
 
 type SuperchatPhase = "validate" | "execute";
 type SuperchatMethod = "GET" | "POST" | "PATCH";
@@ -310,7 +309,7 @@ function buildSender(input: Record<string, unknown>): Record<string, unknown> {
 }
 
 async function requestSuperchatJson(input: SuperchatRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, superchatRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(`${superchatApiVersionPath}${input.path}`, superchatApiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));

--- a/src/providers/survey_monkey/runtime.ts
+++ b/src/providers/survey_monkey/runtime.ts
@@ -16,7 +16,6 @@ const surveyMonkeyApiBaseUrls = [
   "https://api.surveymonkey.ca",
 ] as const;
 
-const surveyMonkeyDefaultRequestTimeoutMs = 30_000;
 const surveyMonkeyValidationPath = "/v3/users/me";
 
 type SurveyMonkeyRequestPhase = "validate" | "execute" | "trigger";
@@ -325,7 +324,7 @@ async function requestSurveyMonkeyJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(undefined, surveyMonkeyDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/systeme_io/runtime.ts
+++ b/src/providers/systeme_io/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const systemeIoApiBaseUrl = "https://api.systeme.io";
-const systemeIoDefaultRequestTimeoutMs = 30_000;
 
 type SystemeIoPhase = "validate" | "execute";
 type SystemeIoMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -380,7 +379,7 @@ function pageParams(input: Record<string, unknown>): Record<string, string | und
 }
 
 async function requestSystemeIoJson(input: SystemeIoRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, systemeIoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const headers: Record<string, string> = {
       "x-api-key": input.apiKey,

--- a/src/providers/taiga/runtime.ts
+++ b/src/providers/taiga/runtime.ts
@@ -49,8 +49,6 @@ interface TaigaListResult {
 
 type TaigaActionHandler = (input: Record<string, unknown>, context: TaigaContext) => Promise<unknown>;
 
-const requestTimeoutMs = 30_000;
-
 export const taigaActionHandlers: Record<string, TaigaActionHandler> = {
   list_projects: actionHandler("list_projects"),
   get_project: actionHandler("get_project"),
@@ -210,7 +208,7 @@ async function requestWithoutToken(input: TaigaRequestInput, authToken?: string)
     "user-agent": providerUserAgent,
   });
   if (authToken) headers.set("authorization", `Bearer ${authToken}`);
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/talenox/executors.ts
+++ b/src/providers/talenox/executors.ts
@@ -19,7 +19,6 @@ import {
 
 const service = "talenox";
 const talenoxApiBaseUrl = "https://api.talenox.com/api/v2";
-const talenoxDefaultRequestTimeoutMs = 30_000;
 const talenoxValidationPath = "/company_settings";
 
 interface TalenoxRequestOptions {
@@ -149,7 +148,7 @@ async function getTalenoxEntity(
 
 async function requestTalenoxJson(options: TalenoxRequestOptions): Promise<unknown> {
   const url = new URL(`${talenoxApiBaseUrl}${options.path}`);
-  const timeout = createProviderTimeout(options.signal, talenoxDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   try {
     const response = await options.fetcher(url, {
       method: "GET",

--- a/src/providers/tanium/runtime.ts
+++ b/src/providers/tanium/runtime.ts
@@ -15,7 +15,6 @@ import {
 
 export const taniumGatewayPath = "/plugin/products/gateway/graphql";
 
-const taniumRequestTimeoutMs = 30_000;
 const taniumValidationOperationName = "OomolConnectValidation";
 const taniumValidationQuery = "query OomolConnectValidation { __typename }";
 
@@ -140,7 +139,7 @@ async function requestTaniumGraphql(input: {
   operationName?: string;
   variables?: Record<string, unknown>;
 }): Promise<TaniumGraphqlPayload> {
-  const timeout = createProviderTimeout(input.signal, taniumRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(input.gatewayUrl, {
       method: "POST",

--- a/src/providers/tapfiliate/runtime.ts
+++ b/src/providers/tapfiliate/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const tapfiliateApiBaseUrl: string = "https://api.tapfiliate.com/1.6";
-const tapfiliateDefaultRequestTimeoutMs = 30_000;
 
 type TapfiliatePhase = "validate" | "execute";
 type TapfiliateActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -283,7 +282,7 @@ async function requestTapfiliateJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: TapfiliatePhase;
 }): Promise<TapfiliateJsonResponse> {
-  const timeout = createProviderTimeout(input.context.signal, tapfiliateDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/tave/runtime.ts
+++ b/src/providers/tave/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const taveApiBaseUrl = "https://workspace.vsco.co/api/v2";
-const defaultTimeoutMs = 30_000;
 
 type TaveActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 type TaveContactKind = "person" | "company" | "location" | "employee";
@@ -93,7 +92,7 @@ interface TaveRequestInput {
 }
 
 async function requestTaveJson(input: TaveRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, defaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const url = new URL(input.path.startsWith("/") ? input.path.slice(1) : input.path, `${taveApiBaseUrl}/`);
     setSearchParams(url, input.params);

--- a/src/providers/teamtailor/executors.ts
+++ b/src/providers/teamtailor/executors.ts
@@ -23,7 +23,6 @@ const service = "teamtailor";
 const teamtailorEuApiBaseUrl = "https://api.teamtailor.com";
 const teamtailorNaApiBaseUrl = "https://api.na.teamtailor.com";
 const teamtailorApiVersion = "20240904";
-const teamtailorDefaultRequestTimeoutMs = 30_000;
 
 type TeamtailorStack = "eu" | "na";
 type TeamtailorPhase = "validate" | "execute";
@@ -165,7 +164,7 @@ async function requestTeamtailorJson(input: {
 }): Promise<unknown> {
   const url = new URL(input.path, `${getTeamtailorBaseUrl(input.stack)}/`);
   setSearchParams(url, input.query ?? {});
-  const timeout = createProviderTimeout(input.context.signal, teamtailorDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url.toString(), {
       method: "GET",

--- a/src/providers/textmagic/runtime.ts
+++ b/src/providers/textmagic/runtime.ts
@@ -22,7 +22,6 @@ import {
 export const textmagicApiBaseUrl = "https://rest.textmagic.com/api/v2";
 
 const textmagicValidationPath = "/user";
-const textmagicRequestTimeoutMs = 30_000;
 
 export interface TextmagicActionContext {
   apiKey: string;
@@ -175,7 +174,7 @@ async function requestTextmagicJson(
     url.searchParams.set(name, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, textmagicRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/the_cat_api/runtime.ts
+++ b/src/providers/the_cat_api/runtime.ts
@@ -18,7 +18,6 @@ import {
 
 const theCatApiBaseUrl = "https://api.thecatapi.com/v1/";
 const theCatApiValidationPath = "/breeds";
-const theCatApiDefaultTimeoutMs = 30_000;
 
 type TheCatApiRequestPhase = "validate" | "execute";
 type TheCatApiContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -164,7 +163,7 @@ async function requestTheCatApiJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   phase: TheCatApiRequestPhase;
 }) {
-  const timeout = createProviderTimeout(input.context.signal, theCatApiDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = buildTheCatApiUrl(input.path, input.query);
 
   try {

--- a/src/providers/the_colony/runtime.ts
+++ b/src/providers/the_colony/runtime.ts
@@ -9,7 +9,6 @@ export const theColonyApiBaseUrl = "https://thecolony.cc/api/v1";
 
 const theColonyTokenPath = "/auth/token";
 const theColonyValidationPath = "/users/me";
-const theColonyDefaultTimeoutMs = 30_000;
 
 type TheColonyRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | readonly (string | number | boolean)[] | undefined;
@@ -267,7 +266,7 @@ async function fetchTheColony(input: {
   phase: TheColonyRequestPhase;
   signal?: AbortSignal;
 }): Promise<Response> {
-  const timeout = createProviderTimeout(input.signal, theColonyDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     return await input.fetcher(input.url.toString(), {
       ...input.init,

--- a/src/providers/the_dog_api/runtime.ts
+++ b/src/providers/the_dog_api/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from "../provider-runtime.ts";
 
 const theDogApiBaseUrl = "https://api.thedogapi.com/v1/";
-const defaultTimeoutMs = 30_000;
 
 type TheDogApiMethod = "GET" | "POST" | "DELETE";
 type TheDogApiHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -196,7 +195,7 @@ async function requestTheDogApiJson(input: {
   body?: Record<string, unknown>;
   phase?: "validate" | "execute";
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, defaultTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const url = new URL(input.path.startsWith("/") ? input.path.slice(1) : input.path, theDogApiBaseUrl);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, value);

--- a/src/providers/thehive/runtime.ts
+++ b/src/providers/thehive/runtime.ts
@@ -160,7 +160,7 @@ async function request(
   path: string,
   options: TheHiveRequestOptions = {},
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, 30_000);
+  const timeout = createProviderTimeout(context.signal);
   const url = new URL(path, `${context.baseUrl}/`);
   try {
     const headers: Record<string, string> = {

--- a/src/providers/tianyancha/runtime.ts
+++ b/src/providers/tianyancha/runtime.ts
@@ -18,7 +18,6 @@ import {
 
 export const tianyanchaApiBaseUrl = "https://open.api.tianyancha.com";
 
-const tianyanchaRequestTimeoutMs = 30_000;
 const tenderSearchTypeCode: Record<string, number> = { title: 1, purchaser: 2, supplier: 3 };
 const tenderNoticeTypeCode: Record<string, number> = { forecast: 1, announcement: 2, result: 4 };
 const relationshipTypeCode: Record<string, string> = {
@@ -218,7 +217,7 @@ async function requestTianyanchaResult(input: {
     if (value !== undefined) url.searchParams.set(name, String(value));
   }
 
-  const timeout = createProviderTimeout(input.context.signal, tianyanchaRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/timebuzzer/runtime.ts
+++ b/src/providers/timebuzzer/runtime.ts
@@ -20,7 +20,6 @@ import {
 
 export const timebuzzerApiBaseUrl = "https://my.timebuzzer.com";
 const apiPath = "/open-api";
-const timeoutMs = 30_000;
 
 export const timebuzzerActionHandlers: ProviderActionHandlers<
   "timebuzzer",
@@ -130,7 +129,7 @@ async function requestTimebuzzer(
 ): Promise<unknown> {
   const url = new URL(`${apiPath}${path}`, timebuzzerApiBaseUrl);
   for (const [name, value] of Object.entries(options.query ?? {})) url.searchParams.set(name, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: options.method ?? "GET",

--- a/src/providers/timecamp/runtime.ts
+++ b/src/providers/timecamp/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const timecampApiBaseUrl = "https://app.timecamp.com/third_party/api";
-const timecampDefaultRequestTimeoutMs = 30_000;
 
 type TimecampPhase = "validate" | "execute";
 type TimecampQueryValue = string | number | boolean | readonly (string | number)[] | undefined;
@@ -241,7 +240,7 @@ async function requestTimecampJson(input: {
   body?: Record<string, unknown>;
   phase: TimecampPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, timecampDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildTimecampUrl(input.path, input.params ?? {}), {

--- a/src/providers/timelinesai/runtime.ts
+++ b/src/providers/timelinesai/runtime.ts
@@ -6,7 +6,6 @@ import { compactObject, optionalBoolean, optionalRecord, optionalString } from "
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const timelinesAiApiBaseUrl = "https://app.timelines.ai/integrations/api";
-const timelinesAiRequestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 export const timelinesAiActionHandlers: ProviderActionHandlers<
@@ -168,7 +167,7 @@ async function request(input: RequestInput) {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, timelinesAiRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/timelink/runtime.ts
+++ b/src/providers/timelink/runtime.ts
@@ -16,7 +16,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const timelinkApiBaseUrl: string = "https://api.timelink.io/api/v1";
-const timelinkRequestTimeoutMs = 30_000;
 
 type TimelinkPhase = "validate" | "execute";
 type TimelinkActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -309,7 +308,7 @@ async function requestTimelinkJson(input: {
   fetcher: typeof fetch;
   phase: TimelinkPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, timelinkRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildTimelinkUrl(input.path, input.query), {

--- a/src/providers/token_metrics/executors.ts
+++ b/src/providers/token_metrics/executors.ts
@@ -15,7 +15,6 @@ import {
 const service = "token_metrics";
 const tokenMetricsApiBaseUrl = "https://api.tokenmetrics.com/v2";
 const tokenMetricsValidationPath = "/tokens";
-const tokenMetricsRequestTimeoutMs = 30_000;
 
 type TokenMetricsPhase = "validate" | "execute";
 type TokenMetricsQueryValue = string | number | undefined;
@@ -119,7 +118,7 @@ async function tokenMetricsGet(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal, tokenMetricsRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: "GET",

--- a/src/providers/tomba/runtime.ts
+++ b/src/providers/tomba/runtime.ts
@@ -10,7 +10,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const tombaApiBaseUrl: string = "https://api.tomba.io/v1";
-const tombaDefaultRequestTimeoutMs = 30_000;
 
 type TombaMode = "validate" | "execute";
 
@@ -152,7 +151,7 @@ async function requestTombaJson(
   input: TombaRequestInput,
   context: TombaActionContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, tombaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildTombaUrl(input), {
       method: input.method,

--- a/src/providers/torii/runtime.ts
+++ b/src/providers/torii/runtime.ts
@@ -13,7 +13,6 @@ import {
 export const toriiApiBaseUrl = "https://api.toriihq.com/v1.0";
 
 const toriiValidationPath = "/orgs/my";
-const toriiDefaultRequestTimeoutMs = 30_000;
 
 type ToriiPhase = "validate" | "execute";
 
@@ -219,7 +218,7 @@ async function requestToriiJson(
   options: ToriiRequestOptions,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, toriiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
 
   try {
     const headers: Record<string, string> = {

--- a/src/providers/tpscheck/runtime.ts
+++ b/src/providers/tpscheck/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from "../provider-runtime.ts";
 
 const tpscheckApiBaseUrl = "https://api.tpscheck.uk";
-const tpscheckDefaultRequestTimeoutMs = 30_000;
 
 type TpscheckRequestPhase = "validate" | "execute";
 type TpscheckActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -99,7 +98,7 @@ async function requestTpscheckJson(
     if (value) url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(context.signal, tpscheckDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   let payload: unknown;
   try {

--- a/src/providers/trawlingweb/runtime.ts
+++ b/src/providers/trawlingweb/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const trawlingwebApiBaseUrl = "https://api.trawlingweb.com";
-const timeoutMs = 30_000;
 
 export const trawlingwebActionHandlers: ProviderActionHandlers<
   "trawlingweb",
@@ -61,7 +60,7 @@ async function requestNews(
   const url = new URL("/", trawlingwebApiBaseUrl);
   url.searchParams.set("token", context.apiKey);
   for (const [name, value] of Object.entries(query)) url.searchParams.set(name, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: { accept: "application/json", "user-agent": providerUserAgent },

--- a/src/providers/tremendous/executors.ts
+++ b/src/providers/tremendous/executors.ts
@@ -21,7 +21,6 @@ import {
 export const tremendousApiBaseUrl = "https://api.tremendous.com/api/v2";
 export const tremendousValidationPath = "/organizations";
 const service = "tremendous";
-const tremendousDefaultRequestTimeoutMs = 30_000;
 
 type TremendousPhase = "validate" | "execute";
 type TremendousActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -274,7 +273,7 @@ async function requestTremendousJson(input: {
   query?: URLSearchParams;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, tremendousDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
 
   try {
     const response = await input.context.fetcher(buildTremendousUrl(input), {

--- a/src/providers/trendshift/runtime.ts
+++ b/src/providers/trendshift/runtime.ts
@@ -9,7 +9,6 @@ import {
 
 export const trendshiftApiBaseUrl = "https://api.trendshift.io";
 export const trendshiftValidationPath = "/v1/trending/daily";
-const requestTimeoutMs = 30_000;
 
 type TrendshiftRequestMode = "validate" | "execute";
 type QueryValue = number | string | undefined;
@@ -141,7 +140,7 @@ async function requestTrendshiftJson(input: {
   for (const [name, value] of Object.entries(input.request.query ?? {})) {
     if (value !== undefined) url.searchParams.set(name, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/triggercmd/runtime.ts
+++ b/src/providers/triggercmd/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const triggercmdApiBaseUrl = "https://www.triggercmd.com";
 
-const triggercmdRequestTimeoutMs = 30_000;
 const listCommandsPath = "/api/command/list";
 
 type TriggercmdRequestPhase = "validate" | "execute";
@@ -93,7 +92,7 @@ export async function validateTriggercmdCredential(
 }
 
 async function requestTriggercmdPayload(input: TriggercmdRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, triggercmdRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     const headers: Record<string, string> = {

--- a/src/providers/turso/runtime.ts
+++ b/src/providers/turso/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 const tursoApiBaseUrl = "https://api.turso.tech";
-const tursoRequestTimeoutMs = 30_000;
 
 type TursoPhase = "validate" | "execute";
 type TursoMethod = "GET" | "POST" | "DELETE";
@@ -166,7 +165,7 @@ async function requestTursoJson(
   input: TursoRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, tursoRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(input.path, tursoApiBaseUrl), {
       method: input.method,

--- a/src/providers/tushare/runtime.ts
+++ b/src/providers/tushare/runtime.ts
@@ -34,7 +34,6 @@ interface TushareRequestInput {
 type TushareActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
 export const tushareApiBaseUrl: string = "https://api.tushare.pro";
-const tushareRequestTimeoutMs = 30_000;
 
 const stockBasicFields = [
   "ts_code",
@@ -343,7 +342,7 @@ async function tushareRequest(
   input: TushareRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, tushareRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(tushareApiBaseUrl, {
       method: "POST",

--- a/src/providers/tuskr/runtime.ts
+++ b/src/providers/tuskr/runtime.ts
@@ -12,7 +12,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const tuskrApiBaseUrl = "https://api.tuskr.live/api";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 
 export interface TuskrActionContext {
@@ -100,7 +99,7 @@ async function tuskrRequest(
   context: TuskrActionContext,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const headers = new Headers(init.headers);
     headers.set("authorization", `Bearer ${context.accessToken}`);

--- a/src/providers/twochat/runtime.ts
+++ b/src/providers/twochat/runtime.ts
@@ -7,7 +7,6 @@ import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "
 export const twochatApiBaseUrl = "https://api.p.2chat.io";
 
 const twochatValidationPath = "/open/info";
-const twochatRequestTimeoutMs = 30_000;
 
 type TwochatRequestPhase = "validate" | "execute";
 type TwochatQueryValue = string | number | boolean | undefined;
@@ -160,7 +159,7 @@ async function requestTwochatJson(input: TwochatRequestInput): Promise<unknown> 
 }
 
 async function requestTwochat(input: TwochatRequestInput): Promise<TwochatResponse> {
-  const timeout = createProviderTimeout(input.signal, twochatRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(input.path, `${twochatApiBaseUrl}/`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) {

--- a/src/providers/typebot/runtime.ts
+++ b/src/providers/typebot/runtime.ts
@@ -20,7 +20,6 @@ import {
 
 export const typebotApiBaseUrl = "https://app.typebot.com/api";
 const validationPath = "/v1/workspaces";
-const timeoutMs = 30_000;
 
 const get =
   (
@@ -87,7 +86,7 @@ async function requestTypebot(
 ): Promise<Record<string, unknown>> {
   const url = new URL(`${typebotApiBaseUrl}${path}`);
   for (const [name, value] of Object.entries(query ?? {})) url.searchParams.set(name, value);
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       headers: {

--- a/src/providers/typeform/runtime.ts
+++ b/src/providers/typeform/runtime.ts
@@ -19,7 +19,6 @@ import {
 
 export const typeformApiBaseUrl: string = "https://api.typeform.com";
 const typeformValidationPath = "/me";
-const typeformDefaultRequestTimeoutMs = 30_000;
 
 type TypeformRequestPhase = "validate" | "execute";
 type TypeformQueryValue = string | number | undefined;
@@ -211,7 +210,7 @@ async function requestTypeformJson(input: {
     }
   }
 
-  const timeoutHandle = createProviderTimeout(input.signal, typeformDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(input.signal);
 
   try {
     const response = await input.fetcher(url, {

--- a/src/providers/u301/runtime.ts
+++ b/src/providers/u301/runtime.ts
@@ -12,7 +12,6 @@ import {
 const u301ApiBaseUrl = "https://api.u301.com";
 const u301DomainsPath = "/v3/shorten/domains";
 const u301ShortenBulkPath = "/v3/shorten/bulk";
-const u301TimeoutMs = 30_000;
 
 type U301RequestPhase = "validate" | "execute";
 type U301ActionHandler = (input: Record<string, unknown>, context: U301ActionContext) => Promise<unknown>;
@@ -132,7 +131,7 @@ async function u301Request(input: U301RequestInput): Promise<unknown> {
     url.searchParams.set("workspaceId", input.workspaceId);
   }
 
-  const timeout = createProviderTimeout(input.signal, u301TimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: input.method,

--- a/src/providers/unione/runtime.ts
+++ b/src/providers/unione/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const unioneApiBaseUrl = "https://api.unione.io/en/transactional/api/v1";
 
-const unioneRequestTimeoutMs = 30_000;
 const unioneValidationPath = "/system/info.json";
 
 type UnionePhase = "validate" | "execute";
@@ -121,7 +120,7 @@ export async function validateUnioneCredential(
 
 async function requestUnioneJson(options: UnioneRequestOptions): Promise<UnioneJsonObject> {
   const url = new URL(options.path, unioneApiBaseUrl);
-  const timeout = createProviderTimeout(options.context.signal, unioneRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.context.signal);
   let response: Response;
   try {
     response = await options.context.fetcher(url, {

--- a/src/providers/unipile/runtime.ts
+++ b/src/providers/unipile/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const unipileValidationPath = "/api/v1/accounts";
-const unipileRequestTimeoutMs = 30_000;
 
 type UnipileRequestPhase = "validate" | "execute";
 type UnipileActionHandler = (input: Record<string, unknown>, context: UnipileActionContext) => Promise<unknown>;
@@ -142,7 +141,7 @@ export async function validateUnipileCredential(
 }
 
 async function requestUnipileJson(input: UnipileRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, unipileRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildUnipileUrl(input.dsn, input.path, input.query), {
       method: "GET",

--- a/src/providers/unsplash/runtime.ts
+++ b/src/providers/unsplash/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const unsplashApiBaseUrl: string = "https://api.unsplash.com";
 const unsplashValidationPath = "/photos";
-const unsplashTimeoutMs = 30_000;
 
 type UnsplashActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
 
@@ -175,7 +174,7 @@ async function requestUnsplashJson(input: {
   query?: Record<string, string | number | undefined>;
   phase: "validate" | "execute";
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, unsplashTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildUnsplashUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/unthread/runtime.ts
+++ b/src/providers/unthread/runtime.ts
@@ -10,7 +10,6 @@ interface ApiKeyProviderActionInput {
 }
 
 export const unthreadApiBaseUrl = "https://api.unthread.io/api";
-const requestTimeoutMs = 30_000;
 
 interface UnthreadActionInput extends ApiKeyProviderActionInput {
   actionName: string;
@@ -124,7 +123,7 @@ export async function executeUnthreadAction(input: UnthreadActionInput, fetcher:
 }
 
 async function requestUnthread(options: UnthreadRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeout = createProviderTimeout(undefined);
   try {
     const response = await options.fetcher(`${unthreadApiBaseUrl}${options.path}`, {
       method: options.method,

--- a/src/providers/uploadcare/runtime.ts
+++ b/src/providers/uploadcare/runtime.ts
@@ -24,7 +24,6 @@ export const uploadcareApiBaseUrl = "https://api.uploadcare.com";
 
 export const uploadcareRestAcceptHeader: string = "application/vnd.uploadcare-v0.7+json";
 export const uploadcareJsonContentType: string = "application/json";
-const uploadcareDefaultRequestTimeoutMs = 30_000;
 
 type UploadcareRequestPhase = "validate" | "execute";
 
@@ -189,7 +188,7 @@ async function requestUploadcareJson(
     secretKey: context.secretKey,
   });
 
-  const timeout = createProviderTimeout(context.signal, uploadcareDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url.toString(), {
       method: request.method,

--- a/src/providers/upstash_redis/runtime.ts
+++ b/src/providers/upstash_redis/runtime.ts
@@ -22,7 +22,6 @@ import {
 } from "../provider-runtime.ts";
 
 const service = "upstash_redis";
-const requestTimeoutMs = 30_000;
 const upstashHostnameSuffix = ".upstash.io";
 
 type UpstashRequestPhase = "validate" | "execute";
@@ -142,7 +141,7 @@ async function executeUpstashCommand(
   command: readonly UpstashCommandArgument[],
   phase: UpstashRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(new URL(context.restUrl), {
       method: "POST",

--- a/src/providers/vectera/runtime.ts
+++ b/src/providers/vectera/runtime.ts
@@ -21,7 +21,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const vecteraApiBaseUrl = "https://www.vectera.com/api/v2";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 type VecteraPhase = "validate" | "execute";
 
@@ -197,7 +196,7 @@ async function requestVecteraJson(input: VecteraRequestInput): Promise<VecteraJs
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value != null) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers = new Headers({
       accept: "application/json",

--- a/src/providers/vida/runtime.ts
+++ b/src/providers/vida/runtime.ts
@@ -25,7 +25,6 @@ interface ApiKeyProviderActionInput {
 }
 
 export const vidaApiBaseUrl = "https://api.vida.dev";
-export const vidaDefaultRequestTimeoutMs = 30_000;
 
 type VidaPhase = "validate" | "execute";
 type VidaActionHandler = (input: Record<string, unknown>, fetcher: typeof fetch, apiKey: string) => Promise<unknown>;
@@ -144,7 +143,7 @@ async function requestVidaJson(input: {
   fetcher: typeof fetch;
   phase: VidaPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined, vidaDefaultRequestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(buildVidaUrl(input.path, input.apiKey, input.params), {

--- a/src/providers/vimeo/runtime.ts
+++ b/src/providers/vimeo/runtime.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const vimeoApiBaseUrl = "https://api.vimeo.com";
-const vimeoDefaultRequestTimeoutMs = 30_000;
 
 type VimeoActionContext = OAuthProviderContext;
 type VimeoActionHandler = ProviderRuntimeHandler<VimeoActionContext>;
@@ -532,7 +531,7 @@ async function vimeoRequestJson(input: VimeoRequestInput): Promise<unknown> {
   }
 
   const method = input.method ?? "GET";
-  const timeout = createProviderTimeout(input.signal, vimeoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const headers: Record<string, string> = {
       authorization: `Bearer ${input.accessToken}`,
@@ -648,7 +647,7 @@ function selectDownloadLink(
 }
 
 async function fetchVimeoDownloadLink(link: string, fetcher: ProviderFetch, signal?: AbortSignal): Promise<Response> {
-  const timeout = createProviderTimeout(signal, vimeoDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     return await fetcher(link, { signal: timeout.signal });
   } catch (error) {

--- a/src/providers/vitally/executors.ts
+++ b/src/providers/vitally/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "vitally";
 const vitallyEuBaseUrl = "https://rest.vitally-eu.io";
-const vitallyRequestTimeoutMs = 30_000;
 
 type VitallyRegion = "us" | "eu";
 type VitallyRequestPhase = "validate" | "execute";
@@ -189,7 +188,7 @@ async function deleteAccount(input: Record<string, unknown>, context: VitallyAct
 }
 
 async function requestVitally(input: VitallyRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, vitallyRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const url = new URL(input.path, input.baseUrl);
     if (input.searchParams) {

--- a/src/providers/voiceflow/executors.ts
+++ b/src/providers/voiceflow/executors.ts
@@ -34,7 +34,6 @@ const service = "voiceflow";
 const generalRuntimeBaseUrl = "https://general-runtime.voiceflow.com";
 const realtimeBaseUrl = "https://realtime-api.voiceflow.com";
 const defaultEnvironmentAlias = "main";
-const voiceflowRequestTimeoutMs = 30_000;
 
 // Fixed-host proxy egress (generalRuntimeBaseUrl / realtimeBaseUrl); DNS-rebinding check is redundant here.
 const voiceflowFetch = createProviderFetch({ skipDnsValidation: true });
@@ -280,7 +279,7 @@ async function listEnvironments(context: VoiceflowActionContext): Promise<unknow
 }
 
 async function requestVoiceflow(input: VoiceflowRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal, voiceflowRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(`${input.baseUrl}${input.path}`, {
       method: input.method,

--- a/src/providers/vonage/runtime.ts
+++ b/src/providers/vonage/runtime.ts
@@ -15,7 +15,6 @@ import {
 
 export const vonageApiBaseUrl = "https://rest.nexmo.com";
 export const vonageReportsApiBaseUrl = "https://api.nexmo.com";
-const vonageRequestTimeoutMs = 30_000;
 const invalidInputSmsStatuses = new Set(["2", "3", "6", "7", "12", "15", "17", "22", "23", "29", "33"]);
 
 export interface VonageContext {
@@ -139,7 +138,7 @@ async function requestVonage(input: VonageRequestInput): Promise<unknown> {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal, vonageRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url.toString(), {
       method: input.method ?? "GET",

--- a/src/providers/vultr/runtime.ts
+++ b/src/providers/vultr/runtime.ts
@@ -24,7 +24,6 @@ import {
 } from "../provider-runtime.ts";
 
 const vultrApiBaseUrl = "https://api.vultr.com/v2";
-const requestTimeoutMs = 30_000;
 
 type VultrRequestPhase = "validate" | "execute";
 
@@ -274,7 +273,7 @@ async function vultrFetch(input: VultrRequestInput): Promise<Response> {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/waboxapp/executors.ts
+++ b/src/providers/waboxapp/executors.ts
@@ -13,7 +13,6 @@ import {
 const service = "waboxapp";
 const waboxappApiBaseUrl = "https://www.waboxapp.com";
 const waboxappValidationPath = "/api/status/{uid}";
-const waboxappRequestTimeoutMs = 30_000;
 
 type WaboxappPhase = "validate" | "execute";
 
@@ -247,7 +246,7 @@ async function requestWaboxapp(
   fetcher: typeof fetch,
   phase: WaboxappPhase,
 ): Promise<WaboxappRequestPayload> {
-  const timeout = createProviderTimeout(input.signal, waboxappRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await fetcher(input.url, {

--- a/src/providers/wachete/runtime.ts
+++ b/src/providers/wachete/runtime.ts
@@ -22,7 +22,6 @@ import {
 export const wacheteApiBaseUrl = "https://api.wachete.com";
 
 const wacheteLoginPath = "/thirdparty/v1/user/apilogin";
-const wacheteRequestTimeoutMs = 30_000;
 
 type WacheteRequestPhase = "validate" | "execute";
 type WacheteActionHandler = (input: Record<string, unknown>, context: WacheteContext) => Promise<unknown>;
@@ -159,7 +158,7 @@ export async function requestWacheteToken(input: {
   signal?: AbortSignal;
   phase: WacheteRequestPhase;
 }): Promise<string> {
-  const timeout = createProviderTimeout(input.signal, wacheteRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildWacheteUrl(wacheteLoginPath), {
       method: "POST",
@@ -208,7 +207,7 @@ async function requestWacheteJson(input: {
     signal: input.context.signal,
     phase: "execute",
   });
-  const timeout = createProviderTimeout(input.context.signal, wacheteRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   const headers: Record<string, string> = {
     accept: "application/json",
     authorization: `Bearer ${token}`,

--- a/src/providers/waffo/runtime.ts
+++ b/src/providers/waffo/runtime.ts
@@ -17,8 +17,6 @@ import {
 
 export const waffoApiBaseUrl = "https://api.waffo.ai";
 
-const waffoRequestTimeoutMs = 30_000;
-
 export interface WaffoCredential {
   merchantId: string;
   privateKey: KeyObject;
@@ -343,7 +341,7 @@ export async function requestWaffoJson(input: WaffoRequestInput): Promise<Record
     headers,
   });
 
-  const timeout = createProviderTimeout(input.context.signal, waffoRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(`${waffoApiBaseUrl}${input.path}`, {
       method: "POST",

--- a/src/providers/wakatime/executors.ts
+++ b/src/providers/wakatime/executors.ts
@@ -14,7 +14,6 @@ import {
 
 const service = "wakatime";
 const wakatimeApiBaseUrl = "https://wakatime.com/api/v1";
-const wakatimeDefaultRequestTimeoutMs = 30_000;
 
 type WakatimeRequestPhase = "validate" | "execute";
 
@@ -193,7 +192,7 @@ async function requestWakatimeJson(input: {
   signal?: AbortSignal;
   query?: URLSearchParams;
 }): Promise<{ response: Response; payload: Record<string, unknown> }> {
-  const timeout = createProviderTimeout(input.signal, wakatimeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const normalizedPath = input.path.startsWith("/") ? input.path.slice(1) : input.path;
     const url = new URL(normalizedPath, `${wakatimeApiBaseUrl}/`);

--- a/src/providers/wangdian/runtime.ts
+++ b/src/providers/wangdian/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const wangdianApiBaseUrl = "https://api.wangdian.cn/openapi2";
-const requestTimeoutMs = 30_000;
 const maximumWindowMs = 30 * 24 * 60 * 60 * 1_000;
 const maximumOrderWindowMs = 60 * 60 * 1_000;
 const chinaTimeOffsetMs = 8 * 60 * 60 * 1_000;
@@ -415,7 +414,7 @@ function normalizeParameters(parameters: Record<string, unknown>): Record<string
 }
 
 async function requestWangdian(input: WangdianRequest): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(`${wangdianApiBaseUrl}/${input.endpoint}`, {
       method: "POST",

--- a/src/providers/wappalyzer/executors.ts
+++ b/src/providers/wappalyzer/executors.ts
@@ -13,7 +13,6 @@ import {
 
 const service = "wappalyzer";
 const wappalyzerApiBaseUrl = "https://api.wappalyzer.com/v2/";
-const wappalyzerDefaultTimeoutMs = 30_000;
 
 interface WappalyzerJsonResponse {
   payload: unknown;
@@ -156,7 +155,7 @@ async function requestWappalyzerJson(input: {
   signal?: AbortSignal;
   query?: Record<string, string | undefined>;
 }): Promise<WappalyzerJsonResponse> {
-  const timeout = createProviderTimeout(input.signal, wappalyzerDefaultTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildWappalyzerUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/web_of_science/runtime.ts
+++ b/src/providers/web_of_science/runtime.ts
@@ -13,7 +13,6 @@ import {
 } from "../provider-runtime.ts";
 
 const webOfScienceApiBaseUrl = "https://api.clarivate.com/apis/wos-starter/v1";
-const webOfScienceRequestTimeoutMs = 30_000;
 
 type WebOfSciencePhase = "validate" | "execute";
 type WebOfScienceContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -128,7 +127,7 @@ async function requestWebOfScienceJson(
   input: WebOfScienceRequest,
   context: WebOfScienceContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, webOfScienceRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildWebOfScienceUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/web_of_science_expanded/runtime.ts
+++ b/src/providers/web_of_science_expanded/runtime.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const webOfScienceExpandedApiBaseUrl = "https://wos-api.clarivate.com/api/wos";
-const webOfScienceExpandedRequestTimeoutMs = 30_000;
 
 type WebOfScienceExpandedPhase = "validate" | "execute";
 type WebOfScienceExpandedContext = Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
@@ -267,7 +266,7 @@ async function requestWebOfScienceExpandedJson(
   input: WebOfScienceExpandedRequest,
   context: WebOfScienceExpandedContext,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, webOfScienceExpandedRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildWebOfScienceExpandedUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/webscraper_io/runtime.ts
+++ b/src/providers/webscraper_io/runtime.ts
@@ -19,7 +19,6 @@ import {
 } from "../provider-runtime.ts";
 
 const webscraperIoApiBaseUrl = "https://api.webscraper.io/api/v1";
-const webscraperIoRequestTimeoutMs = 30_000;
 
 type WebscraperIoPhase = "validate" | "execute";
 type WebscraperIoActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
@@ -175,7 +174,7 @@ async function requestWebscraperIoJson(
   input: WebscraperIoRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, webscraperIoRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildWebscraperIoUrl(input.path, context.apiKey, input.query), {
       method: input.method ?? "GET",
@@ -212,7 +211,7 @@ async function requestWebscraperIoText(
   input: Pick<WebscraperIoRequestInput, "path" | "query" | "phase">,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<string> {
-  const timeout = createProviderTimeout(context.signal, webscraperIoRequestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(buildWebscraperIoUrl(input.path, context.apiKey, input.query), {
       method: "GET",

--- a/src/providers/wecom_bot/runtime.ts
+++ b/src/providers/wecom_bot/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 const wecomBotApiBaseUrl = "https://qyapi.weixin.qq.com";
 const wecomBotWebhookPath = "/cgi-bin/webhook/send";
-const wecomBotRequestTimeoutMs = 30_000;
 const wecomBotValidationSuccessCodes = new Set([0, 40008, 40058, 93017]);
 const utf8Encoder = new TextEncoder();
 
@@ -148,7 +147,7 @@ async function requestWecomBot(input: {
   fetcher: ProviderFetch;
   signal?: AbortSignal;
 }): Promise<WecomBotRequestResult> {
-  const timeout = createProviderTimeout(input.signal, wecomBotRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(buildWecomBotWebhookUrl(input.apiKey), {
       method: "POST",

--- a/src/providers/wejam_ai/runtime.ts
+++ b/src/providers/wejam_ai/runtime.ts
@@ -16,7 +16,6 @@ export const wejamAiApiBaseUrl: string = "https://api.wejam.ai";
 export const wejamAiDataExportPathPrefix: string = "/api/v1/data-exports";
 export const wejamAiValidationPath: string = `${wejamAiDataExportPathPrefix}/users`;
 
-const wejamAiDefaultRequestTimeoutMs = 30_000;
 const wejamAiExportResourceSet = new Set<string>(wejamAiExportResourceValues);
 
 type WejamAiPhase = "validate" | "execute";
@@ -87,7 +86,7 @@ async function requestWejamAiJson(input: {
   signal?: AbortSignal;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, wejamAiDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
 
   let response: Response;
   let payload: unknown;

--- a/src/providers/whatsable/runtime.ts
+++ b/src/providers/whatsable/runtime.ts
@@ -11,7 +11,6 @@ import {
 } from "../provider-runtime.ts";
 
 export const whatsableApiBaseUrl = "https://dashboard.whatsable.app/api/whatsapp/messages/v2.0.0";
-const timeoutMs = 30_000;
 
 export const whatsableActionHandlers: ProviderActionHandlers<
   "whatsable",
@@ -53,7 +52,7 @@ async function requestWhatsable(
 }
 
 async function sendWhatsable(input: Record<string, unknown>, context: ApiKeyProviderContext): Promise<Response> {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     return await context.fetcher(`${whatsableApiBaseUrl}/send`, {
       method: "POST",

--- a/src/providers/wolfram_alpha_api/runtime.ts
+++ b/src/providers/wolfram_alpha_api/runtime.ts
@@ -13,7 +13,6 @@ import {
 export const wolframAlphaApiBaseUrl = "https://api.wolframalpha.com";
 export const wolframAlphaQueryRecognizerUrl = "https://www.wolframalpha.com/queryrecognizer/query.jsp";
 
-const wolframAlphaDefaultRequestTimeoutMs = 30_000;
 const wolframAlphaValidationQuery = "integrate x^2";
 
 type WolframAlphaPhase = "validate" | "execute";
@@ -190,7 +189,7 @@ async function executeRequest(
   signal: AbortSignal | undefined,
   phase: WolframAlphaPhase,
 ): Promise<string> {
-  const timeout = createProviderTimeout(signal, wolframAlphaDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(signal);
   try {
     const response = await fetcher(url, {
       method: "GET",

--- a/src/providers/woot/runtime.ts
+++ b/src/providers/woot/runtime.ts
@@ -22,8 +22,6 @@ import {
 
 export const wootApiBaseUrl = "https://developer.woot.com";
 
-const wootRequestTimeoutMs = 30_000;
-
 type WootRequestPhase = "validate" | "execute";
 
 interface WootRequestContext {
@@ -105,7 +103,7 @@ export async function validateWootCredential(
 }
 
 async function requestWootJson(input: WootJsonRequest): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal, wootRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(input.url, {
       method: input.method,

--- a/src/providers/workable/runtime.ts
+++ b/src/providers/workable/runtime.ts
@@ -10,8 +10,6 @@ import {
   ProviderRequestError,
 } from "../provider-runtime.ts";
 
-const workableDefaultRequestTimeoutMs = 30_000;
-
 interface WorkableContext {
   apiKey: string;
   subdomain: string;
@@ -161,7 +159,7 @@ async function requestWorkableJson(input: WorkableRequestInput): Promise<Record<
 }
 
 async function rawWorkableRequest(input: WorkableRequestInput): Promise<Response> {
-  const timeout = createProviderTimeout(input.signal, workableDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = new URL(`${buildWorkableApiBaseUrl(input.subdomain)}${input.path}`);
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));

--- a/src/providers/workast/runtime.ts
+++ b/src/providers/workast/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const workastApiBaseUrl = "https://api.todobot.io";
 
-const workastRequestTimeoutMs = 30_000;
 const taskWriteKeys = ["text", "description", "startDate", "dueDate", "dueDateTimezone", "dueDateTime"] as const;
 
 type WorkastRequestPhase = "validate" | "execute";
@@ -180,7 +179,7 @@ async function getTask(
 }
 
 async function requestWorkastJson(options: WorkastRequestOptions) {
-  const timeout = createProviderTimeout(options.signal, workastRequestTimeoutMs);
+  const timeout = createProviderTimeout(options.signal);
   const url = new URL(`${workastApiBaseUrl}${options.path}`);
   appendQuery(url, options.query);
   const headers: Record<string, string> = {

--- a/src/providers/workday/runtime.ts
+++ b/src/providers/workday/runtime.ts
@@ -11,8 +11,6 @@ import {
 } from "../provider-runtime.ts";
 import { workdayOAuthScopes } from "./scopes.ts";
 
-const workdayRequestTimeoutMs = 30_000;
-
 interface WorkdayContext {
   accessToken: string;
   metadata: Record<string, unknown>;
@@ -166,7 +164,7 @@ export async function validateWorkdayCredential(
 }
 
 async function requestWorkdayJson(input: WorkdayRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, workdayRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   const url = buildWorkdayApiUrl(
     resolveWorkdayBaseUrl(input.metadata),
     resolveWorkdayTenant(input.metadata),

--- a/src/providers/workiz/runtime.ts
+++ b/src/providers/workiz/runtime.ts
@@ -6,7 +6,6 @@ import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requi
 import { createProviderTimeout, providerUserAgent, ProviderRequestError } from "../provider-runtime.ts";
 
 export const workizApiBaseUrl = "https://api.workiz.com/api/v1";
-const timeoutMs = 30_000;
 
 function setQuery(query: URLSearchParams, name: string, value: unknown) {
   if (value !== undefined) query.set(name, String(value));
@@ -55,7 +54,7 @@ export async function validateWorkizCredential(
   };
 }
 async function request(path: string, context: ApiKeyProviderContext, phase: "validate" | "execute") {
-  const timeout = createProviderTimeout(context.signal, timeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(`${workizApiBaseUrl}/${encodeURIComponent(context.apiKey)}${path}`, {
       headers: { accept: "application/json", "user-agent": providerUserAgent },

--- a/src/providers/worksnaps/executors.ts
+++ b/src/providers/worksnaps/executors.ts
@@ -15,7 +15,6 @@ import {
 export const worksnapsApiBaseUrl = "https://api.worksnaps.com/api";
 const service = "worksnaps";
 const worksnapsValidationPath = "/me.xml";
-const worksnapsRequestTimeoutMs = 30_000;
 
 interface XmlNode {
   name: string;
@@ -205,7 +204,7 @@ async function requestWorksnapsXml(input: {
   phase: "validate" | "execute";
   query?: Record<string, string | undefined>;
 }): Promise<XmlNode> {
-  const timeout = createProviderTimeout(input.context.signal, worksnapsRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildWorksnapsUrl(input.path, input.query), {
       method: "GET",

--- a/src/providers/wrike/runtime.ts
+++ b/src/providers/wrike/runtime.ts
@@ -23,8 +23,6 @@ import {
 
 export const wrikeApiBaseUrl = "https://www.wrike.com/api/v4";
 
-const wrikeDefaultRequestTimeoutMs = 30_000;
-
 type WrikeRequestPhase = "validate" | "execute";
 type WrikeActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
 
@@ -227,7 +225,7 @@ async function wrikeRequest(input: WrikeRequestOptions): Promise<Record<string, 
     appendQueryParam(url, key, value);
   }
 
-  const timeout = createProviderTimeout(input.signal, wrikeDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   let response: Response;
   try {
     response = await input.fetcher(url, {

--- a/src/providers/xata/runtime.ts
+++ b/src/providers/xata/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const xataApiBaseUrl = "https://api.xata.tech";
 const xataValidationPath = "/organizations";
-const xataTimeoutMs = 30_000;
 
 export interface XataContext {
   apiKey: string;
@@ -137,7 +136,7 @@ export async function validateXataCredential(
 }
 
 async function requestXataJson(context: XataContext, path: string, phase: XataPhase): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, xataTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   let response: Response;
   try {
     response = await context.fetcher(new URL(path, xataApiBaseUrl), {

--- a/src/providers/y_gy/runtime.ts
+++ b/src/providers/y_gy/runtime.ts
@@ -14,7 +14,6 @@ import {
 export const yGyApiBaseUrl = "https://api.y.gy/api/v1";
 const linksPath = "/link";
 const maxResponseBytes = 10 * 1024 * 1024;
-const requestTimeoutMs = 30_000;
 const updateFields = [
   "destination_url",
   "password",
@@ -210,7 +209,7 @@ async function requestYGy(
     "user-agent": providerUserAgent,
   };
   if (input.body !== undefined) headers["content-type"] = "application/json";
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/yoplanning/executors.ts
+++ b/src/providers/yoplanning/executors.ts
@@ -17,7 +17,6 @@ import {
 
 const service = "yoplanning";
 const yoplanningApiBaseUrl = "https://yoplanning.pro/api/v3.1";
-const yoplanningRequestTimeoutMs = 30_000;
 
 type RequestPhase = "validate" | "execute";
 type YoplanningHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -166,7 +165,7 @@ async function requestYoplanningJson(input: YoplanningRequestInput): Promise<unk
     if (value !== undefined) url.searchParams.set(name, String(value));
   }
 
-  const timeout = createProviderTimeout(input.context.signal, yoplanningRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(url, {
       method: "GET",

--- a/src/providers/youzan/runtime.ts
+++ b/src/providers/youzan/runtime.ts
@@ -12,7 +12,6 @@ import {
 
 export const youzanApiBaseUrl = "https://open.youzanyun.com";
 const youzanTokenUrl = `${youzanApiBaseUrl}/auth/token`;
-const requestTimeoutMs = 30_000;
 
 type YouzanPhase = "validate" | "execute";
 
@@ -367,7 +366,7 @@ async function fetchYouzanJson(
   fetcher: ProviderFetch,
   parentSignal?: AbortSignal,
 ): Promise<{ response: Response; payload: Record<string, unknown> }> {
-  const timeout = createProviderTimeout(parentSignal, requestTimeoutMs);
+  const timeout = createProviderTimeout(parentSignal);
   try {
     const response = await fetcher(url, { ...init, signal: timeout.signal });
     const text = await response.text();

--- a/src/providers/zendesk/runtime.ts
+++ b/src/providers/zendesk/runtime.ts
@@ -22,7 +22,6 @@ import {
 } from "../provider-runtime.ts";
 
 const zendeskCurrentUserPath = "/api/v2/users/me.json";
-const zendeskRequestTimeoutMs = 30_000;
 
 type ZendeskActionContext =
   | {
@@ -278,7 +277,7 @@ async function requestZendeskJson<T>(input: {
   phase: "validate" | "execute";
   notFoundAsInvalidInput?: boolean;
 }): Promise<T> {
-  const timeout = createProviderTimeout(input.context.signal, zendeskRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const response = await input.context.fetcher(buildZendeskUrl(input.context.baseUrl, input.path, input.query), {
       method: input.method ?? "GET",

--- a/src/providers/zep/runtime.ts
+++ b/src/providers/zep/runtime.ts
@@ -13,7 +13,6 @@ import {
 
 export const zepApiBaseUrl = "https://api.getzep.com/api/v2";
 const validationEndpoint = "/projects/info";
-const requestTimeoutMs = 30_000;
 const maxResponseBytes = 10 * 1024 * 1024;
 
 interface ZepRequestInput {
@@ -181,7 +180,7 @@ async function requestZepJson(
     headers.set("content-type", "application/json");
     body = JSON.stringify(input.body);
   }
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
+  const timeout = createProviderTimeout(context.signal);
   try {
     const response = await context.fetcher(url, {
       method: input.method ?? "GET",

--- a/src/providers/zerobounce/runtime.ts
+++ b/src/providers/zerobounce/runtime.ts
@@ -20,7 +20,6 @@ import {
 } from "../provider-runtime.ts";
 
 const zerobounceApiBaseUrl = "https://api.zerobounce.net";
-const zerobounceDefaultRequestTimeoutMs = 30_000;
 
 type ZerobounceRequestPhase = "validate" | "execute";
 type ZerobounceActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -245,7 +244,7 @@ async function requestZerobounceJson(
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(input.signal, zerobounceDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.signal);
   try {
     const response = await input.fetcher(url, {
       method: "GET",

--- a/src/providers/zixflow/runtime.ts
+++ b/src/providers/zixflow/runtime.ts
@@ -15,7 +15,6 @@ import {
 export const zixflowApiBaseUrl = "https://api.zixflow.com/api/v1";
 
 const zixflowValidationPath = "/workspace-members";
-const zixflowDefaultRequestTimeoutMs = 30_000;
 
 type ZixflowRequestPhase = "validate" | "execute";
 type ZixflowActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -243,7 +242,7 @@ async function requestZixflowRaw(input: ZixflowRequestOptions): Promise<Record<s
 }
 
 async function fetchZixflow(input: ZixflowRequestOptions): Promise<Response> {
-  const timeout = createProviderTimeout(input.context.signal, zixflowDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/zoom/runtime.ts
+++ b/src/providers/zoom/runtime.ts
@@ -13,8 +13,6 @@ import {
 
 export const zoomApiBaseUrl = "https://api.zoom.us/v2";
 
-const zoomDefaultRequestTimeoutMs = 30_000;
-
 type ZoomRequestPhase = "validate" | "execute";
 type ZoomActionHandler = ProviderRuntimeHandler<OAuthProviderContext>;
 
@@ -122,7 +120,7 @@ export async function fetchZoomCurrentAccount(
 }
 
 async function requestZoomJson(input: ZoomRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal, zoomDefaultRequestTimeoutMs);
+  const timeout = createProviderTimeout(input.context.signal);
   try {
     const headers: Record<string, string> = {
       accept: "application/json",

--- a/src/providers/zylvie/runtime.ts
+++ b/src/providers/zylvie/runtime.ts
@@ -28,8 +28,6 @@ type ActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof fetch) =
 
 export const zylvieApiBaseUrl = "https://api.zylvie.com";
 
-const requestTimeoutMs = 30_000;
-
 const productFieldMap = {
   title: "title",
   url: "url",
@@ -220,7 +218,7 @@ export async function requestZylvieJson(input: {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     url.searchParams.set(key, value);
   }
-  const timeoutHandle = createProviderTimeout(undefined, requestTimeoutMs);
+  const timeoutHandle = createProviderTimeout(undefined);
 
   try {
     const response = await input.fetcher(url, {


### PR DESCRIPTION
Third provider-level convergence PR after #441. Stacked on #444 (`refactor/entropy-b1-error-factories`); it retargets once the stack below it lands.

## What changes

- `createProviderTimeout(parentSignal, timeoutMs)` in `provider-runtime.ts` now defaults `timeoutMs` to a module-private `defaultProviderRequestTimeoutMs = 30_000`. The JSDoc says so, and a fake-timer test pins the default (29 999 ms not timed out, 30 000 ms timed out) next to an explicit 5 ms budget.
- 441 provider files drop a module-local constant of the exact form `const <name>(: number)? = 30_000;` whose only reader was the second argument of `createProviderTimeout`, and that call becomes `createProviderTimeout(signal)` (448 call sites; seven files shared one constant between two calls). 13 more callers that passed the literal `30_000` inline drop the argument too. They carried 400-odd different names (`requestTimeoutMs`, `timeoutMs`, `<provider>DefaultRequestTimeoutMs`, ...), which is why the audit rejected the "import one shared constant" shape: it would have been a net-zero, 565-import-line change that no compiler check benefits from.

456 files, net -478 lines.

## Kept on purpose

- 124 `= 30_000` constants stay because they have another reader the default cannot replace: `AbortSignal.timeout(name)` (44), a `"... request timed out after N seconds"` message (45), a raw `setTimeout` (7), an MCP client `timeout` option (6), an `input.timeoutMs ?? name` fallback (5), a `Date.now() + name` deadline, or a cross-file consumer. `tikhubEndpointFailureTtlMs` is a cache TTL, not a timeout, and is untouched.
- The ~70 providers that pass 60 s / 120 s / 300 s keep their constant and their explicit second argument, which now reads as a deliberate override.
- Exported constants were removed only when no other file referenced them (`closeDefaultRequestTimeoutMs`, `deeplDefaultRequestTimeoutMs`, ...); `confluenceDefaultTimeoutMs` has a cross-file reader and stays.

## Wire behavior

None. Every removed constant was `30_000` and every affected call now receives the same `30_000` from the default. The trade-off the audit named still applies: these providers are now coupled to one shared default, so a future change to it moves all of them at once. That is the point.

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1554 tests), `npm run build --workspace web`, `git diff --check`: green.
- `npm run generate:catalog`: all 1451 `catalog/apps/*.json` byte-identical to `origin/main`.
- The diff contains only: removed constant lines, removed second arguments on `createProviderTimeout` calls, adjacent blank lines, and the `provider-runtime.ts` / test change. No comment was removed and none was orphaned. The number of `createProviderTimeout(` call sites is unchanged; every removed constant had exactly one declaration and only second-argument references in its file (checked with an identifier scan that also catches shadowing parameters and template strings).
