### PR TITLE
feat(providers): add Lacuna provider

### DIFF
--- a/src/providers/lacuna/actions.ts
+++ b/src/providers/lacuna/actions.ts
@@ -173,7 +173,7 @@ const hypothesisOutputSchema = s.looseRequiredObject(
 );
 
 const partialDateSchema = s.string("An inclusive publication date bound in YYYY, YYYY-MM, or YYYY-MM-DD format.", {
-  pattern: "^\\d{4}(?:-(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[12]\\d|3[01]))?)?$",
+  pattern: "^(?!0000)\\d{4}(?:-(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[12]\\d|3[01]))?)?$",
 });
 const contextViewSchema = s.stringEnum("The Lacuna response view.", ["context", "full"]);
 

--- a/src/providers/lacuna/actions.ts
+++ b/src/providers/lacuna/actions.ts
@@ -219,7 +219,7 @@ export const lacunaActions: ActionDefinition[] = [
           "bm25_title_abstract",
         ]),
         fields: s.nonEmptyString(
-          "Optional comma-separated lexical fields with optional weights, such as title^4,abstract.",
+          "Optional comma-separated lexical fields with optional weights, such as title^4,abstract. Each field must exist on the searched type: title (paper, cluster, venue, hypothesis), abstract/summary/concepts (paper), name (author, institution, venue), top_names (cluster, hypothesis), venue (paper, venue).",
         ),
       },
       {
@@ -298,7 +298,7 @@ export const lacunaActions: ActionDefinition[] = [
       {
         authorIdOrUrl: s.nonEmptyString("A Lacuna author ID or Lacuna author URL."),
         view: contextViewSchema,
-        includeNeighbors: s.boolean("Whether to include similar researchers in the full author context."),
+        includeNeighbors: s.boolean("Whether to include similar researchers in the author context."),
       },
       { optional: ["view", "includeNeighbors"] },
     ),

--- a/src/providers/lacuna/actions.ts
+++ b/src/providers/lacuna/actions.ts
@@ -1,0 +1,320 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "lacuna";
+
+const entityTypeSchema = s.stringEnum("The Lacuna entity type.", [
+  "paper",
+  "cluster",
+  "direction",
+  "author",
+  "institution",
+  "venue",
+  "hypothesis",
+]);
+const searchFilterTypeSchema = s.stringEnum("The normalized entity type applied by Lacuna.", [
+  "all",
+  "paper",
+  "cluster",
+  "author",
+  "institution",
+  "venue",
+  "hypothesis",
+]);
+const entityIdSchema = s.union(
+  [s.nonEmptyString("A Lacuna entity identifier."), s.positiveInteger("A numeric Lacuna entity identifier.")],
+  { description: "The Lacuna entity identifier." },
+);
+const entityUrlSchema = s.url("The canonical Lacuna page URL for the entity.");
+const searchResultSchema = s.looseRequiredObject(
+  "One Lacuna search result. Additional fields depend on the entity type.",
+  {
+    type: entityTypeSchema,
+    id: s.nonEmptyString("The Lacuna entity identifier."),
+    score: s.number("The relevance score reported by Lacuna."),
+    url: entityUrlSchema,
+    title: s.string("The paper, direction, venue, or hypothesis title when present."),
+    name: s.string("The author or institution name when present."),
+    year: s.integer("The publication year when present."),
+  },
+  { optional: ["title", "name", "year"] },
+);
+const searchOutputSchema = s.requiredObject("A page of Lacuna search results.", {
+  query: s.string("The normalized search query."),
+  type_filter: searchFilterTypeSchema,
+  total_results: s.nonNegativeInteger("The total number of matching Lacuna entities."),
+  results: s.array("The matching Lacuna entities.", searchResultSchema),
+});
+
+const paperSummarySchema = s.looseRequiredObject(
+  "A compact Lacuna paper record. Additional fields may be present in full views.",
+  {
+    id: s.nonEmptyString("The Lacuna paper artifact identifier."),
+    url: entityUrlSchema,
+    title: s.string("The paper title."),
+    year: s.integer("The publication year."),
+    venue: s.string("The publication venue when present."),
+    authors: s.array(
+      "The compact author names or author objects returned for the paper.",
+      s.union([s.string("An author name."), s.looseObject("A Lacuna author record.")]),
+    ),
+  },
+  { optional: ["year", "venue", "authors"] },
+);
+const commonContextProperties: Record<string, JsonSchema> = {
+  type: entityTypeSchema,
+  id: entityIdSchema,
+  context_key: s.string("The stable Lacuna context key."),
+  title: s.string("The entity title when present."),
+  name: s.string("The entity name when present."),
+  url: entityUrlSchema,
+  markdown_url: s.url("The Lacuna Markdown page URL when present."),
+  summary_markdown: s.string("The source-linked Lacuna summary in Markdown when present."),
+  profile_markdown: s.string("The source-linked Lacuna author profile in Markdown when present."),
+};
+
+const paperOutputSchema = s.looseRequiredObject(
+  "A Lacuna paper view with source links and view-specific fields.",
+  {
+    ...commonContextProperties,
+    artifact_id: s.nonEmptyString("The normalized Lacuna paper artifact identifier."),
+  },
+  {
+    optional: [
+      "type",
+      "id",
+      "context_key",
+      "title",
+      "name",
+      "url",
+      "markdown_url",
+      "summary_markdown",
+      "profile_markdown",
+    ],
+  },
+);
+const directionOutputSchema = s.looseRequiredObject(
+  "A Lacuna research direction view with source-linked summaries and related entities.",
+  {
+    ...commonContextProperties,
+    cluster_id: s.positiveInteger("The normalized Lacuna research direction identifier."),
+    papers: s.array("A compact set of papers in the direction when present.", paperSummarySchema),
+  },
+  {
+    optional: [
+      "type",
+      "id",
+      "context_key",
+      "title",
+      "name",
+      "url",
+      "markdown_url",
+      "summary_markdown",
+      "profile_markdown",
+      "papers",
+    ],
+  },
+);
+const directionPapersOutputSchema = s.looseRequiredObject(
+  "One page of papers attached to a Lacuna research direction.",
+  {
+    cluster_id: s.positiveInteger("The normalized Lacuna research direction identifier."),
+    papers: s.array("The papers attached to the research direction.", paperSummarySchema),
+    page: s.positiveInteger("The returned one-based page number."),
+    limit: s.positiveInteger("The returned page size."),
+    total: s.nonNegativeInteger("The total number of papers in the direction."),
+    has_more: s.boolean("Whether another page is available."),
+  },
+  { optional: ["page", "limit", "total", "has_more"] },
+);
+const authorOutputSchema = s.looseRequiredObject(
+  "A Lacuna author context with papers, research directions, and source-linked profile content.",
+  {
+    ...commonContextProperties,
+    author_id: s.nonEmptyString("The normalized Lacuna author identifier."),
+    papers: s.array("A compact set of the author's papers when present.", paperSummarySchema),
+  },
+  {
+    optional: [
+      "type",
+      "id",
+      "context_key",
+      "title",
+      "name",
+      "url",
+      "markdown_url",
+      "summary_markdown",
+      "profile_markdown",
+      "papers",
+    ],
+  },
+);
+const hypothesisOutputSchema = s.looseRequiredObject(
+  "A Lacuna generated research hypothesis with its source-linked summary and directions.",
+  {
+    ...commonContextProperties,
+    hypothesis_id: s.nonEmptyString("The normalized Lacuna hypothesis identifier."),
+  },
+  {
+    optional: [
+      "type",
+      "id",
+      "context_key",
+      "title",
+      "name",
+      "url",
+      "markdown_url",
+      "summary_markdown",
+      "profile_markdown",
+    ],
+  },
+);
+
+const partialDateSchema = s.string("An inclusive publication date bound in YYYY, YYYY-MM, or YYYY-MM-DD format.", {
+  pattern: "^\\d{4}(?:-(?:0[1-9]|1[0-2])(?:-(?:0[1-9]|[12]\\d|3[01]))?)?$",
+});
+const contextViewSchema = s.stringEnum("The Lacuna response view.", ["context", "full"]);
+
+export const lacunaActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "search",
+    description:
+      "Search Lacuna's machine-learning research map for papers, research directions, authors, venues, institutions, or generated hypotheses.",
+    inputSchema: s.object(
+      "Input parameters for searching Lacuna.",
+      {
+        query: s.nonEmptyString("The research query."),
+        searchType: s.stringEnum("The entity type to search, including official aliases.", [
+          "all",
+          "paper",
+          "papers",
+          "cluster",
+          "clusters",
+          "direction",
+          "directions",
+          "author",
+          "authors",
+          "institution",
+          "institutions",
+          "venue",
+          "venues",
+          "hypothesis",
+          "hypotheses",
+          "proposal",
+          "proposals",
+        ]),
+        limit: s.integer("The maximum number of results to return.", { minimum: 1, maximum: 50 }),
+        offset: s.nonNegativeInteger("The zero-based result offset."),
+        dateFrom: partialDateSchema,
+        dateTo: partialDateSchema,
+        venue: s.nonEmptyString("A venue name or key used to filter paper results."),
+        sort: s.stringEnum("The result ordering.", ["relevance", "year_desc", "year_asc"]),
+        rankingProfile: s.stringEnum("The Lacuna ranking profile.", [
+          "default",
+          "lexical",
+          "semantic",
+          "bm25",
+          "bm25_title_abstract",
+        ]),
+        fields: s.nonEmptyString(
+          "Optional comma-separated lexical fields with optional weights, such as title^4,abstract.",
+        ),
+      },
+      {
+        optional: ["searchType", "limit", "offset", "dateFrom", "dateTo", "venue", "sort", "rankingProfile", "fields"],
+      },
+    ),
+    outputSchema: searchOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_paper",
+    description: "Get a Lacuna paper by artifact ID or Lacuna paper URL.",
+    inputSchema: s.object(
+      "Input parameters for getting a Lacuna paper.",
+      {
+        paperIdOrUrl: s.nonEmptyString("A Lacuna paper artifact ID or Lacuna paper URL."),
+        view: s.stringEnum("The paper response view.", [
+          "context",
+          "full",
+          "preview",
+          "blog",
+          "figures",
+          "concepts",
+          "neighbors",
+        ]),
+        figureLimit: s.nonNegativeInteger("The maximum number of figures in the context view."),
+      },
+      { optional: ["view", "figureLimit"] },
+    ),
+    outputSchema: paperOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_direction",
+    description: "Get a Lacuna research direction by numeric ID or Lacuna direction URL.",
+    inputSchema: s.object(
+      "Input parameters for getting a Lacuna research direction.",
+      {
+        directionIdOrUrl: s.union(
+          [
+            s.positiveInteger("A numeric Lacuna research direction identifier."),
+            s.nonEmptyString("A Lacuna research direction identifier or URL."),
+          ],
+          { description: "A Lacuna research direction identifier or URL." },
+        ),
+        view: contextViewSchema,
+      },
+      { optional: ["view"] },
+    ),
+    outputSchema: directionOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_direction_papers",
+    description: "List papers attached to a Lacuna research direction.",
+    inputSchema: s.object(
+      "Input parameters for listing papers in a Lacuna research direction.",
+      {
+        directionIdOrUrl: s.union(
+          [
+            s.positiveInteger("A numeric Lacuna research direction identifier."),
+            s.nonEmptyString("A Lacuna research direction identifier or URL."),
+          ],
+          { description: "A Lacuna research direction identifier or URL." },
+        ),
+        page: s.positiveInteger("The one-based page number."),
+        limit: s.integer("The number of papers to return.", { minimum: 1, maximum: 100 }),
+        view: s.stringEnum("The per-paper response view.", ["compact", "full"]),
+      },
+      { optional: ["page", "limit", "view"] },
+    ),
+    outputSchema: directionPapersOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_author_context",
+    description: "Get a source-linked Lacuna research context for an author.",
+    inputSchema: s.object(
+      "Input parameters for getting a Lacuna author context.",
+      {
+        authorIdOrUrl: s.nonEmptyString("A Lacuna author ID or Lacuna author URL."),
+        view: contextViewSchema,
+        includeNeighbors: s.boolean("Whether to include similar researchers in the full author context."),
+      },
+      { optional: ["view", "includeNeighbors"] },
+    ),
+    outputSchema: authorOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "get_hypothesis",
+    description: "Get a generated Lacuna research hypothesis by ID or Lacuna hypothesis URL.",
+    inputSchema: s.object(
+      "Input parameters for getting a Lacuna research hypothesis.",
+      {
+        hypothesisIdOrUrl: s.nonEmptyString("A Lacuna hypothesis ID or Lacuna hypothesis URL."),
+        view: contextViewSchema,
+      },
+      { optional: ["view"] },
+    ),
+    outputSchema: hypothesisOutputSchema,
+  }),
+];

