### PR TITLE
refactor(aws): make core/aws-sigv4.ts the single SigV4 owner

### DIFF
--- a/src/core/aws-sigv4.test.ts
+++ b/src/core/aws-sigv4.test.ts
@@ -4,8 +4,12 @@ import {
   canonicalizeSearchParams,
   createAwsSigV4PresignedUrl,
   encodeRfc3986,
+  encodeS3ObjectKey,
   sha256Hex,
+  signAwsSigV4Request,
 } from "./aws-sigv4.ts";
+
+const emptyPayloadSha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
 describe("AWS SigV4 presign helper", () => {
   it("matches the AWS GET query-string auth example", () => {
@@ -66,7 +70,7 @@ describe("AWS SigV4 presign helper", () => {
 
   it("encodes reserved characters with RFC 3986 rules", () => {
     expect(encodeRfc3986("file!'()*")).toBe("file%21%27%28%29%2A");
-    expect(sha256Hex("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(sha256Hex("")).toBe(emptyPayloadSha256);
   });
 
   it("collapses tabs and repeated spaces in header values", () => {
@@ -157,5 +161,87 @@ describe("AWS SigV4 presign helper", () => {
     expect(search).not.toContain("%7E");
     // `+`, `/`, and `=` in the session token stay percent-encoded, not form-urlencoded.
     expect(search).toContain("X-Amz-Security-Token=AQoDYXdzEJr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaABC%2Bde%2Ff0g%3D%3D");
+  });
+});
+
+// Vectors from "Examples: Signature Calculations in AWS Signature Version 4"
+// (Amazon S3 API Reference). AWS joins the Authorization components with ","
+// and the AWS SDKs with ", "; the service accepts both, and this repository
+// uses the SDK form.
+describe("AWS SigV4 authorization header helper", () => {
+  const credential = {
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  };
+  const now = new Date("2013-05-24T00:00:00Z");
+
+  it("matches the AWS GET Object header-auth example", () => {
+    const headers = signAwsSigV4Request({
+      credential,
+      method: "GET",
+      url: new URL("https://examplebucket.s3.amazonaws.com/test.txt"),
+      region: "us-east-1",
+      headers: { range: "bytes=0-9", "x-amz-content-sha256": emptyPayloadSha256 },
+      payloadHash: emptyPayloadSha256,
+      now,
+    });
+
+    expect(headers.get("host")).toBe("examplebucket.s3.amazonaws.com");
+    expect(headers.get("x-amz-date")).toBe("20130524T000000Z");
+    expect(headers.get("range")).toBe("bytes=0-9");
+    expect(headers.has("x-amz-security-token")).toBe(false);
+    expect(headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+    );
+  });
+
+  it("matches the AWS PUT Object header-auth example", () => {
+    const payloadHash = sha256Hex("Welcome to Amazon S3.");
+    const url = new URL("https://examplebucket.s3.amazonaws.com/");
+    // The canonical URI is the RFC 3986 encoded key, so `$` must arrive as %24.
+    url.pathname = `/${encodeS3ObjectKey("test$file.text")}`;
+
+    const headers = signAwsSigV4Request({
+      credential,
+      method: "PUT",
+      url,
+      region: "us-east-1",
+      headers: {
+        date: "Fri, 24 May 2013 00:00:00 GMT",
+        "x-amz-storage-class": "REDUCED_REDUNDANCY",
+        "x-amz-content-sha256": payloadHash,
+      },
+      payloadHash,
+      now,
+    });
+
+    expect(payloadHash).toBe("44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072");
+    expect(headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class, Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd",
+    );
+  });
+
+  it("signs the session token and canonical query without mutating the input headers", () => {
+    const input = new Headers({ "x-amz-content-sha256": "UNSIGNED-PAYLOAD" });
+    const url = new URL("https://sts.us-east-1.amazonaws.com/");
+    url.search = canonicalizeSearchParams(new URLSearchParams({ Version: "2011-06-15", Action: "GetCallerIdentity" }));
+
+    const headers = signAwsSigV4Request({
+      credential: { ...credential, sessionToken: "AQoDYXdzEJr//////////wEaABC+de/f0g==" },
+      method: "GET",
+      url,
+      region: "us-east-1",
+      service: "sts",
+      headers: input,
+      payloadHash: "UNSIGNED-PAYLOAD",
+      now,
+    });
+
+    expect(url.search).toBe("?Action=GetCallerIdentity&Version=2011-06-15");
+    expect(Array.from(input.keys())).toEqual(["x-amz-content-sha256"]);
+    expect(headers.get("x-amz-security-token")).toBe("AQoDYXdzEJr//////////wEaABC+de/f0g==");
+    expect(headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=0908fa269713fd585ca0afca91509a0af2821f7f38a810deaa0461644a2f9703",
+    );
   });
 });

--- a/src/core/aws-sigv4.ts
+++ b/src/core/aws-sigv4.ts
@@ -28,15 +28,69 @@ export interface AwsSigV4PresignInput {
 }
 
 /**
+ * `Authorization` header signing input. `url` supplies the signed host, path,
+ * and query; the query is signed verbatim, so callers canonicalize it with
+ * {@link canonicalizeSearchParams} before signing and send exactly that URL.
+ * `payloadHash` is the SHA-256 hex of the body (or `UNSIGNED-PAYLOAD`).
+ */
+export interface AwsSigV4SignInput {
+  credential: AwsSigV4Credential;
+  method: string;
+  url: URL;
+  region: string;
+  payloadHash: string;
+  service?: string;
+  headers?: HeadersInit;
+  now?: Date;
+}
+
+interface AwsSigV4SigningScope {
+  amzDate: string;
+  dateStamp: string;
+  region: string;
+  service: string;
+  credentialScope: string;
+}
+
+/**
+ * Sign a request with the SigV4 `Authorization` header scheme. Returns the
+ * headers to send: a copy of the input headers plus `host`, `x-amz-date`,
+ * `x-amz-security-token` (when the credential carries a session token), and
+ * `authorization`. Signing is local; the function does not send a network
+ * request.
+ */
+export function signAwsSigV4Request(input: AwsSigV4SignInput): Headers {
+  const scope = createSigningScope(input.now ?? new Date(), input.region, input.service ?? defaultAwsServiceName);
+  const headers = new Headers(input.headers);
+  headers.set("host", input.url.host);
+  headers.set("x-amz-date", scope.amzDate);
+  if (input.credential.sessionToken) {
+    headers.set("x-amz-security-token", input.credential.sessionToken);
+  }
+  const canonicalHeaders = buildCanonicalHeaders(headers);
+  const signedHeaders = Object.keys(canonicalHeaders).join(";");
+  const canonicalRequest = [
+    input.method,
+    input.url.pathname,
+    input.url.search.slice(1),
+    formatCanonicalHeaders(canonicalHeaders),
+    signedHeaders,
+    input.payloadHash,
+  ].join("\n");
+  const signature = signCanonicalRequest(input.credential.secretAccessKey, scope, canonicalRequest);
+  headers.set(
+    "authorization",
+    `AWS4-HMAC-SHA256 Credential=${input.credential.accessKeyId}/${scope.credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  );
+  return headers;
+}
+
+/**
  * Build an AWS SigV4 query-string presigned URL. Signing is local; the function
  * does not send a network request.
  */
 export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string {
-  const now = input.now ?? new Date();
-  const amzDate = formatAmzDate(now);
-  const dateStamp = amzDate.slice(0, 8);
-  const service = input.service ?? defaultAwsServiceName;
-  const credentialScope = `${dateStamp}/${input.region}/${service}/aws4_request`;
+  const scope = createSigningScope(input.now ?? new Date(), input.region, input.service ?? defaultAwsServiceName);
   const url = new URL(input.url.href);
   const headers = new Headers();
   for (const [key, value] of Object.entries(input.headers ?? {})) {
@@ -50,8 +104,8 @@ export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string 
   const signedHeaders = Object.keys(canonicalHeaders).join(";");
   const query = new URLSearchParams();
   query.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
-  query.set("X-Amz-Credential", `${input.credential.accessKeyId}/${credentialScope}`);
-  query.set("X-Amz-Date", amzDate);
+  query.set("X-Amz-Credential", `${input.credential.accessKeyId}/${scope.credentialScope}`);
+  query.set("X-Amz-Date", scope.amzDate);
   query.set("X-Amz-Expires", String(input.expiresSeconds));
   query.set("X-Amz-SignedHeaders", signedHeaders);
   if (input.credential.sessionToken) {
@@ -66,11 +120,7 @@ export function createAwsSigV4PresignedUrl(input: AwsSigV4PresignInput): string 
     signedHeaders,
     "UNSIGNED-PAYLOAD",
   ].join("\n");
-  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
-  const signature = hmacHex(
-    getAwsSigningKey(input.credential.secretAccessKey, dateStamp, input.region, service),
-    stringToSign,
-  );
+  const signature = signCanonicalRequest(input.credential.secretAccessKey, scope, canonicalRequest);
   // Append the signature to the canonical query text instead of going through
   // `url.searchParams`, whose setter re-serializes as form-urlencoded and would
   // diverge from the signed bytes for `~`, space, and `*`.
@@ -135,7 +185,7 @@ export function buildCanonicalHeaders(headers: Headers): Record<string, string> 
 /**
  * Format canonical headers as `name:value` lines terminated by a blank line.
  */
-export function formatCanonicalHeaders(headers: Record<string, string>): string {
+function formatCanonicalHeaders(headers: Record<string, string>): string {
   return `${Object.entries(headers)
     .map(([key, value]) => `${key}:${value}`)
     .join("\n")}\n`;
@@ -144,7 +194,7 @@ export function formatCanonicalHeaders(headers: Record<string, string>): string 
 /**
  * Format a timestamp as the AWS `yyyyMMddTHHmmssZ` amz-date value.
  */
-export function formatAmzDate(value: Date): string {
+function formatAmzDate(value: Date): string {
   const year = String(value.getUTCFullYear()).padStart(4, "0");
   const month = String(value.getUTCMonth() + 1).padStart(2, "0");
   const day = String(value.getUTCDate()).padStart(2, "0");
@@ -164,11 +214,30 @@ export function sha256Hex(value: string | Uint8Array): string {
 /**
  * Derive the AWS SigV4 signing key for a date, region, and service.
  */
-export function getAwsSigningKey(secretAccessKey: string, dateStamp: string, region: string, service: string): Buffer {
+function getAwsSigningKey(secretAccessKey: string, dateStamp: string, region: string, service: string): Buffer {
   const kDate = hmacSha256(`AWS4${secretAccessKey}`, dateStamp);
   const kRegion = hmacSha256(kDate, region);
   const kService = hmacSha256(kRegion, service);
   return hmacSha256(kService, "aws4_request");
+}
+
+function createSigningScope(now: Date, region: string, service: string): AwsSigV4SigningScope {
+  const amzDate = formatAmzDate(now);
+  const dateStamp = amzDate.slice(0, 8);
+  return {
+    amzDate,
+    dateStamp,
+    region,
+    service,
+    credentialScope: `${dateStamp}/${region}/${service}/aws4_request`,
+  };
+}
+
+function signCanonicalRequest(secretAccessKey: string, scope: AwsSigV4SigningScope, canonicalRequest: string): string {
+  const stringToSign = ["AWS4-HMAC-SHA256", scope.amzDate, scope.credentialScope, sha256Hex(canonicalRequest)].join(
+    "\n",
+  );
+  return hmacHex(getAwsSigningKey(secretAccessKey, scope.dateStamp, scope.region, scope.service), stringToSign);
 }
 
 function hmacSha256(key: string | Buffer, value: string): Buffer {

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -1,8 +1,9 @@
-import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
+import type { ExecutionContext, ExecutionResult, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAwsSigV4PresignedUrl } from "../../core/aws-sigv4.ts";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
-import { executors } from "./executors.ts";
+import { executors, proxy } from "./executors.ts";
 
 interface CapturedRequest {
   url: URL;
@@ -22,12 +23,24 @@ const credential: Extract<ResolvedCredential, { authType: "custom_credential" }>
   metadata: { region: "us-east-1", bucket: "documents" },
 };
 
+// Access key with an RFC 3986 unreserved `~`: form-urlencoding would turn it
+// into %7E and diverge from the signed query bytes.
+const tildeCredential: typeof credential = {
+  ...credential,
+  values: { ...credential.values, accessKeyId: "AK~IAIOSFODNN7EXAMPLE" },
+  profile: { ...credential.profile, accountId: "AK~IAIOSFODNN7EXAMPLE" },
+};
+
+const goldenSigningTime = new Date("2015-08-30T12:36:00.000Z");
+const helloSha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
 beforeEach(() => {
   setDefaultGuardedFetchDnsLookup(null);
 });
 
 afterEach(() => {
   setDefaultGuardedFetchDnsLookup(undefined);
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -191,6 +204,116 @@ describe("AWS S3 put_object sourceUrl", () => {
   });
 });
 
+// Signature bytes below were frozen from the code-point-ordered SigV4
+// canonical form (the byte order AWS requires); they must stay byte-identical
+// across refactors of the shared SigV4 helpers.
+describe("AWS S3 SigV4 golden vectors", () => {
+  beforeEach(() => {
+    vi.setSystemTime(goldenSigningTime);
+  });
+
+  it("orders signed metadata headers by code point", async () => {
+    const requests = stubResponses([new Response("", { headers: { etag: '"etag-2"' } })]);
+
+    const result = await executePut({
+      bucket: "documents",
+      objectKey: "test.txt",
+      contentText: "hello",
+      metadata: { "file-name": "a", file_name: "b" },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        bucket: "documents",
+        objectKey: "test.txt",
+        url: "https://documents.s3.us-east-1.amazonaws.com/test.txt",
+        etag: '"etag-2"',
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.amzContentSha256).toBe(helloSha256);
+    // "-" (0x2D) sorts before "_" (0x5F) by code point; `localeCompare` reverses them.
+    expect(requests[0]?.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20150830/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-meta-file-name;x-amz-meta-file_name, Signature=400a710252eabbba1228793b2b0292d9b6e2884b895275a2989725c8ad132ea3",
+    );
+  });
+
+  it("signs proxy query parameters in code point order", async () => {
+    const requests = stubResponses([
+      new Response("<ListBucketResult/>", { headers: { "content-type": "application/xml" } }),
+    ]);
+
+    const result = await proxy({ endpoint: "/", method: "GET", query: { Prefix: "a", marker: "b" } }, createContext());
+
+    expect(result).toMatchObject({ ok: true, response: { status: 200 } });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.host).toBe("documents.s3.us-east-1.amazonaws.com");
+    // "P" (0x50) sorts before "m" (0x6D) by code point; `localeCompare` folds case first.
+    expect(requests[0]?.url.search).toBe("?Prefix=a&marker=b");
+    expect(requests[0]?.amzContentSha256).toBe("UNSIGNED-PAYLOAD");
+    expect(requests[0]?.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20150830/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=d8c2c579b616653f899461276027636f74fc150adac10884c8ac6b2f3f755dba",
+    );
+  });
+
+  it("emits the presigned URL with the signed canonical query verbatim", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executeAction(
+      "aws_s3.generate_presigned_url",
+      { bucket: "documents", objectKey: "test.txt", method: "GET", expiresSeconds: 3600 },
+      undefined,
+      tildeCredential,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        bucket: "documents",
+        objectKey: "test.txt",
+        method: "GET",
+        expiresSeconds: 3600,
+        url: "https://documents.s3.us-east-1.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AK~IAIOSFODNN7EXAMPLE%2F20150830%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20150830T123600Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=67b824064fe6cbdde708f883647c05b220f01719b423016b5a575a4ea61cd114",
+      },
+    });
+    const url = readOutputUrl(result);
+    expect(url).toContain("X-Amz-Credential=AK~IAIOSFODNN7EXAMPLE%2F");
+    expect(url).not.toContain("%7E");
+    expect(url).toBe(
+      createAwsSigV4PresignedUrl({
+        credential: { accessKeyId: "AK~IAIOSFODNN7EXAMPLE", secretAccessKey: credential.values.secretAccessKey! },
+        method: "GET",
+        url: new URL("https://documents.s3.us-east-1.amazonaws.com/test.txt"),
+        region: "us-east-1",
+        expiresSeconds: 3600,
+        now: goldenSigningTime,
+      }),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("signs header values with collapsed whitespace", async () => {
+    const requests = stubResponses([new Response("")]);
+
+    const result = await executePut({
+      bucket: "documents",
+      objectKey: "test.txt",
+      contentText: "hello",
+      contentType: "text/plain;\tcharset=utf-8",
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(requests).toHaveLength(1);
+    // Signed as `content-type:text/plain; charset=utf-8`: SigV4 collapses runs of
+    // whitespace (tabs included) to a single space.
+    expect(requests[0]?.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20150830/us-east-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=12de408d276912c098a6eb11b0aa06ac5319ca938ac4e7f94e550db60206cdbf",
+    );
+  });
+});
+
 function stubResponses(responses: Response[]): CapturedRequest[] {
   const requests: CapturedRequest[] = [];
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -235,6 +358,27 @@ function createTransitFileStore(maxBytes: number): {
   };
 }
 
+function readOutputUrl(result: ExecutionResult): string {
+  const output = result.output as { url?: unknown } | undefined;
+  if (!result.ok || typeof output?.url !== "string") {
+    throw new Error(`expected a presigned url, got ${JSON.stringify(result)}`);
+  }
+  return output.url;
+}
+
+function createContext(resolvedCredential = credential, transitFiles?: TransitFileStore): ExecutionContext {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("aws_s3");
+      return resolvedCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return context;
+}
+
 async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
   return executeAction("aws_s3.download_object", input, transitFiles);
 }
@@ -244,18 +388,10 @@ async function executePut(input: Record<string, unknown>) {
 }
 
 async function executeAction(
-  action: "aws_s3.download_object" | "aws_s3.put_object",
+  action: "aws_s3.download_object" | "aws_s3.put_object" | "aws_s3.generate_presigned_url",
   input: Record<string, unknown>,
   transitFiles?: TransitFileStore,
+  resolvedCredential = credential,
 ) {
-  const context: ExecutionContext = {
-    getCredential: async (service) => {
-      expect(service).toBe("aws_s3");
-      return credential;
-    },
-  };
-  if (transitFiles) {
-    context.transitFiles = transitFiles;
-  }
-  return executors[action]!(input, context);
+  return executors[action]!(input, createContext(resolvedCredential, transitFiles));
 }

--- a/src/providers/aws_s3/executors.test.ts
+++ b/src/providers/aws_s3/executors.test.ts
@@ -1,7 +1,6 @@
 import type { ExecutionContext, ExecutionResult, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createAwsSigV4PresignedUrl } from "../../core/aws-sigv4.ts";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { executors, proxy } from "./executors.ts";
 
@@ -281,16 +280,6 @@ describe("AWS S3 SigV4 golden vectors", () => {
     const url = readOutputUrl(result);
     expect(url).toContain("X-Amz-Credential=AK~IAIOSFODNN7EXAMPLE%2F");
     expect(url).not.toContain("%7E");
-    expect(url).toBe(
-      createAwsSigV4PresignedUrl({
-        credential: { accessKeyId: "AK~IAIOSFODNN7EXAMPLE", secretAccessKey: credential.values.secretAccessKey! },
-        method: "GET",
-        url: new URL("https://documents.s3.us-east-1.amazonaws.com/test.txt"),
-        region: "us-east-1",
-        expiresSeconds: 3600,
-        now: goldenSigningTime,
-      }),
-    );
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/src/providers/aws_s3/executors.ts
+++ b/src/providers/aws_s3/executors.ts
@@ -8,7 +8,13 @@ import type {
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
-import { createHash, createHmac } from "node:crypto";
+import {
+  canonicalizeSearchParams,
+  createAwsSigV4PresignedUrl,
+  encodeS3ObjectKey,
+  sha256Hex,
+  signAwsSigV4Request,
+} from "../../core/aws-sigv4.ts";
 import { compactObject, optionalRecord, optionalString, requiredRawString } from "../../core/cast.ts";
 import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
@@ -87,7 +93,6 @@ class AwsS3HttpError extends Error {
 
 const sourceFetchTimeoutMs = 15_000;
 const maxSourceBytes = 20 * 1024 * 1024;
-const awsServiceName = "s3";
 const service = "aws_s3";
 
 export const awsActionHandlers: ProviderActionHandlers<"aws_s3", AwsActionHandler> = {
@@ -162,29 +167,25 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
       headers.set("content-type", "application/json");
     }
-    headers.set("host", url.host);
     headers.set("x-amz-content-sha256", payloadHash);
 
-    const signedRequest = signAwsRequest(
-      createAwsS3Client({
+    const signedHeaders = signAwsSigV4Request({
+      credential: {
         accessKeyId: requireAwsField(credential.values.accessKeyId, "accessKeyId"),
         secretAccessKey: requireAwsField(credential.values.secretAccessKey, "secretAccessKey"),
         sessionToken: optionalString(credential.values.sessionToken)?.trim(),
-        region,
-        fetcher: providerFetch,
-      }),
-      {
-        method,
-        url,
-        headers: Object.fromEntries(headers.entries()),
-        payloadHash,
       },
-    );
-    signedRequest.headers.set("user-agent", providerUserAgent);
+      method,
+      url,
+      region,
+      headers,
+      payloadHash,
+    });
+    signedHeaders.set("user-agent", providerUserAgent);
 
     const response = await providerFetch(url.toString(), {
       method,
-      headers: signedRequest.headers,
+      headers: signedHeaders,
       ...(body === undefined ? {} : { body }),
       signal: context.signal,
     });
@@ -451,10 +452,11 @@ async function awsGeneratePresignedUrl(input: Record<string, unknown>, context: 
     objectKey,
     method,
     expiresSeconds,
-    url: awsPresignUrl(client, {
-      bucket,
-      objectKey,
+    url: createAwsSigV4PresignedUrl({
+      credential: client,
       method,
+      url: buildRequestTarget({ region: client.region, bucket, objectKey }).url,
+      region: client.region,
       expiresSeconds,
       headers: compactObject({
         "content-type": optionalString(input.contentType),
@@ -525,19 +527,20 @@ async function awsS3Request(client: AwsS3ClientConfig, input: AwsS3RequestInput)
   const body = normalizeRequestBody(input.body);
   const payloadHash =
     method === "PUT" ? sha256Hex(body ?? Buffer.alloc(0)) : body == null ? "UNSIGNED-PAYLOAD" : sha256Hex(body);
-  const signedRequest = signAwsRequest(client, {
+  const signedHeaders = signAwsSigV4Request({
+    credential: client,
     method,
     url: target.url,
+    region: client.region,
     headers: compactObject({
       ...input.headers,
-      host: target.url.host,
       "x-amz-content-sha256": payloadHash,
     }),
     payloadHash,
   });
   const response = await client.fetcher(target.url.toString(), {
     method,
-    headers: signedRequest.headers,
+    headers: signedHeaders,
     ...(body == null ? {} : { body }),
     signal: input.signal,
   });
@@ -549,102 +552,6 @@ async function awsS3Request(client: AwsS3ClientConfig, input: AwsS3RequestInput)
   return response;
 }
 
-function awsPresignUrl(
-  client: AwsS3ClientConfig,
-  input: {
-    bucket: string;
-    objectKey: string;
-    method: "GET" | "PUT" | "DELETE";
-    expiresSeconds: number;
-    headers?: Record<string, string | undefined>;
-  },
-) {
-  const now = new Date();
-  const amzDate = formatAmzDate(now);
-  const dateStamp = amzDate.slice(0, 8);
-  const credentialScope = `${dateStamp}/${client.region}/${awsServiceName}/aws4_request`;
-  const target = buildRequestTarget({
-    region: client.region,
-    bucket: input.bucket,
-    objectKey: input.objectKey,
-  });
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(input.headers ?? {})) {
-    if (!value) {
-      continue;
-    }
-    headers.set(key, value);
-  }
-  headers.set("host", target.url.host);
-  const canonicalHeaders = buildCanonicalHeaders(headers);
-  const signedHeaders = Object.keys(canonicalHeaders).join(";");
-  const query = new URLSearchParams();
-  query.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
-  query.set("X-Amz-Credential", `${client.accessKeyId}/${credentialScope}`);
-  query.set("X-Amz-Date", amzDate);
-  query.set("X-Amz-Expires", String(input.expiresSeconds));
-  query.set("X-Amz-SignedHeaders", signedHeaders);
-  if (client.sessionToken) {
-    query.set("X-Amz-Security-Token", client.sessionToken);
-  }
-  target.url.search = canonicalizeSearchParams(query);
-  const canonicalRequest = [
-    input.method,
-    target.url.pathname,
-    target.url.search.slice(1),
-    formatCanonicalHeaders(canonicalHeaders),
-    signedHeaders,
-    "UNSIGNED-PAYLOAD",
-  ].join("\n");
-  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
-  const signature = hmacHex(
-    getSigningKey(client.secretAccessKey, dateStamp, client.region, awsServiceName),
-    stringToSign,
-  );
-  target.url.searchParams.set("X-Amz-Signature", signature);
-  return target.url.toString();
-}
-
-function signAwsRequest(
-  client: AwsS3ClientConfig,
-  input: {
-    method: "GET" | "PUT" | "HEAD" | "DELETE";
-    url: URL;
-    headers: Record<string, string>;
-    payloadHash: string;
-  },
-) {
-  const now = new Date();
-  const amzDate = formatAmzDate(now);
-  const dateStamp = amzDate.slice(0, 8);
-  const credentialScope = `${dateStamp}/${client.region}/${awsServiceName}/aws4_request`;
-  const headers = new Headers(input.headers);
-  headers.set("x-amz-date", amzDate);
-  if (client.sessionToken) {
-    headers.set("x-amz-security-token", client.sessionToken);
-  }
-  const canonicalHeaders = buildCanonicalHeaders(headers);
-  const signedHeaders = Object.keys(canonicalHeaders).join(";");
-  const canonicalRequest = [
-    input.method,
-    input.url.pathname,
-    input.url.search.slice(1),
-    formatCanonicalHeaders(canonicalHeaders),
-    signedHeaders,
-    input.payloadHash,
-  ].join("\n");
-  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${client.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${hmacHex(getSigningKey(client.secretAccessKey, dateStamp, client.region, awsServiceName), stringToSign)}`,
-  ].join(", ");
-  headers.set("authorization", authorization);
-  return {
-    headers,
-  };
-}
-
 function buildRequestTarget(input: {
   region: string;
   bucket?: string;
@@ -652,7 +559,7 @@ function buildRequestTarget(input: {
   query?: Record<string, string | number | boolean | undefined>;
 }) {
   const url = createAwsS3BaseUrl(input.region, input.bucket);
-  url.pathname = input.objectKey ? `/${encodeS3Key(input.objectKey)}` : "/";
+  url.pathname = input.objectKey ? `/${encodeS3ObjectKey(input.objectKey)}` : "/";
   for (const [key, value] of Object.entries(input.query ?? {})) {
     if (value == null) {
       continue;
@@ -694,42 +601,6 @@ function buildObjectUrl(region: string, bucket: string, objectKey: string) {
   }).url.toString();
 }
 
-function buildCanonicalHeaders(headers: Headers) {
-  const entries = Array.from(headers.entries()).map(([key, value]) => ({
-    key: key.toLowerCase(),
-    value: collapseHeaderWhitespace(value),
-  }));
-  entries.sort((left, right) => left.key.localeCompare(right.key));
-  return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
-}
-
-function formatCanonicalHeaders(headers: Record<string, string>) {
-  return `${Object.entries(headers)
-    .map(([key, value]) => `${key}:${value}`)
-    .join("\n")}\n`;
-}
-
-function canonicalizeSearchParams(searchParams: URLSearchParams) {
-  const entries = Array.from(searchParams.entries()).map(([key, value]) => ({
-    key: encodeRfc3986(key),
-    value: encodeRfc3986(value),
-  }));
-  entries.sort((left, right) => {
-    if (left.key === right.key) {
-      return left.value.localeCompare(right.value);
-    }
-    return left.key.localeCompare(right.key);
-  });
-  return entries.map((entry) => `${entry.key}=${entry.value}`).join("&");
-}
-
-function encodeS3Key(value: string) {
-  return value
-    .split("/")
-    .map((segment) => encodeRfc3986(segment))
-    .join("/");
-}
-
 function readObjectKey(input: Record<string, unknown>): string {
   const objectKey = requiredRawString(
     input.objectKey,
@@ -747,15 +618,6 @@ function readObjectKey(input: Record<string, unknown>): string {
 
 function defaultObjectFileName(objectKey: string): string {
   return objectKey.split("/").findLast((segment) => segment.length > 0) ?? "s3-object";
-}
-
-function encodeRfc3986(value: string) {
-  return encodeURIComponent(value)
-    .replaceAll("!", "%21")
-    .replaceAll("'", "%27")
-    .replaceAll("(", "%28")
-    .replaceAll(")", "%29")
-    .replaceAll("*", "%2A");
 }
 
 function normalizeRequestBody(value: AwsS3RequestInput["body"]) {
@@ -1188,37 +1050,4 @@ function parseHeaderInteger(value: string | null | undefined) {
   }
   const parsed = Number(value);
   return Number.isInteger(parsed) ? parsed : null;
-}
-
-function collapseHeaderWhitespace(value: string) {
-  return value.trim().split(" ").filter(Boolean).join(" ");
-}
-
-function formatAmzDate(value: Date) {
-  const year = String(value.getUTCFullYear()).padStart(4, "0");
-  const month = String(value.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(value.getUTCDate()).padStart(2, "0");
-  const hours = String(value.getUTCHours()).padStart(2, "0");
-  const minutes = String(value.getUTCMinutes()).padStart(2, "0");
-  const seconds = String(value.getUTCSeconds()).padStart(2, "0");
-  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
-}
-
-function sha256Hex(value: string | Uint8Array | Buffer) {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function hmac(key: string | Buffer, value: string) {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function hmacHex(key: Buffer, value: string) {
-  return createHmac("sha256", key).update(value).digest("hex");
-}
-
-function getSigningKey(secretAccessKey: string, dateStamp: string, region: string, service: string) {
-  const kDate = hmac(`AWS4${secretAccessKey}`, dateStamp);
-  const kRegion = hmac(kDate, region);
-  const kService = hmac(kRegion, service);
-  return hmac(kService, "aws4_request");
 }

--- a/src/providers/aws_sts/executors.test.ts
+++ b/src/providers/aws_sts/executors.test.ts
@@ -1,8 +1,15 @@
 import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
 import { executors } from "./executors.ts";
+
+interface CapturedStsRequest {
+  url: URL;
+  method: string;
+  headers: Headers;
+  body: string;
+}
 
 const credential: Extract<ResolvedCredential, { authType: "custom_credential" }> = {
   authType: "custom_credential",
@@ -18,8 +25,40 @@ const context: ExecutionContext = {
   getCredential: async () => credential,
 };
 
-afterEach(() => {
+// Key material from the AWS SigV4 test suite. The Authorization values below
+// were frozen from the signing path; they cover the fixed User-Agent
+// (`oomol-connect/0.1`) and must stay byte-identical across refactors of the
+// shared SigV4 helpers.
+const goldenAccessKeyId = "AKIDEXAMPLE";
+const goldenSecretAccessKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+const goldenSessionToken = "AQoDYXdzEJr//////////wEaABC+de/f0g==";
+const goldenSigningTime = new Date("2015-08-30T12:36:00.000Z");
+const goldenRoleArn = "arn:aws:iam::123456789012:role/demo";
+const goldenBody =
+  "Action=AssumeRole&Version=2011-06-15&RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fdemo&RoleSessionName=oomol-connect";
+
+const assumeRoleResponseXml = `<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>assumed-secret</SecretAccessKey>
+      <SessionToken>assumed-token</SessionToken>
+      <Expiration>2015-08-30T13:36:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+  <ResponseMetadata>
+    <RequestId>request-1</RequestId>
+  </ResponseMetadata>
+</AssumeRoleResponse>`;
+
+beforeEach(() => {
   setDefaultGuardedFetchDnsLookup(null);
+});
+
+afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -41,3 +80,78 @@ describe("AWS STS region resolver DNS", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 });
+
+describe("AWS STS SigV4 golden vectors", () => {
+  it("signs assume_role with the frozen Authorization header", async () => {
+    vi.setSystemTime(goldenSigningTime);
+    const requests = stubAssumeRoleResponse();
+
+    const result = await executeAssumeRole({ roleArn: goldenRoleArn }, {});
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        accessKeyId: "ASIAEXAMPLE",
+        secretAccessKey: "assumed-secret",
+        sessionToken: "assumed-token",
+        expiration: "2015-08-30T13:36:00Z",
+        requestId: "request-1",
+      },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("POST");
+    expect(requests[0]?.url.href).toBe("https://sts.ap-southeast-1.amazonaws.com/");
+    expect(requests[0]?.body).toBe(goldenBody);
+    expect(requests[0]?.headers.get("x-amz-date")).toBe("20150830T123600Z");
+    expect(requests[0]?.headers.has("x-amz-security-token")).toBe(false);
+    expect(requests[0]?.headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ap-southeast-1/sts/aws4_request, SignedHeaders=accept;content-type;host;user-agent;x-amz-date, Signature=70ac4788e89158ec83bfea354cbf19a3a8895893bff3f8c57b027668a3ba6928",
+    );
+  });
+
+  it("signs the session token as x-amz-security-token", async () => {
+    vi.setSystemTime(goldenSigningTime);
+    const requests = stubAssumeRoleResponse();
+
+    const result = await executeAssumeRole({ roleArn: goldenRoleArn }, { sessionToken: goldenSessionToken });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.body).toBe(goldenBody);
+    expect(requests[0]?.headers.get("x-amz-security-token")).toBe(goldenSessionToken);
+    expect(requests[0]?.headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/ap-southeast-1/sts/aws4_request, SignedHeaders=accept;content-type;host;user-agent;x-amz-date;x-amz-security-token, Signature=c09ce94c7b086c98337b1f6ea786ef6dcf18cb99fddf21f7eea491c0f9be0ad1",
+    );
+  });
+});
+
+function stubAssumeRoleResponse(): CapturedStsRequest[] {
+  const requests: CapturedStsRequest[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requests.push({
+      url: new URL(request.url),
+      method: request.method,
+      headers: request.headers,
+      body: await request.text(),
+    });
+    return new Response(assumeRoleResponseXml, {
+      headers: { "content-type": "text/xml" },
+    });
+  });
+  return requests;
+}
+
+async function executeAssumeRole(input: Record<string, unknown>, values: { sessionToken?: string }) {
+  const goldenContext: ExecutionContext = {
+    getCredential: async () => ({
+      ...credential,
+      values: {
+        accessKeyId: goldenAccessKeyId,
+        secretAccessKey: goldenSecretAccessKey,
+        ...(values.sessionToken ? { sessionToken: values.sessionToken } : {}),
+      },
+    }),
+  };
+  return executors["aws_sts.assume_role"]!(input, goldenContext);
+}

--- a/src/providers/aws_sts/executors.ts
+++ b/src/providers/aws_sts/executors.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
-import { createHash, createHmac } from "node:crypto";
+import { sha256Hex, signAwsSigV4Request } from "../../core/aws-sigv4.ts";
 import {
   compactObject,
   optionalInteger,
@@ -343,86 +343,24 @@ function signAwsStsRequest(input: {
   url: URL;
   body: string;
 }): Headers {
-  const amzDate = formatAmzDate(input.now);
-  const dateStamp = amzDate.slice(0, 8);
-  const credentialScope = `${dateStamp}/${input.region}/${awsServiceName}/aws4_request`;
-  const headers = new Headers({
-    accept: "application/xml",
-    "content-type": "application/x-www-form-urlencoded; charset=utf-8",
-    host: input.url.host,
-    "user-agent": providerUserAgent,
-    "x-amz-date": amzDate,
+  return signAwsSigV4Request({
+    credential: {
+      accessKeyId: input.accessKeyId,
+      secretAccessKey: input.secretAccessKey,
+      sessionToken: input.sessionToken?.trim(),
+    },
+    method: "POST",
+    url: input.url,
+    region: input.region,
+    service: awsServiceName,
+    headers: {
+      accept: "application/xml",
+      "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+      "user-agent": providerUserAgent,
+    },
+    payloadHash: sha256Hex(input.body),
+    now: input.now,
   });
-  if (input.sessionToken?.trim()) {
-    headers.set("x-amz-security-token", input.sessionToken.trim());
-  }
-
-  const canonicalHeaders = buildCanonicalHeaders(headers);
-  const signedHeaders = Object.keys(canonicalHeaders).join(";");
-  const canonicalRequest = [
-    "POST",
-    input.url.pathname,
-    "",
-    formatCanonicalHeaders(canonicalHeaders),
-    signedHeaders,
-    sha256Hex(input.body),
-  ].join("\n");
-  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, credentialScope, sha256Hex(canonicalRequest)].join("\n");
-  headers.set(
-    "authorization",
-    [
-      `AWS4-HMAC-SHA256 Credential=${input.accessKeyId}/${credentialScope}`,
-      `SignedHeaders=${signedHeaders}`,
-      `Signature=${hmacHex(getSigningKey(input.secretAccessKey, dateStamp, input.region, awsServiceName), stringToSign)}`,
-    ].join(", "),
-  );
-  return headers;
-}
-
-function buildCanonicalHeaders(headers: Headers): Record<string, string> {
-  const entries = Array.from(headers.entries()).map(([key, value]) => ({
-    key: key.toLowerCase(),
-    value: collapseHeaderWhitespace(value),
-  }));
-  entries.sort((left, right) => left.key.localeCompare(right.key));
-  return Object.fromEntries(entries.map((entry) => [entry.key, entry.value]));
-}
-
-function formatCanonicalHeaders(headers: Record<string, string>): string {
-  return `${Object.entries(headers)
-    .map(([key, value]) => `${key}:${value}`)
-    .join("\n")}\n`;
-}
-
-function collapseHeaderWhitespace(value: string): string {
-  return value.trim().split(" ").filter(Boolean).join(" ");
-}
-
-function sha256Hex(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function hmac(key: Buffer | string, value: string): Buffer {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function hmacHex(key: Buffer | string, value: string): string {
-  return createHmac("sha256", key).update(value).digest("hex");
-}
-
-function getSigningKey(secretAccessKey: string, dateStamp: string, region: string, serviceName: string): Buffer {
-  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
-  const dateRegionKey = hmac(dateKey, region);
-  const dateRegionServiceKey = hmac(dateRegionKey, serviceName);
-  return hmac(dateRegionServiceKey, "aws4_request");
-}
-
-function formatAmzDate(value: Date): string {
-  const iso = value.toISOString();
-  return `${iso.slice(0, 4)}${iso.slice(5, 7)}${iso.slice(8, 10)}T${iso.slice(11, 13)}${iso.slice(
-    14,
-    16,
-  )}${iso.slice(17, 19)}Z`;
 }
 
 function normalizeAwsStsError(response: Response, text: string, operation: string): ProviderRequestError {


### PR DESCRIPTION
Eighth provider-level convergence PR after #441, and the one that is not behavior-preserving on purpose. Stacked on the B4 branch (`refactor/entropy-b4-cast-helpers`); it retargets once the stack below it lands. Two commits: the golden-vector tests first, then the refactor, so the second commit can be judged by which frozen bytes it moves.

## What changes

- `src/core/aws-sigv4.ts` becomes the only AWS SigV4 implementation. It gains `signAwsSigV4Request(input): Headers` for Authorization-header signing (returns new `Headers` with `host`, `x-amz-date`, `x-amz-security-token` and `authorization`; does not mutate its input) and shares the scope / string-to-sign / signing-key steps with the existing `createAwsSigV4PresignedUrl`.
- `aws_s3/executors.ts` drops its 11 private copies (`buildCanonicalHeaders`, `formatCanonicalHeaders`, `canonicalizeSearchParams`, `encodeS3Key`, `encodeRfc3986`, `collapseHeaderWhitespace`, `formatAmzDate`, `sha256Hex`, `hmac`, `hmacHex`, `getSigningKey`) and its `node:crypto` import. The proxy and `awsS3Request` sign through `signAwsSigV4Request`; `generate_presigned_url` calls `createAwsSigV4PresignedUrl` directly, which also removes the `url.searchParams.set("X-Amz-Signature", ...)` step that re-serialized the already-signed query. `readObjectKey` / `defaultObjectFileName` stay.
- `aws_sts/executors.ts` drops its 8 private copies and its `node:crypto` import; `signAwsStsRequest` delegates to `signAwsSigV4Request`.

6 files, +469 / -308 (the tests account for the plus side; the two provider modules lose 233 lines).

## Signature bytes: what changes and what does not

The old provider copies disagreed with the AWS SigV4 rules (and with `@smithy/signature-v4`, which core was cross-checked against in #418) in three places: canonical header and query keys were sorted with `localeCompare` instead of by code point, header values kept interior tabs instead of collapsing whitespace to one space, and the presigned query was re-serialized after signing (`~` became `%7E`, `%2A` became `*`, `%20` became `+`). Every one of those produces a signature AWS rejects, so this PR moves bytes only where the old bytes were wrong.

- **aws_sts: unchanged.** Its five signed headers are fixed strings that sort the same under either comparator and contain no tabs. Two golden vectors (`AKIDEXAMPLE` / the AWS example secret, 2015-08-30T12:36:00Z, with and without a session token) were frozen from the code before the refactor and pass unchanged after it.
- **aws_s3: changed in the three cases above, and only there.** Golden vectors frozen against the corrected implementation and cross-checked with an independent computation:
  - `put_object` with user metadata keys `file-name` and `file_name`: `SignedHeaders` now `...;x-amz-meta-file-name;x-amz-meta-file_name` (code point) instead of `...;x-amz-meta-file_name;x-amz-meta-file-name`.
  - proxy with `query: { Prefix: "a", marker: "b" }`: the request is now sent and signed as `?Prefix=a&marker=b` instead of `?marker=b&Prefix=a`.
  - `generate_presigned_url` with a `~` in the access key id: the emitted URL now carries the signed bytes verbatim (`AK~IA...`, no `%7E`) and equals what `createAwsSigV4PresignedUrl` produces.
  - a signed header value `text/plain;\tcharset=utf-8` is now canonicalized as `text/plain; charset=utf-8`.
  For the fixed key sets the typed actions build today (presign query keys, list-objects query keys, standard S3 headers) both orderings agree, so a plain `download_object` / `list_objects` / `put_object` without such metadata signs identically before and after. The reachable differences are on caller-controlled input: proxy query and header names, `metadata` keys, and credentials containing `~` or `*`.
- Core also gains tests against AWS's published GET Object and PUT Object header-auth examples (`f0e8bdb8...` and `98ad7217...`) and a session-token case for `signAwsSigV4Request`.

## Not changed

- `hmacHex` stays private in core: after the refactor no provider needs it. `formatCanonicalHeaders`, `formatAmzDate` and `getAwsSigningKey` lose their `export` for the same reason (nothing outside the module ever imported them). `buildCanonicalHeaders`, `canonicalizeSearchParams`, `encodeRfc3986`, `encodeS3ObjectKey` and `sha256Hex` keep theirs; every one has a consumer.
- `executeAssumeRole` ignores `input.region` and always signs for the default region; that is pre-existing and untouched (the STS vectors are frozen at the default region for that reason).
- `cloudflare_r2/s3-presign.ts`, the other importer of core, is untouched. jimeng_ai (Volcengine) and netsuite (OAuth 1.0) keep their own `sha256Hex` / `encodeRfc3986` copies; they are not AWS SigV4.

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1569 tests), `npm run generate:catalog` (tree clean), `git diff --check`: green.
- Before the refactor commit, the four aws_s3 golden vectors fail with the old bytes recorded in this description and the two aws_sts vectors pass; after it, all pass.
- The frozen values were checked against an implementation written from the AWS spec alone (no import from this repo) and, for the provider paths, against `@smithy/signature-v4`; the two AWS-documented S3 examples match the published signatures.
