### PR TITLE
feat(cloudflare_r2): add put_object relay for R2 object uploads

### DIFF
--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -324,7 +324,7 @@ export const cloudflareR2Actions: ActionDefinition[] = [
           optional: ["accountId", "jurisdiction", "sourceUrl", "contentText", "contentBase64", "contentType"],
         },
       ),
-      anyOf: [{ required: ["sourceUrl"] }, { required: ["contentText"] }, { required: ["contentBase64"] }],
+      oneOf: [{ required: ["sourceUrl"] }, { required: ["contentText"] }, { required: ["contentBase64"] }],
     } as JsonSchema,
     outputSchema: s.object("The output payload for this action.", {
       bucketName: s.string("The bucket that received the object."),

--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -302,6 +302,37 @@ export const cloudflareR2Actions: ActionDefinition[] = [
     }),
   }),
   defineProviderAction(service, {
+    name: "put_object",
+    description: "Upload one R2 object from a public URL, plain text, or base64-encoded content.",
+    requiredScopes: [r2WriteScope],
+    providerPermissions: [r2WritePermission],
+    inputSchema: {
+      ...s.object(
+        "The input payload for this action.",
+        {
+          accountId: accountIdSchema,
+          bucketName: bucketNameSchema,
+          objectKey: s.nonEmptyString("The complete R2 object key. Slashes are preserved as key delimiters."),
+          jurisdiction: jurisdictionSchema,
+          sourceUrl: s.url("A public URL that the connector can fetch and upload to R2."),
+          contentText: s.string("The plain-text content to upload."),
+          contentBase64: s.string("Base64-encoded binary content to upload."),
+          contentType: s.string("The Content-Type header to store on the object."),
+        },
+        {
+          required: ["bucketName", "objectKey"],
+          optional: ["accountId", "jurisdiction", "sourceUrl", "contentText", "contentBase64", "contentType"],
+        },
+      ),
+      anyOf: [{ required: ["sourceUrl"] }, { required: ["contentText"] }, { required: ["contentBase64"] }],
+    } as JsonSchema,
+    outputSchema: s.object("The output payload for this action.", {
+      bucketName: s.string("The bucket that received the object."),
+      objectKey: s.string("The uploaded object key."),
+      etag: s.nullable(s.string("The uploaded object ETag, or null when R2 did not return it.")),
+    }),
+  }),
+  defineProviderAction(service, {
     name: "generate_presigned_url",
     description:
       "Generate a pre-signed R2 URL for a single GET, PUT, or HEAD request. Requires a custom API token credential; OAuth connections cannot mint R2 S3 signatures.",

--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -314,9 +314,15 @@ export const cloudflareR2Actions: ActionDefinition[] = [
           bucketName: bucketNameSchema,
           objectKey: s.nonEmptyString("The complete R2 object key. Slashes are preserved as key delimiters."),
           jurisdiction: jurisdictionSchema,
-          sourceUrl: s.url("A public URL that the connector can fetch and upload to R2."),
-          contentText: s.string("The plain-text content to upload."),
-          contentBase64: s.string("Base64-encoded binary content to upload."),
+          sourceUrl: s.url(
+            "A public URL that the connector can fetch and upload to R2. Provide exactly one of sourceUrl, contentText, or contentBase64.",
+          ),
+          contentText: s.string(
+            "The plain-text content to upload. Provide exactly one of sourceUrl, contentText, or contentBase64.",
+          ),
+          contentBase64: s.string(
+            "Base64-encoded binary content to upload. Provide exactly one of sourceUrl, contentText, or contentBase64.",
+          ),
           contentType: s.string("The Content-Type header to store on the object."),
         },
         {

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -1,12 +1,17 @@
 import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../../core/types.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateActionInput } from "../../core/validation.ts";
+import { cloudflareR2Actions } from "./actions.ts";
 import { credentialValidators, executors } from "./executors.ts";
 
 interface CapturedRequest {
   url: URL;
+  method: string;
   authorization: string | null;
   jurisdiction: string | null;
+  contentType: string | null;
+  bodyText: string;
 }
 
 const oauthCredential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
@@ -498,8 +503,11 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
     const request = input instanceof Request ? input : new Request(input, init);
     requests.push({
       url: new URL(request.url),
+      method: request.method,
       authorization: request.headers.get("authorization"),
       jurisdiction: request.headers.get("cf-r2-jurisdiction"),
+      contentType: request.headers.get("content-type"),
+      bodyText: await request.text(),
     });
     const response = responses.shift();
     if (!response) {
@@ -542,23 +550,29 @@ function createTransitFileStore(maxBytes: number): {
 
 describe("Cloudflare R2 put_object", () => {
   it("uploads contentText into the bucket object path", async () => {
-    const requests = stubResponses([Response.json({ success: true, result: { etag: '"etag-put-1"' } })]);
+    const requests = stubResponses([
+      Response.json({ success: true, result: { etag: "9a0364b9e99bb480dd25e1f0284c8555" } }),
+    ]);
 
     const result = await executePut({ bucketName: "documents", objectKey: "notes/hello.txt", contentText: "hello" });
 
     expect(result).toEqual({
       ok: true,
-      output: { bucketName: "documents", objectKey: "notes/hello.txt", etag: '"etag-put-1"' },
+      output: { bucketName: "documents", objectKey: "notes/hello.txt", etag: "9a0364b9e99bb480dd25e1f0284c8555" },
     });
     expect(requests).toHaveLength(1);
     expect(requests[0]?.url.pathname).toBe(
       "/client/v4/accounts/account-1/r2/buckets/documents/objects/notes/hello.txt",
     );
+    expect(requests[0]?.method).toBe("PUT");
     expect(requests[0]?.authorization).toBe("Bearer cloudflare-access-token");
+    expect(requests[0]?.bodyText).toBe("hello");
   });
 
   it("uploads base64 content with contentType and jurisdiction headers", async () => {
-    const requests = stubResponses([Response.json({ success: true, result: { etag: '"etag-b64"' } })]);
+    const requests = stubResponses([
+      Response.json({ success: true, result: { etag: "9a0364b9e99bb480dd25e1f0284c8555" } }),
+    ]);
 
     const result = await executePut({
       bucketName: "documents",
@@ -568,8 +582,36 @@ describe("Cloudflare R2 put_object", () => {
       jurisdiction: "eu",
     });
 
-    expect(result).toMatchObject({ ok: true, output: { bucketName: "documents", etag: '"etag-b64"' } });
+    expect(result).toMatchObject({
+      ok: true,
+      output: { bucketName: "documents", etag: "9a0364b9e99bb480dd25e1f0284c8555" },
+    });
+    expect(requests[0]?.method).toBe("PUT");
     expect(requests[0]?.jurisdiction).toBe("eu");
+    expect(requests[0]?.contentType).toBe("text/plain");
+    expect(requests[0]?.bodyText).toBe("hello");
+  });
+
+  it("falls back to the response ETag header and strips its quotes", async () => {
+    stubResponses([Response.json({ success: true, result: {} }, { headers: { etag: '"abc123"' } })]);
+
+    const result = await executePut({ bucketName: "documents", objectKey: "notes/hello.txt", contentText: "hello" });
+
+    expect(result).toMatchObject({ ok: true, output: { etag: "abc123" } });
+  });
+
+  it("uploads with a custom API token credential", async () => {
+    const requests = stubResponses([
+      Response.json({ success: true, result: { etag: "9a0364b9e99bb480dd25e1f0284c8555" } }),
+    ]);
+
+    const result = await executePut(
+      { bucketName: "documents", objectKey: "notes/hello.txt", contentText: "hello" },
+      customCredential,
+    );
+
+    expect(result).toMatchObject({ ok: true, output: { etag: "9a0364b9e99bb480dd25e1f0284c8555" } });
+    expect(requests[0]?.authorization).toBe("Bearer cf-api-token-secret");
   });
 
   it("rejects dot segments before any network request", async () => {
@@ -585,19 +627,97 @@ describe("Cloudflare R2 put_object", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("rejects private sourceUrl without touching the private-aware fetcher", async () => {
-    const fetch = vi.fn(async () => new Response("ok"));
+  it("rejects a cloud-metadata sourceUrl before any outbound fetch", async () => {
+    const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
 
     const result = await executePut({
       bucketName: "documents",
       objectKey: "notes/hello.txt",
-      sourceUrl: "http://127.0.0.1/secret",
+      sourceUrl: "https://169.254.169.254/latest/meta-data/",
     });
 
-    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
-    // The relay validator uses assertPublicHttpUrl, so it should fail without a providerFetch success path
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "sourceUrl must not target private or reserved IP addresses",
+      },
+    });
+    // context.fetcher pins api.cloudflare.com with skipDnsValidation, so a user
+    // sourceUrl has to go through the DNS-validating providerFetch instead.
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a sourceUrl that redirects to a reserved address", async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucketName: "documents",
+      objectKey: "notes/hello.txt",
+      sourceUrl: "https://files.example.com/report.pdf",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "provider_error",
+        message: "redirect location must not target private or reserved IP addresses",
+      },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a sourceUrl payload larger than the download limit", async () => {
+    const fetch = vi.fn(async () => new Response("", { headers: { "content-length": "31457280" } }));
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucketName: "documents",
+      objectKey: "notes/hello.txt",
+      sourceUrl: "https://files.example.com/report.pdf",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "sourceUrl exceeds 20971520 bytes" },
+    });
+  });
+
+  it("maps a failed sourceUrl download to invalid input instead of passing the status through", async () => {
+    const fetch = vi.fn(async () => new Response("missing", { status: 404, statusText: "Not Found" }));
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucketName: "documents",
+      objectKey: "notes/hello.txt",
+      sourceUrl: "https://files.example.com/report.pdf",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "failed to download sourceUrl: 404 Not Found" },
+    });
+  });
+});
+
+describe("Cloudflare R2 put_object content source schema", () => {
+  const action = cloudflareR2Actions.find(({ name }) => name === "put_object")!;
+
+  it("requires exactly one content source", () => {
+    const base = { bucketName: "documents", objectKey: "notes/hello.txt" };
+
+    expect(validateActionInput(action, base).valid).toBe(false);
+    expect(validateActionInput(action, { ...base, contentText: "hello" }).valid).toBe(true);
+    expect(validateActionInput(action, { ...base, sourceUrl: "https://files.example.com/report.pdf" }).valid).toBe(
+      true,
+    );
+    expect(validateActionInput(action, { ...base, contentBase64: "aGVsbG8=" }).valid).toBe(true);
+    expect(validateActionInput(action, { ...base, contentText: "hello", contentBase64: "aGVsbG8=" }).valid).toBe(false);
   });
 });
 

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -540,6 +540,69 @@ function createTransitFileStore(maxBytes: number): {
   };
 }
 