--- a/src/providers/lacuna/definition.ts
+++ b/src/providers/lacuna/definition.ts
@@ -1,0 +1,17 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { lacunaActions } from "./actions.ts";
+
+const service = "lacuna";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Lacuna",
+  description:
+    "Search and navigate Lacuna's machine-learning research map, including papers, research directions, authors, and generated hypotheses.",
+  categories: ["AI", "Data"],
+  authTypes: ["no_auth"],
+  auth: [{ type: "no_auth" }],
+  homepageUrl: "https://lacuna.tiptreesystems.com",
+  actions: lacunaActions,
+};

--- a/src/providers/lacuna/executors.ts
+++ b/src/providers/lacuna/executors.ts
@@ -2,14 +2,20 @@ import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
 import type { ProviderFetch } from "../provider-runtime.ts";
 import type { LacunaActionContext } from "./runtime.ts";
 
-import { defineProviderExecutors } from "../provider-runtime.ts";
-import { lacunaActionHandlers } from "./runtime.ts";
+import { defineProviderExecutors, providerFetch } from "../provider-runtime.ts";
+import { lacunaActionHandlers, skipRetryDelay, sleepBeforeRetry } from "./runtime.ts";
 
 export const executors: ProviderExecutors = defineProviderExecutors<LacunaActionContext>({
   service: "lacuna",
   handlers: lacunaActionHandlers,
   createContext(context: ExecutionContext, fetcher: ProviderFetch): LacunaActionContext {
-    return { fetcher, signal: context.signal };
+    return {
+      fetcher,
+      signal: context.signal,
+      // Real Retry-After backoff applies to the shared production fetcher; test
+      // stubs pass a different fetcher and skip the wait.
+      sleep: fetcher === providerFetch ? sleepBeforeRetry : skipRetryDelay,
+    };
   },
   fallbackMessage: "Lacuna request failed.",
 });

--- a/src/providers/lacuna/executors.ts
+++ b/src/providers/lacuna/executors.ts
@@ -1,0 +1,15 @@
+import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { ProviderFetch } from "../provider-runtime.ts";
+import type { LacunaActionContext } from "./runtime.ts";
+
+import { defineProviderExecutors } from "../provider-runtime.ts";
+import { lacunaActionHandlers } from "./runtime.ts";
+
+export const executors: ProviderExecutors = defineProviderExecutors<LacunaActionContext>({
+  service: "lacuna",
+  handlers: lacunaActionHandlers,
+  createContext(context: ExecutionContext, fetcher: ProviderFetch): LacunaActionContext {
+    return { fetcher, signal: context.signal };
+  },
+  fallbackMessage: "Lacuna request failed.",
+});

