### PR TITLE
chore(deps): bump nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7776,9 +7776,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes Dependabot alert [#24](https://github.com/oomol-lab/open-connector/security/dependabot/24) — GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (high).

`customAlphabet` / `customRandom` spin forever when `size` is `0`, hanging the calling thread.

`nanoid` is a transitive dependency: `vite` -> `postcss` -> `nanoid`. `postcss` declares `nanoid: ^3.3.16`, so bumping the lockfile entry from 3.3.16 to 3.3.18 is enough; no `package.json` change needed.

Verified: `npm ci` resolves cleanly, `npm run typecheck` passes, and `npm audit` no longer reports nanoid.