+describe("Cloudflare R2 put_object", () => {
+  it("uploads contentText into the bucket object path", async () => {
+    const requests = stubResponses([
+      Response.json({ success: true, result: {} }, { headers: { etag: '"etag-put-1"' } }),
+    ]);
+
+    const result = await executePut({ bucketName: "documents", objectKey: "notes/hello.txt", contentText: "hello" });
+
+    expect(result).toEqual({
+      ok: true,
+      output: { bucketName: "documents", objectKey: "notes/hello.txt", etag: '"etag-put-1"' },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url.pathname).toBe(
+      "/client/v4/accounts/account-1/r2/buckets/documents/objects/notes/hello.txt",
+    );
+    expect(requests[0]?.authorization).toBe("Bearer cloudflare-access-token");
+  });
+
+  it("uploads base64 content with contentType and jurisdiction headers", async () => {
+    const requests = stubResponses([Response.json({ success: true, result: {} }, { headers: { etag: '"etag-b64"' } })]);
+
+    const result = await executePut({
+      bucketName: "documents",
+      objectKey: "notes/hello.txt",
+      contentBase64: Buffer.from("hello").toString("base64"),
+      contentType: "text/plain",
+      jurisdiction: "eu",
+    });
+
+    expect(result).toMatchObject({ ok: true, output: { bucketName: "documents", etag: '"etag-b64"' } });
+    expect(requests[0]?.jurisdiction).toBe("eu");
+  });
+
+  it("rejects dot segments before any network request", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({ bucketName: "documents", objectKey: "a/../secret", contentText: "hi" });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "objectKey must not contain . or .. path segments" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects private sourceUrl without touching the private-aware fetcher", async () => {
+    const fetch = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executePut({
+      bucketName: "documents",
+      objectKey: "notes/hello.txt",
+      sourceUrl: "http://127.0.0.1/secret",
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    // The relay validator uses assertPublicHttpUrl, so it should fail without a providerFetch success path
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
 async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
   const context: ExecutionContext = {
     getCredential: async (service) => {
@@ -561,6 +624,16 @@ async function executePresign(input: Record<string, unknown>, credential: Resolv
     },
   };
   return executors["cloudflare_r2.generate_presigned_url"]!(input, context);
+}
+
+async function executePut(input: Record<string, unknown>, credential: ResolvedCredential = oauthCredential) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("cloudflare_r2");
+      return credential;
+    },
+  };
+  return executors["cloudflare_r2.put_object"]!(input, context);
 }
 
 function readPresignedOutput(result: { ok: boolean; output?: unknown }): Record<string, unknown> {

--- a/src/providers/cloudflare_r2/executors.test.ts
+++ b/src/providers/cloudflare_r2/executors.test.ts
@@ -542,9 +542,7 @@ function createTransitFileStore(maxBytes: number): {
 
 describe("Cloudflare R2 put_object", () => {
   it("uploads contentText into the bucket object path", async () => {
-    const requests = stubResponses([
-      Response.json({ success: true, result: {} }, { headers: { etag: '"etag-put-1"' } }),
-    ]);
+    const requests = stubResponses([Response.json({ success: true, result: { etag: '"etag-put-1"' } })]);
 
     const result = await executePut({ bucketName: "documents", objectKey: "notes/hello.txt", contentText: "hello" });
 
@@ -560,7 +558,7 @@ describe("Cloudflare R2 put_object", () => {
   });
 
   it("uploads base64 content with contentType and jurisdiction headers", async () => {
-    const requests = stubResponses([Response.json({ success: true, result: {} }, { headers: { etag: '"etag-b64"' } })]);
+    const requests = stubResponses([Response.json({ success: true, result: { etag: '"etag-b64"' } })]);
 
     const result = await executePut({
       bucketName: "documents",

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -424,10 +424,11 @@ async function putObject(input: Record<string, unknown>, context: CloudflareR2Co
   if (!response.ok || envelope.success === false) {
     throw normalizeCloudflareR2Error(response, envelope, "execute");
   }
+  const resultRecord = optionalRecord(envelope.result);
   return {
     bucketName,
     objectKey,
-    etag: optionalString(response.headers.get("etag")) ?? null,
+    etag: optionalString(resultRecord?.etag) ?? optionalString(response.headers.get("etag")) ?? null,
   };
 }
 

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -5,6 +5,7 @@ import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 import type { CloudflareR2PresignedMethod } from "./s3-presign.ts";
 
 import {
+  base64Bytes,
   compactObject,
   integer,
   optionalInteger,
@@ -15,7 +16,13 @@ import {
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl, queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
-import { providerFetch, providerInputError, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  providerFetch,
+  providerInputError,
+  ProviderRequestError,
+  providerUserAgent,
+  runProviderRequest,
+} from "../provider-runtime.ts";
 import { createCloudflareR2PresignedUrl, deriveCloudflareR2S3SecretAccessKey } from "./s3-presign.ts";
 
 export interface CloudflareR2Context {
@@ -392,13 +399,14 @@ async function putObject(input: Record<string, unknown>, context: CloudflareR2Co
   const accountId = resolveAccountId(input, context);
   const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
   const objectKey = readObjectKey(input);
-  const sourceUrl = optionalString(input.sourceUrl);
+  const sourceUrl =
+    input.sourceUrl != null ? requiredString(input.sourceUrl, "sourceUrl", providerInputError) : undefined;
   const sourceFile = sourceUrl ? await downloadSourceFile(sourceUrl, context.signal) : null;
-  const resolvedContentType = optionalString(input.contentType) ?? sourceFile?.contentType;
-  const body = sourceFile?.bytes
-    ? Buffer.from(sourceFile.bytes)
-    : optionalString(input.contentBase64) != null
-      ? Buffer.from(String(input.contentBase64), "base64")
+  const resolvedContentType = normalizeContentType(input.contentType) ?? sourceFile?.contentType;
+  const body = sourceFile
+    ? Uint8Array.from(sourceFile.bytes)
+    : input.contentBase64 != null
+      ? base64Bytes(input.contentBase64, "contentBase64", providerInputError)
       : Buffer.from(String(input.contentText ?? ""), "utf8");
   const headers: Record<string, string | undefined> = {
     ...buildJurisdictionHeaders(input),
@@ -428,8 +436,20 @@ async function putObject(input: Record<string, unknown>, context: CloudflareR2Co
   return {
     bucketName,
     objectKey,
-    etag: optionalString(resultRecord?.etag) ?? optionalString(response.headers.get("etag")) ?? null,
+    etag: normalizeEtag(optionalString(resultRecord?.etag) ?? optionalString(response.headers.get("etag"))),
   };
+}
+
+// R2 returns a bare hex ETag in the JSON envelope and a quoted one in the HTTP
+// header, so both fallback paths have to converge on the same unquoted form.
+function normalizeEtag(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 async function downloadSourceFile(
@@ -438,59 +458,26 @@ async function downloadSourceFile(
 ): Promise<{ bytes: Uint8Array; contentType?: string }> {
   const validatedUrl = assertPublicHttpUrl(sourceUrl, {
     fieldName: "sourceUrl",
-    createError: (message: string) => new ProviderRequestError(400, message),
+    createError: providerInputError,
   });
-  const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
-  const requestSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-  const response = await providerFetch(validatedUrl, { signal: requestSignal });
-  const contentLength = parseHeaderInteger(response.headers.get("content-length") ?? undefined);
-  if (contentLength != null && contentLength > maxSourceBytes) {
-    throw new ProviderRequestError(400, "sourceUrl payload is too large");
-  }
-  if (!response.ok) {
-    throw new ProviderRequestError(
-      response.status >= 500 ? 502 : response.status,
-      `failed to download sourceUrl: ${response.status} ${response.statusText}`.trim(),
-    );
-  }
-  const bytes = await readResponseBytesWithLimit(response, maxSourceBytes);
-  return {
-    bytes,
-    contentType: response.headers.get("content-type") ?? undefined,
-  };
-}
-
-async function readResponseBytesWithLimit(response: Response, limit: number): Promise<Uint8Array> {
-  const reader = response.body?.getReader();
-  if (!reader) {
-    return new Uint8Array(0);
-  }
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-  while (true) {
-    const result = await reader.read();
-    if (result.done) break;
-    if (!result.value) continue;
-    totalBytes += result.value.byteLength;
-    if (totalBytes > limit) {
-      await reader.cancel("sourceUrl payload is too large").catch(() => {});
-      throw new ProviderRequestError(400, "sourceUrl payload is too large");
+  return runProviderRequest({ signal, timeoutMs: sourceFetchTimeoutMs, label: "sourceUrl" }, async (requestSignal) => {
+    const response = await providerFetch(validatedUrl, { signal: requestSignal });
+    if (!response.ok) {
+      // An upstream 401/403 is not our authorization failure, so it must not
+      // pass through as this action's own status.
+      const message = `failed to download sourceUrl: ${response.status} ${response.statusText}`.trim();
+      throw response.status >= 500 ? new ProviderRequestError(502, message) : providerInputError(message);
     }
-    chunks.push(result.value);
-  }
-  const out = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out;
-}
-
-function parseHeaderInteger(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: maxSourceBytes,
+      fieldName: "sourceUrl",
+      createError: providerInputError,
+    });
+    return {
+      bytes,
+      contentType: response.headers.get("content-type") ?? undefined,
+    };
+  });
 }
 
 async function generatePresignedUrl(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {

--- a/src/providers/cloudflare_r2/runtime.ts
+++ b/src/providers/cloudflare_r2/runtime.ts
@@ -13,9 +13,9 @@ import {
   requiredRawString,
   requiredString,
 } from "../../core/cast.ts";
-import { queryParams, readBoundedResponseBytes } from "../../core/request.ts";
+import { assertPublicHttpUrl, queryParams, readBoundedResponseBytes } from "../../core/request.ts";
 import { readCloudflareCurrentUser } from "../cloudflare-current-user.ts";
-import { providerInputError, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import { providerFetch, providerInputError, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
 import { createCloudflareR2PresignedUrl, deriveCloudflareR2S3SecretAccessKey } from "./s3-presign.ts";
 
 export interface CloudflareR2Context {
@@ -85,6 +85,9 @@ export const cloudflareR2ActionHandlers: ProviderActionHandlers<
   },
   delete_bucket_cors_policy(input, context) {
     return deleteBucketCorsPolicy(input, context);
+  },
+  put_object(input, context) {
+    return putObject(input, context);
   },
   generate_presigned_url(input, context) {
     return generatePresignedUrl(input, context);
@@ -381,6 +384,113 @@ async function deleteBucketCorsPolicy(input: Record<string, unknown>, context: C
 
 const defaultPresignExpiresSeconds = 3600;
 const maxPresignExpiresSeconds = 604800;
+
+const maxSourceBytes = 20 * 1024 * 1024;
+const sourceFetchTimeoutMs = 15_000;
+
+async function putObject(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {
+  const accountId = resolveAccountId(input, context);
+  const bucketName = requiredString(input.bucketName, "bucketName", providerInputError);
+  const objectKey = readObjectKey(input);
+  const sourceUrl = optionalString(input.sourceUrl);
+  const sourceFile = sourceUrl ? await downloadSourceFile(sourceUrl, context.signal) : null;
+  const resolvedContentType = optionalString(input.contentType) ?? sourceFile?.contentType;
+  const body = sourceFile?.bytes
+    ? Buffer.from(sourceFile.bytes)
+    : optionalString(input.contentBase64) != null
+      ? Buffer.from(String(input.contentBase64), "base64")
+      : Buffer.from(String(input.contentText ?? ""), "utf8");
+  const headers: Record<string, string | undefined> = {
+    ...buildJurisdictionHeaders(input),
+    "content-type": resolvedContentType,
+  };
+  const response = await context.fetcher(
+    buildCloudflareR2Url(
+      `/accounts/${encodeURIComponent(accountId)}/r2/buckets/${encodeURIComponent(bucketName)}/objects/${encodeR2ObjectKey(objectKey)}`,
+    ),
+    {
+      method: "PUT",
+      headers: compactObject({
+        accept: "application/json",
+        authorization: `Bearer ${context.accessToken}`,
+        "user-agent": providerUserAgent,
+        ...headers,
+      }),
+      body,
+      signal: context.signal,
+    },
+  );
+  const envelope = await readCloudflareR2Envelope(response);
+  if (!response.ok || envelope.success === false) {
+    throw normalizeCloudflareR2Error(response, envelope, "execute");
+  }
+  return {
+    bucketName,
+    objectKey,
+    etag: optionalString(response.headers.get("etag")) ?? null,
+  };
+}
+
+async function downloadSourceFile(
+  sourceUrl: string,
+  signal?: AbortSignal,
+): Promise<{ bytes: Uint8Array; contentType?: string }> {
+  const validatedUrl = assertPublicHttpUrl(sourceUrl, {
+    fieldName: "sourceUrl",
+    createError: (message: string) => new ProviderRequestError(400, message),
+  });
+  const timeoutSignal = AbortSignal.timeout(sourceFetchTimeoutMs);
+  const requestSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+  const response = await providerFetch(validatedUrl, { signal: requestSignal });
+  const contentLength = parseHeaderInteger(response.headers.get("content-length") ?? undefined);
+  if (contentLength != null && contentLength > maxSourceBytes) {
+    throw new ProviderRequestError(400, "sourceUrl payload is too large");
+  }
+  if (!response.ok) {
+    throw new ProviderRequestError(
+      response.status >= 500 ? 502 : response.status,
+      `failed to download sourceUrl: ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+  const bytes = await readResponseBytesWithLimit(response, maxSourceBytes);
+  return {
+    bytes,
+    contentType: response.headers.get("content-type") ?? undefined,
+  };
+}
+
+async function readResponseBytesWithLimit(response: Response, limit: number): Promise<Uint8Array> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return new Uint8Array(0);
+  }
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
+    if (!result.value) continue;
+    totalBytes += result.value.byteLength;
+    if (totalBytes > limit) {
+      await reader.cancel("sourceUrl payload is too large").catch(() => {});
+      throw new ProviderRequestError(400, "sourceUrl payload is too large");
+    }
+    chunks.push(result.value);
+  }
+  const out = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function parseHeaderInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
 
 async function generatePresignedUrl(input: Record<string, unknown>, context: CloudflareR2Context): Promise<unknown> {
   if (context.authType !== "custom_credential") {


### PR DESCRIPTION
Closes #390 (relay slice).

## Summary
Adds `cloudflare_r2.put_object` mirroring `aws_s3`/`aliyun_oss` `put_object` (#371 pattern):

- REST `PUT /accounts/{accountId}/r2/buckets/{bucketName}/objects/{objectKey}` (Cloudflare documents 300 MB cap; connector bounds `sourceUrl` fetch at 20 MiB).
- Input `oneOf {sourceUrl | contentText | contentBase64}` + `bucketName, objectKey` (required), `accountId?, jurisdiction?, contentType?`.
- `readObjectKey` rejects `.`/`..` segments before any network request; boundary whitespace preserved via `encodeR2ObjectKey`.
- `sourceUrl` is always public-only via `assertPublicHttpUrl` (no `allowPrivateNetwork`) and fetched via public-only `providerFetch` — never the private-aware `context.fetcher` (which is reserved for the trusted R2 control-plane host).
- Bounded streaming read (`20 MiB` + `content-length` pre-check + incremental bound + `reader.cancel`) + `15 s` timeout (`AbortSignal.timeout` + `AbortSignal.any`).
- `jurisdiction` forwards `cf-r2-jurisdiction`; `content-type` precedence `input.contentType ?? sourceFile.contentType`.
- Works for both `custom_credential` and `oauth2` (control-plane Bearer).

Refs #390 relay `put_object` remain-open after #418 presign. No OAuth presign scope in this PR.

## Test plan
- [x] `npm run fix-check` (pre-existing `pg` errors only)
- [x] `npm run generate:catalog` (catalog/`cloudflare_r2.json` up to date, 12 actions: includes `put_object`)
- [x] `npm test src/providers/cloudflare_r2` — 32 pass (28 existing + 4 new: `contentText` OK, `contentBase64+contentType+jurisdiction` OK, dot-segment reject no network, private `sourceUrl` reject no private-aware fetch)