--- a/src/providers/lacuna/runtime.test.ts
+++ b/src/providers/lacuna/runtime.test.ts
@@ -48,6 +48,33 @@ describe("Lacuna provider runtime", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("accepts valid year, year-month, and calendar date bounds", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ query: "graph learning", type_filter: "all", total_results: 0, results: [] }),
+    );
+
+    await lacunaActionHandlers.search({ query: "graph learning", dateFrom: "2024", dateTo: "2024-02" }, { fetcher });
+    await lacunaActionHandlers.search(
+      { query: "graph learning", dateFrom: "2024-02-29", dateTo: "2024-12-31" },
+      { fetcher },
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects impossible calendar date bounds before sending a request", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    for (const input of [
+      { query: "graph learning", dateFrom: "2025-02-29" },
+      { query: "graph learning", dateFrom: "2024-02-30" },
+      { query: "graph learning", dateTo: "2025-04-31" },
+    ]) {
+      await expect(lacunaActionHandlers.search(input, { fetcher })).rejects.toMatchObject({ status: 400 });
+    }
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("gets compact paper context and removes MCP-only metadata", async () => {
     const fetcher = vi.fn<typeof fetch>(async (request) => {
       const url = new URL(String(request));

--- a/src/providers/lacuna/runtime.test.ts
+++ b/src/providers/lacuna/runtime.test.ts
@@ -53,19 +53,33 @@ describe("Lacuna provider runtime", () => {
       Response.json({ query: "graph learning", type_filter: "all", total_results: 0, results: [] }),
     );
 
-    await lacunaActionHandlers.search({ query: "graph learning", dateFrom: "2024", dateTo: "2024-02" }, { fetcher });
-    await lacunaActionHandlers.search(
-      { query: "graph learning", dateFrom: "2024-02-29", dateTo: "2024-12-31" },
-      { fetcher },
-    );
+    const bounds = [
+      { dateFrom: "0001", dateTo: "0001" },
+      { dateFrom: "1900-02-28", dateTo: "1900-02" },
+      { dateFrom: "2000-02-29", dateTo: "2000-12-31" },
+      { dateFrom: "2024", dateTo: "2024-02" },
+      { dateFrom: "2024-02-29", dateTo: "2024-12-31" },
+      { dateFrom: "9999", dateTo: "9999-12-31" },
+    ];
+    for (const input of bounds) {
+      await lacunaActionHandlers.search({ query: "graph learning", ...input }, { fetcher });
+    }
 
-    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenCalledTimes(bounds.length);
   });
 
-  it("rejects impossible calendar date bounds before sending a request", async () => {
+  it("rejects malformed and impossible calendar date bounds before sending a request", async () => {
     const fetcher = vi.fn<typeof fetch>();
 
     for (const input of [
+      { query: "graph learning", dateFrom: "0000" },
+      { query: "graph learning", dateFrom: "2024-00" },
+      { query: "graph learning", dateTo: "2024-13" },
+      { query: "graph learning", dateFrom: "2024-1" },
+      { query: "graph learning", dateTo: "2024-01-1" },
+      { query: "graph learning", dateFrom: "2024-01-00" },
+      { query: "graph learning", dateTo: "2024-01-32" },
+      { query: "graph learning", dateFrom: "1900-02-29" },
       { query: "graph learning", dateFrom: "2025-02-29" },
       { query: "graph learning", dateFrom: "2024-02-30" },
       { query: "graph learning", dateTo: "2025-04-31" },
@@ -73,6 +87,34 @@ describe("Lacuna provider runtime", () => {
       await expect(lacunaActionHandlers.search(input, { fetcher })).rejects.toMatchObject({ status: 400 });
     }
     expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects reversed inclusive date ranges while preserving partial-bound semantics", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ query: "graph learning", type_filter: "all", total_results: 0, results: [] }),
+    );
+
+    const validRanges = [
+      { dateFrom: "2024", dateTo: "2024-01" },
+      { dateFrom: "2024-12", dateTo: "2024" },
+      { dateFrom: "2024-02-29", dateTo: "2024-02" },
+      { dateFrom: "2024-02", dateTo: "2024-02-01" },
+    ];
+    for (const input of validRanges) {
+      await lacunaActionHandlers.search({ query: "graph learning", ...input }, { fetcher });
+    }
+
+    for (const input of [
+      { dateFrom: "2025", dateTo: "2024" },
+      { dateFrom: "2024-03", dateTo: "2024-02" },
+      { dateFrom: "2024-03-01", dateTo: "2024-02" },
+      { dateFrom: "2024-02-02", dateTo: "2024-02-01" },
+    ]) {
+      await expect(
+        lacunaActionHandlers.search({ query: "graph learning", ...input }, { fetcher }),
+      ).rejects.toMatchObject({ status: 400 });
+    }
+    expect(fetcher).toHaveBeenCalledTimes(validRanges.length);
   });
 
   it("gets compact paper context and removes MCP-only metadata", async () => {

--- a/src/providers/lacuna/runtime.test.ts
+++ b/src/providers/lacuna/runtime.test.ts
@@ -152,6 +152,9 @@ describe("Lacuna provider runtime", () => {
     await expect(
       lacunaActionHandlers.search({ query: "graph learning", searchType: 123 }, { fetcher }),
     ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      lacunaActionHandlers.search({ query: "graph learning", venue: 123 }, { fetcher }),
+    ).rejects.toMatchObject({ status: 400 });
     expect(fetcher).not.toHaveBeenCalled();
   });
 

--- a/src/providers/lacuna/runtime.test.ts
+++ b/src/providers/lacuna/runtime.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { lacunaActionHandlers, lacunaBaseUrl } from "./runtime.ts";
+
+describe("Lacuna provider runtime", () => {
+  it("normalizes search aliases, query parameters, and Lacuna result URLs", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/api/v1/search");
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        q: "autonomous agents",
+        type: "cluster",
+        limit: "5",
+        offset: "0",
+        sort: "relevance",
+        ranking_profile: "default",
+        fields: "title^4,summary",
+      });
+      return Response.json({
+        query: "autonomous agents",
+        type_filter: "cluster",
+        total_results: 1,
+        results: [{ type: "cluster", id: "91", score: 1, url: "/direction/autonomous-agents/91" }],
+      });
+    });
+
+    const output = await lacunaActionHandlers.search(
+      { query: "autonomous agents", searchType: "directions", limit: 5, fields: "title^4,summary" },
+      { fetcher },
+    );
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(output).toMatchObject({
+      type_filter: "cluster",
+      results: [{ url: `${lacunaBaseUrl}/direction/autonomous-agents/91` }],
+    });
+  });
+
+  it("rejects unsupported semantic search combinations before sending a request", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      lacunaActionHandlers.search(
+        { query: "graph learning", searchType: "authors", rankingProfile: "semantic" },
+        { fetcher },
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("gets compact paper context and removes MCP-only metadata", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/api/v1/context/paper/art_example123");
+      expect(Object.fromEntries(url.searchParams)).toEqual({ view: "compact", figure_limit: "3" });
+      return Response.json({
+        type: "paper",
+        id: "art_example123",
+        url: "/paper/example/art_example123",
+        summary_markdown: "See [direction](/direction/example/91).",
+        _mcp_meta: { compact: true },
+      });
+    });
+
+    const output = await lacunaActionHandlers.get_paper(
+      { paperIdOrUrl: `${lacunaBaseUrl}/paper/example/art_example123`, figureLimit: 3 },
+      { fetcher },
+    );
+
+    expect(output).toEqual({
+      type: "paper",
+      id: "art_example123",
+      artifact_id: "art_example123",
+      url: `${lacunaBaseUrl}/paper/example/art_example123`,
+      summary_markdown: `See [direction](${lacunaBaseUrl}/direction/example/91).`,
+    });
+  });
+
+  it("maps direction paper pagination and the full view", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/api/v1/clusters/91/papers");
+      expect(Object.fromEntries(url.searchParams)).toEqual({ page: "2", limit: "50", view: "complete" });
+      return Response.json({ cluster_id: 91, papers: [] });
+    });
+
+    const output = await lacunaActionHandlers.get_direction_papers(
+      { directionIdOrUrl: `${lacunaBaseUrl}/direction/autonomous-agents/91`, page: 2, limit: 50, view: "full" },
+      { fetcher },
+    );
+
+    expect(output).toEqual({ cluster_id: 91, papers: [] });
+  });
+
+  it("maps full direction, author, and hypothesis routes from Lacuna URLs", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      if (url.pathname === "/api/v1/clusters/91") return Response.json({ type: "direction", id: 91 });
+      if (url.pathname === "/api/v1/context/author/aut_example") {
+        expect(Object.fromEntries(url.searchParams)).toEqual({ include_neighbors: "true" });
+        return Response.json({ type: "author", id: "aut_example" });
+      }
+      if (url.pathname === "/api/v1/hypotheses/0123456789abcdef") {
+        return Response.json({ type: "hypothesis", id: "0123456789abcdef" });
+      }
+      throw new Error(`Unexpected Lacuna path: ${url.pathname}`);
+    });
+
+    await expect(
+      lacunaActionHandlers.get_direction(
+        { directionIdOrUrl: `${lacunaBaseUrl}/direction/example/91`, view: "full" },
+        { fetcher },
+      ),
+    ).resolves.toMatchObject({ cluster_id: 91 });
+    await expect(
+      lacunaActionHandlers.get_author_context(
+        { authorIdOrUrl: `${lacunaBaseUrl}/author/example/aut_example`, view: "full", includeNeighbors: true },
+        { fetcher },
+      ),
+    ).resolves.toMatchObject({ author_id: "aut_example" });
+    await expect(
+      lacunaActionHandlers.get_hypothesis(
+        { hypothesisIdOrUrl: `${lacunaBaseUrl}/hypothesis/example/0123456789ABCDEF`, view: "full" },
+        { fetcher },
+      ),
+    ).resolves.toMatchObject({ hypothesis_id: "0123456789abcdef" });
+  });
+
+  it("rejects foreign URLs before sending a request", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      lacunaActionHandlers.get_paper({ paperIdOrUrl: "https://example.com/paper/x/art_example123" }, { fetcher }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("preserves useful upstream client errors", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => Response.json({ detail: "Paper not found" }, { status: 404 }));
+
+    await expect(lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_missing" }, { fetcher })).rejects.toEqual(
+      expect.objectContaining<Partial<ProviderRequestError>>({ status: 404, message: "Paper not found" }),
+    );
+  });
+});

