### PR TITLE
refactor(providers): share the API-key action request type

### DIFF
--- a/src/providers/appcircle/runtime.ts
+++ b/src/providers/appcircle/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { AppcircleActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -9,14 +9,6 @@ export interface AppcircleCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const appcircleApiBaseUrl = "https://api.appcircle.io";
@@ -95,7 +87,7 @@ export async function validateAppcircleCredential(
 }
 
 export async function executeAppcircleAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: AppcircleActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/dialmycalls/runtime.ts
+++ b/src/providers/dialmycalls/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { DialMyCallsActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -14,14 +14,6 @@ export interface DialmycallsCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const dialMyCallsApiBaseUrl = "https://api.dialmycalls.com/2.0";
@@ -175,7 +167,7 @@ export async function validateDialMyCallsCredential(
 }
 
 export async function executeDialMyCallsAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: DialMyCallsActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/doppler_marketing_automation/runtime.ts
+++ b/src/providers/doppler_marketing_automation/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { DopplerMarketingAutomationActionName } from "./actions.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -16,14 +16,6 @@ export interface DopplerMarketingAutomationCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 export const dopplerMarketingAutomationApiBaseUrl = "https://restapi.fromdoppler.com";
 
 type RequestPhase = "validate" | "execute";
@@ -39,7 +31,7 @@ interface DopplerMarketingRequest {
   phase: RequestPhase;
 }
 
-type DopplerMarketingActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof fetch) => Promise<unknown>;
+type DopplerMarketingActionHandler = (input: ApiKeyActionRequest, fetcher: typeof fetch) => Promise<unknown>;
 
 export const dopplerMarketingAutomationActionHandlers: ProviderActionHandlers<
   "doppler_marketing_automation",
@@ -221,7 +213,7 @@ export async function validateDopplerMarketingAutomationCredential(
 }
 
 export async function executeDopplerMarketingAutomationAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: DopplerMarketingAutomationActionName;
   },
   fetcher: typeof fetch,
@@ -408,7 +400,7 @@ function normalizeMessageResult(payload: unknown) {
   };
 }
 
