### PR TITLE
refactor(providers): share the request timeout and error mapping wrapper

### DIFF
--- a/src/providers/7_shifts/runtime.ts
+++ b/src/providers/7_shifts/runtime.ts
@@ -11,12 +11,7 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export interface SevenShiftsContext extends ApiKeyProviderContext {
   companyGuid?: string;
@@ -179,13 +174,11 @@ export async function validateSevenShiftsCredential(
 }
 
 async function requestSevenShiftsJson(options: SevenShiftsRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.signal);
-
-  try {
+  return runProviderRequest({ signal: options.signal, label: "7shifts" }, async (signal) => {
     const response = await options.fetcher(buildSevenShiftsUrl(options.path, options.query), {
       method: "GET",
       headers: buildSevenShiftsHeaders(options),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSevenShiftsPayload(response);
 
@@ -197,20 +190,7 @@ async function requestSevenShiftsJson(options: SevenShiftsRequestOptions): Promi
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "7shifts request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `7shifts request failed: ${error.message}` : "7shifts request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSevenShiftsUrl(path: string, query?: Record<string, string | undefined>): URL {

--- a/src/providers/adafruit_io/executors.ts
+++ b/src/providers/adafruit_io/executors.ts
@@ -16,14 +16,13 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerResponseError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "adafruit_io";
@@ -252,9 +251,7 @@ async function requestAdafruitIoJson(input: {
   phase: AdafruitIoPhase;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Adafruit IO" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       "user-agent": providerUserAgent,
@@ -268,7 +265,7 @@ async function requestAdafruitIoJson(input: {
       method: input.method,
       headers,
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readAdafruitIoPayload(response);
 
@@ -277,22 +274,7 @@ async function requestAdafruitIoJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Adafruit IO request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Adafruit IO request failed: ${error.message}` : "Adafruit IO request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildAdafruitIoUrl(path: string, query: Record<string, string | undefined> = {}): URL {

--- a/src/providers/adyntel/runtime.ts
+++ b/src/providers/adyntel/runtime.ts
@@ -8,6 +8,7 @@ import {
   isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export interface AdyntelContext extends ApiKeyProviderContext {
@@ -200,48 +201,36 @@ async function requestAdSearch(
 }
 
 async function requestAdyntelJson(options: AdyntelRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(options.context.signal, adyntelDefaultRequestTimeoutMs);
+  return runProviderRequest(
+    { signal: options.context.signal, timeoutMs: adyntelDefaultRequestTimeoutMs, label: "Adyntel" },
+    async (signal) => {
+      const response = await options.context.fetcher(new URL(options.path, adyntelApiBaseUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "user-agent": providerUserAgent,
+        },
+        body: JSON.stringify({
+          api_key: options.context.apiKey,
+          email: options.context.email,
+          ...options.body,
+        }),
+        signal,
+      });
 
-  try {
-    const response = await options.context.fetcher(new URL(options.path, adyntelApiBaseUrl), {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-        "user-agent": providerUserAgent,
-      },
-      body: JSON.stringify({
-        api_key: options.context.apiKey,
-        email: options.context.email,
-        ...options.body,
-      }),
-      signal: timeout.signal,
-    });
+      if (response.status === 204) {
+        return null;
+      }
 
-    if (response.status === 204) {
-      return null;
-    }
+      const payload = await readAdyntelPayload(response);
+      if (!response.ok) {
+        throw createAdyntelError(response.status, payload);
+      }
 
-    const payload = await readAdyntelPayload(response);
-    if (!response.ok) {
-      throw createAdyntelError(response.status, payload);
-    }
-
-    return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Adyntel request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Adyntel request failed: ${error.message}` : "Adyntel request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+      return payload;
+    },
+  );
 }
 
 async function readAdyntelPayload(response: Response): Promise<unknown> {

--- a/src/providers/anrok/executors.ts
+++ b/src/providers/anrok/executors.ts
@@ -5,12 +5,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const anrokApiBaseUrl = "https://api.anrok.com";
@@ -132,9 +131,7 @@ async function requestAnrokJson(input: {
   phase: AnrokPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Anrok" }, async (signal) => {
     const response = await input.context.fetcher(buildAnrokUrl(input.path), {
       method: "POST",
       headers: {
@@ -144,7 +141,7 @@ async function requestAnrokJson(input: {
         "user-agent": providerUserAgent,
       },
       body: JSON.stringify(input.body ?? {}),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readAnrokPayload(response);
 
@@ -153,20 +150,7 @@ async function requestAnrokJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Anrok request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Anrok request failed: ${error.message}` : "Anrok request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildAnrokUrl(path: string): URL {

--- a/src/providers/atlas_so/executors.ts
+++ b/src/providers/atlas_so/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "atlas_so";
@@ -226,14 +225,12 @@ async function requestAtlasSoJson(input: {
   query?: Record<string, AtlasSoQueryValue>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Atlas.so" }, async (signal) => {
     const response = await input.context.fetcher(buildAtlasSoUrl(input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildAtlasSoHeaders(input.context.apiKey, input.body !== undefined),
       body: input.body !== undefined ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
 
     if (!response.ok) {
@@ -242,22 +239,7 @@ async function requestAtlasSoJson(input: {
     }
 
     return await readAtlasSoPayload(response);
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Atlas.so request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Atlas.so request failed: ${error.message}` : "Atlas.so request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildAtlasSoUrl(path: string, query?: Record<string, AtlasSoQueryValue>): URL {

--- a/src/providers/beamer/runtime.ts
+++ b/src/providers/beamer/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const beamerApiBaseUrl = "https://api.getbeamer.com/v0";
 
@@ -214,12 +209,10 @@ async function requestBeamerJson(
   context: BeamerContext,
   phase: BeamerPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Beamer" }, async (signal) => {
     const response = await context.fetcher(url, {
       ...init,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBeamerPayload(response);
 
@@ -228,20 +221,7 @@ async function requestBeamerJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Beamer request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Beamer request failed: ${error.message}` : "Beamer request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function beamerUrl(path: string): URL {

--- a/src/providers/beebole/executors.ts
+++ b/src/providers/beebole/executors.ts
@@ -9,13 +9,12 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "beebole";
@@ -95,8 +94,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestBeeboleGraphql(input: BeeboleGraphqlRequestOptions): Promise<BeeboleGraphqlPayload> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Beebole GraphQL" }, async (signal) => {
     const response = await input.context.fetcher(beeboleGraphqlEndpoint, {
       method: "POST",
       headers: {
@@ -106,7 +104,7 @@ async function requestBeeboleGraphql(input: BeeboleGraphqlRequestOptions): Promi
         "user-agent": providerUserAgent,
       },
       body: JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -116,20 +114,7 @@ async function requestBeeboleGraphql(input: BeeboleGraphqlRequestOptions): Promi
       throw createBeeboleGraphqlError(response.status, payload, input.phase);
     }
     return normalizeBeeboleGraphqlPayload(payload);
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Beebole GraphQL request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Beebole GraphQL request failed: ${error.message}` : "Beebole GraphQL request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 interface BeeboleGraphqlPayload extends Record<string, unknown> {

--- a/src/providers/benchmark_email/runtime.ts
+++ b/src/providers/benchmark_email/runtime.ts
@@ -4,12 +4,7 @@ import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } fro
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const benchmarkEmailValidationMethod = "clientGetProfileDetails";
 
@@ -118,9 +113,7 @@ async function requestBenchmarkEmailJson(input: {
   phase: BenchmarkEmailRequestPhase;
   query?: Record<string, string | undefined>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "benchmark_email" }, async (signal) => {
     const response = await input.context.fetcher(
       buildBenchmarkEmailUrl(input.context.baseUrl, {
         token: input.context.apiKey,
@@ -133,7 +126,7 @@ async function requestBenchmarkEmailJson(input: {
           accept: "application/json",
           "user-agent": providerUserAgent,
         },
-        signal: timeout.signal,
+        signal,
       },
     );
     const payload = await readBenchmarkEmailPayload(response);
@@ -153,20 +146,7 @@ async function requestBenchmarkEmailJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "benchmark_email request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `benchmark_email request failed: ${error.message}` : "benchmark_email request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildBenchmarkEmailUrl(baseUrl: string, query: Record<string, string | undefined> = {}): string {

--- a/src/providers/benzinga/runtime.ts
+++ b/src/providers/benzinga/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const benzingaApiBaseUrl = "https://api.benzinga.com";
 
@@ -115,16 +110,14 @@ async function requestBenzingaJson(input: {
   params: Record<string, string | undefined>;
   phase: BenzingaPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Benzinga" }, async (signal) => {
     const response = await input.context.fetcher(buildBenzingaUrl(input.path, input.context.apiKey, input.params), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBenzingaPayload(response, {
       strictJson: response.ok,
@@ -135,20 +128,7 @@ async function requestBenzingaJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Benzinga request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Benzinga request failed: ${error.message}` : "Benzinga request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildBenzingaUrl(path: string, apiKey: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/bettercontact/runtime.ts
+++ b/src/providers/bettercontact/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const bettercontactApiBaseUrl = "https://app.bettercontact.rocks/api/v2";
 
@@ -158,14 +153,12 @@ async function requestBettercontactJson(
   input: BettercontactRequestInput,
   context: BettercontactContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "BetterContact" }, async (signal) => {
     const response = await context.fetcher(buildBettercontactUrl(input, context.apiKey), {
       method: input.method,
       headers: buildBettercontactHeaders(context.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(compactObject(input.body)),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBettercontactPayload(response);
 
@@ -179,22 +172,7 @@ async function requestBettercontactJson(
     }
 
     return payloadObject;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "BetterContact request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `BetterContact request failed: ${error.message}` : "BetterContact request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildBettercontactUrl(input: BettercontactRequestInput, apiKey: string): URL {

--- a/src/providers/bidsketch/runtime.ts
+++ b/src/providers/bidsketch/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const bidsketchApiBaseUrl: string = "https://bidsketch.com/api/v1";
 const bidsketchValidationPath = "/proposals/stats.json";
@@ -130,13 +125,11 @@ async function requestBidsketchJson(input: {
   phase: BidsketchPhase;
   query?: Record<string, number | undefined>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "BidSketch" }, async (signal) => {
     const response = await input.context.fetcher(buildBidsketchUrl(input.path, input.query), {
       method: "GET",
       headers: buildBidsketchHeaders(input.context.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBidsketchJson(response);
 
@@ -145,22 +138,7 @@ async function requestBidsketchJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "BidSketch request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `BidSketch request failed: ${error.message}` : "BidSketch request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildPaginationQuery(input: Record<string, unknown>): Record<string, number | undefined> {

--- a/src/providers/bigmailer/runtime.ts
+++ b/src/providers/bigmailer/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const bigmailerApiBaseUrl: string = "https://api.bigmailer.io";
 
@@ -292,14 +287,12 @@ async function requestBigmailerJson(input: {
   query?: Record<string, string | number | boolean | undefined>;
   body?: Record<string, unknown>;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "BigMailer" }, async (signal) => {
     const response = await input.fetcher(buildBigmailerUrl(input.path, input.query), {
       method: input.method,
       headers: bigmailerHeaders(input.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBigmailerPayload(response);
     if (!response.ok) {
@@ -311,22 +304,7 @@ async function requestBigmailerJson(input: {
       throw new ProviderRequestError(502, "BigMailer returned an invalid payload");
     }
     return objectPayload ?? {};
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "BigMailer request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `BigMailer request failed: ${error.message}` : "BigMailer request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildBigmailerUrl(path: string, query: Record<string, string | number | boolean | undefined> = {}) {

--- a/src/providers/bigml/runtime.ts
+++ b/src/providers/bigml/runtime.ts
@@ -12,11 +12,10 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export interface BigmlContext {
@@ -136,8 +135,7 @@ async function request(
   context: BigmlContext,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "BigML" }, async (signal) => {
     const url = new URL(path.startsWith("/") ? path.slice(1) : path, `${bigmlApiBaseUrl}/`);
     url.searchParams.set("username", context.username);
     url.searchParams.set("api_key", context.apiKey);
@@ -151,7 +149,7 @@ async function request(
         ...(body === undefined ? {} : { "content-type": "application/json" }),
       },
       body: body === undefined ? undefined : JSON.stringify(body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -173,16 +171,7 @@ async function request(
       );
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) throw new ProviderRequestError(504, "BigML request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `BigML request failed: ${error.message}` : "BigML request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 function buildListQuery(input: Record<string, unknown>): Record<string, unknown> {
   return compactObject({

--- a/src/providers/builder_io/runtime.ts
+++ b/src/providers/builder_io/runtime.ts
@@ -2,12 +2,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const builderIoWriteApiBaseUrl = "https://builder.io";
 
@@ -158,33 +153,19 @@ async function requestBuilderIoJson(input: {
     headers["content-type"] = "application/json";
   }
 
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Builder.io" }, async (signal) => {
     const response = await input.context.fetcher(input.url, {
       method: input.method,
       headers,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBuilderIoPayload(response);
     if (!response.ok) {
       throw createBuilderIoError(response.status, payload);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Builder.io request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Builder.io request failed: ${error.message}` : "Builder.io request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildContentWriteBody(input: Record<string, unknown>): Record<string, unknown> {

--- a/src/providers/builtwith/runtime.ts
+++ b/src/providers/builtwith/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const builtwithApiBaseUrl = "https://api.builtwith.com";
 const builtwithValidationPath = "/whoamiv1/api.json";
@@ -165,16 +160,14 @@ async function builtwithRequest(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "BuiltWith" }, async (signal) => {
     const response = await context.fetcher(buildBuiltwithUrl(input, context.apiKey), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readBuiltwithPayload(response);
 
@@ -188,20 +181,7 @@ async function builtwithRequest(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "BuiltWith request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `BuiltWith request failed: ${error.message}` : "BuiltWith request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildBuiltwithUrl(

--- a/src/providers/calendarific/executors.ts
+++ b/src/providers/calendarific/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "calendarific";
@@ -114,16 +113,14 @@ async function requestCalendarificJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: CalendarificPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Calendarific" }, async (signal) => {
     const response = await input.context.fetcher(buildCalendarificUrl(input.path, input.context.apiKey, input.params), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCalendarificPayload(response);
 
@@ -136,20 +133,7 @@ async function requestCalendarificJson(input: {
       throw new ProviderRequestError(502, "Calendarific returned an invalid payload");
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Calendarific request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Calendarific request failed: ${error.message}` : "Calendarific request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCalendarificUrl(path: string, apiKey: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/callrail/executors.ts
+++ b/src/providers/callrail/executors.ts
@@ -4,12 +4,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "callrail";
@@ -153,13 +152,11 @@ async function requestCallrailJson(input: {
     }
   }
 
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "CallRail" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: "GET",
       headers: callrailHeaders(input.context.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCallrailPayload(response);
 
@@ -168,20 +165,7 @@ async function requestCallrailJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "CallRail request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `CallRail request failed: ${error.message}` : "CallRail request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function callrailHeaders(apiKey: string): Record<string, string> {

--- a/src/providers/central_station_crm/runtime.ts
+++ b/src/providers/central_station_crm/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const centralStationCrmCredentialHelpUrl = "https://centralstationcrm.com/api-basics";
 
@@ -394,38 +389,19 @@ async function deleteRecord(input: { input: CentralStationCrmActionInput; fetche
 }
 
 async function requestCentralStationCrmJson(input: CentralStationCrmRequestInput) {
-  const timeoutHandle = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "CentralStationCRM" }, async (signal) => {
     const response = await input.fetcher(buildCentralStationCrmUrl(input.apiBaseUrl, input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildCentralStationCrmHeaders(input.apiKey, input.body !== undefined),
       ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readCentralStationCrmPayload(response);
     if (!response.ok) {
       throw createCentralStationCrmError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "CentralStationCRM request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error
-        ? `CentralStationCRM request failed: ${error.message}`
-        : "CentralStationCRM request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildCentralStationCrmUrl(apiBaseUrl: string, path: string, query: Record<string, string | undefined> = {}) {

--- a/src/providers/chatarmin/executors.ts
+++ b/src/providers/chatarmin/executors.ts
@@ -5,11 +5,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "chatarmin";
@@ -276,14 +275,12 @@ async function chatarminRequestJson(
   context: ChatarminContext,
   phase: ChatarminRequestPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Chatarmin" }, async (signal) => {
     const response = await context.fetcher(buildChatarminUrl(input.path, input.query), {
       method: input.method,
       headers: chatarminHeaders(context.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readChatarminPayload(response);
 
@@ -292,20 +289,7 @@ async function chatarminRequestJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Chatarmin request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Chatarmin request failed: ${error.message}` : "Chatarmin request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildChatarminUrl(path: string, query: Record<string, string | undefined> = {}): URL {

--- a/src/providers/chorus/executors.ts
+++ b/src/providers/chorus/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "chorus";
@@ -159,9 +158,7 @@ async function requestChorusJson(input: {
   context: ChorusContext;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Chorus" }, async (signal) => {
     const response = await input.context.fetcher(buildChorusUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -169,7 +166,7 @@ async function requestChorusJson(input: {
         authorization: input.apiKey,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readChorusPayload(response);
 
@@ -178,20 +175,7 @@ async function requestChorusJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Chorus request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Chorus request failed: ${error.message}` : "Chorus request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildChorusUrl(path: string, query?: URLSearchParams): URL {

--- a/src/providers/cin7_core/executors.ts
+++ b/src/providers/cin7_core/executors.ts
@@ -11,15 +11,14 @@ import { compactObject, objectArray, optionalRecord, optionalString, requiredStr
 import {
   createProviderFetch,
   createProviderProxyUrl,
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
+  runProviderRequest,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
@@ -256,9 +255,7 @@ async function requestCin7CoreJson(input: {
   phase: Cin7CorePhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Cin7 Core" }, async (signal) => {
     const response = await input.context.fetcher(buildCin7CoreUrl(input), {
       method: input.method,
       headers: {
@@ -268,7 +265,7 @@ async function requestCin7CoreJson(input: {
         "api-auth-accountid": input.context.accountId,
         "api-auth-applicationkey": input.context.applicationKey,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCin7CorePayload(response);
 
@@ -277,20 +274,7 @@ async function requestCin7CoreJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Cin7 Core request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Cin7 Core request failed: ${error.message}` : "Cin7 Core request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCin7CoreUrl(input: { path: string; query?: URLSearchParams }): URL {

--- a/src/providers/clari_copilot/executors.ts
+++ b/src/providers/clari_copilot/executors.ts
@@ -4,12 +4,11 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "clari_copilot";
@@ -137,9 +136,7 @@ async function requestClariCopilotJson(input: {
   context: ClariCopilotContext;
   phase: ClariCopilotPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Clari Copilot" }, async (signal) => {
     const response = await input.context.fetcher(buildClariCopilotUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -148,7 +145,7 @@ async function requestClariCopilotJson(input: {
         "x-api-password": input.context.apiPassword,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readClariCopilotPayload(response);
 
@@ -157,20 +154,7 @@ async function requestClariCopilotJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Clari Copilot request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Clari Copilot request failed: ${error.message}` : "Clari Copilot request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildClariCopilotUrl(path: string, query?: URLSearchParams): URL {

--- a/src/providers/clickmeeting/runtime.ts
+++ b/src/providers/clickmeeting/runtime.ts
@@ -3,13 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-  setSearchParams,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest, setSearchParams } from "../provider-runtime.ts";
 
 export const clickMeetingApiBaseUrl = "https://api.clickmeeting.com/v1";
 
@@ -350,14 +344,12 @@ async function requestClickMeetingJson(
   context: ClickMeetingRequestContext,
   phase: ClickMeetingPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "ClickMeeting" }, async (signal) => {
     const response = await context.fetcher(buildClickMeetingUrl(input.path, input.query), {
       method: input.method,
       headers: buildClickMeetingHeaders(context.apiKey, input.body),
       body: input.body,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readClickMeetingPayload(response);
 
@@ -366,22 +358,7 @@ async function requestClickMeetingJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ClickMeeting request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ClickMeeting request failed: ${error.message}` : "ClickMeeting request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildClickMeetingUrl(path: string, query: Record<string, string | undefined> = {}): URL {

--- a/src/providers/clinicalkey/runtime.ts
+++ b/src/providers/clinicalkey/runtime.ts
@@ -2,11 +2,10 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const clinicalKeyApiBaseUrl = "https://api.elsevier.com/sushi/r51";
@@ -141,38 +140,21 @@ async function requestClinicalKeyJson(input: {
   fetcher: typeof fetch;
   phase: ClinicalKeyRequestPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "ClinicalKey" }, async (signal) => {
     const response = await input.fetcher(buildClinicalKeyUrl(input.path, input.query, input.credentials), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readClinicalKeyPayload(response);
     if (!response.ok) {
       throw createClinicalKeyError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ClinicalKey request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ClinicalKey request failed: ${error.message}` : "ClinicalKey request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildClinicalKeyUrl(

--- a/src/providers/cockroach_labs/runtime.ts
+++ b/src/providers/cockroach_labs/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, objectArray, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const cockroachLabsApiBaseUrl = "https://cockroachlabs.cloud";
@@ -203,8 +202,7 @@ async function requestCockroachLabsJson(input: {
   phase: CockroachLabsRequestPhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "CockroachDB Cloud" }, async (signal) => {
     const response = await input.context.fetcher(buildCockroachLabsUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -213,7 +211,7 @@ async function requestCockroachLabsJson(input: {
         "cc-version": cockroachLabsApiVersion,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCockroachLabsPayload(response);
     if (!response.ok) {
@@ -221,22 +219,7 @@ async function requestCockroachLabsJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "CockroachDB Cloud request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error
-        ? `CockroachDB Cloud request failed: ${error.message}`
-        : "CockroachDB Cloud request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCockroachLabsUrl(path: string, query?: URLSearchParams): URL {

--- a/src/providers/codegen/executors.ts
+++ b/src/providers/codegen/executors.ts
@@ -4,12 +4,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalInteger, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "codegen";
@@ -221,9 +220,7 @@ async function requestCodegenJson(input: {
   phase: CodegenPhase;
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Codegen" }, async (signal) => {
     const response = await input.context.fetcher(new URL(input.path, codegenApiBaseUrl), {
       method: input.method,
       headers: {
@@ -231,7 +228,7 @@ async function requestCodegenJson(input: {
         authorization: `Bearer ${input.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCodegenPayload(response);
 
@@ -240,20 +237,7 @@ async function requestCodegenJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Codegen request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Codegen request failed: ${error.message}` : "Codegen request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildPathWithQuery(path: string, input: Record<string, unknown>, allowedParams: readonly string[]): string {

--- a/src/providers/coinmarketcal/executors.ts
+++ b/src/providers/coinmarketcal/executors.ts
@@ -5,12 +5,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "coinmarketcal";
@@ -97,12 +96,11 @@ async function requestCoinmarketcalJson(
   context: ApiKeyProviderContext,
   mode: "validate" | "execute",
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "coinmarketcal" }, async (signal) => {
     const response = await context.fetcher(buildCoinmarketcalUrl(path, query), {
       method: "GET",
       headers: coinmarketcalHeaders(context.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCoinmarketcalPayload(response);
     if (!response.ok) {
@@ -112,20 +110,7 @@ async function requestCoinmarketcalJson(
       throw new ProviderRequestError(502, "coinmarketcal returned invalid JSON");
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "coinmarketcal request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `coinmarketcal request failed: ${error.message}` : "coinmarketcal request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCoinmarketcalUrl(path: string, query: Record<string, string>): string {

--- a/src/providers/concord/executors.ts
+++ b/src/providers/concord/executors.ts
@@ -12,14 +12,13 @@ import {
   requiredStringArray,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerInputError,
   providerResponseError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "concord";
@@ -131,31 +130,19 @@ async function requestConcordJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ConcordPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Concord" }, async (signal) => {
     const response = await context.fetcher(`${concordApiBaseUrl}${path}`, {
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
         "X-API-KEY": context.apiKey,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readJson(response);
     if (!response.ok) throw createConcordError(response.status, payload, phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Concord request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Concord request failed: ${error.message}` : "Concord request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readJson(response: Response): Promise<unknown> {

--- a/src/providers/contentstack_content_delivery/runtime.ts
+++ b/src/providers/contentstack_content_delivery/runtime.ts
@@ -3,11 +3,10 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const contentstackContentDeliveryApiBaseUrl = "https://cdn.contentstack.io/v3";
@@ -269,34 +268,18 @@ async function requestContentstackJson(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Contentstack Content Delivery" }, async (signal) => {
     const response = await input.fetcher(buildContentstackUrl(input.path, input.query, input.arrayQuery), {
       method: "GET",
       headers: buildContentstackHeaders(input.stackApiKey, input.deliveryToken, input.branch),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readContentstackPayload(response);
     if (!response.ok) {
       throw createContentstackError(response.status, payload, input.phase);
     }
     return requireRecord(payload, "Contentstack response");
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Contentstack Content Delivery request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error
-        ? `Contentstack Content Delivery request failed: ${error.message}`
-        : "Contentstack Content Delivery request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildContentstackUrl(

--- a/src/providers/contentstack_content_management/runtime.ts
+++ b/src/providers/contentstack_content_management/runtime.ts
@@ -3,11 +3,10 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const contentstackContentManagementApiBaseUrl = "https://api.contentstack.io/v3";
@@ -272,35 +271,19 @@ async function requestContentstackJson(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Contentstack Content Management" }, async (signal) => {
     const response = await input.fetcher(buildContentstackUrl(input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildContentstackHeaders(input.managementToken, input.stackApiKey, input.branch),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readContentstackPayload(response);
     if (!response.ok) {
       throw createContentstackError(response.status, payload, input.phase);
     }
     return requireRecord(payload, "Contentstack response");
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Contentstack Content Management request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error
-        ? `Contentstack Content Management request failed: ${error.message}`
-        : "Contentstack Content Management request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildContentstackUrl(path: string, query?: Record<string, string | undefined>): URL {

--- a/src/providers/cronitor/executors.ts
+++ b/src/providers/cronitor/executors.ts
@@ -12,9 +12,7 @@ import { compactObject, optionalRecord, optionalString, requiredRecord, required
 import {
   createProviderFetch,
   createProviderProxyUrl,
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerInputError,
   ProviderRequestError,
@@ -22,6 +20,7 @@ import {
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
+  runProviderRequest,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
@@ -150,12 +149,11 @@ async function requestCronitorJson(input: {
   method?: CronitorMethod;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Cronitor" }, async (signal) => {
     const response = await input.context.fetcher(buildCronitorUrl(input.path), {
       method: input.method ?? "GET",
       headers: buildCronitorHeaders(input.context.apiKey, input.body !== undefined),
-      signal: timeout.signal,
+      signal,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
     });
     const payload = await readCronitorPayload(response);
@@ -163,20 +161,7 @@ async function requestCronitorJson(input: {
       throw createCronitorError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Cronitor request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Cronitor request failed: ${error.message}` : "Cronitor request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCronitorUrl(path: string): URL {

--- a/src/providers/cronly/runtime.ts
+++ b/src/providers/cronly/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const cronlyApiBaseUrl = "https://cronly.app/api";
 type CronlyPhase = "validate" | "execute";
@@ -118,8 +113,7 @@ interface CronlyRequestInput {
   body?: Record<string, unknown>;
 }
 async function requestCronlyJson(input: CronlyRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Cronly" }, async (signal) => {
     const path = input.path.startsWith("/") ? input.path.slice(1) : input.path;
     const response = await input.context.fetcher(new URL(path, `${cronlyApiBaseUrl}/`), {
       method: input.method ?? "GET",
@@ -130,23 +124,13 @@ async function requestCronlyJson(input: CronlyRequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCronlyPayload(response);
     if (!response.ok || optionalString(optionalRecord(payload)?.status) === "error")
       throw createCronlyError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Cronly request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Cronly request failed: ${error.message}` : "Cronly request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 async function readCronlyPayload(response: Response): Promise<unknown> {
   const text = await response.text();

--- a/src/providers/crossref/runtime.ts
+++ b/src/providers/crossref/runtime.ts
@@ -280,9 +280,7 @@ async function requestCrossref(input: {
   apiKey?: string;
   phase?: "execute" | "validate";
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Crossref" }, async (signal) => {
     const headers = new Headers({
       accept: input.accept,
       "user-agent": providerUserAgent,
@@ -294,7 +292,7 @@ async function requestCrossref(input: {
     const response = await input.fetcher(buildCrossrefUrl(input.path, input.params), {
       method: "GET",
       headers,
-      signal: timeoutHandle.signal,
+      signal,
     });
     const body = await readCrossrefResponseText(response);
 
@@ -302,22 +300,7 @@ async function requestCrossref(input: {
       throw createCrossrefError(response.status, parseCrossrefPayload(body), input.phase ?? "execute", !!input.apiKey);
     }
     return { body, response };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Crossref request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Crossref request failed: ${error.message}` : "Crossref request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildCrossrefUrl(path: string, params: Record<string, string | undefined>) {
@@ -890,9 +873,8 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";

--- a/src/providers/crunchbase/executors.ts
+++ b/src/providers/crunchbase/executors.ts
@@ -4,12 +4,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "crunchbase";
@@ -155,8 +154,7 @@ async function requestCrunchbaseJson(input: {
     appendQueryValue(url, key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "crunchbase" }, async (signal) => {
     const response = await input.context.fetcher(url.toString(), {
       method: input.method ?? "GET",
       headers: {
@@ -165,7 +163,7 @@ async function requestCrunchbaseJson(input: {
         "user-agent": providerUserAgent,
         ...(input.body ? { "content-type": "application/json" } : {}),
       },
-      signal: timeout.signal,
+      signal,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
     });
     const payload = await readCrunchbasePayload(response, response.ok);
@@ -173,18 +171,7 @@ async function requestCrunchbaseJson(input: {
       throw createCrunchbaseError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "crunchbase request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `crunchbase request failed: ${error.message}` : "crunchbase request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readCrunchbasePayload(response: Response, requireJson: boolean): Promise<unknown> {

--- a/src/providers/databox/runtime.ts
+++ b/src/providers/databox/runtime.ts
@@ -4,12 +4,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const databoxApiBaseUrl = "https://api.databox.com";
 const validateKeyPath = "/v1/auth/validate-key";
@@ -121,8 +116,7 @@ async function databoxRequestJson(input: {
   phase: DataboxPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Databox" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       "user-agent": providerUserAgent,
@@ -133,22 +127,12 @@ async function databoxRequestJson(input: {
       method: input.method,
       headers,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readDataboxPayload(response);
     if (!response.ok) throw createDataboxError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Databox request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Databox request failed: ${error.message}` : "Databox request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readDataboxPayload(response: Response): Promise<unknown> {

--- a/src/providers/deepgram/runtime.ts
+++ b/src/providers/deepgram/runtime.ts
@@ -10,12 +10,7 @@ import {
   optionalBoolean,
 } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const deepgramApiBaseUrl = "https://api.deepgram.com/v1";
 
@@ -165,13 +160,11 @@ async function requestDeepgramJson(input: {
   fetcher: typeof fetch;
   phase: DeepgramPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Deepgram" }, async (signal) => {
     const response = await input.fetcher(buildDeepgramUrl(input), {
       method: input.method,
       headers: buildDeepgramHeaders(input.apiKey),
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readDeepgramPayload(response);
 
@@ -180,22 +173,7 @@ async function requestDeepgramJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Deepgram request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Deepgram request failed: ${error.message}` : "Deepgram request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildDeepgramHeaders(apiKey: string) {

--- a/src/providers/dialmycalls/runtime.ts
+++ b/src/providers/dialmycalls/runtime.ts
@@ -2,12 +2,7 @@ import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-ru
 import type { DialMyCallsActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export interface DialmycallsCredentialCheck {
   providerAccountId?: string;
@@ -194,16 +189,14 @@ async function requestDialMyCallsJson(input: {
   body?: Record<string, unknown>;
   range?: string;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "DialMyCalls" }, async (signal) => {
     const response = await input.fetcher(buildDialMyCallsUrl(input.path), {
       method: input.method ?? "GET",
       headers: buildDialMyCallsHeaders(input.apiKey, {
         hasBody: input.body !== undefined,
         range: input.range,
       }),
-      signal: timeoutHandle.signal,
+      signal,
       ...(input.body ? { body: JSON.stringify(input.body) } : {}),
     });
     const payload = await readDialMyCallsPayload(response);
@@ -213,22 +206,7 @@ async function requestDialMyCallsJson(input: {
     }
 
     return requireEnvelope(payload);
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "DialMyCalls request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `DialMyCalls request failed: ${error.message}` : "DialMyCalls request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildDialMyCallsUrl(path: string) {

--- a/src/providers/docraptor/executors.ts
+++ b/src/providers/docraptor/executors.ts
@@ -6,12 +6,11 @@ import { Buffer } from "node:buffer";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "docraptor";
@@ -127,39 +126,27 @@ async function postDocraptorJson(input: {
   phase: DocraptorRequestPhase;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal, docraptorRequestTimeoutMs);
-
-  try {
-    const response = await input.fetcher(new URL(input.path, docraptorApiBaseUrl), {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        authorization: buildDocraptorAuthorizationHeader(input.apiKey),
-        "content-type": "application/json",
-        "user-agent": providerUserAgent,
-      },
-      body: JSON.stringify(input.body),
-      signal: timeout.signal,
-    });
-    const payload = await readDocraptorPayload(response);
-    if (!response.ok) {
-      throw createDocraptorError(response, payload, input.phase);
-    }
-    return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "DocRaptor request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `DocRaptor request failed: ${error.message}` : "DocRaptor request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  return runProviderRequest(
+    { signal: input.signal, timeoutMs: docraptorRequestTimeoutMs, label: "DocRaptor" },
+    async (signal) => {
+      const response = await input.fetcher(new URL(input.path, docraptorApiBaseUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: buildDocraptorAuthorizationHeader(input.apiKey),
+          "content-type": "application/json",
+          "user-agent": providerUserAgent,
+        },
+        body: JSON.stringify(input.body),
+        signal,
+      });
+      const payload = await readDocraptorPayload(response);
+      if (!response.ok) {
+        throw createDocraptorError(response, payload, input.phase);
+      }
+      return payload;
+    },
+  );
 }
 
 function buildDocraptorAuthorizationHeader(apiKey: string): string {

--- a/src/providers/document360/executors.ts
+++ b/src/providers/document360/executors.ts
@@ -12,13 +12,12 @@ import {
 } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "document360";
@@ -154,8 +153,7 @@ async function requestJson(input: {
   phase: Phase;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Document360" }, async (signal) => {
     const response = await input.fetcher(buildUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -164,7 +162,7 @@ async function requestJson(input: {
         api_token: input.apiKey,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPayload(response);
     if (!response.ok) throw createError(response.status, payload, input.phase);
@@ -173,17 +171,7 @@ async function requestJson(input: {
     if (record.success === false)
       throw createError(response.status >= 400 ? response.status : 400, record, input.phase);
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Document360 request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Document360 request failed: ${error.message}` : "Document360 request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildUrl(path: string, query: Record<string, string | number | boolean | undefined>): URL {

--- a/src/providers/embase/runtime.ts
+++ b/src/providers/embase/runtime.ts
@@ -2,11 +2,10 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const embaseApiBaseUrl = "https://api.elsevier.com/content/embase";
@@ -112,13 +111,11 @@ async function requestEmbaseJson(input: {
   fetcher: typeof fetch;
   phase: EmbasePhase;
 }): Promise<EmbaseResponse> {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Embase" }, async (signal) => {
     const response = await input.fetcher(buildEmbaseUrl(input.path, input.params), {
       method: "GET",
       headers: buildEmbaseHeaders(input.credentials),
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readEmbasePayload(response);
 
@@ -132,20 +129,7 @@ async function requestEmbaseJson(input: {
     }
 
     return { payload: payloadRecord, quota: readEmbaseQuota(response.headers) };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Embase request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Embase request failed: ${error.message}` : "Embase request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildEmbaseUrl(path: string, params: Record<string, string | undefined>) {

--- a/src/providers/encharge/runtime.ts
+++ b/src/providers/encharge/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const enchargeApiBaseUrl = "https://api.encharge.io/v1";
 
@@ -105,34 +100,22 @@ async function validateEnchargeApiKey(options: EnchargeRequestOptions): Promise<
 
 async function rawEnchargeRequest(options: EnchargeRequestOptions): Promise<Response> {
   const url = new URL(resolveEnchargePath(options.path), `${enchargeApiBaseUrl}/`);
-  const timeout = createProviderTimeout(options.context.signal, enchargeDefaultRequestTimeoutMs);
-
-  try {
-    return await options.context.fetcher(url, {
-      method: options.method ?? "GET",
-      signal: timeout.signal,
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-        "user-agent": providerUserAgent,
-        "X-Encharge-Token": options.context.apiKey,
-      },
-      body: options.body === undefined ? undefined : JSON.stringify(options.body),
-    });
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Encharge request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Encharge request failed: ${error.message}` : "Encharge request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  return runProviderRequest(
+    { signal: options.context.signal, timeoutMs: enchargeDefaultRequestTimeoutMs, label: "Encharge" },
+    async (signal) => {
+      return await options.context.fetcher(url, {
+        method: options.method ?? "GET",
+        signal,
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "user-agent": providerUserAgent,
+          "X-Encharge-Token": options.context.apiKey,
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      });
+    },
+  );
 }
 
 function buildSendEmailBody(input: Record<string, unknown>): Record<string, unknown> {

--- a/src/providers/europe_pmc/request.ts
+++ b/src/providers/europe_pmc/request.ts
@@ -1,10 +1,5 @@
 import { optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const europePmcApiBaseUrl = "https://www.ebi.ac.uk/europepmc/webservices/rest";
 export const europePmcAnnotationsApiBaseUrl = "https://www.ebi.ac.uk/europepmc/annotations_api";
@@ -66,9 +61,7 @@ export async function requestEuropePmcText(input: {
   accept: string;
   fetcher: typeof fetch;
 }): Promise<{ body: string; contentType: string | null }> {
-  const timeoutHandle = createProviderTimeout(undefined, requestTimeoutMs);
-
-  try {
+  return runProviderRequest({ timeoutMs: requestTimeoutMs, label: "Europe PMC" }, async (signal) => {
     const headers = new Headers({
       accept: input.accept,
       "user-agent": providerUserAgent,
@@ -82,7 +75,7 @@ export async function requestEuropePmcText(input: {
         method: input.method ?? "GET",
         headers,
         ...(input.jsonBody === undefined ? {} : { body: JSON.stringify(input.jsonBody) }),
-        signal: timeoutHandle.signal,
+        signal,
       },
     );
     const body = await response.text();
@@ -95,22 +88,7 @@ export async function requestEuropePmcText(input: {
       body,
       contentType: response.headers.get("content-type"),
     };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Europe PMC request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Europe PMC request failed: ${error.message}` : "Europe PMC request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildEuropePmcUrl(baseUrl: string, path: string, params: Record<string, QueryParameter> = {}) {

--- a/src/providers/expofp/runtime.ts
+++ b/src/providers/expofp/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const expofpApiBaseUrl = "https://app.expofp.com/api/v1";
 
@@ -140,8 +135,7 @@ async function requestExpofpJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ExpofpPhase,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "ExpoFP" }, async (signal) => {
     const response = await context.fetcher(new URL(path.replace(/^\//, ""), `${expofpApiBaseUrl}/`), {
       method: "POST",
       headers: {
@@ -153,27 +147,14 @@ async function requestExpofpJson(
         token: context.apiKey,
         ...payload,
       }),
-      signal: timeout.signal,
+      signal,
     });
     const parsed = await readExpofpPayload(response);
     if (!response.ok) {
       throw createExpofpError(response.status, parsed, phase);
     }
     return parsed;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ExpoFP request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ExpoFP request failed: ${error.message}` : "ExpoFP request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readExpofpPayload(response: Response): Promise<unknown> {

--- a/src/providers/freshstatus/runtime.ts
+++ b/src/providers/freshstatus/runtime.ts
@@ -1,11 +1,10 @@
 import { Buffer } from "node:buffer";
 import { compactObject, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const freshstatusApiBaseUrl = "https://public-api.freshstatus.io/api/v1/";
@@ -207,8 +206,7 @@ function mapDisplayOptions(value: unknown, mapping: Record<string, string>): Rec
 }
 
 async function requestFreshstatus(input: FreshstatusRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Freshstatus" }, async (signal) => {
     const response = await input.context.fetcher(new URL(input.path, freshstatusApiBaseUrl), {
       method: input.method ?? "GET",
       headers: {
@@ -218,23 +216,12 @@ async function requestFreshstatus(input: FreshstatusRequestInput): Promise<unkno
         "user-agent": providerUserAgent,
       },
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPayload(response);
     if (!response.ok) throw createFreshstatusError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Freshstatus request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Freshstatus request failed: ${error.message}` : "Freshstatus request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readPayload(response: Response): Promise<unknown> {

--- a/src/providers/full_contact/executors.ts
+++ b/src/providers/full_contact/executors.ts
@@ -15,14 +15,13 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const fullContactApiBaseUrl = "https://api.fullcontact.com/v3";
@@ -184,14 +183,12 @@ async function requestFullContactJson(
   },
   context: FullContactRequestContext,
 ) {
-  const timeoutHandle = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "FullContact" }, async (signal) => {
     const response = await context.fetcher(new URL(input.endpoint, `${fullContactApiBaseUrl}/`), {
       method: "POST",
       headers: buildFullContactHeaders(context.apiKey),
       body: JSON.stringify(stripUndefined(input.body)),
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readFullContactPayload(response);
 
@@ -205,22 +202,7 @@ async function requestFullContactJson(
     }
 
     return payloadObject;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "FullContact request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `FullContact request failed: ${error.message}` : "FullContact request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildFullContactHeaders(apiKey: string) {

--- a/src/providers/gatherup/runtime.ts
+++ b/src/providers/gatherup/runtime.ts
@@ -3,11 +3,10 @@ import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export interface GatherupContext {
@@ -111,9 +110,7 @@ export async function validateGatherupCredential(
 }
 
 async function requestGatherupJson(input: GatherupRequestInput) {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "GatherUp" }, async (signal) => {
     const response = await input.fetcher(buildGatherupUrl(input), {
       method: "GET",
       headers: {
@@ -121,27 +118,14 @@ async function requestGatherupJson(input: GatherupRequestInput) {
         authorization: `Bearer ${input.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readGatherupPayload(response);
     if (!response.ok) {
       throw createGatherupError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "GatherUp request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `GatherUp request failed: ${error.message}` : "GatherUp request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildGatherupUrl(input: GatherupRequestInput) {

--- a/src/providers/genpage/runtime.ts
+++ b/src/providers/genpage/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ApiKeyProviderContext, ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const genpageApiBaseUrl = "https://backend.genpage.ai";
 type Method = "GET" | "POST";
@@ -83,8 +78,7 @@ async function request(input: RequestInput): Promise<unknown> {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, Array.isArray(value) ? value.join(",") : String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "GenPage" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: input.method,
       headers: {
@@ -94,22 +88,12 @@ async function request(input: RequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPayload(response);
     if (!response.ok) throw createError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "GenPage request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `GenPage request failed: ${error.message}` : "GenPage request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 async function readPayload(response: Response): Promise<unknown> {
   const text = await response.text();

--- a/src/providers/gosquared/executors.ts
+++ b/src/providers/gosquared/executors.ts
@@ -11,13 +11,12 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
+  runProviderRequest,
   setSearchParams,
 } from "../provider-runtime.ts";
 
@@ -179,16 +178,14 @@ async function requestGosquaredReport(
 }
 
 async function requestGosquaredJson(options: GosquaredRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.signal);
-
-  try {
+  return runProviderRequest({ signal: options.signal, label: "GoSquared" }, async (signal) => {
     const response = await options.fetcher(buildGosquaredUrl(options), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readGosquaredPayload(response);
 
@@ -202,20 +199,7 @@ async function requestGosquaredJson(options: GosquaredRequestOptions): Promise<R
     }
 
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "GoSquared request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `GoSquared request failed: ${error.message}` : "GoSquared request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildGosquaredUrl(options: Pick<GosquaredRequestOptions, "path" | "apiKey" | "siteToken" | "query">): URL {

--- a/src/providers/gptzero/executors.ts
+++ b/src/providers/gptzero/executors.ts
@@ -17,13 +17,12 @@ import {
   requiredRecord,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "gptzero";
@@ -91,8 +90,7 @@ export const credentialValidators: CredentialValidators = {
 };
 
 async function requestGptzeroJson(input: GptzeroJsonRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "GPTZero" }, async (signal) => {
     const response = await input.context.fetcher(new URL(gptzeroPredictTextPath, gptzeroApiBaseUrl), {
       method: "POST",
       headers: {
@@ -107,7 +105,7 @@ async function requestGptzeroJson(input: GptzeroJsonRequestOptions): Promise<unk
           version: input.version,
         }),
       ),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -117,20 +115,7 @@ async function requestGptzeroJson(input: GptzeroJsonRequestOptions): Promise<unk
       throw createGptzeroError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "GPTZero request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `GPTZero request failed: ${error.message}` : "GPTZero request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function normalizeGptzeroPredictionPayload(payload: unknown): Record<string, unknown> {

--- a/src/providers/grafana/runtime.ts
+++ b/src/providers/grafana/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, encodePathSegment, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const defaultNamespace = "default";
 const folderParentAnnotation = "grafana.app/folder";
@@ -413,34 +408,19 @@ async function grafanaRequestJson(
     }
   }
 
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Grafana" }, async (signal) => {
     const response = await context.fetcher(url, {
       method: request.method,
       headers: grafanaHeaders(context.apiKey, request.body !== undefined),
       body: request.body === undefined ? undefined : JSON.stringify(request.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readGrafanaPayload(response);
     if (!response.ok) {
       throw createGrafanaError(response, payload, context.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Grafana request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Grafana request failed: ${error.message}` : "Grafana request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function grafanaHeaders(apiKey: string, hasJsonBody: boolean): Record<string, string> {

--- a/src/providers/heartbeat/executors.ts
+++ b/src/providers/heartbeat/executors.ts
@@ -4,14 +4,13 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "heartbeat";
@@ -157,9 +156,7 @@ async function requestHeartbeatJson(input: {
       url.searchParams.set(name, value);
     }
   }
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Heartbeat" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: "GET",
       headers: {
@@ -167,27 +164,14 @@ async function requestHeartbeatJson(input: {
         authorization: `Bearer ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readHeartbeatPayload(response);
     if (!response.ok) {
       throw createHeartbeatError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Heartbeat request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Heartbeat request failed: ${error.message}` : "Heartbeat request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readHeartbeatPayload(response: Response): Promise<unknown> {

--- a/src/providers/holded/runtime.ts
+++ b/src/providers/holded/runtime.ts
@@ -2,12 +2,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const holdedApiBaseUrl = "https://api.holded.com/api/v2";
 
@@ -155,8 +150,7 @@ export async function validateHoldedCredential(
 }
 
 async function requestHoldedJson(input: HoldedRequestInput): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Holded" }, async (signal) => {
     const response = await input.context.fetcher(buildHoldedUrl(input.path, input.query), {
       method: input.method,
       headers: {
@@ -166,7 +160,7 @@ async function requestHoldedJson(input: HoldedRequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readHoldedPayload(response);
 
@@ -175,20 +169,7 @@ async function requestHoldedJson(input: HoldedRequestInput): Promise<unknown> {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Holded request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Holded request failed: ${error.message}` : "Holded request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildHoldedUrl(path: string, query: Record<string, string | undefined>): URL {

--- a/src/providers/hub_planner/executors.ts
+++ b/src/providers/hub_planner/executors.ts
@@ -4,13 +4,12 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "hub_planner";
@@ -206,8 +205,7 @@ async function requestHubPlannerJson<T>(input: {
   signal?: AbortSignal;
 }): Promise<T> {
   const url = buildHubPlannerUrl(input.path, input.query);
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Hub Planner" }, async (signal) => {
     const response = await input.fetcher(url, {
       method: input.method,
       headers: {
@@ -216,7 +214,7 @@ async function requestHubPlannerJson<T>(input: {
         "content-type": "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
       ...(input.body ? { body: JSON.stringify(input.body) } : {}),
     });
     const payload = await readHubPlannerPayload(response, !response.ok);
@@ -232,21 +230,7 @@ async function requestHubPlannerJson<T>(input: {
     }
 
     return payload as T;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Hub Planner request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Hub Planner request failed: ${error.message}` : "Hub Planner request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildHubPlannerUrl(path: string, query: Record<string, HubPlannerQueryValue> = {}) {

--- a/src/providers/instabot/runtime.ts
+++ b/src/providers/instabot/runtime.ts
@@ -2,12 +2,7 @@ import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-ru
 import type { InstabotActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export interface InstabotCredentialCheck {
   providerAccountId?: string;
@@ -188,8 +183,7 @@ async function listUsers(
 }
 
 async function requestInstabotJson(input: InstabotRequestInput) {
-  const timeoutHandle = createProviderTimeout(undefined);
-  try {
+  return runProviderRequest({ label: "Instabot" }, async (signal) => {
     const url = new URL(input.path.replace(/^\//, ""), `${instabotApiBaseUrl}/`);
     for (const [key, value] of Object.entries(input.query ?? {})) {
       if (value !== undefined) {
@@ -206,7 +200,7 @@ async function requestInstabotJson(input: InstabotRequestInput) {
         "x-instabot-api-key": input.credential.apiKey,
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readPayload(response);
     if (!response.ok) {
@@ -221,20 +215,7 @@ async function requestInstabotJson(input: InstabotRequestInput) {
       throw createInstabotError(response.status, record, input.phase);
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Instabot request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Instabot request failed: ${error.message}` : "Instabot request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 async function readPayload(response: Response) {

--- a/src/providers/jigsawstack/runtime.ts
+++ b/src/providers/jigsawstack/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const jigsawstackApiBaseUrl = "https://api.jigsawstack.com";
 const jigsawstackValidationPath = "/v1/web/search/suggest";
@@ -159,14 +154,12 @@ async function requestJigsawstackJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   request: JigsawstackRequest,
 ): Promise<Record<string, unknown>> {
-  const timeoutHandle = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "JigsawStack" }, async (signal) => {
     const response = await context.fetcher(buildJigsawstackUrl(request.path, request.query), {
       method: request.method ?? "GET",
       headers: jigsawstackHeaders(context.apiKey),
       body: request.body ? JSON.stringify(request.body) : undefined,
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readJigsawstackPayload(response);
     if (!response.ok) {
@@ -178,22 +171,7 @@ async function requestJigsawstackJson(
       throw new ProviderRequestError(502, "JigsawStack returned invalid JSON object");
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "JigsawStack request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `JigsawStack request failed: ${error.message}` : "JigsawStack request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function jigsawstackHeaders(apiKey: string): Record<string, string> {

--- a/src/providers/kandji/runtime.ts
+++ b/src/providers/kandji/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { createHash } from "node:crypto";
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 type KandjiPhase = "validate" | "execute";
 type KandjiActionHandler = (input: Record<string, unknown>, context: KandjiActionContext) => Promise<unknown>;
@@ -179,13 +174,11 @@ async function requestKandjiJson(input: {
   phase: KandjiPhase;
   notFoundAsInvalidInput?: boolean;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Kandji" }, async (signal) => {
     const response = await input.fetcher(buildKandjiUrl(input.apiUrl, input.path, input.query), {
       method: "GET",
       headers: buildKandjiHeaders(input.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKandjiPayload(response);
 
@@ -194,21 +187,7 @@ async function requestKandjiJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Kandji request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Kandji request failed: ${error.message}` : "Kandji request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function isAllowedKandjiApiHost(hostname: string): boolean {

--- a/src/providers/kernel/executors.ts
+++ b/src/providers/kernel/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "kernel";
@@ -153,40 +152,26 @@ async function requestKernelJson(input: KernelRequestInput): Promise<{
   payload: unknown;
   pagination: ReturnType<typeof readKernelPagination>;
 }> {
-  const timeout = createProviderTimeout(input.context.signal, kernelDefaultRequestTimeoutMs);
+  return runProviderRequest(
+    { signal: input.context.signal, timeoutMs: kernelDefaultRequestTimeoutMs, label: "Kernel" },
+    async (signal) => {
+      const response = await input.context.fetcher(buildKernelUrl(input.path, input.query), {
+        method: input.method,
+        headers: buildKernelHeaders(input),
+        body: input.body ? JSON.stringify(input.body) : undefined,
+        signal,
+      });
+      if (!response.ok) {
+        const payload = await readKernelErrorPayload(response);
+        throw createKernelError(response, payload, input.phase);
+      }
 
-  try {
-    const response = await input.context.fetcher(buildKernelUrl(input.path, input.query), {
-      method: input.method,
-      headers: buildKernelHeaders(input),
-      body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
-    });
-    if (!response.ok) {
-      const payload = await readKernelErrorPayload(response);
-      throw createKernelError(response, payload, input.phase);
-    }
-
-    return {
-      payload: await readKernelPayload(response),
-      pagination: readKernelPagination(response.headers),
-    };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Kernel request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Kernel request failed: ${error.message}` : "Kernel request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+      return {
+        payload: await readKernelPayload(response),
+        pagination: readKernelPagination(response.headers),
+      };
+    },
+  );
 }
 
 function buildKernelHeaders(input: KernelRequestInput): Record<string, string> {

--- a/src/providers/keyword/runtime.ts
+++ b/src/providers/keyword/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const keywordApiBaseUrl = "https://app.keyword.com";
 
@@ -106,9 +101,7 @@ async function requestKeywordJson(
     query?: Record<string, string | undefined>;
   },
 ) {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Keyword.com" }, async (signal) => {
     const response = await context.fetcher(buildKeywordUrl(request.path, request.query), {
       method: "GET",
       headers: {
@@ -116,29 +109,14 @@ async function requestKeywordJson(
         authorization: `Bearer ${context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKeywordPayload(response);
     if (!response.ok) {
       throw createKeywordError(response, payload, context.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Keyword.com request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Keyword.com request failed: ${error.message}` : "Keyword.com request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKeywordUrl(path: string, query: Record<string, string | undefined> = {}) {

--- a/src/providers/kintone/runtime.ts
+++ b/src/providers/kintone/runtime.ts
@@ -12,11 +12,10 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 type KintonePhase = "validate" | "execute";
@@ -170,8 +169,7 @@ async function requestKintoneJson(input: {
   query?: Record<string, KintoneQueryValue | undefined>;
   phase: KintonePhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Kintone" }, async (signal) => {
     const response = await input.context.fetcher(buildKintoneUrl(input.context.apiBaseUrl, input.path, input.query), {
       method: "GET",
       headers: {
@@ -179,7 +177,7 @@ async function requestKintoneJson(input: {
         authorization: `Bearer ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKintonePayload(response);
     if (!response.ok) {
@@ -190,20 +188,7 @@ async function requestKintoneJson(input: {
       throw new ProviderRequestError(502, "Kintone returned an invalid payload");
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Kintone request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Kintone request failed: ${error.message}` : "Kintone request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKintoneUrl(

--- a/src/providers/kit/runtime.ts
+++ b/src/providers/kit/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const kitApiBaseUrl = "https://api.kit.com/v4";
 
@@ -219,9 +214,7 @@ async function requestKitJson(input: {
   phase: KitPhase;
   signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Kit" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       "user-agent": providerUserAgent,
@@ -235,7 +228,7 @@ async function requestKitJson(input: {
       method: input.method,
       headers,
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKitPayload(response);
 
@@ -248,22 +241,7 @@ async function requestKitJson(input: {
       throw new ProviderRequestError(502, "Kit returned an invalid payload");
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Kit request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Kit request failed: ${error.message}` : "Kit request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKitUrl(path: string, params: Record<string, string | undefined>) {

--- a/src/providers/klazify/executors.ts
+++ b/src/providers/klazify/executors.ts
@@ -11,11 +11,10 @@ import {
   optionalString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "klazify";
@@ -242,9 +241,7 @@ async function requestKlazifyJson(input: {
   signal?: AbortSignal;
   phase: KlazifyPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Klazify" }, async (signal) => {
     const response = await input.fetcher(buildKlazifyUrl(input.path), {
       method: "POST",
       headers: {
@@ -254,7 +251,7 @@ async function requestKlazifyJson(input: {
         "user-agent": providerUserAgent,
       },
       body: JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKlazifyPayload(response);
 
@@ -267,22 +264,7 @@ async function requestKlazifyJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Klazify request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Klazify request failed: ${error.message}` : "Klazify request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKlazifyUrl(path: string): URL {

--- a/src/providers/klipfolio/runtime.ts
+++ b/src/providers/klipfolio/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const klipfolioApiBaseUrl = "https://api.klipfolio.com/api/1.0";
 
@@ -134,9 +129,7 @@ async function requestKlipfolioJson(input: {
   signal?: AbortSignal;
   phase: KlipfolioPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Klipfolio" }, async (signal) => {
     const response = await input.fetcher(buildKlipfolioUrl(input.path, input.params ?? {}), {
       method: input.method,
       headers: {
@@ -144,7 +137,7 @@ async function requestKlipfolioJson(input: {
         "kf-api-key": input.apiKey,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKlipfolioPayload(response);
 
@@ -153,21 +146,7 @@ async function requestKlipfolioJson(input: {
     }
 
     return payload ?? {};
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Klipfolio request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Klipfolio request failed: ${error.message}` : "Klipfolio request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKlipfolioUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/knock/runtime.ts
+++ b/src/providers/knock/runtime.ts
@@ -5,11 +5,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { compactObject, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const knockApiBaseUrl = "https://api.knock.app/v1";
@@ -153,9 +152,7 @@ async function requestKnockJson(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   mode: KnockRequestMode,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Knock" }, async (signal) => {
     const headers = knockHeaders(context.apiKey);
     if (request.idempotencyKey) {
       headers["Idempotency-Key"] = request.idempotencyKey;
@@ -165,7 +162,7 @@ async function requestKnockJson(
       method: request.method,
       headers,
       body: request.body === undefined ? undefined : JSON.stringify(request.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKnockPayload(response);
 
@@ -178,22 +175,7 @@ async function requestKnockJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Knock request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Knock request failed: ${error.message}` : "Knock request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKnockUrl(path: string, query: Record<string, string | string[] | undefined> = {}): URL {

--- a/src/providers/komari/runtime.ts
+++ b/src/providers/komari/runtime.ts
@@ -5,12 +5,11 @@ import type { KomariOperation } from "./operations.ts";
 import { optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   mapProviderActionHandlers,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 import { komariOperations } from "./operations.ts";
 
@@ -320,8 +319,7 @@ async function requestKomariRpc(
   phase: KomariRequestPhase,
 ): Promise<unknown> {
   const url = new URL(rpcPath, `${context.baseUrl}/`);
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Komari" }, async (signal) => {
     const response = await context.fetcher(url, {
       method: "POST",
       headers: {
@@ -331,7 +329,7 @@ async function requestKomariRpc(
         "user-agent": providerUserAgent,
       },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readJsonResponse(response);
     if (!response.ok) {
@@ -351,20 +349,7 @@ async function requestKomariRpc(
       throw new ProviderRequestError(502, "Komari returned a JSON-RPC response without a result");
     }
     return envelope.result;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Komari request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Komari request failed: ${error.message}` : "Komari request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {

--- a/src/providers/kommo/runtime.ts
+++ b/src/providers/kommo/runtime.ts
@@ -10,12 +10,7 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const kommoCredentialHelpUrl = "https://developers.kommo.com/docs/long-lived-token";
 const kommoPrivateIntegrationHelpUrl = "https://developers.kommo.com/docs/private-integration";
@@ -290,34 +285,18 @@ async function getRecord<TRecord extends Record<string, unknown>>(input: {
 }
 
 async function requestKommoJson(input: KommoRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Kommo" }, async (signal) => {
     const response = await input.fetcher(buildKommoUrl(input.apiBaseUrl, input.path, input.query), {
       method: "GET",
       headers: buildKommoHeaders(input.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readKommoPayload(response);
     if (!response.ok) {
       throw createKommoError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Kommo request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Kommo request failed: ${error.message}` : "Kommo request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildKommoUrl(apiBaseUrl: string, path: string, query: Record<string, QueryValue | undefined> = {}): URL {

--- a/src/providers/label_studio/executors.ts
+++ b/src/providers/label_studio/executors.ts
@@ -18,15 +18,14 @@ import {
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerInputError,
   providerResponseError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "label_studio";
@@ -271,14 +270,12 @@ async function requestLabelStudioJson(input: {
   body?: unknown;
   notFoundAsInvalidInput?: boolean;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Label Studio" }, async (signal) => {
     const response = await input.fetcher(buildLabelStudioUrl(input.baseUrl, input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildLabelStudioHeaders(input.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readLabelStudioPayload(response);
 
@@ -287,22 +284,7 @@ async function requestLabelStudioJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Label Studio request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Label Studio request failed: ${error.message}` : "Label Studio request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildLabelStudioUrl(

--- a/src/providers/leadmagic/executors.ts
+++ b/src/providers/leadmagic/executors.ts
@@ -18,12 +18,11 @@ import {
   optionalStringOrNull,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "leadmagic";
@@ -183,14 +182,12 @@ async function requestLeadmagicJson(
   input: LeadmagicRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "LeadMagic" }, async (signal) => {
     const response = await context.fetcher(buildLeadmagicUrl(input.path), {
       method: input.method,
       headers: buildLeadmagicHeaders(context.apiKey, Boolean(input.body)),
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readLeadmagicPayload(response);
 
@@ -204,22 +201,7 @@ async function requestLeadmagicJson(
     }
 
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "LeadMagic request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `LeadMagic request failed: ${error.message}` : "LeadMagic request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildLeadmagicUrl(path: string): string {

--- a/src/providers/lexoffice/runtime.ts
+++ b/src/providers/lexoffice/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const lexofficeApiBaseUrl = "https://api.lexware.io";
@@ -207,13 +206,12 @@ export async function validateLexofficeCredential(
 }
 
 async function requestLexofficeJson(input: LexofficeRequestOptions): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Lexoffice" }, async (signal) => {
     const response = await input.fetcher(buildLexofficeUrl(input.path, input.query), {
       method: input.method,
       headers: buildLexofficeHeaders(input.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readLexofficePayload(response);
     if (!response.ok) {
@@ -223,20 +221,7 @@ async function requestLexofficeJson(input: LexofficeRequestOptions): Promise<unk
       throw new ProviderRequestError(502, "Lexoffice returned an empty response");
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Lexoffice request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Lexoffice request failed: ${error.message}` : "Lexoffice request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildLexofficeUrl(path: string, query?: Record<string, string | undefined>): string {

--- a/src/providers/liveagent/executors.ts
+++ b/src/providers/liveagent/executors.ts
@@ -10,14 +10,13 @@ import { createHash } from "node:crypto";
 import { compactObject, optionalInteger, optionalNumber, optionalRawString, optionalRecord } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "liveagent";
@@ -350,14 +349,12 @@ async function requestLiveagentJson(input: {
   readonly body?: unknown;
   readonly signal?: AbortSignal;
 }) {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "LiveAgent" }, async (signal) => {
     const response = await input.fetcher(buildLiveagentUrl(input.apiBaseUrl, input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildLiveagentHeaders(input.apiKey, input.body !== undefined),
       ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readLiveagentPayload(response);
 
@@ -366,22 +363,7 @@ async function requestLiveagentJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "LiveAgent request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `LiveAgent request failed: ${error.message}` : "LiveAgent request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildLiveagentUrl(apiBaseUrl: string, path: string, query?: Record<string, QueryValue>) {

--- a/src/providers/lob/executors.ts
+++ b/src/providers/lob/executors.ts
@@ -6,11 +6,10 @@ import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
 import { compactJson, queryParams } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "lob";
@@ -168,33 +167,19 @@ async function requestLobJson(input: {
     url.searchParams.set(key, value);
   }
 
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "lob" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: input.method,
       headers: lobHeaders(input.context.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readLobPayload(response);
     if (!response.ok) {
       throw createLobError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "lob request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `lob request failed: ${error.message}` : "lob request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function lobHeaders(apiKey: string, hasBody: boolean): Record<string, string> {

--- a/src/providers/longbridge/runtime.ts
+++ b/src/providers/longbridge/runtime.ts
@@ -14,12 +14,11 @@ import {
 } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   mapProviderActionHandlers,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 import { longbridgeOAuthScopes } from "./actions.ts";
 import { indexSymbolToCounterId, symbolToCounterId } from "./counter-id.ts";
@@ -379,28 +378,14 @@ export async function validateLongbridgeCredential(
 
 export async function requestLongbridgeJson(input: LongbridgeRequestOptions): Promise<unknown> {
   const url = buildLongbridgeUrl(input.path, input.query);
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
-    const response = await input.context.fetcher(url, buildLongbridgeRequestInit(input, timeout.signal));
+  return runProviderRequest({ signal: input.context.signal, label: "Longbridge" }, async (signal) => {
+    const response = await input.context.fetcher(url, buildLongbridgeRequestInit(input, signal));
     const payload = await readLongbridgeJson(response);
     if (!response.ok) {
       throw mapLongbridgeHttpError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Longbridge request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Longbridge request failed: ${error.message}` : "Longbridge request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildLongbridgeRequestInit(input: LongbridgeRequestOptions, signal: AbortSignal): RequestInit {

--- a/src/providers/markettime/executors.ts
+++ b/src/providers/markettime/executors.ts
@@ -9,13 +9,12 @@ import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { optionalInteger, optionalRecord, optionalString, requiredRecord, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "markettime";
@@ -123,8 +122,7 @@ async function requestMarkettime(input: MarkettimeRequestInput): Promise<unknown
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value != null) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "MarketTime" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: input.method ?? "GET",
       headers: {
@@ -134,25 +132,14 @@ async function requestMarkettime(input: MarkettimeRequestInput): Promise<unknown
         "x-api-key": input.context.apiKey,
       },
       body: input.body == null ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readJson(response, response.ok);
     if (!response.ok) throw createMarkettimeError(response, payload, input.phase);
     const envelope = optionalRecord(payload);
     if (envelope?.success === false) throw createMarkettimeError(response, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "MarketTime request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `MarketTime request failed: ${error.message}` : "MarketTime request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function parseListResponse(payload: unknown): Record<string, unknown> {

--- a/src/providers/memberstack/runtime.ts
+++ b/src/providers/memberstack/runtime.ts
@@ -10,12 +10,7 @@ import {
   optionalString,
   requiredString,
 } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const memberstackApiBaseUrl = "https://admin.memberstack.com";
 
@@ -172,9 +167,7 @@ async function requestMemberstackJson(input: {
   emptySuccess?: boolean;
   phase: MemberstackPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Memberstack" }, async (signal) => {
     const body = input.body && Object.keys(input.body).length > 0 ? input.body : undefined;
     const headers: Record<string, string> = {
       accept: "application/json",
@@ -189,7 +182,7 @@ async function requestMemberstackJson(input: {
       method: input.method,
       headers,
       body: body ? JSON.stringify(body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readMemberstackPayload(response);
 
@@ -206,22 +199,7 @@ async function requestMemberstackJson(input: {
       throw new ProviderRequestError(502, "Memberstack returned an invalid payload");
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Memberstack request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Memberstack request failed: ${error.message}` : "Memberstack request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildMemberstackUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/metatextai/runtime.ts
+++ b/src/providers/metatextai/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const metatextaiApiBaseUrl = "https://guard-api.metatext.ai";
 
@@ -133,9 +128,7 @@ async function metatextaiRequestJson(input: {
   phase: MetatextaiPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "MetatextAI" }, async (signal) => {
     const response = await input.context.fetcher(buildUrl(input.path), {
       method: input.method,
       headers: {
@@ -145,7 +138,7 @@ async function metatextaiRequestJson(input: {
         "user-agent": providerUserAgent,
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readJsonResponse(response);
 
@@ -154,20 +147,7 @@ async function metatextaiRequestJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "MetatextAI request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `MetatextAI request failed: ${error.message}` : "MetatextAI request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildUrl(path: string): string {

--- a/src/providers/mezmo/runtime.ts
+++ b/src/providers/mezmo/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.ts";
 
 import { optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const mezmoApiBaseUrl = "https://api.mezmo.com";
 
@@ -129,9 +124,7 @@ async function requestMezmoJson(input: {
   context: MezmoActionContext;
   phase: MezmoPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Mezmo" }, async (signal) => {
     const response = await input.context.fetcher(buildMezmoUrl(input.path, input.params), {
       method: "GET",
       headers: {
@@ -139,7 +132,7 @@ async function requestMezmoJson(input: {
         authorization: `Token ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readMezmoPayload(response);
 
@@ -148,21 +141,7 @@ async function requestMezmoJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Mezmo request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Mezmo request failed: ${error.message}` : "Mezmo request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildMezmoUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/motion/executors.ts
+++ b/src/providers/motion/executors.ts
@@ -10,12 +10,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { optionalRecord, optionalString, requiredString, stringArray } from "../../core/cast.ts";
 import { jsonObject, queryParams } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "motion";
@@ -261,13 +260,11 @@ async function requestMotionJson(input: {
   query?: Record<string, string>;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Motion" }, async (signal) => {
     const response = await input.context.fetcher(buildMotionUrl(input.path, input.query), {
       method: input.method ?? "GET",
       headers: buildMotionHeaders(input.context.apiKey, input.body),
-      signal: timeout.signal,
+      signal,
       ...(input.body ? { body: JSON.stringify(input.body) } : {}),
     });
     const payload = await readMotionPayload(response);
@@ -277,22 +274,7 @@ async function requestMotionJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Motion request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Motion request failed: ${error.message}` : "Motion request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildMotionUrl(path: string, query?: Record<string, string>): URL {

--- a/src/providers/ninox/executors.ts
+++ b/src/providers/ninox/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const ninoxApiBaseUrl = "https://api.ninox.com/v1";
@@ -318,9 +317,7 @@ async function deleteRecords(input: Record<string, unknown>, context: ApiKeyProv
 }
 
 async function requestNinoxJson(input: NinoxRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Ninox" }, async (signal) => {
     const response = await input.context.fetcher(buildNinoxUrl(input.path, input.query), {
       method: input.method ?? "GET",
       headers: {
@@ -330,7 +327,7 @@ async function requestNinoxJson(input: NinoxRequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
 
     if (input.allowNoContent && response.status === 204) {
@@ -343,21 +340,7 @@ async function requestNinoxJson(input: NinoxRequestInput): Promise<unknown> {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Ninox request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Ninox request failed: ${error.message}` : "Ninox request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildNinoxUrl(path: string, query?: Record<string, NinoxQueryValue>): URL {

--- a/src/providers/nylas/runtime.ts
+++ b/src/providers/nylas/runtime.ts
@@ -11,12 +11,7 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 type NylasActionContext = ApiKeyProviderContext;
 type NylasPhase = "validate" | "execute";
@@ -169,8 +164,7 @@ export async function validateNylasCredential(
 }
 
 async function requestNylasJson(options: NylasRequestOptions): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(options.context.signal);
-  try {
+  return runProviderRequest({ signal: options.context.signal, label: "Nylas" }, async (signal) => {
     const response = await options.context.fetcher(buildNylasUrl(options.path, options.params ?? {}), {
       method: "GET",
       headers: {
@@ -178,7 +172,7 @@ async function requestNylasJson(options: NylasRequestOptions): Promise<Record<st
         authorization: `Bearer ${options.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readNylasPayload(response);
     if (!response.ok) {
@@ -190,20 +184,7 @@ async function requestNylasJson(options: NylasRequestOptions): Promise<Record<st
       throw new ProviderRequestError(502, "Nylas returned an invalid payload");
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Nylas request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Nylas request failed: ${error.message}` : "Nylas request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildNylasUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/one_password_events/runtime.ts
+++ b/src/providers/one_password_events/runtime.ts
@@ -16,12 +16,11 @@ import {
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerResponseError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const onePasswordEventsValidationPath = "/api/v2/auth/introspect";
@@ -189,8 +188,7 @@ async function requestOnePasswordEventsJson(input: {
   phase: OnePasswordEventsPhase;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "1Password Events" }, async (signal) => {
     const response = await input.context.fetcher(new URL(input.path, `${input.context.baseUrl}/`), {
       method: input.method,
       headers: {
@@ -200,7 +198,7 @@ async function requestOnePasswordEventsJson(input: {
         "user-agent": providerUserAgent,
       },
       ...(input.method === "POST" ? { body: JSON.stringify(input.body ?? {}) } : {}),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readOnePasswordEventsPayload(response);
 
@@ -209,22 +207,7 @@ async function requestOnePasswordEventsJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "1Password Events request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `1Password Events request failed: ${error.message}` : "1Password Events request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readOnePasswordEventsPayload(response: Response): Promise<unknown> {

--- a/src/providers/openalex/executors.ts
+++ b/src/providers/openalex/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
   setSearchParams,
 } from "../provider-runtime.ts";
 import { openalexApiBaseUrl, openalexEntityValues } from "./constants.ts";
@@ -148,16 +147,14 @@ async function requestOpenAlexJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   phase: OpenAlexPhase;
 }): Promise<Record<string, unknown>> {
-  const timeoutHandle = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "OpenAlex" }, async (signal) => {
     const response = await input.context.fetcher(buildOpenAlexUrl(input.path, input.apiKey, input.params), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readOpenAlexPayload(response);
 
@@ -166,22 +163,7 @@ async function requestOpenAlexJson(input: {
     }
 
     return requireRecord(payload, "OpenAlex returned an invalid payload");
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "OpenAlex request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `OpenAlex request failed: ${error.message}` : "OpenAlex request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildOpenAlexUrl(path: string, apiKey: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/passcreator/runtime.ts
+++ b/src/providers/passcreator/runtime.ts
@@ -13,11 +13,10 @@ import {
   requiredStringArray,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const passcreatorApiBaseUrl = "https://app.passcreator.com";
@@ -124,43 +123,29 @@ async function requestPasscreatorJson(input: {
   fetcher: typeof fetch;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeoutHandle = createProviderTimeout(input.signal, passcreatorDefaultRequestTimeoutMs);
+  return runProviderRequest(
+    { signal: input.signal, timeoutMs: passcreatorDefaultRequestTimeoutMs, label: "Passcreator" },
+    async (signal) => {
+      const response = await input.fetcher(input.url, {
+        method: input.method,
+        headers: {
+          accept: "application/json",
+          authorization: input.apiKey,
+          ...(input.body ? { "content-type": "application/json" } : {}),
+          "user-agent": providerUserAgent,
+        },
+        body: input.body ? JSON.stringify(input.body) : undefined,
+        signal,
+      });
+      const payload = await readPasscreatorPayload(response);
 
-  try {
-    const response = await input.fetcher(input.url, {
-      method: input.method,
-      headers: {
-        accept: "application/json",
-        authorization: input.apiKey,
-        ...(input.body ? { "content-type": "application/json" } : {}),
-        "user-agent": providerUserAgent,
-      },
-      body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeoutHandle.signal,
-    });
-    const payload = await readPasscreatorPayload(response);
-
-    if (!response.ok) {
-      throw createPasscreatorError(response.status, payload);
-    }
-    assertSuccessfulPasscreatorPayload(payload);
-    return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Passcreator request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Passcreator request failed: ${error.message}` : "Passcreator request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+      if (!response.ok) {
+        throw createPasscreatorError(response.status, payload);
+      }
+      assertSuccessfulPasscreatorPayload(payload);
+      return payload;
+    },
+  );
 }
 
 function buildListPassesUrl(input: Record<string, unknown>) {

--- a/src/providers/postgrid/executors.ts
+++ b/src/providers/postgrid/executors.ts
@@ -11,12 +11,11 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "postgrid";
@@ -172,14 +171,12 @@ async function requestPostgridJson(input: {
   context: ApiKeyProviderContext;
   phase: PostgridPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "PostGrid" }, async (signal) => {
     const response = await input.context.fetcher(buildPostgridUrl(input.path, input.params ?? {}), {
       method: input.method,
       headers: postgridHeaders(input.context.apiKey, input.body !== undefined),
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPostgridPayload(response);
 
@@ -192,22 +189,7 @@ async function requestPostgridJson(input: {
       throw new ProviderRequestError(502, "PostGrid returned an invalid payload", payload);
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "PostGrid request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `PostGrid request failed: ${error.message}` : "PostGrid request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildPostgridUrl(path: string, params: Record<string, string | undefined>): string {

--- a/src/providers/promptlayer/runtime.ts
+++ b/src/providers/promptlayer/runtime.ts
@@ -20,12 +20,11 @@ import {
 } from "../../core/cast.ts";
 import { compactJson } from "../../core/request.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   ProviderRequestError,
   providerResponseError,
   providerUserAgent,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const promptLayerApiBaseUrl = "https://api.promptlayer.com";
@@ -195,8 +194,7 @@ export async function validatePromptLayerCredential(
 }
 
 async function requestPromptLayerJson(input: PromptLayerRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "PromptLayer" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       "user-agent": providerUserAgent,
@@ -210,7 +208,7 @@ async function requestPromptLayerJson(input: PromptLayerRequestInput): Promise<R
       method: input.method,
       headers,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPromptLayerPayload(response);
     if (!response.ok) {
@@ -221,20 +219,7 @@ async function requestPromptLayerJson(input: PromptLayerRequestInput): Promise<R
       throw new ProviderRequestError(502, "PromptLayer returned an invalid payload");
     }
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "PromptLayer request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `PromptLayer request failed: ${error.message}` : "PromptLayer request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildPromptLayerUrl(path: string, query: Record<string, PromptLayerQueryValue> = {}): URL {

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -282,6 +282,18 @@ describe("runProviderRequest", () => {
       vi.useRealTimers();
     }
   });
+
+  it("maps a caller abort with a custom reason to 504", async () => {
+    const controller = new AbortController();
+    const pending = runProviderRequest({ label: "Skio", signal: controller.signal }, (signal) => {
+      return new Promise<never>((_, reject) => signal.addEventListener("abort", () => reject(signal.reason)));
+    });
+    controller.abort(new Error("cancelled by caller"));
+    const error = await pending.catch((e) => e);
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    expect(error.status).toBe(504);
+    expect(error.message).toBe("Skio request timed out");
+  });
 });
 
 describe("isAbortSignalError", () => {

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -17,6 +17,7 @@ import {
   ProviderRequestError,
   providerResponseError,
   readProviderJson,
+  runProviderRequest,
   toProviderExecutionError,
 } from "./provider-runtime.ts";
 
@@ -221,6 +222,65 @@ describe("isAbortLikeError", () => {
     expect(isAbortLikeError(new TypeError("fetch failed"))).toBe(false);
     expect(isAbortLikeError({ name: "AbortError" })).toBe(false);
     expect(isAbortLikeError(undefined)).toBe(false);
+  });
+});
+
+describe("runProviderRequest", () => {
+  it("returns the request result and passes ProviderRequestError through untouched", async () => {
+    await expect(runProviderRequest({ label: "Skio" }, async () => "ok")).resolves.toBe("ok");
+
+    const inner = new ProviderRequestError(404, "not found", { id: 1 });
+    await expect(runProviderRequest({ label: "Skio" }, async () => Promise.reject(inner))).rejects.toBe(inner);
+  });
+
+  it("maps AbortError, TimeoutError and a fired timeout to 504 with the provider label", async () => {
+    for (const reason of [new DOMException("aborted", "AbortError"), new DOMException("timed out", "TimeoutError")]) {
+      const error = await runProviderRequest({ label: "Skio" }, async () => Promise.reject(reason)).catch((e) => e);
+      expect(error).toBeInstanceOf(ProviderRequestError);
+      expect(error.status).toBe(504);
+      expect(error.message).toBe("Skio request timed out");
+    }
+
+    const timedOut = await runProviderRequest(
+      { label: "Skio", timeoutMs: 5 },
+      (signal) =>
+        new Promise<never>((_, reject) => signal.addEventListener("abort", () => reject(new Error("aborted by test")))),
+    ).catch((e) => e);
+    expect(timedOut.status).toBe(504);
+    expect(timedOut.message).toBe("Skio request timed out");
+  });
+
+  it("maps every other failure to 502 and keeps the Error message", async () => {
+    const withMessage = await runProviderRequest({ label: "Skio" }, async () =>
+      Promise.reject(new Error("boom")),
+    ).catch((e) => e);
+    expect(withMessage.status).toBe(502);
+    expect(withMessage.message).toBe("Skio request failed: boom");
+    expect(withMessage.details).toBeUndefined();
+
+    const nonError = await runProviderRequest({ label: "Skio" }, async () => Promise.reject("boom")).catch((e) => e);
+    expect(nonError.status).toBe(502);
+    expect(nonError.message).toBe("Skio request failed");
+  });
+
+  it("forwards the caller signal and clears the timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const seen: AbortSignal[] = [];
+      const pending = runProviderRequest({ label: "Skio", signal: controller.signal }, (signal) => {
+        seen.push(signal);
+        return new Promise<never>((_, reject) => signal.addEventListener("abort", () => reject(signal.reason)));
+      });
+      expect(vi.getTimerCount()).toBe(1);
+      controller.abort();
+      const error = await pending.catch((e) => e);
+      expect(error.status).toBe(504);
+      expect(seen[0]?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -726,7 +726,7 @@ export async function runProviderRequest<T>(
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
+    if (timeout.didTimeout() || isAbortLikeError(error) || isAbortSignalError(timeout.signal, error)) {
       throw new ProviderRequestError(504, `${options.label} request timed out`);
     }
     throw new ProviderRequestError(

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -695,6 +695,50 @@ export function isAbortSignalError(signal: AbortSignal | undefined, error: unkno
 }
 
 /**
+ * Options for {@link runProviderRequest}.
+ */
+export interface ProviderRequestOptions {
+  /** Caller signal, usually the execution context's; aborting it aborts the request. */
+  signal?: AbortSignal;
+  /** Provider-local budget for the whole request; defaults to 30 seconds. */
+  timeoutMs?: number;
+  /** Provider name used in the timeout and failure messages, e.g. `"Skio"`. */
+  label: string;
+}
+
+/**
+ * Run a provider request under the shared timeout and error mapping.
+ *
+ * `request` receives the combined abort signal and should perform the fetch and
+ * read the body. A `ProviderRequestError` thrown inside passes through
+ * untouched; a timeout or abort becomes `504 "<label> request timed out"`; any
+ * other failure becomes `502 "<label> request failed[: <message>]"`. The
+ * timeout is always cleaned up.
+ */
+export async function runProviderRequest<T>(
+  options: ProviderRequestOptions,
+  request: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const timeout = createProviderTimeout(options.signal, options.timeoutMs);
+  try {
+    return await request(timeout.signal);
+  } catch (error) {
+    if (error instanceof ProviderRequestError) {
+      throw error;
+    }
+    if (timeout.didTimeout() || isAbortLikeError(error)) {
+      throw new ProviderRequestError(504, `${options.label} request timed out`);
+    }
+    throw new ProviderRequestError(
+      502,
+      error instanceof Error ? `${options.label} request failed: ${error.message}` : `${options.label} request failed`,
+    );
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+/**
  * Set defined query parameters on a URL.
  */
 export function setSearchParams(url: URL, query: Record<string, string | undefined>): void {

--- a/src/providers/proxiedmail/executors.ts
+++ b/src/providers/proxiedmail/executors.ts
@@ -16,13 +16,12 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "proxiedmail";
@@ -206,8 +205,7 @@ async function requestProxiedmailJson(input: {
   signal?: AbortSignal;
   phase: ProxiedmailRequestPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "ProxiedMail" }, async (signal) => {
     const response = await input.fetcher(buildProxiedmailUrl(input.path), {
       method: input.method,
       headers: {
@@ -217,7 +215,7 @@ async function requestProxiedmailJson(input: {
         "user-agent": providerUserAgent,
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProxiedmailPayload(response);
 
@@ -226,20 +224,7 @@ async function requestProxiedmailJson(input: {
     }
 
     return payload ?? {};
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ProxiedMail request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ProxiedMail request failed: ${error.message}` : "ProxiedMail request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildProxiedmailUrl(path: string): URL {

--- a/src/providers/prtg_classic/runtime.ts
+++ b/src/providers/prtg_classic/runtime.ts
@@ -4,12 +4,7 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { assertPublicHttpUrl } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 import { deviceSortColumns, sensorSortColumns } from "./constants.ts";
 
 export const prtgClassicTablePath = "/table.json";
@@ -186,15 +181,14 @@ async function requestPrtgClassicTableJson(options: PrtgClassicRequestOptions): 
   });
   assertPrtgClassicRequestUrl(url);
 
-  const timeout = createProviderTimeout(options.context.signal);
-  try {
+  return runProviderRequest({ signal: options.context.signal, label: "PRTG Classic" }, async (signal) => {
     const response = await options.context.fetcher(url, {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPrtgClassicPayload(response);
 
@@ -204,20 +198,7 @@ async function requestPrtgClassicTableJson(options: PrtgClassicRequestOptions): 
     throwIfPrtgClassicPayloadError(payload, options.mode);
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "PRTG Classic request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `PRTG Classic request failed: ${error.message}` : "PRTG Classic request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function assertPrtgClassicRequestUrl(url: URL): void {

--- a/src/providers/sage_sales_management/runtime.ts
+++ b/src/providers/sage_sales_management/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 type SageSalesManagementPhase = "validate" | "execute";
 interface SageSalesManagementCredentials {
@@ -353,9 +348,7 @@ async function requestSageSalesManagementJsonWithStatus(input: {
   extraHeaders?: Record<string, string>;
   body?: Record<string, unknown>;
 }) {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Sage Sales Management" }, async (signal) => {
     const response = await input.fetcher(buildSageSalesManagementUrl(input.path, input.query), {
       method: input.method,
       headers: compactObject({
@@ -366,7 +359,7 @@ async function requestSageSalesManagementJsonWithStatus(input: {
         "user-agent": providerUserAgent,
       }),
       ...(input.body ? { body: JSON.stringify(input.body) } : {}),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPayload(response);
 
@@ -378,24 +371,7 @@ async function requestSageSalesManagementJsonWithStatus(input: {
       status: response.status,
       payload,
     };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Sage Sales Management request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error
-        ? `Sage Sales Management request failed: ${error.message}`
-        : "Sage Sales Management request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSageSalesManagementUrl(path: string, query: Record<string, string | number> = {}) {

--- a/src/providers/salesmate/executors.ts
+++ b/src/providers/salesmate/executors.ts
@@ -11,9 +11,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   createProviderProxyUrl,
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -21,6 +19,7 @@ import {
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
+  runProviderRequest,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
@@ -189,30 +188,19 @@ async function requestSalesmateJson(
   input: SalesmateRequestInput,
   context: SalesmateRequestContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Salesmate" }, async (signal) => {
     const response = await context.fetcher(buildSalesmateUrl(input, context.linkName), {
       method: input.method,
       headers: buildSalesmateHeaders(context, Boolean(input.body)),
       body: input.body ? JSON.stringify(compactObject(input.body)) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSalesmatePayload(response);
     if (!response.ok) throw createSalesmateError(response.status, payload, input.phase);
     const payloadObject = optionalRecord(payload);
     if (!payloadObject) throw new ProviderRequestError(502, "Salesmate returned an invalid payload");
     return payloadObject;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Salesmate request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Salesmate request failed: ${error.message}` : "Salesmate request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSalesmateUrl(input: SalesmateRequestInput, linkName: string): URL {

--- a/src/providers/semantic_scholar/executors.ts
+++ b/src/providers/semantic_scholar/executors.ts
@@ -9,15 +9,14 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import { compactObject, optionalRawString, optionalRecord } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   mapProviderActionSources,
   providerProxyEndpointPrefixes,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "semantic_scholar";
@@ -347,14 +346,12 @@ async function requestSemanticScholarJson(input: {
   fetcher: typeof fetch;
   phase: SemanticScholarPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Semantic Scholar" }, async (signal) => {
     const response = await input.fetcher(buildSemanticScholarUrl(input), {
       method: input.method,
       headers: buildSemanticScholarHeaders(input),
       body: input.method === "POST" ? JSON.stringify(input.body ?? {}) : undefined,
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readSemanticScholarPayload(response);
 
@@ -363,22 +360,7 @@ async function requestSemanticScholarJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Semantic Scholar request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Semantic Scholar request failed: ${error.message}` : "Semantic Scholar request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildSemanticScholarHeaders(input: { method: "GET" | "POST"; apiKey: string }) {

--- a/src/providers/semrush/executors.ts
+++ b/src/providers/semrush/executors.ts
@@ -3,13 +3,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalIntegerLike, optionalRawString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineProviderExecutors,
-  isAbortLikeError,
   mapProviderActionSources,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const semrushApiBaseUrl = "https://api.semrush.com";
@@ -128,16 +127,14 @@ async function requestSemrushReport(input: {
   fetcher: typeof fetch;
   phase: SemrushPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Semrush" }, async (signal) => {
     const response = await input.fetcher(buildSemrushUrl(input.apiKey, input.params), {
       method: "GET",
       headers: {
         accept: "text/csv, text/plain, */*",
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const text = await response.text();
 
@@ -146,22 +143,7 @@ async function requestSemrushReport(input: {
     }
 
     return parseSemrushCsvReport(text);
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Semrush request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Semrush request failed: ${error.message}` : "Semrush request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildSemrushUrl(apiKey: string, params: Record<string, string | undefined>) {

--- a/src/providers/shippo/executors.ts
+++ b/src/providers/shippo/executors.ts
@@ -11,15 +11,14 @@ import { compactObject, optionalInteger, optionalRecord, optionalString, require
 import {
   createProviderFetch,
   createProviderProxyUrl,
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   normalizeProviderProxyHeaders,
   ProviderRequestError,
   providerUserAgent,
   readProviderProxyErrorMessage,
   readProviderProxyResponse,
   requireApiKeyCredential,
+  runProviderRequest,
   toProviderProxyError,
 } from "../provider-runtime.ts";
 
@@ -206,8 +205,7 @@ async function requestShippoJson(input: ShippoRequestInput): Promise<unknown> {
     }
   }
 
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Shippo" }, async (signal) => {
     const response = await input.fetcher(url, {
       method: input.method ?? "GET",
       headers: {
@@ -218,7 +216,7 @@ async function requestShippoJson(input: ShippoRequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
 
     const payload = await readJsonResponse(response);
@@ -226,20 +224,7 @@ async function requestShippoJson(input: ShippoRequestInput): Promise<unknown> {
       throw mapShippoError(response.status, payload);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Shippo request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Shippo request failed: ${error.message}` : "Shippo request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function paginationQuery(input: Record<string, unknown>): Record<string, string | undefined> {

--- a/src/providers/shortpixel/runtime.ts
+++ b/src/providers/shortpixel/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const shortpixelAccountApiBaseUrl = "https://api.shortpixel.com/v2";
 const shortpixelCdnApiBaseUrl = "https://no-cdn.shortpixel.ai";
@@ -131,16 +126,14 @@ async function requestShortpixelJson(
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">,
   phase: ShortpixelPhase,
 ) {
-  const timeoutHandle = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "ShortPixel" }, async (signal) => {
     const response = await context.fetcher(input.url, {
       method: input.method,
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readShortpixelPayload(response);
 
@@ -153,22 +146,7 @@ async function requestShortpixelJson(
       throw new ProviderRequestError(502, "ShortPixel returned an invalid payload");
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ShortPixel request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ShortPixel request failed: ${error.message}` : "ShortPixel request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 async function readShortpixelPayload(response: Response) {

--- a/src/providers/signaturely/runtime.ts
+++ b/src/providers/signaturely/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const signaturelyApiBaseUrl = "https://api.signaturely.com/api/v1/";
@@ -90,8 +89,7 @@ async function request(
   method = "GET",
   body?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Signaturely" }, async (signal) => {
     const response = await context.fetcher(new URL(path, signaturelyApiBaseUrl), {
       method,
       headers: {
@@ -101,7 +99,7 @@ async function request(
         ...(body ? { "content-type": "application/json" } : {}),
       },
       body: body ? JSON.stringify(body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -120,17 +118,7 @@ async function request(
       throw new ProviderRequestError(status, message, payload);
     }
     return record(payload, "Signaturely response");
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Signaturely request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Signaturely request failed: ${error.message}` : "Signaturely request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 function normalizeList(payload: Record<string, unknown>): Record<string, unknown> {
   if (!Array.isArray(payload.items)) throw new ProviderRequestError(502, "Signaturely folder items are missing");

--- a/src/providers/simplesat/runtime.ts
+++ b/src/providers/simplesat/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRawString, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const simplesatApiBaseUrl = "https://api.simplesat.io";
 export const simplesatValidationPath = "/api/v1/surveys";
@@ -225,14 +220,12 @@ export async function validateSimplesatCredential(
 }
 
 async function requestSimplesatJson(input: SimplesatRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Simplesat" }, async (signal) => {
     const response = await input.fetcher(buildSimplesatUrl(input), {
       method: input.method,
       headers: buildSimplesatHeaders(input.apiKey, input.body),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSimplesatPayload(response);
     if (!response.ok) {
@@ -240,20 +233,7 @@ async function requestSimplesatJson(input: SimplesatRequestInput): Promise<unkno
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Simplesat request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Simplesat request failed: ${error.message}` : "Simplesat request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSimplesatHeaders(apiKey: string, body: Record<string, unknown> | undefined): Record<string, string> {

--- a/src/providers/skio/runtime.ts
+++ b/src/providers/skio/runtime.ts
@@ -8,11 +8,10 @@ import type {
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   mapProviderActionSources,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const skioApiBaseUrl = "https://api.skio.com/public-rest-api-http";
@@ -142,8 +141,7 @@ async function requestSkioJson(input: {
   context: Pick<ApiKeyProviderContext, "fetcher" | "signal">;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Skio" }, async (signal) => {
     const response = await input.context.fetcher(buildSkioUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -151,27 +149,14 @@ async function requestSkioJson(input: {
         authorization: `API ${input.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readPayload(response);
     if (!response.ok) {
       throw createSkioError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Skio request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Skio request failed: ${error.message}` : "Skio request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSkioUrl(path: string, query?: URLSearchParams): URL {

--- a/src/providers/sling/executors.ts
+++ b/src/providers/sling/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "sling";
@@ -141,8 +140,7 @@ async function requestSlingJson(input: {
   phase: SlingPhase;
   signal?: AbortSignal;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Sling" }, async (signal) => {
     const response = await input.fetcher(buildSlingUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -150,21 +148,12 @@ async function requestSlingJson(input: {
         Accept: "application/json",
         "User-Agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSlingPayload(response, { allowPlainText: !response.ok });
     if (!response.ok) throw createSlingError(response.status, payload, input.phase);
     return payload ?? {};
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) throw new ProviderRequestError(504, "Sling request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Sling request failed: ${error.message}` : "Sling request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSlingUrl(path: string, query: Record<string, SlingQueryValue | undefined>): URL {

--- a/src/providers/smartrecruiters/runtime.ts
+++ b/src/providers/smartrecruiters/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const smartrecruitersApiBaseUrl = "https://api.smartrecruiters.com";
 
@@ -115,8 +110,7 @@ async function requestSmartRecruitersJson(
   input: SmartRecruitersRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "SmartRecruiters" }, async (signal) => {
     const response = await context.fetcher(buildSmartRecruitersUrl(input.path, input.query), {
       method: input.method,
       headers: {
@@ -124,7 +118,7 @@ async function requestSmartRecruitersJson(
         "user-agent": providerUserAgent,
         "X-SmartToken": context.apiKey,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSmartRecruitersPayload(response);
 
@@ -136,20 +130,7 @@ async function requestSmartRecruitersJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "SmartRecruiters request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `SmartRecruiters request failed: ${error.message}` : "SmartRecruiters request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSmartRecruitersUrl(path: string, query: Partial<SmartRecruitersQuery> = {}): URL {

--- a/src/providers/smartsheet/runtime.ts
+++ b/src/providers/smartsheet/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const smartsheetApiBaseUrl = "https://api.smartsheet.com/2.0";
 const smartsheetIntegrationSource = "AI,OOMOL,oomol-connect";
@@ -162,28 +157,17 @@ async function requestSmartsheetJson(input: {
   phase: SmartsheetPhase;
   body?: unknown;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Smartsheet" }, async (signal) => {
     const response = await input.context.fetcher(buildSmartsheetUrl(input.path, input.params), {
       method: input.method,
       headers: buildSmartsheetHeaders(input.context.apiKey, input.body !== undefined),
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSmartsheetPayload(response);
     if (!response.ok) throw createSmartsheetError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Smartsheet request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Smartsheet request failed: ${error.message}` : "Smartsheet request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSmartsheetUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/smtp2go/runtime.ts
+++ b/src/providers/smtp2go/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRawString, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const smtp2goApiBaseUrl = "https://api.smtp2go.com/v3";
 
@@ -200,9 +195,7 @@ async function requestSmtp2goJson(input: {
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">;
   phase: Smtp2goPhase;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "SMTP2GO" }, async (signal) => {
     const response = await input.context.fetcher(buildSmtp2goUrl(input.path), {
       method: "POST",
       headers: {
@@ -212,7 +205,7 @@ async function requestSmtp2goJson(input: {
         "X-Smtp2go-Api-Key": input.context.apiKey,
       },
       body: JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSmtp2goPayload(response);
 
@@ -225,22 +218,7 @@ async function requestSmtp2goJson(input: {
       throw new ProviderRequestError(502, "SMTP2GO returned an invalid payload");
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "SMTP2GO request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `SMTP2GO request failed: ${error.message}` : "SMTP2GO request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSmtp2goUrl(path: string): string {

--- a/src/providers/snyk/runtime.ts
+++ b/src/providers/snyk/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 type QueryValue = string | number | boolean | readonly (string | number | boolean)[] | undefined;
@@ -173,8 +172,7 @@ export async function validateSnykCredential(
 }
 
 async function requestJson(input: RequestInput): Promise<SnykResponse> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Snyk" }, async (signal) => {
     const url = buildUrl(input.path, input.query, input.commaArrays);
     const response = await input.context.fetcher(url, {
       headers: {
@@ -183,7 +181,7 @@ async function requestJson(input: RequestInput): Promise<SnykResponse> {
         "content-type": "application/vnd.api+json",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -204,16 +202,7 @@ async function requestJson(input: RequestInput): Promise<SnykResponse> {
     const object = optionalRecord(payload);
     if (!object) throw new ProviderRequestError(502, "Snyk returned a non-object response");
     return object;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) throw new ProviderRequestError(504, "Snyk request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Snyk request failed: ${error.message}` : "Snyk request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildUrl(path: string, query: Record<string, QueryValue> = {}, commaArrays: readonly string[] = []): URL {

--- a/src/providers/sonarcloud/runtime.ts
+++ b/src/providers/sonarcloud/runtime.ts
@@ -13,12 +13,11 @@ import {
   requiredStringArray,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 import { sonarCloudAllowedApiBaseUrls, sonarCloudDefaultApiBaseUrl } from "./constants.ts";
 
@@ -169,8 +168,7 @@ export async function validateSonarCloudCredential(
 }
 
 async function requestSonarCloudJson(input: SonarCloudRequest): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "SonarQube Cloud" }, async (signal) => {
     const response = await input.context.fetcher(buildSonarCloudUrl(input), {
       method: "GET",
       headers: {
@@ -178,23 +176,12 @@ async function requestSonarCloudJson(input: SonarCloudRequest): Promise<unknown>
         authorization: `Bearer ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readSonarCloudPayload(response);
     if (!response.ok) throw createSonarCloudError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "SonarQube Cloud request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `SonarQube Cloud request failed: ${error.message}` : "SonarQube Cloud request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSonarCloudUrl(input: SonarCloudRequest): string {

--- a/src/providers/sportsdata/runtime.ts
+++ b/src/providers/sportsdata/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.t
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const sportsdataApiBaseUrl = "https://api.sportsdata.io";
@@ -106,11 +105,10 @@ async function requestSportsdata(
   signal: AbortSignal | undefined,
   phase: RequestPhase,
 ): Promise<unknown[]> {
-  const timeout = createProviderTimeout(signal);
-  try {
+  return runProviderRequest({ signal, label: "SportsDataIO" }, async (signal) => {
     const response = await fetcher(new URL(path, sportsdataApiBaseUrl), {
       headers: { accept: "application/json", [apiKeyHeader]: apiKey, "user-agent": providerUserAgent },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: null,
@@ -120,18 +118,7 @@ async function requestSportsdata(
     if (!response.ok) throw createSportsdataError(response.status, payload, phase);
     if (!Array.isArray(payload)) throw new ProviderRequestError(502, "SportsDataIO returned a non-array response");
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "SportsDataIO request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `SportsDataIO request failed: ${error.message}` : "SportsDataIO request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function createSportsdataError(status: number, payload: unknown, phase: RequestPhase): ProviderRequestError {

--- a/src/providers/sslmate_cert_spotter_api/runtime.ts
+++ b/src/providers/sslmate_cert_spotter_api/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const certSpotterMonitoringApiBaseUrl: string = "https://sslmate.com/api/v3/monitoring";
 export const certSpotterCtSearchApiBaseUrl: string = "https://api.certspotter.com/v1";
@@ -188,33 +183,19 @@ async function requestCertSpotterJson(input: {
   body?: string;
   phase: CertSpotterRequestPhase;
 }): Promise<{ response: Response; payload: unknown }> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Cert Spotter" }, async (signal) => {
     const response = await input.context.fetcher(input.url, {
       method: input.method,
       headers: buildCertSpotterHeaders(input.context.apiKey, input.body ? "application/json" : undefined),
       body: input.body,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readCertSpotterPayload(response);
     if (!response.ok) {
       throw createCertSpotterError(response, payload, input.phase);
     }
     return { response, payload };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Cert Spotter request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Cert Spotter request failed: ${error.message}` : "Cert Spotter request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildCertSpotterHeaders(apiKey: string, contentType?: string): Headers {

--- a/src/providers/stack_overflow_for_teams/runtime.ts
+++ b/src/providers/stack_overflow_for_teams/runtime.ts
@@ -4,12 +4,11 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const stackOverflowForTeamsApiBaseUrl = "https://api.stackoverflowteams.com/v3/";
@@ -113,15 +112,14 @@ async function requestPaginated(
 async function requestJson(input: RequestInput): Promise<unknown> {
   const url = new URL(`teams/${encodeURIComponent(input.team)}/${input.path}`, stackOverflowForTeamsApiBaseUrl);
   if (input.query) url.search = input.query.toString();
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Stack Internal" }, async (signal) => {
     const response = await input.fetcher(url, {
       headers: {
         accept: "application/json",
         authorization: `Bearer ${input.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: {},
@@ -129,18 +127,7 @@ async function requestJson(input: RequestInput): Promise<unknown> {
     });
     if (!response.ok) throw mapError(response, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Stack Internal request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Stack Internal request failed: ${error.message}` : "Stack Internal request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function mapError(response: Response, payload: unknown, phase: "validate" | "execute"): ProviderRequestError {

--- a/src/providers/statamic/executors.ts
+++ b/src/providers/statamic/executors.ts
@@ -4,12 +4,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "statamic";
@@ -112,8 +111,7 @@ async function requestStatamicJson(input: {
   phase: StatamicPhase;
   body?: Record<string, unknown>;
 }): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Statamic" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       authorization: `Bearer ${input.context.apiKey}`,
@@ -127,7 +125,7 @@ async function requestStatamicJson(input: {
       method: input.method,
       headers,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readStatamicPayload(response);
 
@@ -140,20 +138,7 @@ async function requestStatamicJson(input: {
       throw new ProviderRequestError(502, "Statamic returned an invalid payload");
     }
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Statamic request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Statamic request failed: ${error.message}` : "Statamic request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildStatamicUrl(path: string): string {

--- a/src/providers/store_leads/executors.ts
+++ b/src/providers/store_leads/executors.ts
@@ -4,13 +4,12 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { objectArray, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerResponseError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "store_leads";
@@ -137,8 +136,7 @@ async function requestStoreLeadsJson(input: {
   phase: StoreLeadsPhase;
   query?: URLSearchParams;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Store Leads" }, async (signal) => {
     const response = await input.context.fetcher(buildStoreLeadsUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -146,27 +144,14 @@ async function requestStoreLeadsJson(input: {
         authorization: `Bearer ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readStoreLeadsPayload(response);
     if (!response.ok) {
       throw createStoreLeadsError(response.status, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Store Leads request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Store Leads request failed: ${error.message}` : "Store Leads request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildStoreLeadsUrl(path: string, query?: URLSearchParams): string {

--- a/src/providers/storecensus/executors.ts
+++ b/src/providers/storecensus/executors.ts
@@ -4,12 +4,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "storecensus";
@@ -114,8 +113,7 @@ async function requestStorecensusJson(input: {
   query?: URLSearchParams;
   body?: unknown;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "StoreCensus" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       authorization: `Bearer ${input.context.apiKey}`,
@@ -131,7 +129,7 @@ async function requestStorecensusJson(input: {
       method: input.method,
       headers,
       body,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readStorecensusPayload(response);
 
@@ -140,20 +138,7 @@ async function requestStorecensusJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "StoreCensus request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `StoreCensus request failed: ${error.message}` : "StoreCensus request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildStorecensusUrl(path: string, query?: URLSearchParams): string {

--- a/src/providers/systeme_io/runtime.ts
+++ b/src/providers/systeme_io/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const systemeIoApiBaseUrl = "https://api.systeme.io";
 
@@ -379,8 +374,7 @@ function pageParams(input: Record<string, unknown>): Record<string, string | und
 }
 
 async function requestSystemeIoJson(input: SystemeIoRequestInput): Promise<unknown> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Systeme.io" }, async (signal) => {
     const headers: Record<string, string> = {
       "x-api-key": input.apiKey,
       "user-agent": providerUserAgent,
@@ -388,7 +382,7 @@ async function requestSystemeIoJson(input: SystemeIoRequestInput): Promise<unkno
     const init: RequestInit = {
       method: input.method,
       headers,
-      signal: timeout.signal,
+      signal,
     };
     if (input.body !== undefined && (input.method === "POST" || input.method === "PUT" || input.method === "PATCH")) {
       headers["content-type"] = "application/json";
@@ -399,17 +393,7 @@ async function requestSystemeIoJson(input: SystemeIoRequestInput): Promise<unkno
     const payload = await readSystemeIoPayload(response, { strictJson: response.ok });
     if (!response.ok) throw createSystemeIoError(response.status, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error))
-      throw new ProviderRequestError(504, "Systeme.io request timed out");
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Systeme.io request failed: ${error.message}` : "Systeme.io request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildSystemeIoUrl(path: string, params: Record<string, string | undefined>): URL {

--- a/src/providers/timecamp/runtime.ts
+++ b/src/providers/timecamp/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalRawString, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 const timecampApiBaseUrl = "https://app.timecamp.com/third_party/api";
 
@@ -240,9 +235,7 @@ async function requestTimecampJson(input: {
   body?: Record<string, unknown>;
   phase: TimecampPhase;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "TimeCamp" }, async (signal) => {
     const response = await input.context.fetcher(buildTimecampUrl(input.path, input.params ?? {}), {
       method: input.method,
       headers: {
@@ -252,7 +245,7 @@ async function requestTimecampJson(input: {
         ...(input.body ? { "content-type": "application/json" } : {}),
       },
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readTimecampPayload(response);
 
@@ -261,22 +254,7 @@ async function requestTimecampJson(input: {
     }
 
     return payload ?? {};
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "TimeCamp request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `TimeCamp request failed: ${error.message}` : "TimeCamp request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildTimecampUrl(path: string, params: Record<string, TimecampQueryValue>): URL {

--- a/src/providers/timelink/runtime.ts
+++ b/src/providers/timelink/runtime.ts
@@ -8,12 +8,7 @@ import {
   optionalString as asOptionalString,
   requiredString,
 } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const timelinkApiBaseUrl: string = "https://api.timelink.io/api/v1";
 
@@ -308,9 +303,7 @@ async function requestTimelinkJson(input: {
   fetcher: typeof fetch;
   phase: TimelinkPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Timelink" }, async (signal) => {
     const response = await input.fetcher(buildTimelinkUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -318,7 +311,7 @@ async function requestTimelinkJson(input: {
         authorization: `Bearer ${input.token}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readTimelinkPayload(response);
 
@@ -332,22 +325,7 @@ async function requestTimelinkJson(input: {
     }
 
     return payloadRecord;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Timelink request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Timelink request failed: ${error.message}` : "Timelink request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildTimelinkUrl(path: string, query: Record<string, string[] | string | undefined>) {

--- a/src/providers/tomba/runtime.ts
+++ b/src/providers/tomba/runtime.ts
@@ -2,12 +2,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalIntegerLike, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const tombaApiBaseUrl: string = "https://api.tomba.io/v1";
 
@@ -151,13 +146,12 @@ async function requestTombaJson(
   input: TombaRequestInput,
   context: TombaActionContext,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Tomba" }, async (signal) => {
     const response = await context.fetcher(buildTombaUrl(input), {
       method: input.method,
       headers: buildTombaHeaders(context.credential, Boolean(input.body)),
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readTombaPayload(response);
     if (!response.ok) {
@@ -168,18 +162,7 @@ async function requestTombaJson(
       throw new ProviderRequestError(502, "Tomba returned an invalid payload");
     }
     return payloadObject;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Tomba request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Tomba request failed: ${error.message}` : "Tomba request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildTombaUrl(input: TombaRequestInput): URL {

--- a/src/providers/torii/runtime.ts
+++ b/src/providers/torii/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const toriiApiBaseUrl = "https://api.toriihq.com/v1.0";
 
@@ -218,9 +213,7 @@ async function requestToriiJson(
   options: ToriiRequestOptions,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal);
-
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Torii" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       authorization: `Bearer ${context.apiKey}`,
@@ -233,7 +226,7 @@ async function requestToriiJson(
     const response = await context.fetcher(buildToriiUrl(options), {
       method: "GET",
       headers,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readToriiPayload(response);
 
@@ -242,20 +235,7 @@ async function requestToriiJson(
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Torii request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Torii request failed: ${error.message}` : "Torii request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildToriiUrl(options: { path: string; query?: URLSearchParams; extraQuery?: Record<string, unknown> }): URL {

--- a/src/providers/tremendous/executors.ts
+++ b/src/providers/tremendous/executors.ts
@@ -10,12 +10,11 @@ import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 import { optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import { jsonObject } from "../../core/request.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const tremendousApiBaseUrl = "https://api.tremendous.com/api/v2";
@@ -273,14 +272,12 @@ async function requestTremendousJson(input: {
   query?: URLSearchParams;
   body?: Record<string, unknown>;
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Tremendous" }, async (signal) => {
     const response = await input.context.fetcher(buildTremendousUrl(input), {
       method: input.method,
       headers: buildTremendousHeaders(input.context.apiKey, Boolean(input.body)),
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readTremendousPayload(response);
 
@@ -289,20 +286,7 @@ async function requestTremendousJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Tremendous request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Tremendous request failed: ${error.message}` : "Tremendous request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildTremendousUrl(input: { path: string; query?: URLSearchParams }): URL {

--- a/src/providers/trendshift/runtime.ts
+++ b/src/providers/trendshift/runtime.ts
@@ -1,11 +1,6 @@
 import { createHash } from "node:crypto";
 import { compactObject, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest } from "../provider-runtime.ts";
 
 export const trendshiftApiBaseUrl = "https://api.trendshift.io";
 export const trendshiftValidationPath = "/v1/trending/daily";
@@ -140,8 +135,7 @@ async function requestTrendshiftJson(input: {
   for (const [name, value] of Object.entries(input.request.query ?? {})) {
     if (value !== undefined) url.searchParams.set(name, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Trendshift" }, async (signal) => {
     const response = await input.context.fetcher(url, {
       method: "GET",
       headers: {
@@ -149,24 +143,13 @@ async function requestTrendshiftJson(input: {
         authorization: `Bearer ${input.context.apiKey}`,
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const result = await readTrendshiftPayload(response);
     if (!response.ok) throw createTrendshiftError(response.status, result.payload, input.mode);
     if (!result.isJson) throw new ProviderRequestError(502, "Trendshift returned invalid JSON");
     return result.payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Trendshift request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Trendshift request failed: ${error.message}` : "Trendshift request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readTrendshiftPayload(response: Response): Promise<{ payload: unknown; isJson: boolean }> {

--- a/src/providers/u301/runtime.ts
+++ b/src/providers/u301/runtime.ts
@@ -2,12 +2,7 @@ import type { CredentialValidationResult } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 const u301ApiBaseUrl = "https://api.u301.com";
 const u301DomainsPath = "/v3/shorten/domains";
@@ -131,8 +126,7 @@ async function u301Request(input: U301RequestInput): Promise<unknown> {
     url.searchParams.set("workspaceId", input.workspaceId);
   }
 
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "U301" }, async (signal) => {
     const response = await input.fetcher(url, {
       method: input.method,
       headers: compactObject({
@@ -142,27 +136,14 @@ async function u301Request(input: U301RequestInput): Promise<unknown> {
         "content-type": input.body === undefined ? undefined : "application/json",
       }) as HeadersInit,
       body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readResponsePayload(response);
     if (!response.ok) {
       throw createU301Error(response, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "U301 request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `U301 request failed: ${error.message}` : "U301 request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readResponsePayload(response: Response): Promise<unknown> {

--- a/src/providers/uniswap_api/runtime.ts
+++ b/src/providers/uniswap_api/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const uniswapApiBaseUrl = "https://trade-api.gateway.uniswap.org/v1";
 export const uniswapApiDefaultRequestTimeoutMs = 15_000;
@@ -190,40 +185,29 @@ async function uniswapApiRequest(
   input: UniswapRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(context.signal, uniswapApiDefaultRequestTimeoutMs);
-  try {
-    const response = await context.fetcher(buildUniswapApiUrl(input.path), {
-      method: input.method,
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-        "user-agent": providerUserAgent,
-        "x-api-key": context.apiKey,
-        ...input.headers,
-      },
-      body: JSON.stringify(input.body),
-      signal: timeout.signal,
-    });
-    const payload = await readJsonPayload(response);
-    if (!response.ok) {
-      throw createUniswapApiError(response.status, payload);
-    }
+  return runProviderRequest(
+    { signal: context.signal, timeoutMs: uniswapApiDefaultRequestTimeoutMs, label: "uniswap_api" },
+    async (signal) => {
+      const response = await context.fetcher(buildUniswapApiUrl(input.path), {
+        method: input.method,
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "user-agent": providerUserAgent,
+          "x-api-key": context.apiKey,
+          ...input.headers,
+        },
+        body: JSON.stringify(input.body),
+        signal,
+      });
+      const payload = await readJsonPayload(response);
+      if (!response.ok) {
+        throw createUniswapApiError(response.status, payload);
+      }
 
-    return readRequiredObject(payload, "payload");
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "uniswap_api request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `uniswap_api request failed: ${error.message}` : "uniswap_api request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+      return readRequiredObject(payload, "payload");
+    },
+  );
 }
 
 function buildUniswapApiUrl(path: string): URL {

--- a/src/providers/unsplash/runtime.ts
+++ b/src/providers/unsplash/runtime.ts
@@ -3,12 +3,7 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ApiKeyProviderContext } from "../provider-runtime.ts";
 
 import { compactObject, optionalInteger, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const unsplashApiBaseUrl: string = "https://api.unsplash.com";
 const unsplashValidationPath = "/photos";
@@ -174,8 +169,7 @@ async function requestUnsplashJson(input: {
   query?: Record<string, string | number | undefined>;
   phase: "validate" | "execute";
 }): Promise<unknown> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Unsplash" }, async (signal) => {
     const response = await input.context.fetcher(buildUnsplashUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -183,27 +177,14 @@ async function requestUnsplashJson(input: {
         "accept-version": "v1",
         "user-agent": providerUserAgent,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readUnsplashPayload(response);
     if (!response.ok) {
       throw createUnsplashError(response, payload, input.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Unsplash request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Unsplash request failed: ${error.message}` : "Unsplash request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildUnsplashUrl(path: string, query?: Record<string, string | number | undefined>): string {

--- a/src/providers/uploadcare/runtime.ts
+++ b/src/providers/uploadcare/runtime.ts
@@ -12,13 +12,7 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import { queryParams } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  providerUserAgent,
-  ProviderRequestError,
-  setSearchParams,
-} from "../provider-runtime.ts";
+import { providerUserAgent, ProviderRequestError, runProviderRequest, setSearchParams } from "../provider-runtime.ts";
 
 export const uploadcareApiBaseUrl = "https://api.uploadcare.com";
 
@@ -188,32 +182,18 @@ async function requestUploadcareJson(
     secretKey: context.secretKey,
   });
 
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Uploadcare" }, async (signal) => {
     const response = await context.fetcher(url.toString(), {
       method: request.method,
       headers,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readUploadcarePayload(response);
     if (!response.ok) {
       throw createUploadcareError(response, payload, request.phase);
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Uploadcare request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Uploadcare request failed: ${error.message}` : "Uploadcare request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 export function signUploadcareRequest(input: {

--- a/src/providers/vida/runtime.ts
+++ b/src/providers/vida/runtime.ts
@@ -2,12 +2,7 @@ import type { ApiKeyActionRequest, ProviderActionHandlers } from "../provider-ru
 import type { VidaActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export interface VidaCredentialCheck {
   providerAccountId?: string;
@@ -135,16 +130,14 @@ async function requestVidaJson(input: {
   fetcher: typeof fetch;
   phase: VidaPhase;
 }) {
-  const timeoutHandle = createProviderTimeout(undefined);
-
-  try {
+  return runProviderRequest({ label: "Vida" }, async (signal) => {
     const response = await input.fetcher(buildVidaUrl(input.path, input.apiKey, input.params), {
       method: "GET",
       headers: {
         accept: "application/json",
         "user-agent": providerUserAgent,
       },
-      signal: timeoutHandle.signal,
+      signal,
     });
     const payload = await readVidaPayload(response, { strictJson: response.ok });
 
@@ -153,22 +146,7 @@ async function requestVidaJson(input: {
     }
 
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeoutHandle.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Vida request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Vida request failed: ${error.message}` : "Vida request failed",
-    );
-  } finally {
-    timeoutHandle.cleanup();
-  }
+  });
 }
 
 function buildVidaUrl(path: string, apiKey: string, params: Record<string, string | undefined>) {

--- a/src/providers/vonage/runtime.ts
+++ b/src/providers/vonage/runtime.ts
@@ -5,12 +5,11 @@ import type { ProviderFetch } from "../provider-runtime.ts";
 import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
   readProviderJsonBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const vonageApiBaseUrl = "https://rest.nexmo.com";
@@ -138,8 +137,7 @@ async function requestVonage(input: VonageRequestInput): Promise<unknown> {
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, String(value));
   }
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Vonage" }, async (signal) => {
     const response = await input.context.fetcher(url.toString(), {
       method: input.method ?? "GET",
       headers: {
@@ -149,7 +147,7 @@ async function requestVonage(input: VonageRequestInput): Promise<unknown> {
         "user-agent": providerUserAgent,
       },
       body: input.body,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readProviderJsonBody(response, {
       emptyBody: {},
@@ -157,18 +155,7 @@ async function requestVonage(input: VonageRequestInput): Promise<unknown> {
     });
     if (!response.ok) throw mapHttpError(response, payload, input.phase);
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Vonage request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Vonage request failed: ${error.message}` : "Vonage request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function mapHttpError(response: Response, payload: unknown, phase: "validate" | "execute"): ProviderRequestError {

--- a/src/providers/wappalyzer/executors.ts
+++ b/src/providers/wappalyzer/executors.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "wappalyzer";
@@ -155,8 +154,7 @@ async function requestWappalyzerJson(input: {
   signal?: AbortSignal;
   query?: Record<string, string | undefined>;
 }): Promise<WappalyzerJsonResponse> {
-  const timeout = createProviderTimeout(input.signal);
-  try {
+  return runProviderRequest({ signal: input.signal, label: "Wappalyzer" }, async (signal) => {
     const response = await input.fetcher(buildWappalyzerUrl(input.path, input.query), {
       method: "GET",
       headers: {
@@ -164,7 +162,7 @@ async function requestWappalyzerJson(input: {
         "user-agent": providerUserAgent,
         "x-api-key": input.apiKey,
       },
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readWappalyzerPayload(response);
     if (!response.ok) {
@@ -174,20 +172,7 @@ async function requestWappalyzerJson(input: {
       payload,
       creditHeaders: readCreditHeaders(response.headers),
     };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Wappalyzer request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Wappalyzer request failed: ${error.message}` : "Wappalyzer request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildWappalyzerUrl(path: string, query: Record<string, string | undefined> = {}): URL {

--- a/src/providers/winston_ai/runtime.ts
+++ b/src/providers/winston_ai/runtime.ts
@@ -4,12 +4,7 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { optionalRecord, optionalString } from "../../core/cast.ts";
 import { jsonObject } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 type WinstonAiRequestPhase = "validate" | "execute";
 type WinstonAiActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
@@ -102,34 +97,25 @@ async function requestWinstonAiJson(
   input: WinstonAiRequestInput,
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
 ): Promise<unknown> {
-  const timeout = createProviderTimeout(context.signal, winstonAiDefaultRequestTimeoutMs);
-  try {
-    const response = await context.fetcher(new URL(input.path, winstonAiApiBaseUrl), {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        authorization: `Bearer ${context.apiKey}`,
-        "content-type": "application/json",
-        "user-agent": providerUserAgent,
-      },
-      body: JSON.stringify(input.body),
-      signal: timeout.signal,
-    });
-    const payload = await readWinstonAiPayload(response);
-    if (!response.ok) throw createWinstonAiError(response, payload, input.phase);
-    return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Winston AI request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Winston AI request failed: ${error.message}` : "Winston AI request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  return runProviderRequest(
+    { signal: context.signal, timeoutMs: winstonAiDefaultRequestTimeoutMs, label: "Winston AI" },
+    async (signal) => {
+      const response = await context.fetcher(new URL(input.path, winstonAiApiBaseUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${context.apiKey}`,
+          "content-type": "application/json",
+          "user-agent": providerUserAgent,
+        },
+        body: JSON.stringify(input.body),
+        signal,
+      });
+      const payload = await readWinstonAiPayload(response);
+      if (!response.ok) throw createWinstonAiError(response, payload, input.phase);
+      return payload;
+    },
+  );
 }
 
 async function readWinstonAiPayload(response: Response): Promise<Record<string, unknown>> {

--- a/src/providers/worksnaps/executors.ts
+++ b/src/providers/worksnaps/executors.ts
@@ -5,11 +5,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 import { Buffer } from "node:buffer";
 import { compactObject, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const worksnapsApiBaseUrl = "https://api.worksnaps.com/api";
@@ -204,12 +203,11 @@ async function requestWorksnapsXml(input: {
   phase: "validate" | "execute";
   query?: Record<string, string | undefined>;
 }): Promise<XmlNode> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Worksnaps" }, async (signal) => {
     const response = await input.context.fetcher(buildWorksnapsUrl(input.path, input.query), {
       method: "GET",
       headers: buildWorksnapsHeaders(input.context.apiKey),
-      signal: timeout.signal,
+      signal,
     });
     const text = await response.text();
     if (!response.ok) {
@@ -219,20 +217,7 @@ async function requestWorksnapsXml(input: {
       throw new ProviderRequestError(502, "Worksnaps returned an empty response");
     }
     return parseXmlDocument(text);
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Worksnaps request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Worksnaps request failed: ${error.message}` : "Worksnaps request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildWorksnapsUrl(path: string, query?: Record<string, string | undefined>): URL {

--- a/src/providers/zenrows/executors.ts
+++ b/src/providers/zenrows/executors.ts
@@ -16,14 +16,13 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
   defineApiKeyProviderExecutors,
   defineProviderProxy,
-  isAbortLikeError,
   providerInputError,
   providerProxyEndpointPrefixes,
   ProviderRequestError,
   providerUserAgent,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 const service = "zenrows";
@@ -149,41 +148,29 @@ async function requestZenrowsUrl(
   authLocation: ZenrowsAuthLocation,
   phase: ZenrowsPhase,
 ): Promise<Response> {
-  const timeout = createProviderTimeout(context.signal, zenrowsDefaultRequestTimeoutMs);
-
-  try {
-    const response = await context.fetcher(
-      buildZenrowsUrl(url, query, authLocation === "query" ? context.apiKey : undefined),
-      {
-        method: "GET",
-        headers: {
-          accept: "*/*",
-          ...(authLocation === "header" ? { "x-api-key": context.apiKey } : {}),
-          "user-agent": providerUserAgent,
+  return runProviderRequest(
+    { signal: context.signal, timeoutMs: zenrowsDefaultRequestTimeoutMs, label: "ZenRows" },
+    async (signal) => {
+      const response = await context.fetcher(
+        buildZenrowsUrl(url, query, authLocation === "query" ? context.apiKey : undefined),
+        {
+          method: "GET",
+          headers: {
+            accept: "*/*",
+            ...(authLocation === "header" ? { "x-api-key": context.apiKey } : {}),
+            "user-agent": providerUserAgent,
+          },
+          signal,
         },
-        signal: timeout.signal,
-      },
-    );
+      );
 
-    if (!response.ok) {
-      throw createZenrowsError(response.status, await response.text(), phase);
-    }
+      if (!response.ok) {
+        throw createZenrowsError(response.status, await response.text(), phase);
+      }
 
-    return response;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "ZenRows request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `ZenRows request failed: ${error.message}` : "ZenRows request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+      return response;
+    },
+  );
 }
 
 function buildZenrowsUrl(url: string, query: Record<string, ZenrowsQueryValue>, apiKey: string | undefined): string {

--- a/src/providers/zenscrape/runtime.ts
+++ b/src/providers/zenscrape/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRawString, optionalRecord } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const zenscrapeApiBaseUrl = "https://app.zenscrape.com/api/v1";
@@ -68,34 +67,25 @@ async function requestZenscrapeRaw(
   context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
   phase: ZenscrapePhase,
 ): Promise<{ response: Response; bodyText: string }> {
-  const timeout = createProviderTimeout(context.signal, requestTimeoutMs);
-  try {
-    const response = await context.fetcher(buildZenscrapeUrl(query, context.apiKey), {
-      method: "GET",
-      headers: {
-        accept: "*/*",
-        "user-agent": providerUserAgent,
-        ...forwardHeaders,
-      },
-      signal: timeout.signal,
-    });
-    const bodyText = await readProviderTextBody(response, "Zenscrape response", maxResponseBytes);
-    if (!response.ok) {
-      throw createZenscrapeError(response.status, bodyText, phase);
-    }
-    return { response, bodyText };
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Zenscrape request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Zenscrape request failed: ${error.message}` : "Zenscrape request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  return runProviderRequest(
+    { signal: context.signal, timeoutMs: requestTimeoutMs, label: "Zenscrape" },
+    async (signal) => {
+      const response = await context.fetcher(buildZenscrapeUrl(query, context.apiKey), {
+        method: "GET",
+        headers: {
+          accept: "*/*",
+          "user-agent": providerUserAgent,
+          ...forwardHeaders,
+        },
+        signal,
+      });
+      const bodyText = await readProviderTextBody(response, "Zenscrape response", maxResponseBytes);
+      if (!response.ok) {
+        throw createZenscrapeError(response.status, bodyText, phase);
+      }
+      return { response, bodyText };
+    },
+  );
 }
 
 function buildZenscrapeUrl(query: Record<string, string | number | boolean | undefined>, apiKey: string): URL {

--- a/src/providers/zep/runtime.ts
+++ b/src/providers/zep/runtime.ts
@@ -4,11 +4,10 @@ import type { ApiKeyProviderContext, ProviderRuntimeHandler } from "../provider-
 
 import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderTimeout,
-  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   readProviderTextBody,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 export const zepApiBaseUrl = "https://api.getzep.com/api/v2";
@@ -180,31 +179,19 @@ async function requestZepJson(
     headers.set("content-type", "application/json");
     body = JSON.stringify(input.body);
   }
-  const timeout = createProviderTimeout(context.signal);
-  try {
+  return runProviderRequest({ signal: context.signal, label: "Zep" }, async (signal) => {
     const response = await context.fetcher(url, {
       method: input.method ?? "GET",
       headers,
       body,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readZepPayload(response);
     if (!response.ok) {
       throw createZepError(response.status, payload, input.phase ?? "execute");
     }
     return payload;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) throw error;
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Zep request timed out");
-    }
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Zep request failed: ${error.message}` : "Zep request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 async function readZepPayload(response: Response): Promise<unknown> {

--- a/src/providers/zoom/runtime.ts
+++ b/src/providers/zoom/runtime.ts
@@ -4,12 +4,7 @@ import type { OAuthProviderContext, ProviderFetch, ProviderRuntimeHandler } from
 
 import { compactObject, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
-import {
-  createProviderTimeout,
-  isAbortLikeError,
-  ProviderRequestError,
-  providerUserAgent,
-} from "../provider-runtime.ts";
+import { ProviderRequestError, providerUserAgent, runProviderRequest } from "../provider-runtime.ts";
 
 export const zoomApiBaseUrl = "https://api.zoom.us/v2";
 
@@ -120,8 +115,7 @@ export async function fetchZoomCurrentAccount(
 }
 
 async function requestZoomJson(input: ZoomRequestInput): Promise<Record<string, unknown>> {
-  const timeout = createProviderTimeout(input.context.signal);
-  try {
+  return runProviderRequest({ signal: input.context.signal, label: "Zoom" }, async (signal) => {
     const headers: Record<string, string> = {
       accept: "application/json",
       authorization: `Bearer ${input.context.accessToken}`,
@@ -135,7 +129,7 @@ async function requestZoomJson(input: ZoomRequestInput): Promise<Record<string, 
       method: input.method ?? "GET",
       headers,
       body: input.body ? JSON.stringify(input.body) : undefined,
-      signal: timeout.signal,
+      signal,
     });
     const payload = await readZoomPayload(response);
 
@@ -152,22 +146,7 @@ async function requestZoomJson(input: ZoomRequestInput): Promise<Record<string, 
     }
 
     return record;
-  } catch (error) {
-    if (error instanceof ProviderRequestError) {
-      throw error;
-    }
-
-    if (timeout.didTimeout() || isAbortLikeError(error)) {
-      throw new ProviderRequestError(504, "Zoom request timed out");
-    }
-
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Zoom request failed: ${error.message}` : "Zoom request failed",
-    );
-  } finally {
-    timeout.cleanup();
-  }
+  });
 }
 
 function buildZoomUrl(path: string, query?: Record<string, string | undefined>): URL {


### PR DESCRIPTION
Sixth provider-level convergence PR after #441. Stacked on #447 (`refactor/entropy-b7-api-key-request`); it retargets once the stack below it lands.

## What changes

- `provider-runtime.ts` exports `runProviderRequest(options, request)`: it creates the provider timeout (`createProviderTimeout`, 30 s default), calls `request(signal)`, rethrows any `ProviderRequestError`, maps an abort or timeout to `504 "<label> request timed out"`, maps any other failure to `502 "<label> request failed: <message>"` (or `"<label> request failed"` for a non-`Error` throw), and always cleans up the timer. Four tests cover the boundary cases: passthrough of an inner `ProviderRequestError` with details, `AbortError` / `TimeoutError` / a fired timer, an `Error` and a non-`Error` failure, and a caller-supplied signal.
- 126 provider request helpers whose `try { fetch ... read body ... return } catch { rethrow guard; 504; 502 } finally { cleanup }` was exactly that shape now call `runProviderRequest({ signal, label }, async (signal) => { ... })` with the same body inside the callback. The provider label and, where present, the explicit `timeoutMs` are threaded through, so the status codes and message text are unchanged.

128 files, net -2065 lines.

## What was converted, and what was not

The audit found 329 catch blocks with this timeout/abort ladder across 319 files, in 56 semantic variants. Only sites that are byte-equivalent under the helper were converted, selected by script:

- the block has the `instanceof ProviderRequestError` rethrow guard, the 504 message is exactly `"<label> request timed out"`, the 502 pair is exactly `` `<label> request failed: ${error.message}` `` / `"<label> request failed"` with the same label, no raw `error` is passed as `details`, and the catch has no extra branches (149 blocks);
- and `createProviderTimeout` is the statement right before the `try`, the try body refers to the timeout only as `timeout.signal`, and nothing follows the `finally` inside the function (126 of those 149).

Left alone on purpose: the 23 canonical blocks where the timeout is created earlier or code follows the `finally` (converting would move the timeout window; adyntel's credential-validation block also uses its own messages), the 40-odd sites that time-box only the fetch and read the body after `finally`, the 46 without a rethrow guard (converting would change how guarded-fetch and SSRF-block messages surface), the 72 that attach the raw error as `details`, the branded or non-canonical messages, and one-offs with extra branches.

## Wire behavior

None. For every converted site the helper produces the same `ProviderRequestError` (status, message, no details) as the deleted block, and `ProviderRequestError` thrown inside the callback passes through untouched. The evaluation order is the same: the timeout is created before the request, and the message is built from a label that is a string literal at every converted site (no template interpolation moved earlier).

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1558 tests), `npm run build --workspace web`, `git diff --check`: green.
- `npm run generate:catalog`: all 1451 `catalog/apps/*.json` byte-identical to `origin/main`.
- The classifier re-run on the result finds 0 remaining convertible blocks; the only surviving `createProviderTimeout` + `isAbortLikeError` ladders are the non-canonical ones listed above.
- Differential run: for 16 converted providers the module at the base commit and the converted module were driven through their real exported handlers with the same injected fetcher over abort, timeout, `Error`, non-`Error`, inner `ProviderRequestError` with details, a fired timer, 200/4xx/5xx bodies, parent-signal aborts and a mid-body stream failure: 261 comparisons of status, message, details and resolved value, 0 differences, 0 leaked timers. A structural check over all 126 sites confirms each callback body equals the old try body modulo `timeout.signal` -> `signal`, with no outer `signal` shadowed, no `this` / `arguments`, and the try as the function's last statement.