--- a/src/providers/lacuna/runtime.test.ts
+++ b/src/providers/lacuna/runtime.test.ts
@@ -14,7 +14,7 @@ describe("Lacuna provider runtime", () => {
         offset: "0",
         sort: "relevance",
         ranking_profile: "default",
-        fields: "title^4,summary",
+        fields: "title^4,top_names",
       });
       return Response.json({
         query: "autonomous agents",
@@ -25,7 +25,7 @@ describe("Lacuna provider runtime", () => {
     });
 
     const output = await lacunaActionHandlers.search(
-      { query: "autonomous agents", searchType: "directions", limit: 5, fields: "title^4,summary" },
+      { query: "autonomous agents", searchType: "directions", limit: 5, fields: "title^4,top_names" },
       { fetcher },
     );
 
@@ -117,6 +117,44 @@ describe("Lacuna provider runtime", () => {
     expect(fetcher).toHaveBeenCalledTimes(validRanges.length);
   });
 
+  it("rejects lexical fields the searched type does not carry", async () => {
+    const rejectingFetcher = vi.fn<typeof fetch>();
+
+    for (const input of [
+      { query: "graph learning", searchType: "author", fields: "abstract" },
+      { query: "graph learning", searchType: "authors", fields: "name,title" },
+      { query: "graph learning", searchType: "directions", fields: "summary" },
+    ]) {
+      await expect(lacunaActionHandlers.search(input, { fetcher: rejectingFetcher })).rejects.toMatchObject({
+        status: 400,
+      });
+    }
+    expect(rejectingFetcher).not.toHaveBeenCalled();
+
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ query: "graph learning", type_filter: "cluster", total_results: 0, results: [] }),
+    );
+
+    await lacunaActionHandlers.search(
+      { query: "graph learning", searchType: "directions", fields: "title^2,top_names" },
+      { fetcher },
+    );
+    await lacunaActionHandlers.search({ query: "graph learning", fields: "abstract,name" }, { fetcher });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects wrong-typed enum and alias inputs instead of silently using the default", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_example123", view: 123 }, { fetcher }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      lacunaActionHandlers.search({ query: "graph learning", searchType: 123 }, { fetcher }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("gets compact paper context and removes MCP-only metadata", async () => {
     const fetcher = vi.fn<typeof fetch>(async (request) => {
       const url = new URL(String(request));
@@ -169,8 +207,8 @@ describe("Lacuna provider runtime", () => {
         expect(Object.fromEntries(url.searchParams)).toEqual({ include_neighbors: "true" });
         return Response.json({ type: "author", id: "aut_example" });
       }
-      if (url.pathname === "/api/v1/hypotheses/0123456789abcdef") {
-        return Response.json({ type: "hypothesis", id: "0123456789abcdef" });
+      if (url.pathname === "/api/v1/hypotheses/db4199b6b8055f3e") {
+        return Response.json({ type: "hypothesis", id: "db4199b6b8055f3e" });
       }
       throw new Error(`Unexpected Lacuna path: ${url.pathname}`);
     });
@@ -189,10 +227,70 @@ describe("Lacuna provider runtime", () => {
     ).resolves.toMatchObject({ author_id: "aut_example" });
     await expect(
       lacunaActionHandlers.get_hypothesis(
-        { hypothesisIdOrUrl: `${lacunaBaseUrl}/hypothesis/example/0123456789ABCDEF`, view: "full" },
+        {
+          hypothesisIdOrUrl: `${lacunaBaseUrl}/hypothesis/spectral-hydrodynamics-of-heteropolymer-folding-DB4199B6B8055F3E`,
+          view: "full",
+        },
         { fetcher },
       ),
-    ).resolves.toMatchObject({ hypothesis_id: "0123456789abcdef" });
+    ).resolves.toMatchObject({ hypothesis_id: "db4199b6b8055f3e" });
+  });
+
+  it("accepts the fused direction and hypothesis URLs Lacuna search returns", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      if (url.pathname === "/api/v1/context/direction/21526") return Response.json({ type: "direction", id: 21526 });
+      if (url.pathname === "/api/v1/context/hypothesis/db4199b6b8055f3e") {
+        return Response.json({ type: "hypothesis", id: "db4199b6b8055f3e" });
+      }
+      throw new Error(`Unexpected Lacuna path: ${url.pathname}`);
+    });
+
+    const directionUrls = [
+      "/direction/trajectory-controllable-video-diffusion-21526",
+      `${lacunaBaseUrl}/direction/trajectory-controllable-video-diffusion-21526`,
+      `${lacunaBaseUrl}/direction/trajectory-controllable-video-diffusion-21526/md`,
+      `${lacunaBaseUrl}/cluster/trajectory-controllable-video-diffusion-21526`,
+      "21526",
+      `${lacunaBaseUrl}/direction/autonomous-agents/21526`,
+    ];
+    for (const directionIdOrUrl of directionUrls) {
+      await expect(lacunaActionHandlers.get_direction({ directionIdOrUrl }, { fetcher })).resolves.toMatchObject({
+        cluster_id: 21526,
+      });
+    }
+
+    const hypothesisUrls = [
+      "/hypothesis/spectral-hydrodynamics-of-heteropolymer-folding-db4199b6b8055f3e",
+      `${lacunaBaseUrl}/hypothesis/spectral-hydrodynamics-of-heteropolymer-folding-db4199b6b8055f3e/md`,
+      "db4199b6b8055f3e",
+    ];
+    for (const hypothesisIdOrUrl of hypothesisUrls) {
+      await expect(lacunaActionHandlers.get_hypothesis({ hypothesisIdOrUrl }, { fetcher })).resolves.toMatchObject({
+        hypothesis_id: "db4199b6b8055f3e",
+      });
+    }
+    expect(fetcher).toHaveBeenCalledTimes(directionUrls.length + hypothesisUrls.length);
+  });
+
+  it("rejects identifiers Lacuna itself cannot address", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    for (const input of [
+      lacunaActionHandlers.get_direction(
+        { directionIdOrUrl: `${lacunaBaseUrl}/direction/txn_ab12cd34ef` },
+        { fetcher },
+      ),
+      lacunaActionHandlers.get_direction({ directionIdOrUrl: "/direction/txn_ab12cd34ef" }, { fetcher }),
+      lacunaActionHandlers.get_hypothesis({ hypothesisIdOrUrl: `${lacunaBaseUrl}/hypothesis/example` }, { fetcher }),
+      lacunaActionHandlers.get_author_context({ authorIdOrUrl: ".." }, { fetcher }),
+      lacunaActionHandlers.get_author_context({ authorIdOrUrl: "author/.." }, { fetcher }),
+      lacunaActionHandlers.get_author_context({ authorIdOrUrl: "author/%" }, { fetcher }),
+      lacunaActionHandlers.get_author_context({ authorIdOrUrl: `${lacunaBaseUrl}/author/%` }, { fetcher }),
+    ]) {
+      await expect(input).rejects.toMatchObject({ status: 400 });
+    }
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("rejects foreign URLs before sending a request", async () => {
@@ -210,5 +308,111 @@ describe("Lacuna provider runtime", () => {
     await expect(lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_missing" }, { fetcher })).rejects.toEqual(
       expect.objectContaining<Partial<ProviderRequestError>>({ status: 404, message: "Paper not found" }),
     );
+  });
+
+  it("keeps the upstream status when a gateway returns a non-JSON error page", async () => {
+    const fetcher = vi.fn<typeof fetch>(
+      async () =>
+        new Response("<html><body>404 Not Found</body></html>", {
+          status: 404,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+
+    await expect(lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_missing" }, { fetcher })).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("retries retryable Lacuna statuses and surfaces the final failure", async () => {
+    const statuses = [429, 200];
+    const fetcher = vi.fn<typeof fetch>(async () => {
+      const status = statuses.shift() ?? 200;
+      return status === 200
+        ? Response.json({ type: "paper", id: "art_example123" })
+        : Response.json({ detail: "Slow down" }, { status, headers: { "retry-after": "30" } });
+    });
+    const sleep = vi.fn(async () => {});
+
+    await expect(
+      lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_example123" }, { fetcher, sleep }),
+    ).resolves.toMatchObject({ artifact_id: "art_example123" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+
+    const alwaysThrottled = vi.fn<typeof fetch>(async () => Response.json({ detail: "Slow down" }, { status: 429 }));
+
+    await expect(
+      lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_example123" }, { fetcher: alwaysThrottled, sleep }),
+    ).rejects.toMatchObject({ status: 429, message: "Slow down" });
+    expect(alwaysThrottled).toHaveBeenCalledTimes(3);
+  });
+
+  it("absolutizes only same-origin Lacuna links in Markdown and URL fields", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        type: "paper",
+        id: "art_example123",
+        url: "//evil.example/paper/art_example123",
+        markdown_url: "/paper/art_example123/md",
+        canonical_url: "https://arxiv.org/abs/2401.12345",
+        summary_markdown: [
+          "See [paper](/paper/art_example123) and [author](/author/aut_example).",
+          "The preprint lives at https://arxiv.org/pdf/2401.12345 today.",
+          "Trailing punctuation stays outside the link: /direction/trajectory-controllable-video-diffusion-21526,",
+        ].join("\n"),
+      }),
+    );
+
+    const output = await lacunaActionHandlers.get_paper({ paperIdOrUrl: "art_example123", view: "full" }, { fetcher });
+
+    expect(output).toMatchObject({
+      url: "//evil.example/paper/art_example123",
+      markdown_url: `${lacunaBaseUrl}/paper/art_example123/md`,
+      canonical_url: "https://arxiv.org/abs/2401.12345",
+      summary_markdown: [
+        `See [paper](${lacunaBaseUrl}/paper/art_example123) and [author](${lacunaBaseUrl}/author/aut_example).`,
+        "The preprint lives at https://arxiv.org/pdf/2401.12345 today.",
+        `Trailing punctuation stays outside the link: ${lacunaBaseUrl}/direction/trajectory-controllable-video-diffusion-21526,`,
+      ].join("\n"),
+    });
+  });
+
+  it("drops an upstream __proto__ key instead of poisoning the returned record", async () => {
+    const fetcher = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          '{"query":"graph learning","type_filter":"all","total_results":0,"results":[],"__proto__":{"polluted":true}}',
+          { headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const output = (await lacunaActionHandlers.search({ query: "graph learning" }, { fetcher })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(Object.hasOwn(output, "__proto__")).toBe(false);
+    expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
+    expect((output as { polluted?: unknown }).polluted).toBeUndefined();
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it("reports open-ended integer bounds without the maximum safe integer", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(lacunaActionHandlers.search({ query: "graph learning", offset: -1 }, { fetcher })).rejects.toEqual(
+      expect.objectContaining<Partial<ProviderRequestError>>({
+        status: 400,
+        message: "offset must be an integer greater than or equal to 0.",
+      }),
+    );
+    await expect(lacunaActionHandlers.search({ query: "graph learning", limit: 0 }, { fetcher })).rejects.toEqual(
+      expect.objectContaining<Partial<ProviderRequestError>>({
+        status: 400,
+        message: "limit must be an integer between 1 and 50.",
+      }),
+    );
+    expect(fetcher).not.toHaveBeenCalled();
   });
 });

--- a/src/providers/lacuna/runtime.ts
+++ b/src/providers/lacuna/runtime.ts
@@ -51,6 +51,12 @@ export interface LacunaActionContext {
   signal?: AbortSignal;
 }
 
+interface PartialDate {
+  value: string;
+  earliestDay: number;
+  latestDay: number;
+}
+
 export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRuntimeHandler<LacunaActionContext>> = {
   async search(input, context): Promise<unknown> {
     const query = requiredString(input.query, "query", providerInputError);
@@ -60,6 +66,7 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
     const fields = optionalString(input.fields);
     const dateFrom = readPartialDate(input.dateFrom, "dateFrom");
     const dateTo = readPartialDate(input.dateTo, "dateTo");
+    validateDateRange(dateFrom, dateTo);
     validateSearchOptions(searchType, rankingProfile, sort, fields);
 
     const limit = readBoundedInteger(input.limit, "limit", 1, 50, 10);
@@ -72,8 +79,8 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
       sort,
       ranking_profile: rankingProfile,
     });
-    setOptionalParam(params, "date_from", dateFrom);
-    setOptionalParam(params, "date_to", dateTo);
+    setOptionalParam(params, "date_from", dateFrom?.value);
+    setOptionalParam(params, "date_to", dateTo?.value);
     setOptionalParam(params, "venue", input.venue);
     if (fields) params.set("fields", fields);
     return requestLacunaJson("/api/v1/search", params, context);
@@ -289,24 +296,44 @@ function readOptionalBoundedInteger(value: unknown, fieldName: string, min: numb
   return number;
 }
 
-function readPartialDate(value: unknown, fieldName: string): string | undefined {
+function readPartialDate(value: unknown, fieldName: string): PartialDate | undefined {
   if (value === undefined) return undefined;
   const text = optionalString(value);
   const match = text?.match(partialDatePattern);
   if (!text || !match) {
     throw providerInputError(`${fieldName} must be a valid date in YYYY, YYYY-MM, or YYYY-MM-DD format.`);
   }
-  if (!match[2] || !match[3]) return text;
 
   const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]!) {
+  const month = match[2] ? Number(match[2]) : undefined;
+  const day = match[3] ? Number(match[3]) : undefined;
+  if (year < 1 || (month !== undefined && (month < 1 || month > 12))) {
     throw providerInputError(`${fieldName} must be a valid date in YYYY, YYYY-MM, or YYYY-MM-DD format.`);
   }
-  return text;
+
+  const startMonth = month ?? 1;
+  const endMonth = month ?? 12;
+  const endOfMonth = readDaysInMonth(year, endMonth);
+  if (day !== undefined && (day < 1 || day > endOfMonth)) {
+    throw providerInputError(`${fieldName} must be a valid date in YYYY, YYYY-MM, or YYYY-MM-DD format.`);
+  }
+  return {
+    value: text,
+    earliestDay: year * 10_000 + startMonth * 100 + (day ?? 1),
+    latestDay: year * 10_000 + endMonth * 100 + (day ?? endOfMonth),
+  };
+}
+
+function readDaysInMonth(year: number, month: number): number {
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return daysInMonth[month - 1]!;
+}
+
+function validateDateRange(dateFrom?: PartialDate, dateTo?: PartialDate): void {
+  if (dateFrom && dateTo && dateFrom.earliestDay > dateTo.latestDay) {
+    throw providerInputError("dateFrom must not be after dateTo.");
+  }
 }
 
 function setOptionalParam(params: URLSearchParams, name: string, value: unknown): void {

--- a/src/providers/lacuna/runtime.ts
+++ b/src/providers/lacuna/runtime.ts
@@ -1,0 +1,357 @@
+import type { ProviderActionHandlers, ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+
+import { optionalBoolean, optionalInteger, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
+import {
+  ProviderRequestError,
+  providerInputError,
+  providerResponseError,
+  providerUserAgent,
+  readProviderJsonBody,
+  runProviderRequest,
+} from "../provider-runtime.ts";
+
+export const lacunaBaseUrl = "https://lacuna.tiptreesystems.com";
+const retryableStatuses = new Set([429, 502, 503, 504]);
+const maxRetries = 2;
+const maxResponseBytes = 8 * 1024 * 1024;
+
+const searchTypeAliases: Record<string, string> = {
+  all: "all",
+  paper: "paper",
+  papers: "paper",
+  cluster: "cluster",
+  clusters: "cluster",
+  direction: "cluster",
+  directions: "cluster",
+  author: "author",
+  authors: "author",
+  institution: "institution",
+  institutions: "institution",
+  venue: "venue",
+  venues: "venue",
+  hypothesis: "hypothesis",
+  hypotheses: "hypothesis",
+  proposal: "hypothesis",
+  proposals: "hypothesis",
+};
+const rankingAliases: Record<string, string> = {
+  default: "default",
+  lexical: "default",
+  semantic: "semantic",
+  bm25: "bm25_title_abstract",
+  bm25_title_abstract: "bm25_title_abstract",
+};
+const allowedFields = new Set(["title", "abstract", "summary", "concepts", "name", "top_names", "venue"]);
+const markdownPathPattern =
+  /\/(author|cluster|direction|figures|hypothesis|institution|node|paper|pdf|venue)\/[^\s)\]"']+/g;
+
+export interface LacunaActionContext {
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRuntimeHandler<LacunaActionContext>> = {
+  async search(input, context): Promise<unknown> {
+    const query = requiredString(input.query, "query", providerInputError);
+    const searchType = readAlias(input.searchType, "searchType", searchTypeAliases, "all");
+    const rankingProfile = readAlias(input.rankingProfile, "rankingProfile", rankingAliases, "default");
+    const sort = readEnum(input.sort, "sort", ["relevance", "year_desc", "year_asc"], "relevance");
+    const fields = optionalString(input.fields);
+    validateSearchOptions(searchType, rankingProfile, sort, fields);
+
+    const limit = readBoundedInteger(input.limit, "limit", 1, 50, 10);
+    const offset = readBoundedInteger(input.offset, "offset", 0, Number.MAX_SAFE_INTEGER, 0);
+    const params = new URLSearchParams({
+      q: query,
+      type: searchType,
+      limit: String(limit),
+      offset: String(offset),
+      sort,
+      ranking_profile: rankingProfile,
+    });
+    setOptionalParam(params, "date_from", input.dateFrom);
+    setOptionalParam(params, "date_to", input.dateTo);
+    setOptionalParam(params, "venue", input.venue);
+    if (fields) params.set("fields", fields);
+    return requestLacunaJson("/api/v1/search", params, context);
+  },
+
+  async get_paper(input, context): Promise<unknown> {
+    const paperId = readPaperId(input.paperIdOrUrl);
+    const view = readEnum(
+      input.view,
+      "view",
+      ["context", "full", "preview", "blog", "figures", "concepts", "neighbors"],
+      "context",
+    );
+    const path =
+      view === "context"
+        ? `/api/v1/context/paper/${encodeURIComponent(paperId)}`
+        : view === "full"
+          ? `/api/v1/papers/${encodeURIComponent(paperId)}`
+          : `/api/v1/papers/${encodeURIComponent(paperId)}/${view}`;
+    const params = new URLSearchParams();
+    if (view === "context") {
+      params.set("view", "compact");
+      const figureLimit = readOptionalBoundedInteger(input.figureLimit, "figureLimit", 0, Number.MAX_SAFE_INTEGER);
+      if (figureLimit !== undefined) params.set("figure_limit", String(figureLimit));
+    }
+    return withStableId(await requestLacunaJson(path, params, context), "artifact_id", paperId);
+  },
+
+  async get_direction(input, context): Promise<unknown> {
+    const directionId = readDirectionId(input.directionIdOrUrl);
+    const view = readEnum(input.view, "view", ["context", "full"], "context");
+    const path = view === "context" ? `/api/v1/context/direction/${directionId}` : `/api/v1/clusters/${directionId}`;
+    const params = view === "context" ? new URLSearchParams({ view: "compact" }) : new URLSearchParams();
+    return withStableId(await requestLacunaJson(path, params, context), "cluster_id", directionId);
+  },
+
+  async get_direction_papers(input, context): Promise<unknown> {
+    const directionId = readDirectionId(input.directionIdOrUrl);
+    const page = readBoundedInteger(input.page, "page", 1, Number.MAX_SAFE_INTEGER, 1);
+    const limit = readBoundedInteger(input.limit, "limit", 1, 100, 24);
+    const view = readEnum(input.view, "view", ["compact", "full"], "compact");
+    const params = new URLSearchParams({
+      page: String(page),
+      limit: String(limit),
+      view: view === "full" ? "complete" : "compact",
+    });
+    const payload = await requestLacunaJson(`/api/v1/clusters/${directionId}/papers`, params, context);
+    return withStableId(payload, "cluster_id", directionId);
+  },
+
+  async get_author_context(input, context): Promise<unknown> {
+    const authorId = readRouteId(input.authorIdOrUrl, "authorIdOrUrl", "author");
+    const view = readEnum(input.view, "view", ["context", "full"], "context");
+    const includeNeighbors = optionalBoolean(input.includeNeighbors) ?? false;
+    const params = new URLSearchParams({ include_neighbors: String(includeNeighbors) });
+    if (view === "context") params.set("view", "compact");
+    const payload = await requestLacunaJson(`/api/v1/context/author/${encodeURIComponent(authorId)}`, params, context);
+    return withStableId(payload, "author_id", authorId);
+  },
+
+  async get_hypothesis(input, context): Promise<unknown> {
+    const hypothesisId = readHypothesisId(input.hypothesisIdOrUrl);
+    const view = readEnum(input.view, "view", ["context", "full"], "context");
+    const path =
+      view === "context" ? `/api/v1/context/hypothesis/${hypothesisId}` : `/api/v1/hypotheses/${hypothesisId}`;
+    const params = view === "context" ? new URLSearchParams({ view: "compact" }) : new URLSearchParams();
+    return withStableId(await requestLacunaJson(path, params, context), "hypothesis_id", hypothesisId);
+  },
+};
+
+async function requestLacunaJson(
+  path: string,
+  params: URLSearchParams,
+  context: LacunaActionContext,
+): Promise<Record<string, unknown>> {
+  return runProviderRequest({ label: "Lacuna", signal: context.signal }, async (signal) => {
+    const url = new URL(path, lacunaBaseUrl);
+    url.search = params.toString();
+
+    for (let attempt = 0; ; attempt += 1) {
+      const response = await context.fetcher(url, {
+        headers: { accept: "application/json", "user-agent": providerUserAgent },
+        signal,
+      });
+      if (retryableStatuses.has(response.status) && attempt < maxRetries) {
+        await response.body?.cancel();
+        await waitForRetry(response.headers.get("retry-after"), attempt, signal);
+        continue;
+      }
+
+      const payload = await readProviderJsonBody(response, {
+        emptyBody: null,
+        invalidJsonMessage: "Lacuna returned invalid JSON.",
+        maxBytes: maxResponseBytes,
+      });
+      if (!response.ok) {
+        throw new ProviderRequestError(
+          response.status >= 500 ? 502 : response.status,
+          readErrorMessage(payload) ?? `Lacuna request failed with HTTP ${response.status}.`,
+          payload,
+        );
+      }
+      const record = optionalRecord(payload);
+      if (!record) throw providerResponseError("Lacuna returned an invalid response object.");
+      return normalizeLacunaRecord(record);
+    }
+  });
+}
+
+function validateSearchOptions(searchType: string, rankingProfile: string, sort: string, fields?: string): void {
+  if (rankingProfile === "semantic") {
+    if (searchType !== "all" && searchType !== "paper") {
+      throw providerInputError("semantic ranking supports only paper or all searches.");
+    }
+    if (fields) throw providerInputError("semantic ranking cannot be combined with fields.");
+    if (sort !== "relevance") throw providerInputError("semantic ranking cannot be combined with year sorting.");
+  }
+  if (rankingProfile === "bm25_title_abstract" && (searchType === "author" || searchType === "institution")) {
+    throw providerInputError("BM25 title/abstract ranking does not support author or institution searches.");
+  }
+  if (!fields) return;
+  for (const weightedField of fields.split(",")) {
+    const [field, rawWeight, ...extra] = weightedField.trim().split("^");
+    if (!field || extra.length > 0 || !allowedFields.has(field)) {
+      throw providerInputError(`Unsupported Lacuna search field: ${weightedField.trim() || "empty field"}.`);
+    }
+    if (rawWeight !== undefined) {
+      const weight = Number(rawWeight);
+      if (!Number.isFinite(weight) || weight <= 0 || weight > 100) {
+        throw providerInputError(
+          `Search field weight must be greater than 0 and at most 100: ${weightedField.trim()}.`,
+        );
+      }
+    }
+  }
+}
+
+function readPaperId(value: unknown): string {
+  const input = requiredString(value, "paperIdOrUrl", providerInputError);
+  const candidate = readRouteCandidate(input, "paperIdOrUrl");
+  const match = candidate.match(/art_[A-Za-z0-9_-]+/);
+  if (!match) throw providerInputError("paperIdOrUrl must contain a Lacuna art_ paper identifier.");
+  return match[0];
+}
+
+function readDirectionId(value: unknown): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+  const input = requiredString(value, "directionIdOrUrl", providerInputError);
+  const candidate = readRouteCandidate(input, "directionIdOrUrl");
+  const match = candidate.match(/(?:^|\/)(\d+)\/?$/);
+  const directionId = match ? Number(match[1]) : Number(candidate);
+  if (!Number.isSafeInteger(directionId) || directionId <= 0) {
+    throw providerInputError("directionIdOrUrl must contain a positive Lacuna direction identifier.");
+  }
+  return directionId;
+}
+
+function readHypothesisId(value: unknown): string {
+  const input = requiredString(value, "hypothesisIdOrUrl", providerInputError);
+  const candidate = readRouteCandidate(input, "hypothesisIdOrUrl");
+  const match = candidate.match(/(?:^|\/)([0-9a-fA-F]{16})\/?$/);
+  if (!match) throw providerInputError("hypothesisIdOrUrl must contain a 16-character Lacuna hypothesis ID.");
+  return match[1].toLowerCase();
+}
+
+function readRouteId(value: unknown, fieldName: string, route: string): string {
+  const input = requiredString(value, fieldName, providerInputError);
+  const candidate = readRouteCandidate(input, fieldName);
+  if (!candidate.includes("/")) return candidate;
+  const parts = candidate.split("/").filter(Boolean);
+  const routeIndex = parts.indexOf(route);
+  if (routeIndex < 0 || routeIndex === parts.length - 1) {
+    throw providerInputError(`${fieldName} must be a Lacuna ${route} ID or URL.`);
+  }
+  return decodeURIComponent(parts.at(-1) ?? "");
+}
+
+function readRouteCandidate(input: string, fieldName: string): string {
+  if (!input.startsWith("/") && !/^[a-z][a-z\d+.-]*:/i.test(input)) return input;
+  let url: URL;
+  try {
+    url = new URL(input, lacunaBaseUrl);
+  } catch {
+    throw providerInputError(`${fieldName} must be a valid Lacuna ID or URL.`);
+  }
+  if (url.origin !== lacunaBaseUrl) throw providerInputError(`${fieldName} must use ${lacunaBaseUrl}.`);
+  return decodeURIComponent(url.pathname);
+}
+
+function readAlias(value: unknown, fieldName: string, aliases: Record<string, string>, fallback: string): string {
+  const raw = optionalString(value)?.toLowerCase() ?? fallback;
+  const normalized = aliases[raw];
+  if (!normalized) throw providerInputError(`${fieldName} has an unsupported value: ${raw}.`);
+  return normalized;
+}
+
+function readEnum<T extends string>(value: unknown, fieldName: string, allowed: readonly T[], fallback: T): T {
+  const raw = optionalString(value) ?? fallback;
+  if (!allowed.includes(raw as T)) throw providerInputError(`${fieldName} has an unsupported value: ${raw}.`);
+  return raw as T;
+}
+
+function readBoundedInteger(value: unknown, fieldName: string, min: number, max: number, fallback: number): number {
+  return readOptionalBoundedInteger(value, fieldName, min, max) ?? fallback;
+}
+
+function readOptionalBoundedInteger(value: unknown, fieldName: string, min: number, max: number): number | undefined {
+  if (value === undefined) return undefined;
+  const number = optionalInteger(value);
+  if (number === undefined || number < min || number > max) {
+    throw providerInputError(`${fieldName} must be an integer between ${min} and ${max}.`);
+  }
+  return number;
+}
+
+function setOptionalParam(params: URLSearchParams, name: string, value: unknown): void {
+  const text = optionalString(value);
+  if (text) params.set(name, text);
+}
+
+function withStableId(
+  payload: Record<string, unknown>,
+  fieldName: string,
+  value: string | number,
+): Record<string, unknown> {
+  return { ...payload, [fieldName]: value };
+}
+
+function normalizeLacunaRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "_mcp_meta") continue;
+    output[key] = normalizeLacunaValue(value, key);
+  }
+  return output;
+}
+
+function normalizeLacunaValue(value: unknown, key: string): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalizeLacunaValue(item, key));
+  const record = optionalRecord(value);
+  if (record) return normalizeLacunaRecord(record);
+  if (typeof value !== "string") return value;
+  if ((key === "url" || key.endsWith("_url")) && value.startsWith("/")) {
+    return new URL(value, lacunaBaseUrl).toString();
+  }
+  if (
+    ["article_markdown", "content", "description", "markdown", "profile_markdown", "summary_markdown"].includes(key)
+  ) {
+    return value.replace(markdownPathPattern, (path) => new URL(path, lacunaBaseUrl).toString());
+  }
+  return value;
+}
+
+function readErrorMessage(payload: unknown): string | undefined {
+  const record = optionalRecord(payload);
+  if (!record) return optionalString(payload);
+  return optionalString(record.detail) ?? optionalString(record.message) ?? optionalString(record.error);
+}
+
+async function waitForRetry(retryAfter: string | null, attempt: number, signal: AbortSignal): Promise<void> {
+  const retryAfterMs = readRetryAfterMs(retryAfter);
+  const delayMs = retryAfterMs ?? 500 * 2 ** attempt;
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, delayMs);
+    const abort = (): void => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", abort);
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    if (signal.aborted) abort();
+    else signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function readRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.min(seconds * 1000, 30_000);
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? undefined : Math.min(Math.max(date - Date.now(), 0), 30_000);
+}

--- a/src/providers/lacuna/runtime.ts
+++ b/src/providers/lacuna/runtime.ts
@@ -107,7 +107,7 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
         ranking_profile: rankingProfile,
         date_from: dateFrom?.value,
         date_to: dateTo?.value,
-        venue: optionalString(input.venue),
+        venue: readOptionalText(input.venue, "venue"),
         fields,
       },
       context,

--- a/src/providers/lacuna/runtime.ts
+++ b/src/providers/lacuna/runtime.ts
@@ -8,9 +8,11 @@ import {
   providerUserAgent,
   readProviderJsonBody,
   runProviderRequest,
+  setSearchParams,
 } from "../provider-runtime.ts";
 
 export const lacunaBaseUrl = "https://lacuna.tiptreesystems.com";
+const lacunaOrigin = new URL(lacunaBaseUrl).origin;
 const retryableStatuses = new Set([429, 502, 503, 504]);
 const maxRetries = 2;
 const maxResponseBytes = 8 * 1024 * 1024;
@@ -41,14 +43,37 @@ const rankingAliases: Record<string, string> = {
   bm25: "bm25_title_abstract",
   bm25_title_abstract: "bm25_title_abstract",
 };
-const allowedFields = new Set(["title", "abstract", "summary", "concepts", "name", "top_names", "venue"]);
+// Lexical fields the Lacuna ranker accepts, mapped to the search types whose
+// documents actually carry them. Requesting a field the target type lacks makes
+// the server match nothing on that leg and silently fall back to substring
+// ranking, so the combination is rejected locally instead.
+const searchFieldTypes = new Map<string, ReadonlySet<string>>([
+  ["title", new Set(["paper", "cluster", "venue", "hypothesis"])],
+  ["abstract", new Set(["paper"])],
+  ["summary", new Set(["paper"])],
+  ["concepts", new Set(["paper"])],
+  ["name", new Set(["author", "institution", "venue"])],
+  ["top_names", new Set(["cluster", "hypothesis"])],
+  ["venue", new Set(["paper", "venue"])],
+]);
+// The leading `(?<!\w)` keeps paths inside absolute third-party URLs
+// (`https://arxiv.org/pdf/x`) from being rewritten onto the Lacuna origin.
 const markdownPathPattern =
-  /\/(author|cluster|direction|figures|hypothesis|institution|node|paper|pdf|venue)\/[^\s)\]"']+/g;
+  /(?<!\w)\/(?:author|cluster|direction|figures|hypothesis|institution|node|paper|pdf|venue)\/[^\s)\]"'>]+/g;
+const markdownTrailingPunctuationPattern = /[.,;:]+$/;
 const partialDatePattern = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/;