-function credentialContext(input: ApiKeyProviderActionInput) {
+function credentialContext(input: ApiKeyActionRequest) {
   return {
     apiKey: requiredString(input.apiKey, "apiKey", (message) => new ProviderRequestError(400, message)),
     accountEmail: requireAccountEmail(

--- a/src/providers/faktoora/runtime.ts
+++ b/src/providers/faktoora/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { FaktooraActionName } from "./actions.ts";
 
 import { requiredString } from "../../core/cast.ts";
@@ -9,14 +9,6 @@ export interface FaktooraCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const faktooraApiBaseUrl = "https://api.faktoora.com/api/v1";
@@ -138,7 +130,7 @@ export async function validateFaktooraCredential(
 export async function executeFaktooraAction(
   actionName: FaktooraActionName,
   input: Record<string, unknown>,
-  providerInput: ApiKeyProviderActionInput,
+  providerInput: ApiKeyActionRequest,
   fetcher: typeof fetch,
 ): Promise<unknown> {
   return faktooraActionHandlers[actionName](input, {

--- a/src/providers/helpdesk/runtime.ts
+++ b/src/providers/helpdesk/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { HelpdeskActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -16,19 +16,11 @@ export interface HelpdeskCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 export const helpdeskApiBaseUrl = "https://api.helpdesk.com";
 const helpdeskValidationEndpoint = "/v1/licenses";
 
 type HelpdeskRequestPhase = "validate" | "execute";
-type HelpdeskActionInput = ApiKeyProviderActionInput & {
+type HelpdeskActionInput = ApiKeyActionRequest & {
   actionName: HelpdeskActionName;
   input: Record<string, unknown>;
 };
@@ -350,7 +342,7 @@ function readIntegerHeader(headers: Headers, name: string) {
   return Number.isInteger(parsed) ? parsed : null;
 }
 
-function readActionCredential(input: ApiKeyProviderActionInput) {
+function readActionCredential(input: ApiKeyActionRequest) {
   return {
     apiKey: input.apiKey,
     accountId: requireStoredHelpdeskAccountId(input.values),

--- a/src/providers/infolobby/runtime.ts
+++ b/src/providers/infolobby/runtime.ts
@@ -1,3 +1,4 @@
+import type { ApiKeyActionRequest } from "../provider-runtime.ts";
 import type { InfolobbyActionName } from "./actions.ts";
 
 import { compactObject, requiredString } from "../../core/cast.ts";
@@ -8,14 +9,6 @@ export interface InfolobbyCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const infolobbyApiBaseUrl = "https://infolobby.com/api";
@@ -55,7 +48,7 @@ export async function validateInfolobbyCredential(
 }
 
 export async function executeInfolobbyAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: InfolobbyActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/instabot/runtime.ts
+++ b/src/providers/instabot/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { InstabotActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -14,14 +14,6 @@ export interface InstabotCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 const instabotApiBaseUrl = "https://api.instabot.io/v1";
@@ -144,7 +136,7 @@ export async function validateInstabotCredential(
 }
 
 export async function executeInstabotAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: InstabotActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/leadboxer/runtime.ts
+++ b/src/providers/leadboxer/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { isIP } from "node:net";
 import { domainToASCII } from "node:url";
@@ -17,16 +17,8 @@ export interface LeadboxerCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 type LeadboxerRequestPhase = "validate" | "execute";
-type LeadboxerActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof fetch) => Promise<unknown>;
+type LeadboxerActionHandler = (input: ApiKeyActionRequest, fetcher: typeof fetch) => Promise<unknown>;
 
 export const leadboxerApiBaseUrl = "https://api.leadboxer.com";
 
@@ -67,10 +59,7 @@ export async function validateLeadboxerCredential(
   };
 }
 
-export async function executeLeadboxerAction(
-  input: ApiKeyProviderActionInput,
-  fetcher: typeof fetch,
-): Promise<unknown> {
+export async function executeLeadboxerAction(input: ApiKeyActionRequest, fetcher: typeof fetch): Promise<unknown> {
   const handler = getProviderActionHandler(leadboxerActionHandlers, input.actionName);
   if (!handler) {
     throw new ProviderRequestError(500, `LeadBoxer action is not implemented yet: ${input.actionName}`);
@@ -133,7 +122,7 @@ export async function requestLeadboxerJson(input: {
 }
 
 async function executeLookup(
-  input: ApiKeyProviderActionInput,
+  input: ApiKeyActionRequest,
   fetcher: typeof fetch,
   path: string,
   lookupField: "ip" | "domain",

--- a/src/providers/leadiq/runtime.ts
+++ b/src/providers/leadiq/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
 import { ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
@@ -10,19 +10,11 @@ export interface LeadiqCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 export const leadiqApiBaseUrl = "https://api.leadiq.com";
 export const leadiqGraphqlPath = "/graphql";
 
 type LeadiqRequestPhase = "validate" | "execute";
-type LeadiqActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof fetch) => Promise<unknown>;
+type LeadiqActionHandler = (input: ApiKeyActionRequest, fetcher: typeof fetch) => Promise<unknown>;
 
 interface GraphqlRequest {
   query: string;

--- a/src/providers/more_trees/runtime.ts
+++ b/src/providers/more_trees/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { MoreTreesActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -16,14 +16,6 @@ export interface MoreTreesCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 export const moreTreesAccountOrigin = "https://user-management-service.platform.moretrees.eco";
 export const moreTreesProjectOrigin = "https://project-management-service.platform.moretrees.eco";
 export const moreTreesTransactionOrigin = "https://transaction-management-service.platform.moretrees.eco";
@@ -35,7 +27,7 @@ const moreTreesProjectsPath = "/project-management-api/external/projects";
 const moreTreesPlantPath = "/transaction-management-api/external/plant";
 
 type MoreTreesRequestPhase = "validate" | "execute";
-type MoreTreesActionInput = ApiKeyProviderActionInput & {
+type MoreTreesActionInput = ApiKeyActionRequest & {
   actionName: MoreTreesActionName;
   input: Record<string, unknown>;
 };

--- a/src/providers/payrexx/runtime.ts
+++ b/src/providers/payrexx/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { PayrexxActionName } from "./actions.ts";
 
 import {
@@ -18,14 +18,6 @@ export interface PayrexxCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 export const payrexxApiBaseUrl = "https://api.payrexx.com/v1.16";
 
 const requestTimeoutMs = 30_000;
@@ -33,7 +25,7 @@ const requestTimeoutMs = 30_000;
 type QueryValue = string | number | boolean | undefined;
 type PayrexxPhase = "validate" | "execute";
 type PayrexxHandler = (
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: PayrexxActionName;
     input: Record<string, unknown>;
   },
@@ -161,7 +153,7 @@ export async function validatePayrexxCredential(
 }
 
 export async function executePayrexxAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: PayrexxActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/productlane/runtime.ts
+++ b/src/providers/productlane/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProductlaneActionName } from "./actions.ts";
 
 import { requiredString } from "../../core/cast.ts";
@@ -10,14 +10,6 @@ export interface ProductlaneCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const productlaneApiBaseUrl = "https://productlane.com/api/v2";
@@ -190,7 +182,7 @@ export async function validateProductlaneCredential(
 }
 
 export async function executeProductlaneAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: ProductlaneActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -200,6 +200,22 @@ export interface ApiKeyProviderContext {
   signal?: AbortSignal;
 }
 
+/**
+ * Request an API-key provider action handler receives: the resolved key, the
+ * provider-local action name, the schema-validated action input, the full
+ * credential field map (`values` also carries `apiKey`) and the runtime
+ * metadata the credential validator stored on the connection. Executors pass
+ * every field; the optional markers only let provider-local helpers accept a
+ * narrower request.
+ */
+export interface ApiKeyActionRequest {
+  apiKey: string;
+  actionName: string;
+  input: Record<string, unknown>;
+  providerMetadata?: Record<string, unknown>;
+  values?: Record<string, string>;
+}
+
 export interface OAuthProviderContext {
   accessToken: string;
   tokenType?: string;

--- a/src/providers/splunk_http_event_collector/runtime.ts
+++ b/src/providers/splunk_http_event_collector/runtime.ts
@@ -1,19 +1,10 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { SplunkHttpEventCollectorActionName } from "./actions.ts";
 
+import { createHash, randomUUID } from "node:crypto";
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
-import { createHash, randomUUID } from "node:crypto";
 
 export interface SplunkHttpEventCollectorCredentialCheck {
   providerAccountId?: string;
@@ -32,7 +23,7 @@ interface SplunkHecExpectedResponse {
   readonly code: number;
 }
 
-interface SplunkHecActionInput extends ApiKeyProviderActionInput {
+interface SplunkHecActionInput extends ApiKeyActionRequest {
   readonly actionName: SplunkHttpEventCollectorActionName;
   readonly input: Record<string, unknown>;
 }

--- a/src/providers/supermemory/runtime.ts
+++ b/src/providers/supermemory/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { SupermemoryActionName } from "./actions.ts";
 
 import { compactObject, requiredString } from "../../core/cast.ts";
@@ -9,14 +9,6 @@ export interface SupermemoryCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 type SupermemoryActionHandler = (
@@ -112,7 +104,7 @@ export async function validateSupermemoryApiKey(
 }
 
 export function executeSupermemoryAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: SupermemoryActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/vida/runtime.ts
+++ b/src/providers/vida/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 import type { VidaActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
@@ -14,14 +14,6 @@ export interface VidaCredentialCheck {
   accountLabel: string;
   providerScopes: string[];
   providerMetadata: Record<string, unknown>;
-}
-
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
 }
 
 export const vidaApiBaseUrl = "https://api.vida.dev";
@@ -112,7 +104,7 @@ export async function validateVidaCredential(
 }
 
 export async function executeVidaAction(
-  input: ApiKeyProviderActionInput & {
+  input: ApiKeyActionRequest & {
     actionName: VidaActionName;
     input: Record<string, unknown>;
   },

--- a/src/providers/zylvie/runtime.ts
+++ b/src/providers/zylvie/runtime.ts
@@ -1,4 +1,4 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
@@ -15,16 +15,8 @@ export interface ZylvieCredentialCheck {
   providerMetadata: Record<string, unknown>;
 }
 
-interface ApiKeyProviderActionInput {
-  apiKey: string;
-  actionName: string;
-  input: Record<string, unknown>;
-  providerMetadata?: Record<string, unknown>;
-  values?: Record<string, string>;
-}
-
 type RequestPhase = "validate" | "execute";
-type ActionHandler = (input: ApiKeyProviderActionInput, fetcher: typeof fetch) => Promise<unknown>;
+type ActionHandler = (input: ApiKeyActionRequest, fetcher: typeof fetch) => Promise<unknown>;
 
 export const zylvieApiBaseUrl = "https://api.zylvie.com";
 
@@ -197,7 +189,7 @@ export async function validateZylvieCredential(
   };
 }
 
-export async function executeZylvieAction(input: ApiKeyProviderActionInput, fetcher: typeof fetch): Promise<unknown> {
+export async function executeZylvieAction(input: ApiKeyActionRequest, fetcher: typeof fetch): Promise<unknown> {
   const handler = getProviderActionHandler(actionHandlers, input.actionName);
   if (!handler) {
     throw new ProviderRequestError(500, `Zylvie action is not implemented yet: ${input.actionName}`);
@@ -254,7 +246,7 @@ export async function requestZylvieJson(input: {
 }
 
 async function mutation(
-  input: ApiKeyProviderActionInput,
+  input: ApiKeyActionRequest,
   fetcher: typeof fetch,
   path: string,
   method: "POST" | "PUT" | "DELETE",


### PR DESCRIPTION
Fifth provider-level convergence PR after #441. Stacked on #446 (`refactor/entropy-b6-dead-exports`); it retargets once the stack below it lands.

## What changes

- `provider-runtime.ts` exports `ApiKeyActionRequest`, the object an API-key provider's action handler receives: `{ apiKey; actionName; input; providerMetadata?; values? }`.
- 16 provider `runtime.ts` files (appcircle, dialmycalls, doppler_marketing_automation, faktoora, helpdesk, infolobby, instabot, leadboxer, leadiq, more_trees, payrexx, productlane, splunk_http_event_collector, supermemory, vida, zylvie) delete a byte-identical local `interface ApiKeyProviderActionInput` and import the shared type instead.

17 files, net -118 lines. Type-only: nothing changes at runtime or on `/v1`.

## Why this shape

The audit found 27 local `ApiKeyProviderActionInput` interfaces, but only these 16 are the same fact. The other 11 differ (central_station_crm and kobotoolbox add `signal?`, kobotoolbox and pinpoint make `providerMetadata` required, qianfan carries `transitFiles?`, clickhelp types `values` as `Record<string, unknown>`, reversecontact has no metadata at all, and five put `values` first as required) and stay provider-local; collapsing them would change what each handler is allowed to read.

The private source repository owns this type once under the name `ApiKeyProviderActionInput`. That name is not reused here on purpose: the port skill asks OSS code to read as written for this repository, and `ApiKeyActionRequest` sits next to the existing `ApiKeyProviderContext` (which is a different fact: it carries the guarded fetcher, not the action name and input).

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1554 tests), `npm run build --workspace web`, `git diff --check`: green.
- `npm run generate:catalog`: all 1451 `catalog/apps/*.json` byte-identical to `origin/main`.
- `rg 'interface ApiKeyProviderActionInput' src/providers` goes from 27 to 11, and the shape histogram of the remaining 11 contains only singletons plus the five-copy `values`-first group.
