### PR TITLE
refactor(providers): define eighteen hand-written proxies with defineProviderProxy

### DIFF
--- a/src/providers/agora/executors.ts
+++ b/src/providers/agora/executors.ts
@@ -3,26 +3,13 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 
 import { Buffer } from "node:buffer";
-import {
-  createProviderFetch,
-  createProviderProxyUrl,
-  defineProviderExecutors,
-  normalizeProviderProxyHeaders,
-  ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
-  requireApiKeyCredential,
-  toProviderProxyError,
-} from "../provider-runtime.ts";
+import { defineProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
 import { agoraActionHandlers, agoraApiBaseUrl, readAgoraCustomerId, validateAgoraCredential } from "./runtime.ts";
 
 const service = "agora";
-const agoraFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
@@ -39,34 +26,21 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    readAgoraCustomerId((await requireApiKeyCredential(context, service)).values);
+    return agoraApiBaseUrl;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
     const credential = await requireApiKeyCredential(context, service);
     const customerId = readAgoraCustomerId(credential.values);
-    const url = createProviderProxyUrl(agoraApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("authorization", `Basic ${Buffer.from(`${customerId}:${credential.apiKey}`).toString("base64")}`);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
-
-    const response = await agoraFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/autotask/executors.ts
+++ b/src/providers/autotask/executors.ts
@@ -1,23 +1,12 @@
-import type {
-  CredentialValidators,
-  ProviderExecutors,
-  ProviderProxyExecutor,
-  ProxyExecutionResult,
-} from "../../core/types.ts";
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 import type { AutotaskActionContext } from "./runtime.ts";
 
 import { optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
-  providerFetch,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import { autotaskActionHandlers, resolveAutotaskApiBaseUrl, validateAutotaskCredential } from "./runtime.ts";
 
@@ -40,42 +29,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<AutotaskActi
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
     const credential = await requireApiKeyCredential(context, service);
-    const secret = requiredCredentialValue(credential.values.secret, "secret");
-    const integrationCode = requiredCredentialValue(credential.values.integrationCode, "integrationCode");
-    const url = createProviderProxyUrl(
-      `${resolveAutotaskApiBaseUrl(credential.metadata)}/${autotaskApiVersionPath}`,
-      input.endpoint,
-      input.query,
-    );
-    const headers = normalizeProviderProxyHeaders(input.headers);
+    // Reject an incomplete credential before header normalization, keeping the 401/400 precedence.
+    requiredCredentialValue(credential.values.secret, "secret");
+    requiredCredentialValue(credential.values.integrationCode, "integrationCode");
+    return `${resolveAutotaskApiBaseUrl(credential.metadata)}/${autotaskApiVersionPath}`;
+  },
+  auth: { type: "api_key_header", name: "username" },
+  async customizeRequest({ context, headers }) {
+    const credential = await requireApiKeyCredential(context, service);
     headers.set("accept", "application/json");
-    headers.set("username", credential.apiKey);
-    headers.set("secret", secret);
-    headers.set("apiintegrationcode", integrationCode);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
-
-    const response = await providerFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+    headers.set("secret", requiredCredentialValue(credential.values.secret, "secret"));
+    headers.set("apiintegrationcode", requiredCredentialValue(credential.values.integrationCode, "integrationCode"));
+  },
+});
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {

--- a/src/providers/clicksend/executors.ts
+++ b/src/providers/clicksend/executors.ts
@@ -4,27 +4,19 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ClicksendActionContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import { clicksendActionHandlers, clicksendApiBaseUrl, validateClicksendCredential } from "./runtime.ts";
 
 const service = "clicksend";
-const clicksendFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors<ClicksendActionContext>({
   service,
@@ -42,36 +34,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<ClicksendAct
   fallbackMessage: "unknown clicksend action",
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await requireApiKeyCredential(context, service);
+    return clicksendApiBaseUrl;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
     const credential = await requireApiKeyCredential(context, service);
-    const url = createProviderProxyUrl(clicksendApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set(
       "authorization",
       `Basic ${Buffer.from(`${requireClicksendUsername(credential.values)}:${credential.apiKey}`).toString("base64")}`,
     );
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
-
-    const response = await clicksendFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {

--- a/src/providers/clickup/executors.ts
+++ b/src/providers/clickup/executors.ts
@@ -3,21 +3,10 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ClickupActionContext } from "./runtime.ts";
 
-import {
-  createProviderProxyUrl,
-  defineProviderExecutors,
-  normalizeProviderProxyHeaders,
-  providerFetch,
-  ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
-  toProviderProxyError,
-} from "../provider-runtime.ts";
+import { defineProviderExecutors, defineProviderProxy, ProviderRequestError } from "../provider-runtime.ts";
 import { clickupActionHandlers, clickupApiOrigin, validateClickupCredential } from "./runtime.ts";
 
 const service = "clickup";
@@ -48,39 +37,26 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await context.getCredential(service);
-    if (credential?.authType !== "api_key" && credential?.authType !== "oauth2") {
-      throw new ProviderRequestError(401, "Configure clickup credentials first.");
-    }
-    const url = createProviderProxyUrl(clickupApiOrigin, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set(
-      "authorization",
-      credential.authType === "oauth2" ? `${credential.tokenType} ${credential.accessToken}` : credential.apiKey,
-    );
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await readClickupAuthorization(context);
+    return clickupApiOrigin;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    headers.set("authorization", await readClickupAuthorization(context));
+  },
+});
 
-    const response = await providerFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
+async function readClickupAuthorization(context: ExecutionContext): Promise<string> {
+  const credential = await context.getCredential(service);
+  if (credential?.authType !== "api_key" && credential?.authType !== "oauth2") {
+    throw new ProviderRequestError(401, "Configure clickup credentials first.");
   }
-};
+  return credential.authType === "oauth2" ? `${credential.tokenType} ${credential.accessToken}` : credential.apiKey;
+}
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/contentstack_content_management/executors.ts
+++ b/src/providers/contentstack_content_management/executors.ts
@@ -3,21 +3,14 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 
 import { optionalString } from "../../core/cast.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import {
   contentstackContentManagementActionHandlers,
@@ -26,7 +19,6 @@ import {
 
 const service = "contentstack_content_management";
 const contentstackContentManagementApiBaseUrl = "https://api.contentstack.io/v3";
-const contentstackContentManagementFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const executors: ProviderExecutors = defineProviderExecutors({
   service,
@@ -44,42 +36,35 @@ export const executors: ProviderExecutors = defineProviderExecutors({
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    readContentstackStackApiKey((await requireApiKeyCredential(context, service)).values);
+    return contentstackContentManagementApiBaseUrl;
+  },
+  auth: { type: "api_key_authorization", prefix: "" },
+  async customizeRequest({ context, headers }) {
     const credential = await requireApiKeyCredential(context, service);
-    const stackApiKey = optionalString(credential.values.stackApiKey);
-    if (!stackApiKey) {
-      throw new ProviderRequestError(400, "Contentstack Stack API Key is required");
-    }
-    const url = createProviderProxyUrl(contentstackContentManagementApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
     const branch = optionalString(credential.values.branch) ?? optionalString(credential.metadata.branch);
-    headers.set("authorization", credential.apiKey);
-    headers.set("api_key", stackApiKey);
-    headers.set("user-agent", providerUserAgent);
+    headers.set("api_key", readContentstackStackApiKey(credential.values));
     if (branch) {
       headers.set("branch", branch);
     }
     if (!headers.has("content-type")) {
       headers.set("content-type", "application/json");
     }
+  },
+  skipDnsValidation: true,
+});
 
-    const response = await contentstackContentManagementFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
+function readContentstackStackApiKey(values: Record<string, string>): string {
+  const stackApiKey = optionalString(values.stackApiKey);
+  if (!stackApiKey) {
+    throw new ProviderRequestError(400, "Contentstack Stack API Key is required");
   }
-};
+  return stackApiKey;
+}
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/crisp/executors.ts
+++ b/src/providers/crisp/executors.ts
@@ -4,7 +4,6 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
@@ -19,22 +18,16 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "crisp";
 const crispApiBaseUrl = "https://api.crisp.chat/v1";
-const crispFetch = createProviderFetch({ skipDnsValidation: true });
 
 type CrispRequestPhase = "validate" | "execute";
 type CrispTokenTier = "website" | "plugin";
@@ -125,38 +118,19 @@ export const executors: ProviderExecutors = defineProviderExecutors<CrispContext
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, service);
-    const crispCredential = readCrispCredential({
-      apiKey: credential.apiKey,
-      values: credential.values,
-      metadata: credential.metadata,
-    });
-    const url = createProviderProxyUrl(crispApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("user-agent", providerUserAgent);
-    applyCrispAuthHeaders(headers, crispCredential);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
-
-    const response = await crispFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    readCrispCredential(await requireApiKeyCredential(context, service));
+    return crispApiBaseUrl;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    applyCrispAuthHeaders(headers, readCrispCredential(await requireApiKeyCredential(context, service)));
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/customerio/executors.ts
+++ b/src/providers/customerio/executors.ts
@@ -3,22 +3,15 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { CustomerioCredentialContext } from "./runtime.ts";
 
 import { Buffer } from "node:buffer";
 import {
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   providerFetch,
-  ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireCustomCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import {
   customerioActionHandlers,
@@ -37,42 +30,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<CustomerioCr
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireCustomCredential(context, service);
-    const customerioContext = resolveCustomerioCredentialContext(
-      credential.values,
-      providerFetch,
-      context.signal,
-      credential.metadata,
-    );
-    const url = createProviderProxyUrl(customerioContext.apiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: async (context) => (await resolveCustomerioProxyContext(context)).apiBaseUrl,
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    const customerioContext = await resolveCustomerioProxyContext(context);
     headers.set(
       "authorization",
       `Basic ${Buffer.from(`${customerioContext.siteId}:${customerioContext.apiKey}`).toString("base64")}`,
     );
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
+  },
+});
 
-    const response = await providerFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+async function resolveCustomerioProxyContext(context: ExecutionContext): Promise<CustomerioCredentialContext> {
+  const credential = await requireCustomCredential(context, service);
+  return resolveCustomerioCredentialContext(credential.values, providerFetch, context.signal, credential.metadata);
+}
 
 export const credentialValidators: CredentialValidators = {
   customCredential(input, { fetcher, signal }) {

--- a/src/providers/dataforseo/executors.ts
+++ b/src/providers/dataforseo/executors.ts
@@ -3,28 +3,19 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 
 import { Buffer } from "node:buffer";
 import { optionalNumber, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireCustomCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import { dataForSeoActionHandlers, dataForSeoApiBaseUrl, requestDataForSeoUserData } from "./runtime.ts";
 
 const service = "dataforseo";
-
-const dataForSeoFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface DataForSeoContext {
   login: string;
@@ -50,39 +41,27 @@ export const executors: ProviderExecutors = defineProviderExecutors<DataForSeoCo
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireCustomCredential(context, service);
-    const login = requiredString(credential.values.login, "login", (message) => new ProviderRequestError(400, message));
-    const password = requiredString(
-      credential.values.password,
-      "password",
-      (message) => new ProviderRequestError(400, message),
-    );
-    const url = createProviderProxyUrl(dataForSeoApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    readDataForSeoLogin((await requireCustomCredential(context, service)).values);
+    return dataForSeoApiBaseUrl;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
+    const { login, password } = readDataForSeoLogin((await requireCustomCredential(context, service)).values);
     headers.set("authorization", `Basic ${Buffer.from(`${login}:${password}`).toString("base64")}`);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
+  },
+  skipDnsValidation: true,
+});
 
-    const response = await dataForSeoFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+function readDataForSeoLogin(values: Record<string, string>): { login: string; password: string } {
+  return {
+    login: requiredString(values.login, "login", (message) => new ProviderRequestError(400, message)),
+    password: requiredString(values.password, "password", (message) => new ProviderRequestError(400, message)),
+  };
+}
 
 export const credentialValidators: CredentialValidators = {
   async customCredential(input, { fetcher }) {

--- a/src/providers/discourse/executors.ts
+++ b/src/providers/discourse/executors.ts
@@ -4,7 +4,6 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
@@ -20,21 +19,15 @@ import {
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderFetch,
-  createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 export const discourseDefaultRequestTimeoutMs = 30_000;
-
-const discourseProxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 type DiscourseHttpMethod = "GET" | "POST";
 type DiscoursePhase = "validate" | "execute";
@@ -216,42 +209,33 @@ export const executors: ProviderExecutors = defineProviderExecutors<DiscourseAct
   allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, "discourse");
-    const discourseCredential: DiscourseCredential = {
-      baseUrl: normalizeDiscourseBaseUrl(credential.values.baseUrl ?? credential.metadata.baseUrl),
-      apiKey: credential.apiKey,
-      apiUsername: requireCredentialField(
-        credential.values.apiUsername ?? credential.metadata.apiUsername,
-        "apiUsername",
-      ),
-    };
-    const url = createProviderProxyUrl(discourseCredential.baseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("api-key", discourseCredential.apiKey);
-    headers.set("api-username", discourseCredential.apiUsername);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service: "discourse",
+  baseUrl: async (context) => (await readDiscourseProxyCredential(context)).baseUrl,
+  auth: { type: "api_key_header", name: "api-key" },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  customizeRequest({ headers, credential }) {
+    if (credential?.authType !== "api_key") {
+      return;
     }
+    headers.set(
+      "api-username",
+      requireCredentialField(credential.values.apiUsername ?? credential.metadata.apiUsername, "apiUsername"),
+    );
+  },
+});
 
-    const response = await discourseProxyFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+async function readDiscourseProxyCredential(context: ExecutionContext): Promise<DiscourseCredential> {
+  const credential = await requireApiKeyCredential(context, "discourse");
+  return {
+    baseUrl: normalizeDiscourseBaseUrl(credential.values.baseUrl ?? credential.metadata.baseUrl),
+    apiKey: credential.apiKey,
+    apiUsername: requireCredentialField(
+      credential.values.apiUsername ?? credential.metadata.apiUsername,
+      "apiUsername",
+    ),
+  };
+}
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {

--- a/src/providers/docsbot_ai/executors.ts
+++ b/src/providers/docsbot_ai/executors.ts
@@ -1,23 +1,6 @@
-import type {
-  CredentialValidators,
-  ProviderExecutors,
-  ProviderProxyExecutor,
-  ProxyExecutionResult,
-} from "../../core/types.ts";
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
 
-import {
-  createProviderFetch,
-  createProviderProxyUrl,
-  defineApiKeyProviderExecutors,
-  normalizeProviderProxyEndpoint,
-  normalizeProviderProxyHeaders,
-  ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
-  requireApiKeyCredential,
-  toProviderProxyError,
-} from "../provider-runtime.ts";
+import { defineApiKeyProviderExecutors, defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
 import {
   docsbotAiActionHandlers,
   docsbotAiAdminBaseUrl,
@@ -27,40 +10,27 @@ import {
 
 const service = "docsbot_ai";
 
-const docsbotAiFetch = createProviderFetch({ skipDnsValidation: true });
-
 export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, docsbotAiActionHandlers, {
   skipDnsValidation: true,
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, service);
-    const endpoint = normalizeProviderProxyEndpoint(input.endpoint);
-    const url = createProviderProxyUrl(resolveDocsbotAiProxyBaseUrl(endpoint), endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `Bearer ${credential.apiKey}`);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await requireApiKeyCredential(context, service);
+    return docsbotAiAdminBaseUrl;
+  },
+  auth: { type: "api_key_authorization", prefix: "Bearer " },
+  allowedOrigins: [docsbotAiApiBaseUrl],
+  customizeRequest({ endpoint, url }) {
+    if (resolveDocsbotAiProxyBaseUrl(endpoint) === docsbotAiApiBaseUrl) {
+      url.host = new URL(docsbotAiApiBaseUrl).host;
+      url.pathname = url.pathname.slice(new URL(docsbotAiAdminBaseUrl).pathname.length);
     }
-
-    const response = await docsbotAiFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher, signal }) {

--- a/src/providers/erpnext/executors.ts
+++ b/src/providers/erpnext/executors.ts
@@ -3,7 +3,6 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
@@ -11,19 +10,14 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "erpnext";
-const proxyFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 const erpnextLoggedUserMethod = "frappe.auth.get_logged_user";
 const erpnextGetCountMethod = "frappe.client.get_count";
 const erpnextGetValueMethod = "frappe.client.get_value";
@@ -209,37 +203,27 @@ export const executors: ProviderExecutors = defineProviderExecutors<ErpnextActio
   allowPrivateNetwork: isPrivateNetworkAccessAllowed,
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, service);
-    const baseUrl = normalizeBaseUrl(
-      optionalString(credential.values.baseUrl) ?? optionalString(credential.metadata.baseUrl),
-    );
-    const apiSecret = readRequiredString(credential.values.apiSecret, "apiSecret");
-    const url = createProviderProxyUrl(baseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `token ${credential.apiKey}:${apiSecret}`);
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: async (context) => (await readErpnextProxyCredential(context)).baseUrl,
+  auth: { type: "none" },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  async customizeRequest({ context, headers }) {
+    const credential = await readErpnextProxyCredential(context);
+    headers.set("authorization", `token ${credential.apiKey}:${credential.apiSecret}`);
+  },
+});
 
-    const response = await proxyFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+async function readErpnextProxyCredential(
+  context: ExecutionContext,
+): Promise<Pick<ErpnextActionContext, "apiKey" | "apiSecret" | "baseUrl">> {
+  const credential = await requireApiKeyCredential(context, service);
+  const baseUrl = normalizeBaseUrl(
+    optionalString(credential.values.baseUrl) ?? optionalString(credential.metadata.baseUrl),
+  );
+  const apiSecret = readRequiredString(credential.values.apiSecret, "apiSecret");
+  return { apiKey: credential.apiKey, apiSecret, baseUrl };
+}
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/kaggle/executors.ts
+++ b/src/providers/kaggle/executors.ts
@@ -4,29 +4,22 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { Buffer } from "node:buffer";
 import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredRecord } from "../../core/cast.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "kaggle";
 const kaggleApiBaseUrl = "https://www.kaggle.com/api/v1";
 const kaggleValidationPath = "/competitions/list";
-const kaggleFetch = createProviderFetch({ skipDnsValidation: true });
 
 type KaggleRequestPhase = "validate" | "execute";
 type QueryValue = string | number | boolean | undefined;
@@ -84,35 +77,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<KaggleContex
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    const credential = await requireApiKeyCredential(context, service);
+    normalizeKaggleUsername(credential.values.username ?? credential.metadata.username);
+    return kaggleApiBaseUrl;
+  },
+  auth: { type: "none" },
+  async customizeRequest({ context, headers }) {
     const credential = await requireApiKeyCredential(context, service);
     const username = normalizeKaggleUsername(credential.values.username ?? credential.metadata.username);
-    const url = createProviderProxyUrl(kaggleApiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set("accept", "application/json");
     headers.set("authorization", buildBasicAuthHeader(username, credential.apiKey));
-    headers.set("user-agent", providerUserAgent);
-    if (input.body !== undefined && !headers.has("content-type") && typeof input.body !== "string") {
-      headers.set("content-type", "application/json");
-    }
-
-    const response = await kaggleFetch(url, {
-      method: input.method,
-      headers,
-      body:
-        input.body === undefined ? undefined : typeof input.body === "string" ? input.body : JSON.stringify(input.body),
-      signal: context.signal,
-    });
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {

--- a/src/providers/qianfan/executors.ts
+++ b/src/providers/qianfan/executors.ts
@@ -1,23 +1,11 @@
 import type { CredentialValidators, ProviderProxyExecutor } from "../../core/types.ts";
 
-import {
-  createProviderFetch,
-  createProviderProxyUrl,
-  normalizeProviderProxyEndpoint,
-  normalizeProviderProxyHeaders,
-  ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
-  requireApiKeyCredential,
-  toProviderProxyError,
-} from "../provider-runtime.ts";
+import { defineProviderProxy } from "../provider-runtime.ts";
 import { executors, qianfanApiBaseUrl, qianfanApiOrigin, validateQianfanCredential } from "./runtime.ts";
 
 export { executors };
 
 const service = "qianfan";
-const qianfanFetch = createProviderFetch({ skipDnsValidation: true });
 
 export const credentialValidators: CredentialValidators = {
   apiKey(input, { fetcher }) {
@@ -25,44 +13,21 @@ export const credentialValidators: CredentialValidators = {
   },
 };
 
-export const proxy: ProviderProxyExecutor = async (input, context) => {
-  try {
-    const endpoint = normalizeProviderProxyEndpoint(input.endpoint);
-    const credential = await requireApiKeyCredential(context, service);
-    const url = createProviderProxyUrl(qianfanProxyBaseUrl(endpoint), endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `Bearer ${credential.apiKey}`);
-    headers.set("user-agent", providerUserAgent);
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: qianfanApiOrigin,
+  auth: { type: "api_key_authorization", prefix: "Bearer " },
+  customizeRequest({ endpoint, url, headers }) {
+    const baseUrl = qianfanProxyBaseUrl(endpoint);
+    if (baseUrl !== qianfanApiOrigin) {
+      url.pathname = `${new URL(baseUrl).pathname}${url.pathname}`;
+    }
     if (!headers.has("accept")) {
       headers.set("accept", "application/json");
     }
-
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
-    }
-
-    const response = await qianfanFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-
-    return {
-      ok: true,
-      response: await readProviderProxyResponse(response),
-    };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 function qianfanProxyBaseUrl(endpoint: string): string {
   if (endpoint === "/v2" || endpoint.startsWith("/v2/") || endpoint.startsWith("/video/generations")) {

--- a/src/providers/qianfan/executors.ts
+++ b/src/providers/qianfan/executors.ts
@@ -1,6 +1,6 @@
 import type { CredentialValidators, ProviderProxyExecutor } from "../../core/types.ts";
 
-import { defineProviderProxy } from "../provider-runtime.ts";
+import { defineProviderProxy, requireApiKeyCredential } from "../provider-runtime.ts";
 import { executors, qianfanApiBaseUrl, qianfanApiOrigin, validateQianfanCredential } from "./runtime.ts";
 
 export { executors };
@@ -15,7 +15,11 @@ export const credentialValidators: CredentialValidators = {
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({
   service,
-  baseUrl: qianfanApiOrigin,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await requireApiKeyCredential(context, service);
+    return qianfanApiOrigin;
+  },
   auth: { type: "api_key_authorization", prefix: "Bearer " },
   customizeRequest({ endpoint, url, headers }) {
     const baseUrl = qianfanProxyBaseUrl(endpoint);

--- a/src/providers/quickbase/executors.ts
+++ b/src/providers/quickbase/executors.ts
@@ -15,21 +15,14 @@ import {
 import { encodePathSegment } from "../../core/request.ts";
 import { arrayPayload, firstString, objectPayload, requestJson } from "../http-json-runtime.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "quickbase";
 const apiBaseUrl = "https://api.quickbase.com/v1";
-const quickbaseFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface QuickbaseContext {
   apiKey: string;
@@ -150,44 +143,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<QuickbaseCon
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context) => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await requireApiKeyCredential(context, service);
+    return apiBaseUrl;
+  },
+  auth: { type: "api_key_authorization", prefix: "QB-USER-TOKEN " },
+  async customizeRequest({ context, headers }) {
     const credential = await requireApiKeyCredential(context, service);
-    const url = createProviderProxyUrl(apiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `QB-USER-TOKEN ${credential.apiKey}`);
     headers.set("qb-realm-hostname", normalizeRealmHostname(credential.values.realmHostname));
-    headers.set("user-agent", providerUserAgent);
     if (!headers.has("accept")) {
       headers.set("accept", "application/json");
     }
-
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
-    }
-
-    const response = await quickbaseFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-
-    return {
-      ok: true,
-      response: await readProviderProxyResponse(response),
-    };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/rocket_chat/executors.ts
+++ b/src/providers/rocket_chat/executors.ts
@@ -4,7 +4,6 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
@@ -12,21 +11,16 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
-  toProviderProxyError,
+  requireCustomCredential,
 } from "../provider-runtime.ts";
 
 const service = "rocket_chat";
 const requestTimeoutMs = 30_000;
 const validationPath = "/me";
-
-const privateAwareFetch = createProviderFetch({ allowPrivateNetwork: isPrivateNetworkAccessAllowed });
 
 interface RocketChatCredential {
   baseUrl: string;
@@ -212,41 +206,22 @@ export const credentialValidators: CredentialValidators = {
   },
 };
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await context.getCredential(service);
-    if (credential?.authType !== "custom_credential") {
-      throw new ProviderRequestError(401, "Configure rocket_chat custom credentials first.");
-    }
-    const rocketChatCredential = readRocketChatCredential(credential.values);
-    const url = createProviderProxyUrl(rocketChatCredential.apiBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("user-agent", providerUserAgent);
-    headers.set("X-Auth-Token", rocketChatCredential.authToken);
-    headers.set("X-User-Id", rocketChatCredential.userId);
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: async (context) => (await readRocketChatProxyCredential(context)).apiBaseUrl,
+  auth: { type: "none" },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  async customizeRequest({ context, headers }) {
+    const credential = await readRocketChatProxyCredential(context);
+    headers.set("X-Auth-Token", credential.authToken);
+    headers.set("X-User-Id", credential.userId);
+  },
+});
 
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
-    }
-
-    const response = await privateAwareFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+async function readRocketChatProxyCredential(context: ExecutionContext): Promise<RocketChatCredential> {
+  const credential = await requireCustomCredential(context, service);
+  return readRocketChatCredential(credential.values);
+}
 
 async function requestRocketChatObject(options: {
   credential: RocketChatCredential;

--- a/src/providers/salesmate/executors.ts
+++ b/src/providers/salesmate/executors.ts
@@ -4,23 +4,17 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import { compactObject, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
-  providerFetch,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
   runProviderRequest,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "salesmate";
@@ -110,41 +104,23 @@ export const credentialValidators: CredentialValidators = {
   },
 };
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: async (context) => {
     const credential = await requireApiKeyCredential(context, service);
-    const linkName = readStoredLinkName(credential.values, credential.metadata);
-    const url = createProviderProxyUrl(salesmateApiBaseUrl(linkName), input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
+    return salesmateApiBaseUrl(readStoredLinkName(credential.values, credential.metadata));
+  },
+  auth: { type: "api_key_header", name: "accessToken" },
+  customizeRequest({ headers, credential }) {
     if (!headers.has("accept")) {
       headers.set("accept", "application/json");
     }
-    headers.set("user-agent", providerUserAgent);
-    headers.set("accessToken", credential.apiKey);
-    headers.set("x-linkname", normalizeSalesmateLinkName(linkName));
-
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
+    if (credential?.authType !== "api_key") {
+      return;
     }
-
-    const response = await providerFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+    headers.set("x-linkname", readStoredLinkName(credential.values, credential.metadata));
+  },
+});
 
 async function validateSalesmateCredential(
   apiKey: string,

--- a/src/providers/simple_analytics/executors.ts
+++ b/src/providers/simple_analytics/executors.ts
@@ -3,27 +3,18 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ApiKeyProviderContext, ProviderFetch } from "../provider-runtime.ts";
 
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   defineProviderExecutors,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
-  providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 import { simpleAnalyticsActionHandlers, simpleAnalyticsBaseUrl, validateSimpleAnalyticsCredential } from "./runtime.ts";
 
 const service = "simple_analytics";
-
-const simpleAnalyticsFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface SimpleAnalyticsContext extends ApiKeyProviderContext {
   userId?: string;
@@ -44,42 +35,30 @@ export const executors: ProviderExecutors = defineProviderExecutors<SimpleAnalyt
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, service);
-    const userId = credential.values.userId || readMetadataUserId(credential.metadata);
-    if (!userId) {
-      throw new ProviderRequestError(400, "userId is required");
-    }
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    readSimpleAnalyticsUserId(await requireApiKeyCredential(context, service));
+    return simpleAnalyticsBaseUrl;
+  },
+  auth: { type: "api_key_header", name: "api-key" },
+  async customizeRequest({ context, headers }) {
+    headers.set("user-id", readSimpleAnalyticsUserId(await requireApiKeyCredential(context, service)));
+  },
+  skipDnsValidation: true,
+});
 
-    const url = createProviderProxyUrl(simpleAnalyticsBaseUrl, input.endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("api-key", credential.apiKey);
-    headers.set("user-id", userId);
-    headers.set("user-agent", providerUserAgent);
-
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
-    }
-
-    const response = await simpleAnalyticsFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-    return { ok: true, response: await readProviderProxyResponse(response) };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
+function readSimpleAnalyticsUserId(credential: {
+  values: Record<string, string>;
+  metadata: Record<string, unknown>;
+}): string {
+  const userId = credential.values.userId || readMetadataUserId(credential.metadata);
+  if (!userId) {
+    throw new ProviderRequestError(400, "userId is required");
   }
-};
+  return userId;
+}
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {

--- a/src/providers/voiceflow/executors.ts
+++ b/src/providers/voiceflow/executors.ts
@@ -3,7 +3,6 @@ import type {
   ExecutionContext,
   ProviderExecutors,
   ProviderProxyExecutor,
-  ProxyExecutionResult,
 } from "../../core/types.ts";
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
@@ -16,18 +15,12 @@ import {
   requiredString,
 } from "../../core/cast.ts";
 import {
-  createProviderFetch,
-  createProviderProxyUrl,
   createProviderTimeout,
   defineProviderExecutors,
-  normalizeProviderProxyEndpoint,
-  normalizeProviderProxyHeaders,
+  defineProviderProxy,
   ProviderRequestError,
   providerUserAgent,
-  readProviderProxyErrorMessage,
-  readProviderProxyResponse,
   requireApiKeyCredential,
-  toProviderProxyError,
 } from "../provider-runtime.ts";
 
 const service = "voiceflow";
@@ -36,7 +29,6 @@ const realtimeBaseUrl = "https://realtime-api.voiceflow.com";
 const defaultEnvironmentAlias = "main";
 
 // Fixed-host proxy egress (generalRuntimeBaseUrl / realtimeBaseUrl); DNS-rebinding check is redundant here.
-const voiceflowFetch = createProviderFetch({ skipDnsValidation: true });
 
 interface VoiceflowActionContext {
   apiKey: string;
@@ -109,42 +101,23 @@ export const executors: ProviderExecutors = defineProviderExecutors<VoiceflowAct
   },
 });
 
-export const proxy: ProviderProxyExecutor = async (input, context): Promise<ProxyExecutionResult> => {
-  try {
-    const credential = await requireApiKeyCredential(context, service);
-    const endpoint = normalizeProviderProxyEndpoint(input.endpoint);
-    const url = createProviderProxyUrl(resolveProxyBaseUrl(endpoint), endpoint, input.query);
-    const headers = normalizeProviderProxyHeaders(input.headers);
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  async baseUrl(context) {
+    // Reject an unusable credential before header normalization, keeping the 401/400 precedence.
+    await requireApiKeyCredential(context, service);
+    return generalRuntimeBaseUrl;
+  },
+  auth: { type: "api_key_authorization", prefix: "" },
+  allowedOrigins: [realtimeBaseUrl],
+  customizeRequest({ endpoint, url, headers }) {
+    if (resolveProxyBaseUrl(endpoint) === realtimeBaseUrl) {
+      url.host = new URL(realtimeBaseUrl).host;
+    }
     headers.set("accept", "application/json");
-    headers.set("authorization", credential.apiKey);
-    headers.set("user-agent", providerUserAgent);
-
-    const init: RequestInit = {
-      method: input.method,
-      headers,
-      signal: context.signal,
-    };
-    if (input.body !== undefined) {
-      init.body = typeof input.body === "string" ? input.body : JSON.stringify(input.body);
-      if (!headers.has("content-type") && typeof input.body !== "string") {
-        headers.set("content-type", "application/json");
-      }
-    }
-
-    const response = await voiceflowFetch(url, init);
-    if (!response.ok) {
-      const text = await readProviderProxyErrorMessage(response, "");
-      throw new ProviderRequestError(response.status, text || `provider request failed with HTTP ${response.status}`);
-    }
-
-    return {
-      ok: true,
-      response: await readProviderProxyResponse(response),
-    };
-  } catch (error) {
-    return toProviderProxyError(error, "provider request failed");
-  }
-};
+  },
+  skipDnsValidation: true,
+});
 
 export const credentialValidators: CredentialValidators = {
   async apiKey(input, { fetcher, signal }) {


### PR DESCRIPTION
Ninth and last provider-level convergence PR after #441. Stacked on #450 (`refactor/entropy-b9-sigv4`); it retargets once the stack below it lands. One commit per provider.

## What changes

18 providers replace a hand-written `export const proxy: ProviderProxyExecutor = async (input, context) => { ... }` with `defineProviderProxy({ ... })`: agora, autotask, clicksend, clickup, contentstack_content_management, crisp, customerio, dataforseo, discourse, docsbot_ai, erpnext, kaggle, qianfan, quickbase, rocket_chat, salesmate, simple_analytics, voiceflow.

18 files, net -426 lines. The audit listed ~32 candidates; the 14 that did not survive the differential harness are named below.

## Why each conversion keeps a base-URL resolver

`defineProviderProxy` normalizes the caller's headers *before* it resolves the credential, while every hand-written body read the credential first. That ordering is observable: `Headers.set` throws a `TypeError` for a non-Latin-1 value (`"中文"`) or an invalid name (`"x y"`), and `ProxyRunner` does not validate header names or values, so on an unconfigured connection the hand-written body answered `401 authorization_failed` where a naive conversion answers `internal_error`. Every conversion here therefore reads (and validates) the credential inside the `baseUrl` resolver, which runs first, so the 401/400 precedence is preserved. Providers whose credential also feeds a header read it again in `customizeRequest`; `ConnectionService.forConnection().getCredential` is not memoized, so those providers now do two credential store reads per proxy request (the action path's `resolveForExecution` memoizes, the proxy path never did).

Where a single custom header carries the key, the conversion uses `auth: { type: "api_key_header", name }` so the header joins `additionalSensitiveHeaders` and is stripped on a cross-origin redirect. That is how autotask's `username`, discourse's `api-key` and salesmate's `accessToken` become redirect-safe; `accessToken` was previously forwarded across origins. Basic credentials are built in `customizeRequest` with `Buffer.from(...).toString("base64")` rather than `auth: { type: "api_key_basic" }`, because the shared branch uses `btoa` and would change the bytes for non-ASCII credentials.

## Wire behavior

Each conversion was proved against the old module with a differential harness (both modules loaded side by side, DNS disabled, `globalThis.fetch` stubbed, every outbound URL / method / sorted headers / body and the returned `ProxyExecutionResult` compared) over 21 to 66 scenarios per provider: 2xx JSON / binary / text, 204, HEAD, 4xx with body, 5xx empty, object body, non-ASCII object body, string body with and without a caller content-type, caller headers including blocked and invalid ones, queries containing `~`, space, `+`, `/`, `?`, `&`, `=` and non-scalar values, cross-origin 302 with credential headers, same-origin 303, 307 replay, unconfigured connection, wrong credential type, and every "configured but missing field" variant.

The only remaining difference is unreachable through `/v1`: for an endpoint that `createProviderProxyUrl` rejects (absolute URL, `//host`, backslash, `..`, empty) combined with an unconfigured connection, the old body answered 401 and the new one answers 400. `ProxyRunner.assertRelativeEndpoint` rejects exactly those endpoints with 400 before any executor is loaded, and `loadProxyExecutor` is its only production caller, so no client can observe the flip.

## Not converted

- **Header-ordering exposure with a static base URL** (sendspark, figma, bluesky, shippo, cin7_core, razorpay, cronitor, contentstack_content_delivery): nothing runs before header normalization when the base URL is a constant, so the `internal_error` difference above is reachable. Converting them needs `defineProviderProxy` to resolve auth before normalizing headers, or to map a `Headers` `TypeError` to 400 — a shared-module change with its own review.
- **`content-type` on string bodies** (algolia, gagelist, hotjar): the hand-written bodies set `application/json` for a string body too; `defineProviderProxy` sets it only for object bodies and `customizeRequest` cannot see the body.
- **docker_hub, sage_sales_management**: they issue an auxiliary login request before failing, so the outbound request list differs on the rejected-endpoint path.
- **dingtalk_bot**: signing plus a branded fallback message.

The wider set the audit measured (signing proxies, body rewriters, non-JSON content types, retry loops, bespoke error mappers, custom response caps) stays hand-written; `AGENTS.md` explicitly sanctions that shape.

## Verification

- `npm run fix-check`, `npx vitest run` (163 files, 1569 tests), `npm run build --workspace web`, `git diff --check`, `npx oxlint` with `no-unused-vars` forced on: green.
- `npm run generate:catalog`: all 1451 `catalog/apps/*.json` byte-identical to `origin/main`.
- Per-provider harness logs record every scenario and its old/new result.