+// Live direction URLs fuse the id into the slug (`/direction/{slug}-{id}`) and
+// may carry a trailing `/md` Markdown segment.
+const directionRoutePattern = /\/(?:direction|cluster)\/(?:[^/?#]*-)?(\d+)(?:[/?#]|$)/;
+const trailingNumericSegmentPattern = /(?:^|\/)(\d+)\/?$/;
+const hypothesisRoutePattern = /\/hypothesis\/([^/?#]+)/;
+const hypothesisIdPattern = /([0-9a-fA-F]{16})$/;
+const routeIdPattern = /^[A-Za-z0-9_.:-]+$/;
 
 export interface LacunaActionContext {
   fetcher: ProviderFetch;
   signal?: AbortSignal;
+  sleep?(delayMs: number, signal?: AbortSignal): Promise<void>;
 }
 
 interface PartialDate {
@@ -71,19 +96,22 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
 
     const limit = readBoundedInteger(input.limit, "limit", 1, 50, 10);
     const offset = readBoundedInteger(input.offset, "offset", 0, Number.MAX_SAFE_INTEGER, 0);
-    const params = new URLSearchParams({
-      q: query,
-      type: searchType,
-      limit: String(limit),
-      offset: String(offset),
-      sort,
-      ranking_profile: rankingProfile,
-    });
-    setOptionalParam(params, "date_from", dateFrom?.value);
-    setOptionalParam(params, "date_to", dateTo?.value);
-    setOptionalParam(params, "venue", input.venue);
-    if (fields) params.set("fields", fields);
-    return requestLacunaJson("/api/v1/search", params, context);
+    return requestLacunaJson(
+      "/api/v1/search",
+      {
+        q: query,
+        type: searchType,
+        limit: String(limit),
+        offset: String(offset),
+        sort,
+        ranking_profile: rankingProfile,
+        date_from: dateFrom?.value,
+        date_to: dateTo?.value,
+        venue: optionalString(input.venue),
+        fields,
+      },
+      context,
+    );
   },
 
   async get_paper(input, context): Promise<unknown> {
@@ -100,21 +128,21 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
         : view === "full"
           ? `/api/v1/papers/${encodeURIComponent(paperId)}`
           : `/api/v1/papers/${encodeURIComponent(paperId)}/${view}`;
-    const params = new URLSearchParams();
+    const query: Record<string, string | undefined> = {};
     if (view === "context") {
-      params.set("view", "compact");
+      query.view = "compact";
       const figureLimit = readOptionalBoundedInteger(input.figureLimit, "figureLimit", 0, Number.MAX_SAFE_INTEGER);
-      if (figureLimit !== undefined) params.set("figure_limit", String(figureLimit));
+      if (figureLimit !== undefined) query.figure_limit = String(figureLimit);
     }
-    return withStableId(await requestLacunaJson(path, params, context), "artifact_id", paperId);
+    return { ...(await requestLacunaJson(path, query, context)), artifact_id: paperId };
   },
 
   async get_direction(input, context): Promise<unknown> {
     const directionId = readDirectionId(input.directionIdOrUrl);
     const view = readEnum(input.view, "view", ["context", "full"], "context");
     const path = view === "context" ? `/api/v1/context/direction/${directionId}` : `/api/v1/clusters/${directionId}`;
-    const params = view === "context" ? new URLSearchParams({ view: "compact" }) : new URLSearchParams();
-    return withStableId(await requestLacunaJson(path, params, context), "cluster_id", directionId);
+    const query = view === "context" ? { view: "compact" } : {};
+    return { ...(await requestLacunaJson(path, query, context)), cluster_id: directionId };
   },
 
   async get_direction_papers(input, context): Promise<unknown> {
@@ -122,43 +150,46 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
     const page = readBoundedInteger(input.page, "page", 1, Number.MAX_SAFE_INTEGER, 1);
     const limit = readBoundedInteger(input.limit, "limit", 1, 100, 24);
     const view = readEnum(input.view, "view", ["compact", "full"], "compact");
-    const params = new URLSearchParams({
-      page: String(page),
-      limit: String(limit),
-      view: view === "full" ? "complete" : "compact",
-    });
-    const payload = await requestLacunaJson(`/api/v1/clusters/${directionId}/papers`, params, context);
-    return withStableId(payload, "cluster_id", directionId);
+    const payload = await requestLacunaJson(
+      `/api/v1/clusters/${directionId}/papers`,
+      { page: String(page), limit: String(limit), view: view === "full" ? "complete" : "compact" },
+      context,
+    );
+    return { ...payload, cluster_id: directionId };
   },
 
   async get_author_context(input, context): Promise<unknown> {
     const authorId = readRouteId(input.authorIdOrUrl, "authorIdOrUrl", "author");
     const view = readEnum(input.view, "view", ["context", "full"], "context");
     const includeNeighbors = optionalBoolean(input.includeNeighbors) ?? false;
-    const params = new URLSearchParams({ include_neighbors: String(includeNeighbors) });
-    if (view === "context") params.set("view", "compact");
-    const payload = await requestLacunaJson(`/api/v1/context/author/${encodeURIComponent(authorId)}`, params, context);
-    return withStableId(payload, "author_id", authorId);
+    const payload = await requestLacunaJson(
+      `/api/v1/context/author/${encodeURIComponent(authorId)}`,
+      { include_neighbors: String(includeNeighbors), view: view === "context" ? "compact" : undefined },
+      context,
+    );
+    return { ...payload, author_id: authorId };
   },
 
   async get_hypothesis(input, context): Promise<unknown> {
     const hypothesisId = readHypothesisId(input.hypothesisIdOrUrl);
     const view = readEnum(input.view, "view", ["context", "full"], "context");
     const path =
-      view === "context" ? `/api/v1/context/hypothesis/${hypothesisId}` : `/api/v1/hypotheses/${hypothesisId}`;
-    const params = view === "context" ? new URLSearchParams({ view: "compact" }) : new URLSearchParams();
-    return withStableId(await requestLacunaJson(path, params, context), "hypothesis_id", hypothesisId);
+      view === "context"
+        ? `/api/v1/context/hypothesis/${encodeURIComponent(hypothesisId)}`
+        : `/api/v1/hypotheses/${encodeURIComponent(hypothesisId)}`;
+    const query = view === "context" ? { view: "compact" } : {};
+    return { ...(await requestLacunaJson(path, query, context)), hypothesis_id: hypothesisId };
   },
 };
 
 async function requestLacunaJson(
   path: string,
-  params: URLSearchParams,
+  query: Record<string, string | undefined>,
   context: LacunaActionContext,
 ): Promise<Record<string, unknown>> {
   return runProviderRequest({ label: "Lacuna", signal: context.signal }, async (signal) => {
     const url = new URL(path, lacunaBaseUrl);
-    url.search = params.toString();
+    setSearchParams(url, query);
 
     for (let attempt = 0; ; attempt += 1) {
       const response = await context.fetcher(url, {
@@ -167,13 +198,16 @@ async function requestLacunaJson(
       });
       if (retryableStatuses.has(response.status) && attempt < maxRetries) {
         await response.body?.cancel();
-        await waitForRetry(response.headers.get("retry-after"), attempt, signal);
+        await waitForRetry(context, response.headers.get("retry-after"), attempt, signal);
         continue;
       }
 
       const payload = await readProviderJsonBody(response, {
         emptyBody: null,
         invalidJsonMessage: "Lacuna returned invalid JSON.",
+        // A gateway error page is not JSON; keep its real status instead of
+        // reporting the parse failure as a 502.
+        invalidJsonFallback: response.ok ? undefined : (text) => ({ detail: text.slice(0, 500) }),
         maxBytes: maxResponseBytes,
       });
       if (!response.ok) {
@@ -204,8 +238,15 @@ function validateSearchOptions(searchType: string, rankingProfile: string, sort:
   if (!fields) return;
   for (const weightedField of fields.split(",")) {
     const [field, rawWeight, ...extra] = weightedField.trim().split("^");
-    if (!field || extra.length > 0 || !allowedFields.has(field)) {
+    const supportedTypes = field ? searchFieldTypes.get(field) : undefined;
+    if (!field || extra.length > 0 || !supportedTypes) {
       throw providerInputError(`Unsupported Lacuna search field: ${weightedField.trim() || "empty field"}.`);
+    }
+    // The "all" search type spans every document type, so any field applies.
+    if (searchType !== "all" && !supportedTypes.has(searchType)) {
+      throw providerInputError(
+        `Search field ${field} does not exist on ${searchType} results; it applies to: ${[...supportedTypes].sort().join(", ")}.`,
+      );
     }
     if (rawWeight !== undefined) {
       const weight = Number(rawWeight);
@@ -230,7 +271,7 @@ function readDirectionId(value: unknown): number {
   if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
   const input = requiredString(value, "directionIdOrUrl", providerInputError);
   const candidate = readRouteCandidate(input, "directionIdOrUrl");
-  const match = candidate.match(/(?:^|\/)(\d+)\/?$/);
+  const match = candidate.match(directionRoutePattern) ?? candidate.match(trailingNumericSegmentPattern);
   const directionId = match ? Number(match[1]) : Number(candidate);
   if (!Number.isSafeInteger(directionId) || directionId <= 0) {
     throw providerInputError("directionIdOrUrl must contain a positive Lacuna direction identifier.");
@@ -241,7 +282,10 @@ function readDirectionId(value: unknown): number {
 function readHypothesisId(value: unknown): string {
   const input = requiredString(value, "hypothesisIdOrUrl", providerInputError);
   const candidate = readRouteCandidate(input, "hypothesisIdOrUrl");
-  const match = candidate.match(/(?:^|\/)([0-9a-fA-F]{16})\/?$/);
+  // Live hypothesis URLs fuse the id into the slug (`/hypothesis/{slug}-{id}`)
+  // and may carry a trailing `/md` Markdown segment.
+  const segment = candidate.match(hypothesisRoutePattern)?.[1] ?? candidate;
+  const match = segment.match(hypothesisIdPattern);
   if (!match) throw providerInputError("hypothesisIdOrUrl must contain a 16-character Lacuna hypothesis ID.");
   return match[1].toLowerCase();
 }
@@ -249,13 +293,22 @@ function readHypothesisId(value: unknown): string {
 function readRouteId(value: unknown, fieldName: string, route: string): string {
   const input = requiredString(value, fieldName, providerInputError);
   const candidate = readRouteCandidate(input, fieldName);
-  if (!candidate.includes("/")) return candidate;
+  if (!candidate.includes("/")) return readRouteIdShape(candidate, fieldName, route);
   const parts = candidate.split("/").filter(Boolean);
   const routeIndex = parts.indexOf(route);
   if (routeIndex < 0 || routeIndex === parts.length - 1) {
     throw providerInputError(`${fieldName} must be a Lacuna ${route} ID or URL.`);
   }
-  return decodeURIComponent(parts.at(-1) ?? "");
+  return readRouteIdShape(decodeRouteText(parts.at(-1) ?? "", fieldName), fieldName, route);
+}
+
+function readRouteIdShape(id: string, fieldName: string, route: string): string {
+  // Dots survive encodeURIComponent, so an unchecked ".." would collapse the
+  // request path instead of addressing a record.
+  if (id === "." || id === ".." || !routeIdPattern.test(id)) {
+    throw providerInputError(`${fieldName} must be a Lacuna ${route} ID or URL.`);
+  }
+  return id;
 }
 
 function readRouteCandidate(input: string, fieldName: string): string {
@@ -266,21 +319,36 @@ function readRouteCandidate(input: string, fieldName: string): string {
   } catch {
     throw providerInputError(`${fieldName} must be a valid Lacuna ID or URL.`);
   }
-  if (url.origin !== lacunaBaseUrl) throw providerInputError(`${fieldName} must use ${lacunaBaseUrl}.`);
-  return decodeURIComponent(url.pathname);
+  if (url.origin !== lacunaOrigin) throw providerInputError(`${fieldName} must use ${lacunaBaseUrl}.`);
+  return decodeRouteText(url.pathname, fieldName);
+}
+
+function decodeRouteText(value: string, fieldName: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw providerInputError(`${fieldName} must be a valid Lacuna ID or URL.`);
+  }
 }
 
 function readAlias(value: unknown, fieldName: string, aliases: Record<string, string>, fallback: string): string {
-  const raw = optionalString(value)?.toLowerCase() ?? fallback;
-  const normalized = aliases[raw];
-  if (!normalized) throw providerInputError(`${fieldName} has an unsupported value: ${raw}.`);
-  return normalized;
+  const raw = readOptionalText(value, fieldName)?.toLowerCase() ?? fallback;
+  if (!Object.hasOwn(aliases, raw)) throw providerInputError(`${fieldName} has an unsupported value: ${raw}.`);
+  return aliases[raw]!;
 }
 
 function readEnum<T extends string>(value: unknown, fieldName: string, allowed: readonly T[], fallback: T): T {
-  const raw = optionalString(value) ?? fallback;
+  const raw = readOptionalText(value, fieldName) ?? fallback;
   if (!allowed.includes(raw as T)) throw providerInputError(`${fieldName} has an unsupported value: ${raw}.`);
   return raw as T;
+}
+
+function readOptionalText(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) return undefined;
+  const text = optionalString(value);
+  // Falling back to the default here would silently ignore a wrong-typed input.
+  if (text === undefined) throw providerInputError(`${fieldName} must be a non-empty string.`);
+  return text;
 }
 
 function readBoundedInteger(value: unknown, fieldName: string, min: number, max: number, fallback: number): number {
@@ -291,7 +359,11 @@ function readOptionalBoundedInteger(value: unknown, fieldName: string, min: numb
   if (value === undefined) return undefined;
   const number = optionalInteger(value);
   if (number === undefined || number < min || number > max) {
-    throw providerInputError(`${fieldName} must be an integer between ${min} and ${max}.`);
+    throw providerInputError(
+      max === Number.MAX_SAFE_INTEGER
+        ? `${fieldName} must be an integer greater than or equal to ${min}.`
+        : `${fieldName} must be an integer between ${min} and ${max}.`,
+    );
   }
   return number;
 }
@@ -336,23 +408,12 @@ function validateDateRange(dateFrom?: PartialDate, dateTo?: PartialDate): void {
   }
 }
 
-function setOptionalParam(params: URLSearchParams, name: string, value: unknown): void {
-  const text = optionalString(value);
-  if (text) params.set(name, text);
-}
-
-function withStableId(
-  payload: Record<string, unknown>,
-  fieldName: string,
-  value: string | number,
-): Record<string, unknown> {
-  return { ...payload, [fieldName]: value };
-}
-
 function normalizeLacunaRecord(record: Record<string, unknown>): Record<string, unknown> {
   const output: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    if (key === "_mcp_meta") continue;
+    // An own "__proto__" key would reach the Object.prototype setter and poison
+    // the prototype of the record handed back to the caller.
+    if (key === "_mcp_meta" || key === "__proto__") continue;
     output[key] = normalizeLacunaValue(value, key);
   }
   return output;
@@ -363,15 +424,35 @@ function normalizeLacunaValue(value: unknown, key: string): unknown {
   const record = optionalRecord(value);
   if (record) return normalizeLacunaRecord(record);
   if (typeof value !== "string") return value;
-  if ((key === "url" || key.endsWith("_url")) && value.startsWith("/")) {
-    return new URL(value, lacunaBaseUrl).toString();
+  if (key === "url" || key.endsWith("_url")) {
+    return absolutizeLacunaPath(value) ?? value;
   }
   if (
     ["article_markdown", "content", "description", "markdown", "profile_markdown", "summary_markdown"].includes(key)
   ) {
-    return value.replace(markdownPathPattern, (path) => new URL(path, lacunaBaseUrl).toString());
+    return value.replace(markdownPathPattern, (matched) => {
+      const path = matched.replace(markdownTrailingPunctuationPattern, "");
+      return (absolutizeLacunaPath(path) ?? path) + matched.slice(path.length);
+    });
   }
   return value;
+}
+
+/**
+ * Resolve a Lacuna-relative path against the Lacuna site, or return undefined
+ * when the value is not a same-origin relative path. Protocol-relative values
+ * (`//host/x`) and backslash forms resolve off-origin, so the result is checked
+ * rather than trusted.
+ */
+function absolutizeLacunaPath(value: string): string | undefined {
+  if (!value.startsWith("/") || value.startsWith("//")) return undefined;
+  let url: URL;
+  try {
+    url = new URL(value, lacunaBaseUrl);
+  } catch {
+    return undefined;
+  }
+  return url.origin === lacunaOrigin ? url.toString() : undefined;
 }
 
 function readErrorMessage(payload: unknown): string | undefined {
@@ -380,22 +461,45 @@ function readErrorMessage(payload: unknown): string | undefined {
   return optionalString(record.detail) ?? optionalString(record.message) ?? optionalString(record.error);
 }
 
-async function waitForRetry(retryAfter: string | null, attempt: number, signal: AbortSignal): Promise<void> {
+async function waitForRetry(
+  context: LacunaActionContext,
+  retryAfter: string | null,
+  attempt: number,
+  signal: AbortSignal,
+): Promise<void> {
   const retryAfterMs = readRetryAfterMs(retryAfter);
-  const delayMs = retryAfterMs ?? 500 * 2 ** attempt;
-  await new Promise<void>((resolve, reject) => {
+  await (context.sleep ?? sleepBeforeRetry)(retryAfterMs ?? 500 * 2 ** attempt, signal);
+}
+
+/**
+ * Wait out a Lacuna retry delay, rejecting as soon as the request is aborted.
+ */
+export function sleepBeforeRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(readAbortReason(signal));
+  return new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      signal.removeEventListener("abort", abort);
+      signal?.removeEventListener("abort", abort);
       resolve();
     }, delayMs);
     const abort = (): void => {
       clearTimeout(timeout);
-      signal.removeEventListener("abort", abort);
-      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+      signal?.removeEventListener("abort", abort);
+      reject(readAbortReason(signal));
     };
-    if (signal.aborted) abort();
-    else signal.addEventListener("abort", abort, { once: true });
+    signal?.addEventListener("abort", abort, { once: true });
   });
+}
+
+/**
+ * Skip the Lacuna retry delay. Tests and validators pass their own fetcher and
+ * must not wait out real backoff.
+ */
+export function skipRetryDelay(_delayMs: number, signal?: AbortSignal): Promise<void> {
+  return signal?.aborted ? Promise.reject(readAbortReason(signal)) : Promise.resolve();
+}
+
+function readAbortReason(signal?: AbortSignal): unknown {
+  return signal?.reason ?? new DOMException("Aborted", "AbortError");
 }
 
 function readRetryAfterMs(value: string | null): number | undefined {

--- a/src/providers/lacuna/runtime.ts
+++ b/src/providers/lacuna/runtime.ts
@@ -44,6 +44,7 @@ const rankingAliases: Record<string, string> = {
 const allowedFields = new Set(["title", "abstract", "summary", "concepts", "name", "top_names", "venue"]);
 const markdownPathPattern =
   /\/(author|cluster|direction|figures|hypothesis|institution|node|paper|pdf|venue)\/[^\s)\]"']+/g;
+const partialDatePattern = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/;
 
 export interface LacunaActionContext {
   fetcher: ProviderFetch;
@@ -57,6 +58,8 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
     const rankingProfile = readAlias(input.rankingProfile, "rankingProfile", rankingAliases, "default");
     const sort = readEnum(input.sort, "sort", ["relevance", "year_desc", "year_asc"], "relevance");
     const fields = optionalString(input.fields);
+    const dateFrom = readPartialDate(input.dateFrom, "dateFrom");
+    const dateTo = readPartialDate(input.dateTo, "dateTo");
     validateSearchOptions(searchType, rankingProfile, sort, fields);
 
     const limit = readBoundedInteger(input.limit, "limit", 1, 50, 10);
@@ -69,8 +72,8 @@ export const lacunaActionHandlers: ProviderActionHandlers<"lacuna", ProviderRunt
       sort,
       ranking_profile: rankingProfile,
     });
-    setOptionalParam(params, "date_from", input.dateFrom);
-    setOptionalParam(params, "date_to", input.dateTo);
+    setOptionalParam(params, "date_from", dateFrom);
+    setOptionalParam(params, "date_to", dateTo);
     setOptionalParam(params, "venue", input.venue);
     if (fields) params.set("fields", fields);
     return requestLacunaJson("/api/v1/search", params, context);
@@ -284,6 +287,26 @@ function readOptionalBoundedInteger(value: unknown, fieldName: string, min: numb
     throw providerInputError(`${fieldName} must be an integer between ${min} and ${max}.`);
   }
   return number;
+}
+
+function readPartialDate(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) return undefined;
+  const text = optionalString(value);
+  const match = text?.match(partialDatePattern);
+  if (!text || !match) {
+    throw providerInputError(`${fieldName} must be a valid date in YYYY, YYYY-MM, or YYYY-MM-DD format.`);
+  }
+  if (!match[2] || !match[3]) return text;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]!) {
+    throw providerInputError(`${fieldName} must be a valid date in YYYY, YYYY-MM, or YYYY-MM-DD format.`);
+  }
+  return text;
 }
 
 function setOptionalParam(params: URLSearchParams, name: string, value: unknown): void {


### PR DESCRIPTION
## Summary

- add a native, no-auth Lacuna provider for machine-learning and AI research discovery
- implement search, paper, research-direction, direction-paper, author-context, and generated-hypothesis actions
- accept Lacuna entity IDs or canonical Lacuna URLs and normalize source links into absolute URLs
- route all Lacuna API egress through the shared SSRF-guarded provider fetch
- use bounded JSON response reads, the shared 30-second request timeout and error mapping, and retries for transient upstream responses
- add targeted runtime coverage for search aliases, route mapping, URL parsing, response normalization, input validation, unsafe URL rejection, and upstream errors

## Provider actions

| Action | Purpose |
| --- | --- |
| `lacuna.search` | Search papers, research directions, authors, institutions, venues, and generated hypotheses |
| `lacuna.get_paper` | Retrieve paper context, full records, previews, figures, concepts, blogs, or neighboring papers |
| `lacuna.get_direction` | Retrieve compact or full research-direction context |
| `lacuna.get_direction_papers` | List papers attached to a research direction with pagination |
| `lacuna.get_author_context` | Retrieve an author's profile, papers, and research directions |
| `lacuna.get_hypothesis` | Retrieve a generated research hypothesis and its source-linked context |

## Upstream validation

- checked the public Lacuna MCP installation and API behavior for endpoint paths, search aliases, ranking profiles, pagination, response views, and entity identifiers
- verified that the public Lacuna service requires no credentials
- exercised all six actions through the real open-connector executor path against the public Lacuna API
- confirmed that relative Lacuna entity and Markdown links are returned as absolute source URLs
- confirmed that user-supplied Lacuna URLs are used only to extract entity identifiers; provider requests remain pinned to the fixed Lacuna API origin

## Verification

- `npm run generate:catalog`
  - passed
  - generated 1,455 apps and 15,190 actions
  - confirmed the generated registry contains the lazy-loaded `lacuna` executor and all six action contracts

- `npm run fix-check`
  - passed
  - lint, formatting, and TypeScript checks completed successfully

- `npm test -- --run src/providers/lacuna/runtime.test.ts`
  - passed
  - 1 test file passed
  - 7 tests passed

- `npm test`
  - passed
  - 165 test files passed and 1 was skipped
  - 1,576 tests passed and 4 were skipped

- `npm run build:web`
  - passed
  - the production Web console build completed successfully

- local Web console verification
  - Lacuna appeared as a no-auth, locally executable provider
  - all six actions completed successfully against the public Lacuna API
  - search, paper, direction, direction-paper, author-context, and hypothesis results were inspected manually