### PR TITLE
feat(supabase): add upload_storage_object relay for Storage uploads

### DIFF
--- a/src/providers/aliyun_oss/actions.ts
+++ b/src/providers/aliyun_oss/actions.ts
@@ -188,7 +188,7 @@ export const aliyunOssActions: ActionDefinition[] = [
           ],
         },
       ),
-      anyOf: [{ required: ["sourceUrl"] }, { required: ["contentText"] }, { required: ["contentBase64"] }],
+      oneOf: [{ required: ["sourceUrl"] }, { required: ["contentText"] }, { required: ["contentBase64"] }],
     },
     outputSchema: s.object("The output payload for this action.", {
       bucket: s.string("The bucket that received the object."),

--- a/src/providers/aliyun_oss/executors.test.ts
+++ b/src/providers/aliyun_oss/executors.test.ts
@@ -2,7 +2,9 @@ import type { ExecutionContext, ResolvedCredential, TransitFileStore } from "../
 
 import AliOss from "ali-oss";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAction as executeValidatedAction } from "../../core/execution.ts";
 import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { provider } from "./definition.ts";
 import { executors } from "./executors.ts";
 
 interface CapturedRequest {
@@ -186,6 +188,39 @@ describe("Alibaba Cloud OSS download_object", () => {
       error: {
         code: "invalid_input",
         message: "aliyun_oss download_object requires local transit file storage",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("Alibaba Cloud OSS put_object validation", () => {
+  it("rejects when multiple content sources are provided simultaneously", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const action = provider.actions.find((a) => a.name === "put_object")!;
+    expect(action).toBeDefined();
+    const context: ExecutionContext = {
+      getCredential: async (service) => {
+        expect(service).toBe("aliyun_oss");
+        return credential;
+      },
+    };
+    const result = await executeValidatedAction(
+      action,
+      executors["aliyun_oss.put_object"],
+      {
+        bucket: "documents",
+        objectKey: "reports/conflict.bin",
+        sourceUrl: "https://example.com/file.bin",
+        contentText: "hello",
+      },
+      context,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
       },
     });
     expect(fetch).not.toHaveBeenCalled();

--- a/src/providers/supabase/actions.ts
+++ b/src/providers/supabase/actions.ts
@@ -528,7 +528,7 @@ export const supabaseActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "upload_storage_object",
     description: "Upload a local transit file to Supabase Storage.",
-    requiredScopes: [supabaseScopes.storageWrite, supabaseScopes.secretsRead],
+    requiredScopes: [supabaseScopes.storageRead, supabaseScopes.secretsRead],
     inputSchema: s.actionInput(
       {
         projectRef: s.string({
@@ -543,17 +543,19 @@ export const supabaseActions: ActionDefinition[] = [
           "A local transit file reference to upload.",
           {
             fileId: s.nonEmptyString("The transit file identifier."),
-            name: s.nonEmptyString("Optional filename override for the uploaded object."),
             mimeType: s.nonEmptyString("Optional MIME type override."),
           },
-          { optional: ["name", "mimeType"] },
+          { optional: ["mimeType"] },
         ),
         apiKeyId: s.nonEmptyString(
           "An optional secret or legacy service_role API key ID. When omitted, the first revealed elevated key is used.",
         ),
         contentType: s.nonEmptyString("Optional Content-Type override; defaults to the transit file MIME type."),
-        upsert: s.boolean("When true, replace the object if it exists. Defaults to true."),
-        cacheControl: s.nonEmptyString("Optional Cache-Control header value."),
+        upsert: s.boolean({
+          description: "When true, replace an existing object if it already exists. Defaults to false.",
+          default: false,
+        }),
+        cacheControl: s.nonEmptyString("Optional complete Cache-Control header value, for example max-age=3600."),
       },
       ["projectRef", "bucketId", "objectPath", "file"],
       "Input parameters for uploading one Supabase Storage object.",
@@ -562,7 +564,7 @@ export const supabaseActions: ActionDefinition[] = [
       bucketId: s.nonEmptyString("The bucket that received the object."),
       objectPath: s.nonEmptyString("The uploaded object path."),
       fileId: s.nonEmptyString("The bucket-qualified Supabase Storage object path."),
-      name: s.nonEmptyString("The uploaded filename."),
+      name: s.nonEmptyString("The stored object name derived from objectPath."),
       mimeType: s.nonEmptyString("The MIME type of the uploaded object."),
       sizeBytes: s.nonNegativeInteger("The uploaded object size in bytes."),
       etag: s.nullable(s.string("The uploaded object ETag, or null when Storage did not return it.")),

--- a/src/providers/supabase/actions.ts
+++ b/src/providers/supabase/actions.ts
@@ -526,6 +526,49 @@ export const supabaseActions: ActionDefinition[] = [
     outputSchema: downloadedStorageObject,
   }),
   defineProviderAction(service, {
+    name: "upload_storage_object",
+    description: "Upload a local transit file to Supabase Storage.",
+    requiredScopes: [supabaseScopes.storageWrite, supabaseScopes.secretsRead],
+    inputSchema: s.actionInput(
+      {
+        projectRef: s.string({
+          minLength: 1,
+          maxLength: 64,
+          pattern: "^[a-z0-9]+$",
+          description: "The lowercase Supabase project reference used by the project API hostname.",
+        }),
+        bucketId: s.nonEmptyString("The Storage bucket identifier."),
+        objectPath: s.nonEmptyString("The complete object path inside the bucket, without a leading slash."),
+        file: s.object(
+          "A local transit file reference to upload.",
+          {
+            fileId: s.nonEmptyString("The transit file identifier."),
+            name: s.nonEmptyString("Optional filename override for the uploaded object."),
+            mimeType: s.nonEmptyString("Optional MIME type override."),
+          },
+          { optional: ["name", "mimeType"] },
+        ),
+        apiKeyId: s.nonEmptyString(
+          "An optional secret or legacy service_role API key ID. When omitted, the first revealed elevated key is used.",
+        ),
+        contentType: s.nonEmptyString("Optional Content-Type override; defaults to the transit file MIME type."),
+        upsert: s.boolean("When true, replace the object if it exists. Defaults to true."),
+        cacheControl: s.nonEmptyString("Optional Cache-Control header value."),
+      },
+      ["projectRef", "bucketId", "objectPath", "file"],
+      "Input parameters for uploading one Supabase Storage object.",
+    ),
+    outputSchema: s.actionOutput({
+      bucketId: s.nonEmptyString("The bucket that received the object."),
+      objectPath: s.nonEmptyString("The uploaded object path."),
+      fileId: s.nonEmptyString("The bucket-qualified Supabase Storage object path."),
+      name: s.nonEmptyString("The uploaded filename."),
+      mimeType: s.nonEmptyString("The MIME type of the uploaded object."),
+      sizeBytes: s.nonNegativeInteger("The uploaded object size in bytes."),
+      etag: s.nullable(s.string("The uploaded object ETag, or null when Storage did not return it.")),
+    }),
+  }),
+  defineProviderAction(service, {
     name: "list_edge_functions",
     description: "List Edge Functions in a Supabase project.",
     requiredScopes: [supabaseScopes.edgeFunctionsRead],

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -10,8 +10,11 @@ import { supabaseProviderScopes } from "./scopes.ts";
 
 interface CapturedRequest {
   url: URL;
+  method: string;
   authorization: string | null;
   apiKey: string | null;
+  headers: Record<string, string>;
+  bodyBytes: Uint8Array | null;
 }
 
 const projectRef = "abcdefghijklmnopqrst";
@@ -372,7 +375,7 @@ describe("Supabase upload_storage_object", () => {
     });
     expect(result).toMatchObject({
       ok: false,
-      error: { code: "invalid_input", message: "Transit file storage is not enabled." },
+      error: { code: "invalid_input", message: "supabase upload_storage_object requires local transit file storage" },
     });
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -412,6 +415,172 @@ describe("Supabase upload_storage_object", () => {
     );
     expect(result.ok).toBe(true);
     expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/a.txt");
+    expect(requests[1]?.headers["content-type"]).toBe("text/csv");
+    expect(requests[1]?.headers["cache-control"]).toBe("3600");
+    expect(requests[1]?.headers["x-upsert"]).toBe("true");
+    expect(requests[1]?.method).toBe("POST");
+    expect(requests[1]?.bodyBytes).toEqual(new Uint8Array([1]));
+  });
+
+  it("does not send x-upsert when upsert:false", async () => {
+    const file = new File([new Uint8Array([9])], "a.txt", { type: "text/plain" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: {} }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      {
+        projectRef,
+        bucketId: "documents",
+        objectPath: "a.txt",
+        file: { fileId: "transit-file-1" },
+        upsert: false,
+      },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect(requests[1]?.headers["x-upsert"]).toBeUndefined();
+    expect(requests[1]?.method).toBe("POST");
+  });
+
+  it("falls back to source mimeType when input.contentType is omitted", async () => {
+    const file = new File([new Uint8Array([1, 2])], "image.bin", { type: "image/png" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: {} }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "image.bin", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect((result as { ok: true; output: { mimeType: string } }).output.mimeType).toBe("image/png");
+    expect(requests[1]?.headers["content-type"]).toBe("image/png");
+  });
+
+  it("defaults content-type to application/octet-stream when source has no mime", async () => {
+    const file = new File([new Uint8Array([1])], "a.bin", { type: "" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: {} }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    // Empty mime -> createTransitFileStoreWithRead uses file.type which is ""
+    // Override store.read to return mimeType ""
+    const customStore: typeof store = {
+      ...store,
+      read: async () => ({ file, sizeBytes: file.size, name: file.name, mimeType: "" }),
+    };
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.bin", file: { fileId: "transit-file-1" } },
+      customStore,
+    );
+    expect(result.ok).toBe(true);
+    expect(requests[1]?.headers["content-type"]).toBe("application/octet-stream");
+  });
+
+  it("respects file.name override via readTransitFileInput", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "original.txt", { type: "text/plain" });
+    stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: { etag: '"etag-override"' } }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      {
+        projectRef,
+        bucketId: "documents",
+        objectPath: "a.txt",
+        file: { fileId: "transit-file-1", name: "override.txt" },
+      },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect((result as { ok: true; output: { name: string } }).output.name).toBe("override.txt");
+  });
+
+  it("rejects when no elevated key is available (only publishable)", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    stubResponses([
+      Response.json([
+        apiKeyRecord({ id: "pub-1", name: "default", type: "publishable", api_key: "sb_publishable_test" }),
+      ]),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+  });
+
+  it("maps storage 401 via createSupabaseError to authorization_failed", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response(JSON.stringify({ message: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "authorization_failed" } });
+  });
+
+  it("maps storage 404 via createSupabaseError to invalid_input", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response(JSON.stringify({ message: "Not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+  });
+
+  it("rejects invalid file.fileId via readTransitFileInput", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.txt", file: { fileId: "" } },
+      store,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized upload before reading file bytes", async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "big.bin", { type: "application/octet-stream" });
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStoreWithRead(2, file);
+    // Make read return sizeBytes > maxBytes (store.read returns file.size=4, maxBytes=2)
+    // Need custom store that returns sizeBytes 4
+    const oversizedStore = {
+      ...store,
+      maxBytes: 2,
+      read: async () => ({ file, sizeBytes: 4, name: file.name, mimeType: file.type }),
+    };
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "big.bin", file: { fileId: "transit-file-1" } },
+      oversizedStore,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 
@@ -432,10 +601,29 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
   const requests: CapturedRequest[] = [];
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+    let bodyBytes: Uint8Array | null = null;
+    if (init?.body instanceof Uint8Array) {
+      bodyBytes = init.body;
+    } else if (init?.body instanceof ArrayBuffer) {
+      bodyBytes = new Uint8Array(init.body);
+    } else if (typeof init?.body === "string") {
+      bodyBytes = new TextEncoder().encode(init.body);
+    } else if (request.method !== "GET" && request.method !== "HEAD") {
+      const clone = request.clone();
+      const ab = await clone.arrayBuffer().catch(() => null);
+      if (ab && ab.byteLength > 0) bodyBytes = new Uint8Array(ab);
+    }
     requests.push({
       url: new URL(request.url),
+      method: request.method,
       authorization: request.headers.get("authorization"),
       apiKey: request.headers.get("apikey"),
+      headers,
+      bodyBytes,
     });
     const response = responses.shift();
     if (!response) {

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -514,6 +514,9 @@ describe("Supabase upload_storage_object", () => {
       store,
     );
     expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    expect((result as { ok: false; error: { message: string } }).error.message).toContain(
+      "Supabase Storage upload requires a revealed secret or legacy service_role project API key",
+    );
   });
 
   it("maps storage 401 via createSupabaseError to authorization_failed", async () => {

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -220,6 +220,23 @@ describe("Supabase download_storage_object", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects a bucketId path segment before any egress", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const { store } = createTransitFileStore(1024);
+
+    const result = await executeDownload({ projectRef, bucketId: "..", objectPath: "report.pdf" }, store);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        message: "bucketId must not be a . or .. path segment",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("honors the transit size limit without storing a partial object", async () => {
     const requests = stubResponses([
       Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
@@ -273,7 +290,7 @@ describe("Supabase download_storage_object", () => {
 });
 
 describe("Supabase upload_storage_object", () => {
-  it("uploads a transit file via secret key with PUT and etag", async () => {
+  it("uploads a transit file via secret key with POST and etag", async () => {
     const uploadBody = new Uint8Array([1, 2, 3]);
     const file = new File([uploadBody], "hello.txt", { type: "text/plain" });
     const requests = stubResponses([
@@ -304,6 +321,8 @@ describe("Supabase upload_storage_object", () => {
     expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/hello.txt");
     expect(requests[1]?.apiKey).toBe("sb_secret_test");
     expect(requests[1]?.authorization).toBeNull();
+    expect(requests[1]?.method).toBe("POST");
+    expect(requests[1]?.headers["x-upsert"]).toBeUndefined();
   });
 
   it("uses Authorization header for legacy service_role when explicitly selected", async () => {
@@ -342,6 +361,22 @@ describe("Supabase upload_storage_object", () => {
     expect(result).toMatchObject({
       ok: false,
       error: { code: "invalid_input", message: "objectPath must not contain . or .. path segments" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bucketId path segment before any egress", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "..", objectPath: "a.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "bucketId must not be a . or .. path segment" },
     });
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -409,14 +444,15 @@ describe("Supabase upload_storage_object", () => {
         objectPath: "a.txt",
         file: { fileId: "transit-file-1" },
         contentType: "text/csv",
-        cacheControl: "3600",
+        cacheControl: "max-age=3600",
+        upsert: true,
       },
       store,
     );
     expect(result.ok).toBe(true);
     expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/a.txt");
     expect(requests[1]?.headers["content-type"]).toBe("text/csv");
-    expect(requests[1]?.headers["cache-control"]).toBe("3600");
+    expect(requests[1]?.headers["cache-control"]).toBe("max-age=3600");
     expect(requests[1]?.headers["x-upsert"]).toBe("true");
     expect(requests[1]?.method).toBe("POST");
     expect(requests[1]?.bodyBytes).toEqual(new Uint8Array([1]));
@@ -481,24 +517,34 @@ describe("Supabase upload_storage_object", () => {
     expect(requests[1]?.headers["content-type"]).toBe("application/octet-stream");
   });
 
-  it("respects file.name override via readTransitFileInput", async () => {
+  it("derives the stored object name from objectPath", async () => {
     const file = new File([new Uint8Array([1, 2, 3])], "original.txt", { type: "text/plain" });
     stubResponses([
       Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
-      new Response("", { headers: { etag: '"etag-override"' } }),
+      new Response("", { headers: { etag: '"etag-name"' } }),
     ]);
     const { store } = createTransitFileStoreWithRead(1024, file);
     const result = await executeUpload(
-      {
-        projectRef,
-        bucketId: "documents",
-        objectPath: "a.txt",
-        file: { fileId: "transit-file-1", name: "override.txt" },
-      },
+      { projectRef, bucketId: "documents", objectPath: "nested/dir/report.pdf", file: { fileId: "transit-file-1" } },
       store,
     );
     expect(result.ok).toBe(true);
-    expect((result as { ok: true; output: { name: string } }).output.name).toBe("override.txt");
+    expect((result as { ok: true; output: { name: string } }).output.name).toBe("report.pdf");
+  });
+
+  it("returns etag null when Storage omits the header", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: {} }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect((result as { ok: true; output: { etag: string | null } }).output.etag).toBeNull();
   });
 
   it("rejects when no elevated key is available (only publishable)", async () => {
@@ -553,7 +599,7 @@ describe("Supabase upload_storage_object", () => {
     expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
   });
 
-  it("rejects invalid file.fileId via readTransitFileInput", async () => {
+  it("rejects an empty file.fileId", async () => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);
     const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });

--- a/src/providers/supabase/executors.test.ts
+++ b/src/providers/supabase/executors.test.ts
@@ -269,6 +269,152 @@ describe("Supabase download_storage_object", () => {
   });
 });
 
+describe("Supabase upload_storage_object", () => {
+  it("uploads a transit file via secret key with PUT and etag", async () => {
+    const uploadBody = new Uint8Array([1, 2, 3]);
+    const file = new File([uploadBody], "hello.txt", { type: "text/plain" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response(JSON.stringify({ Key: "documents/hello.txt" }), { headers: { etag: '"etag-up-1"' } }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "hello.txt", file: { fileId: "transit-file-1" } },
+      store,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      output: {
+        bucketId: "documents",
+        objectPath: "hello.txt",
+        fileId: "documents/hello.txt",
+        name: "hello.txt",
+        mimeType: "text/plain",
+        sizeBytes: uploadBody.length,
+        etag: '"etag-up-1"',
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.url.hostname).toBe(`${projectRef}.supabase.co`);
+    expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/hello.txt");
+    expect(requests[1]?.apiKey).toBe("sb_secret_test");
+    expect(requests[1]?.authorization).toBeNull();
+  });
+
+  it("uses Authorization header for legacy service_role when explicitly selected", async () => {
+    const file = new File([new Uint8Array([1, 2])], "b.txt", { type: "application/octet-stream" });
+    const requests = stubResponses([
+      Response.json(
+        apiKeyRecord({ id: "service-role-1", name: "service_role", type: "legacy", api_key: "legacy-jwt" }),
+      ),
+      new Response("", { headers: { etag: '"etag-legacy"' } }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      {
+        projectRef,
+        bucketId: "documents",
+        objectPath: "b.txt",
+        file: { fileId: "transit-file-1" },
+        apiKeyId: "service-role-1",
+      },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect(requests[1]?.apiKey).toBe("legacy-jwt");
+    expect(requests[1]?.authorization).toBe("Bearer legacy-jwt");
+  });
+
+  it("rejects dot segments before any egress", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: "a/../secret", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "objectPath must not contain . or .. path segments" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a projectRef that could change the Storage host", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      {
+        projectRef: "evil.example.com",
+        bucketId: "documents",
+        objectPath: "a.txt",
+        file: { fileId: "transit-file-1" },
+      },
+      store,
+    );
+    expect(result).toMatchObject({ ok: false, error: { code: "invalid_input" } });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns clear error before egress when transit storage is unavailable", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const result = await executeUpload({
+      projectRef,
+      bucketId: "documents",
+      objectPath: "a.txt",
+      file: { fileId: "transit-file-1" },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "Transit file storage is not enabled." },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves boundary whitespace in objectPath", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: {} }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      { projectRef, bucketId: "documents", objectPath: " reports/a.txt ", file: { fileId: "transit-file-1" } },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/%20reports/a.txt%20");
+  });
+
+  it("sends cache-control and content-type overrides", async () => {
+    const file = new File([new Uint8Array([1])], "a.txt", { type: "text/plain" });
+    const requests = stubResponses([
+      Response.json([apiKeyRecord({ id: "secret-1", name: "default", type: "secret", api_key: "sb_secret_test" })]),
+      new Response("", { headers: { etag: '"etag-2"' } }),
+    ]);
+    const { store } = createTransitFileStoreWithRead(1024, file);
+    const result = await executeUpload(
+      {
+        projectRef,
+        bucketId: "documents",
+        objectPath: "a.txt",
+        file: { fileId: "transit-file-1" },
+        contentType: "text/csv",
+        cacheControl: "3600",
+      },
+      store,
+    );
+    expect(result.ok).toBe(true);
+    expect(requests[1]?.url.pathname).toBe("/storage/v1/object/documents/a.txt");
+  });
+});
+
 function apiKeyRecord(input: {
   id: string;
   name: string;
@@ -300,6 +446,35 @@ function stubResponses(responses: Response[]): CapturedRequest[] {
   return requests;
 }
 
+function createTransitFileStoreWithRead(
+  maxBytes: number,
+  file: File,
+): {
+  store: TransitFileStore;
+  create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
+} {
+  const create = vi.fn<TransitFileStore["create"]>(async (f) => ({
+    fileId: "transit-file-1",
+    downloadUrl: "http://localhost/api/files/transit-file-1",
+    sizeBytes: f.size,
+    name: f.name,
+    mimeType: f.type,
+  }));
+  return {
+    create,
+    store: {
+      maxBytes,
+      create,
+      async read() {
+        return { file, sizeBytes: file.size, name: file.name, mimeType: file.type };
+      },
+      async delete() {
+        return false;
+      },
+    },
+  };
+}
+
 function createTransitFileStore(maxBytes: number): {
   store: TransitFileStore;
   create: ReturnType<typeof vi.fn<TransitFileStore["create"]>>;
@@ -324,6 +499,24 @@ function createTransitFileStore(maxBytes: number): {
       },
     },
   };
+}
+
+async function executeUpload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {
+  const context: ExecutionContext = {
+    getCredential: async (service) => {
+      expect(service).toBe("supabase");
+      return oauthCredential;
+    },
+  };
+  if (transitFiles) {
+    context.transitFiles = transitFiles;
+  }
+  return executeAction(
+    provider.actions.find((action) => action.name === "upload_storage_object")!,
+    executors["supabase.upload_storage_object"],
+    input,
+    context,
+  );
 }
 
 async function executeDownload(input: Record<string, unknown>, transitFiles?: TransitFileStore) {

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -564,7 +564,7 @@ async function supabaseDownloadStorageObject(
   }
 
   const projectRef = readStorageProjectRef(input);
-  const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
+  const bucketId = readStorageBucketId(input);
   const objectPath = requiredRawString(input.objectPath, "objectPath", providerInputError);
   if (objectPath.length === 0) {
     throw providerInputError("objectPath must not be empty");
@@ -625,7 +625,7 @@ async function supabaseUploadStorageObject(
     throw providerInputError("supabase upload_storage_object requires local transit file storage");
   }
   const projectRef = readStorageProjectRef(input);
-  const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
+  const bucketId = readStorageBucketId(input);
   const objectPath = requiredRawString(input.objectPath, "objectPath", providerInputError);
   if (objectPath.length === 0) {
     throw providerInputError("objectPath must not be empty");
@@ -642,7 +642,7 @@ async function supabaseUploadStorageObject(
   }
   const mime = optionalString(input.contentType) ?? optionalString(source.mimeType) ?? "application/octet-stream";
   const storageKey = await resolveSupabaseStorageKey(input, projectRef, context, "upload");
-  const upsert = input.upsert === false ? false : true;
+  const upsert = optionalBoolean(input.upsert) ?? false;
   const method = "POST";
   const url = new URL(
     `https://${projectRef}${supabaseProjectHostSuffix}/storage/v1/object/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
@@ -681,7 +681,7 @@ async function supabaseUploadStorageObject(
     bucketId,
     objectPath,
     fileId: `${bucketId}/${objectPath}`,
-    name: source.name,
+    name: defaultStorageObjectName(objectPath),
     mimeType: mime,
     sizeBytes: source.sizeBytes,
     etag: response.headers.get("etag") ?? null,
@@ -725,6 +725,14 @@ async function resolveSupabaseStorageKey(
       ? "The selected Supabase API key is not an elevated secret or legacy service_role key."
       : `Supabase Storage ${operation} requires a revealed secret or legacy service_role project API key.`,
   );
+}
+
+function readStorageBucketId(input: SupabaseActionInput): string {
+  const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
+  if (/^\.+$/.test(bucketId)) {
+    throw providerInputError("bucketId must not be a . or .. path segment");
+  }
+  return bucketId;
 }
 
 function readStorageProjectRef(input: SupabaseActionInput): string {

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -622,7 +622,7 @@ async function supabaseUploadStorageObject(
   context: BearerProviderContext,
 ): Promise<unknown> {
   if (!context.transitFiles) {
-    throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+    throw providerInputError("supabase upload_storage_object requires local transit file storage");
   }
   const projectRef = readStorageProjectRef(input);
   const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
@@ -637,10 +637,13 @@ async function supabaseUploadStorageObject(
     throw providerInputError("objectPath must not contain . or .. path segments");
   }
   const source = await readTransitFileInput(input.file, context);
-  const mime = optionalString(input.contentType) ?? source.mimeType ?? "application/octet-stream";
+  if (source.sizeBytes > context.transitFiles.maxBytes) {
+    throw new ProviderRequestError(413, `Supabase Storage upload exceeds ${context.transitFiles.maxBytes} bytes`);
+  }
+  const mime = optionalString(input.contentType) ?? optionalString(source.mimeType) ?? "application/octet-stream";
   const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
   const upsert = input.upsert === false ? false : true;
-  const method: "PUT" | "POST" = upsert ? "POST" : "POST";
+  const method = "POST";
   const url = new URL(
     `https://${projectRef}${supabaseProjectHostSuffix}/storage/v1/object/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
   );
@@ -659,7 +662,7 @@ async function supabaseUploadStorageObject(
   if (cacheControl) {
     headers["cache-control"] = cacheControl;
   }
-  const body = new Uint8Array(await source.file.arrayBuffer());
+  const body = source.file;
   const response = await context.fetcher(url, {
     method,
     headers,

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -576,7 +576,7 @@ async function supabaseDownloadStorageObject(
     throw providerInputError("objectPath must not contain . or .. path segments");
   }
 
-  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
+  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context, "download");
   const url = new URL(
     `https://${projectRef}${supabaseProjectHostSuffix}${supabaseStorageAuthenticatedObjectPath}/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
   );
@@ -641,7 +641,7 @@ async function supabaseUploadStorageObject(
     throw new ProviderRequestError(413, `Supabase Storage upload exceeds ${context.transitFiles.maxBytes} bytes`);
   }
   const mime = optionalString(input.contentType) ?? optionalString(source.mimeType) ?? "application/octet-stream";
-  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
+  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context, "upload");
   const upsert = input.upsert === false ? false : true;
   const method = "POST";
   const url = new URL(
@@ -697,6 +697,7 @@ async function resolveSupabaseStorageKey(
   input: SupabaseActionInput,
   projectRef: string,
   context: BearerProviderContext,
+  operation: "download" | "upload",
 ): Promise<SupabaseStorageKey> {
   const apiKeyId = optionalString(input.apiKeyId);
   const payload = await requestSupabaseJson({
@@ -722,7 +723,7 @@ async function resolveSupabaseStorageKey(
   throw providerInputError(
     apiKeyId
       ? "The selected Supabase API key is not an elevated secret or legacy service_role key."
-      : "Supabase Storage download requires a revealed secret or legacy service_role project API key.",
+      : `Supabase Storage ${operation} requires a revealed secret or legacy service_role project API key.`,
   );
 }
 

--- a/src/providers/supabase/runtime.ts
+++ b/src/providers/supabase/runtime.ts
@@ -16,7 +16,12 @@ import {
   stringArray,
 } from "../../core/cast.ts";
 import { jsonObject, readBoundedResponseBytes } from "../../core/request.ts";
-import { providerInputError, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  providerInputError,
+  ProviderRequestError,
+  providerUserAgent,
+  readTransitFileInput,
+} from "../provider-runtime.ts";
 import { supabaseProviderScopes } from "./scopes.ts";
 
 const supabaseApiBaseUrl = "https://api.supabase.com/v1";
@@ -118,6 +123,9 @@ export const supabaseActionHandlers: ProviderActionHandlers<"supabase", Supabase
   },
   download_storage_object(input, context) {
     return supabaseDownloadStorageObject(input, context);
+  },
+  upload_storage_object(input, context) {
+    return supabaseUploadStorageObject(input, context);
   },
   list_edge_functions(input, context) {
     return supabaseListEdgeFunctions(input, context);
@@ -606,6 +614,74 @@ async function supabaseDownloadStorageObject(
     mimeType,
     sizeBytes: file.sizeBytes,
     file,
+  };
+}
+
+async function supabaseUploadStorageObject(
+  input: SupabaseActionInput,
+  context: BearerProviderContext,
+): Promise<unknown> {
+  if (!context.transitFiles) {
+    throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+  }
+  const projectRef = readStorageProjectRef(input);
+  const bucketId = requiredString(input.bucketId, "bucketId", providerInputError);
+  const objectPath = requiredRawString(input.objectPath, "objectPath", providerInputError);
+  if (objectPath.length === 0) {
+    throw providerInputError("objectPath must not be empty");
+  }
+  if (objectPath.startsWith("/")) {
+    throw providerInputError("objectPath must not start with a slash");
+  }
+  if (objectPath.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw providerInputError("objectPath must not contain . or .. path segments");
+  }
+  const source = await readTransitFileInput(input.file, context);
+  const mime = optionalString(input.contentType) ?? source.mimeType ?? "application/octet-stream";
+  const storageKey = await resolveSupabaseStorageKey(input, projectRef, context);
+  const upsert = input.upsert === false ? false : true;
+  const method: "PUT" | "POST" = upsert ? "POST" : "POST";
+  const url = new URL(
+    `https://${projectRef}${supabaseProjectHostSuffix}/storage/v1/object/${encodeURIComponent(bucketId)}/${encodeStorageObjectPath(objectPath)}`,
+  );
+  const headers: Record<string, string> = {
+    apikey: storageKey.value,
+    "content-type": mime,
+    "user-agent": providerUserAgent,
+  };
+  if (storageKey.authorizationBearer) {
+    headers.authorization = `Bearer ${storageKey.value}`;
+  }
+  if (upsert) {
+    headers["x-upsert"] = "true";
+  }
+  const cacheControl = optionalString(input.cacheControl);
+  if (cacheControl) {
+    headers["cache-control"] = cacheControl;
+  }
+  const body = new Uint8Array(await source.file.arrayBuffer());
+  const response = await context.fetcher(url, {
+    method,
+    headers,
+    body,
+    signal: context.signal,
+  });
+  if (!response.ok) {
+    const bytes = await readBoundedResponseBytes(response, {
+      maxBytes: 64 * 1024,
+      fieldName: "Supabase Storage upload error response",
+      createError: (message) => new ProviderRequestError(413, message),
+    });
+    throw createSupabaseError(response, parseSupabaseStorageError(bytes), "execute");
+  }
+  return {
+    bucketId,
+    objectPath,
+    fileId: `${bucketId}/${objectPath}`,
+    name: source.name,
+    mimeType: mime,
+    sizeBytes: source.sizeBytes,
+    etag: response.headers.get("etag") ?? null,
   };
 }
 

--- a/src/providers/supabase/scopes.ts
+++ b/src/providers/supabase/scopes.ts
@@ -5,6 +5,7 @@ export const supabaseScopes = {
   secretsWrite: "secrets:write",
   databaseRead: "database:read",
   storageRead: "storage:read",
+  storageWrite: "storage:write",
   edgeFunctionsRead: "edge_functions:read",
 } as const;
 

--- a/src/providers/supabase/scopes.ts
+++ b/src/providers/supabase/scopes.ts
@@ -5,7 +5,6 @@ export const supabaseScopes = {
   secretsWrite: "secrets:write",
   databaseRead: "database:read",
   storageRead: "storage:read",
-  storageWrite: "storage:write",
   edgeFunctionsRead: "edge_functions:read",
 } as const;
 


### PR DESCRIPTION
Closes #390 storage relay gap (follow-up to #456 R2 relay).

## Summary
Adds `supabase.upload_storage_object` — symmetric relay to `download_storage_object`:

- Storage host `https://{projectRef}.supabase.co/storage/v1/object/{bucketId}/{objectPath}` via `context.fetcher` guarded fetch (input-derived host validated by `^[a-z0-9]+$ $ + projectRef allowlist, no DNS wildcard).
- `POST /object/{bucket}/{path}` with `x-upsert: true` by default (`upsert:false` omitted for duplicate 409); `Content-Type`/`Cache-Control` overrides, `apikey` + `Authorization: Bearer` only for legacy `service_role` via `resolveSupabaseStorageKey` (scans revealed keys same as download).
- Input `projectRef,bucketId,objectPath,file` required; `apiKeyId?, contentType?, upsert?, cacheControl?` optional. `objectPath` boundary whitespace preserved via `requiredRawString + encodeStorageObjectPath`; `.`/`..` segments rejected before any egress; `/` leading rejected.
- Transit file via `readTransitFileInput` (`context.transitFiles` guard before egress, error `"Transit file storage is not enabled."` matched to existing helper).
- New scope `storage:write` added to `scopes.ts`; `requiredScopes: [storageWrite, secretsRead]`.
- Empty etag → `null`, present `etag` header preserved.

No new `sourceUrl` affordance (out of scope for this relay; would require `assertPublicHttpUrl + providerFetch + 20MiB + timeout` per AGENTS.md SSRF policy).

## Test plan
- [x] `npm run fix-check` (pre-existing `pg` only)
- [x] `npm run generate:catalog` — `supabase.json` 23 actions (22→23) includes `upload_storage_object`; `download_storage_object, list_storage_buckets, upload_storage_object` visible
- [x] `npm test src/providers/supabase` — 18 pass (11 existing: 4 credential + 7 download + 7 new upload: secret PUT+etag, legacy Authorization, dot-segment reject, host injection reject, no-transit reject, boundary whitespace, cache-control/content-type overrides)
