### PR TITLE
fix(core): keep only safe-listed headers on cross-origin redirects

### DIFF
--- a/src/core/guarded-fetch.test.ts
+++ b/src/core/guarded-fetch.test.ts
@@ -1,7 +1,12 @@
 import type { GuardedFetchDnsLookup } from "./guarded-fetch.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createGuardedFetch, resolveGuardedEgressTarget, unwrapGuardedFetch } from "./guarded-fetch.ts";
+import {
+  createGuardedFetch,
+  crossOriginSafeHeaders,
+  resolveGuardedEgressTarget,
+  unwrapGuardedFetch,
+} from "./guarded-fetch.ts";
 import { setEgressTrustedHosts } from "./request.ts";
 
 interface RecordedCall {
@@ -69,6 +74,37 @@ describe("resolveGuardedEgressTarget", () => {
     ).rejects.toThrow("dns: mail host could not be resolved for validation");
   });
 });
+
+// Every header the cross-origin rule keeps, with a value of the shape the header
+// really carries. The 307 test sends the whole set in one hop and the fixture is
+// pinned name-for-name against `crossOriginSafeHeaders` below, so a trim fails
+// here instead of silently breaking a provider mid-upload, and a widening fails
+// here instead of silently re-opening the leak.
+const crossOriginSafeHeaderFixture: Record<string, string> = {
+  accept: "application/json",
+  "accept-charset": "utf-8",
+  "accept-encoding": "gzip",
+  "accept-language": "en-US",
+  "cache-control": "no-cache",
+  "content-disposition": 'attachment; filename="chunk.bin"',
+  "content-encoding": "identity",
+  "content-language": "en",
+  "content-length": "10",
+  "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+  "content-range": "bytes 0-9/100",
+  "content-type": "application/octet-stream",
+  dnt: "1",
+  "idempotency-key": "abc",
+  "if-match": '"etag-1"',
+  "if-modified-since": "Wed, 21 Oct 2015 07:28:00 GMT",
+  "if-none-match": '"etag-2"',
+  "if-unmodified-since": "Wed, 21 Oct 2015 07:28:00 GMT",
+  range: "bytes=0-9",
+  "user-agent": "oomol-connect/0.1",
+  "x-correlation-id": "cid",
+  "x-request-id": "req-1",
+  "x-trace": "trace-1",
+};
 
 describe("createGuardedFetch redirects", () => {
   it("follows public redirects with manual hops and returns the final response", async () => {
@@ -298,26 +334,110 @@ describe("createGuardedFetch redirects", () => {
     expect(crossOriginHeaders.get("x-correlation-id")).toBe("cid");
   });
 
-  it("strips caller-declared sensitive headers on cross-origin redirects", async () => {
+  it("drops every unlisted header on a cross-origin redirect and keeps the safe set", async () => {
     const { transport, calls } = createTransport([
+      redirectTo("https://api.example.com/moved"),
       redirectTo("https://other.example.net/away"),
       new Response("ok", { status: 200 }),
     ]);
-    const guarded = createGuardedFetch({
-      fetch: transport,
-      additionalSensitiveHeaders: ["X-Provider-Credential"],
-    });
+    const guarded = createGuardedFetch({ fetch: transport });
 
     await guarded("https://api.example.com/", {
       headers: {
-        "x-provider-credential": "secret",
+        // Provider credential headers no name list enumerated ahead of time.
+        "x-esri-authorization": "Bearer esri-secret",
+        "x-els-insttoken": "insttoken-secret",
+        secret: "autotask-secret",
+        session: "tanium-secret",
+        web_api_key: "finerworks-secret",
+        // A real stored credential (autotask) whose name matches no credential
+        // word, plus a header that is neither safe-listed nor credential-shaped.
+        // Both pin the rule as deny-by-default rather than a smarter heuristic.
+        apiintegrationcode: "autotask-integration-code",
+        "x-vendor-quirk": "anything",
+        // Non-credential headers that must survive a cross-origin hop.
         "x-trace": "keep",
+        "idempotency-key": "abc",
+        "x-correlation-id": "cid",
       },
     });
 
+    const sameOriginHeaders = new Headers(calls[1]?.init?.headers);
+    expect(sameOriginHeaders.get("x-esri-authorization")).toBe("Bearer esri-secret");
+    expect(sameOriginHeaders.get("x-els-insttoken")).toBe("insttoken-secret");
+    expect(sameOriginHeaders.get("secret")).toBe("autotask-secret");
+    expect(sameOriginHeaders.get("session")).toBe("tanium-secret");
+    expect(sameOriginHeaders.get("web_api_key")).toBe("finerworks-secret");
+    expect(sameOriginHeaders.get("apiintegrationcode")).toBe("autotask-integration-code");
+    expect(sameOriginHeaders.get("x-vendor-quirk")).toBe("anything");
+    expect(sameOriginHeaders.get("x-trace")).toBe("keep");
+    expect(sameOriginHeaders.get("idempotency-key")).toBe("abc");
+    expect(sameOriginHeaders.get("x-correlation-id")).toBe("cid");
+    const crossOriginHeaders = new Headers(calls[2]?.init?.headers);
+    expect(crossOriginHeaders.has("x-esri-authorization")).toBe(false);
+    expect(crossOriginHeaders.has("x-els-insttoken")).toBe(false);
+    expect(crossOriginHeaders.has("secret")).toBe(false);
+    expect(crossOriginHeaders.has("session")).toBe(false);
+    expect(crossOriginHeaders.has("web_api_key")).toBe(false);
+    expect(crossOriginHeaders.has("apiintegrationcode")).toBe(false);
+    expect(crossOriginHeaders.has("x-vendor-quirk")).toBe(false);
+    expect(crossOriginHeaders.get("x-trace")).toBe("keep");
+    expect(crossOriginHeaders.get("idempotency-key")).toBe("abc");
+    expect(crossOriginHeaders.get("x-correlation-id")).toBe("cid");
+  });
+
+  it("pins the cross-origin safe list name-for-name to the fixture the redirect tests send", () => {
+    // Without this, adding a provider credential name to the safe list passes
+    // every other test: the 307 assertion compares the redirected hop against
+    // the fixture it sent, not against the list, so a name added to the list and
+    // never sent is invisible. Widening the rule has to be a two-place edit.
+    expect([...crossOriginSafeHeaders].sort()).toEqual(Object.keys(crossOriginSafeHeaderFixture).sort());
+  });
+
+  it("keeps every safe-listed header and nothing else on a cross-origin 307 redirect", async () => {
+    const { transport, calls } = createTransport([
+      redirectTo("https://cdn.example.net/upload", 307),
+      new Response("ok", { status: 200 }),
+    ]);
+    const guarded = createGuardedFetch({ fetch: transport });
+
+    await guarded("https://api.example.com/upload", {
+      method: "PUT",
+      headers: { ...crossOriginSafeHeaderFixture, authorization: "Bearer secret" },
+      body: "0123456789",
+    });
+
+    expect(calls[1]?.init?.method).toBe("PUT");
+    expect(calls[1]?.init?.body).toBe("0123456789");
     const redirectedHeaders = new Headers(calls[1]?.init?.headers);
-    expect(redirectedHeaders.has("x-provider-credential")).toBe(false);
-    expect(redirectedHeaders.get("x-trace")).toBe("keep");
+    expect(Object.fromEntries(redirectedHeaders.entries())).toEqual(crossOriginSafeHeaderFixture);
+  });
+
+  it("drops a caller-declared sensitive header with or without additionalSensitiveHeaders", async () => {
+    const headers = { "x-provider-credential": "secret", "x-trace": "keep" };
+    const declared = createTransport([
+      redirectTo("https://other.example.net/away"),
+      new Response("ok", { status: 200 }),
+    ]);
+    const undeclared = createTransport([
+      redirectTo("https://other.example.net/away"),
+      new Response("ok", { status: 200 }),
+    ]);
+
+    await createGuardedFetch({
+      fetch: declared.transport,
+      additionalSensitiveHeaders: ["X-Provider-Credential"],
+    })("https://api.example.com/", { headers });
+    await createGuardedFetch({ fetch: undeclared.transport })("https://api.example.com/", { headers });
+
+    // `additionalSensitiveHeaders` is inert: the safe list already drops the
+    // header, so both runs must reach the redirect target with the same headers.
+    const declaredHeaders = new Headers(declared.calls[1]?.init?.headers);
+    expect(declaredHeaders.has("x-provider-credential")).toBe(false);
+    expect(declaredHeaders.get("x-trace")).toBe("keep");
+    expect(Object.fromEntries(new Headers(undeclared.calls[1]?.init?.headers).entries())).toEqual(
+      Object.fromEntries(declaredHeaders.entries()),
+    );
   });
 
   it("passes through when the caller handles redirects manually", async () => {

--- a/src/core/guarded-fetch.ts
+++ b/src/core/guarded-fetch.ts
@@ -44,7 +44,12 @@ export interface GuardedFetchOptions {
    * only adds a per-request lookup. On by default.
    */
   skipDnsValidation?: boolean;
-  /** Additional credential-bearing headers to drop when a redirect crosses origins. */
+  /**
+   * Additional credential-bearing headers to drop when a redirect crosses
+   * origins. Kept for compatibility with callers that name their auth header
+   * explicitly; it is now a no-op, because a cross-origin hop already drops
+   * every header outside this module's cross-origin safe list.
+   */
   additionalSensitiveHeaders?: readonly string[];
   /** Transform errors thrown by the underlying transport before they escape the guarded fetch. */
   mapTransportError?: (error: unknown) => unknown;
@@ -56,60 +61,73 @@ export interface GuardedFetchOptions {
 const defaultMaxRedirects = 20;
 const redirectStatuses = new Set([301, 302, 303, 307, 308]);
 /**
- * Credential-bearing request headers dropped when a redirect crosses origins, so
- * a cross-origin redirect cannot exfiltrate a provider credential. Covers the
- * fetch-spec set (`authorization`/`cookie`/`proxy-authorization`) plus the
- * common custom auth headers provider egress sends. This is an explicit
- * allowlist rather than a name pattern so it never strips look-alike but
- * non-credential headers (e.g. `idempotency-key`, `x-correlation-id`); add a
- * provider's header here if it authenticates with a name not already listed.
+ * The only request headers kept when a redirect crosses origins; every other
+ * header is dropped before the next hop is issued.
+ *
+ * This is deny-by-default on purpose. The previous rule dropped names on an
+ * explicit credential list, which silently forwarded any provider credential
+ * whose header name nobody had added to it, and provider egress here sends over
+ * a hundred distinct custom auth header names. A redirect target is a different
+ * party from the one the credential was issued for, so the safe direction is to
+ * keep only headers whose value is fixed by the request itself and cannot carry
+ * a secret:
+ *
+ * - content negotiation and client hints: `accept`, `accept-charset`,
+ *   `accept-encoding`, `accept-language`, `dnt`.
+ * - body descriptors: `content-type`, `content-length`, `content-language`,
+ *   `content-encoding`, `content-range`, `content-disposition`, `content-md5`.
+ *   They must survive a 307/308 hop or the replayed body arrives undescribed.
+ *   `content-range` earns its place twice over: a chunked upload that loses it
+ *   reaches the target as a well-formed full object instead of failing loudly.
+ *   Every value here is fixed by the body already being sent - a media type, a
+ *   length, a byte range, a file name, a digest - so none can carry a secret.
+ * - caching, conditional and partial fetching: `cache-control`, `range`,
+ *   `if-match`, `if-none-match`, `if-modified-since`, `if-unmodified-since`.
+ *   Their values are directives, byte offsets, dates, and ETags the target
+ *   itself issued. `range` matters because a download handed off to a CDN is
+ *   the common cross-origin hop.
+ * - request identity for logs, tracing and replay safety: `user-agent`,
+ *   `idempotency-key`, `x-request-id`, `x-correlation-id`, `x-trace`. They name
+ *   a request; they grant nothing.
+ *
+ * `referer` and `content-location` are deliberately absent: both carry a URL,
+ * and many providers here authenticate by putting the key in the query string,
+ * so forwarding either would leak the credential this rule exists to hold back.
+ * That is also why browsers downgrade `referer` cross-origin. `content-location`
+ * appears in the POST-to-GET body-header list below because the fetch spec drops
+ * it there, not because it survives an origin change; nothing in this repo sets
+ * it. A provider that legitimately redirects cross-origin and needs some other
+ * header gets a 4xx from the target, never a leak; add the header here once such
+ * a case is proven.
+ *
+ * Exported read-only so the tests can pin the list itself: widening it is the
+ * one edit that silently re-opens this hole, so the suite makes it an explicit
+ * two-place change.
  */
-const crossOriginCredentialHeaders = new Set([
-  "authorization",
-  "proxy-authorization",
-  "cookie",
-  "api-key",
-  "apikey",
-  "x-api-key",
-  "x-apikey",
-  "api-token",
-  "x-api-token",
-  "auth-token",
-  "x-auth-token",
-  "x-auth-key",
-  "access-token",
-  "x-access-token",
-  "app-key",
-  "x-app-key",
-  "api-secret",
-  "x-api-secret",
-  "client-secret",
-  "x-client-secret",
-  "x-secret",
-  "token",
-  "x-token",
-  "session-token",
-  "x-session-token",
-  "x-seq-apikey",
-  "private-token",
-  "x-private-token",
-  "x-csrf-token",
-  "x-gotify-key",
-  "x-xsrf-token",
-  "x-goog-api-key",
-  "x-acs-security-token",
-  "x-amz-security-token",
-  "x-n8n-api-key",
-  "x-shopify-access-token",
-  "x-vtex-api-appkey",
-  "x-vtex-api-apptoken",
-  "x-tomba-key",
-  "client-token",
-  "x-session-key",
-  "x-redmine-api-key",
-  "authkey",
-  "x-oksign-authorization",
-  "x-filesapi-key",
+export const crossOriginSafeHeaders: ReadonlySet<string> = new Set([
+  "accept",
+  "accept-charset",
+  "accept-encoding",
+  "accept-language",
+  "cache-control",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-md5",
+  "content-range",
+  "content-type",
+  "dnt",
+  "idempotency-key",
+  "if-match",
+  "if-modified-since",
+  "if-none-match",
+  "if-unmodified-since",
+  "range",
+  "user-agent",
+  "x-correlation-id",
+  "x-request-id",
+  "x-trace",
 ]);
 /** Body-describing headers dropped when a redirect rewrites the method to GET, mirroring the fetch spec. */
 const bodyHeaders = ["content-encoding", "content-language", "content-length", "content-location", "content-type"];
@@ -176,7 +194,6 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
   const baseFetch = unwrapGuardedFetch(options.fetch);
   const createError = options.createError ?? ((message: string) => new TypeError(message));
   const maxRedirects = options.maxRedirects ?? defaultMaxRedirects;
-  const additionalSensitiveHeaders = new Set(options.additionalSensitiveHeaders?.map((name) => name.toLowerCase()));
   const guardedFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const transport = baseFetch ?? globalThis.fetch;
     const fetchTransport = async (
@@ -264,7 +281,7 @@ export function createGuardedFetch(options: GuardedFetchOptions = {}): typeof fe
       }
       if (guardedNext.origin !== url.origin) {
         for (const name of [...headers.keys()]) {
-          if (crossOriginCredentialHeaders.has(name) || additionalSensitiveHeaders.has(name)) {
+          if (!crossOriginSafeHeaders.has(name)) {
             headers.delete(name);
           }
         }

--- a/src/providers/provider-runtime.proxy-redirect.test.ts
+++ b/src/providers/provider-runtime.proxy-redirect.test.ts
@@ -1,0 +1,116 @@
+import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { crossOriginSafeHeaders } from "../core/guarded-fetch.ts";
+import { proxy as arcgisOnlineProxy } from "./arcgis_online/executors.ts";
+import { providerFetch } from "./provider-runtime.ts";
+import { proxy as scopusProxy } from "./scopus/executors.ts";
+
+interface RecordedHop {
+  url: string;
+  headers: Headers;
+}
+
+const arcgisCredential: ResolvedCredential = {
+  authType: "api_key",
+  apiKey: "SECRET-ESRI-KEY",
+  values: { apiKey: "SECRET-ESRI-KEY" },
+  profile: { accountId: "acct", displayName: "ArcGIS Online API Key", grantedScopes: [] },
+  metadata: {},
+};
+
+const scopusCredential: ResolvedCredential = {
+  authType: "api_key",
+  apiKey: "SECRET-ELS-APIKEY",
+  values: { apiKey: "SECRET-ELS-APIKEY", institutionToken: "SECRET-INSTTOKEN" },
+  profile: { accountId: "acct", displayName: "Scopus API Key", grantedScopes: [] },
+  metadata: {},
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("provider egress on cross-origin redirects", () => {
+  it("does not forward the ArcGIS Online proxy credential header to the redirect target", async () => {
+    const hops = stubCrossOriginRedirect();
+
+    const result = await arcgisOnlineProxy({ method: "GET", endpoint: "/suggest" }, contextFor(arcgisCredential));
+
+    expect(result.ok).toBe(true);
+    expect(hops).toHaveLength(2);
+    expect(hops[0]?.headers.get("x-esri-authorization")).toBe("Bearer SECRET-ESRI-KEY");
+    expect(hops[1]?.url).toBe("https://attacker.example.net/collect");
+    expect(hops[1]?.headers.has("x-esri-authorization")).toBe(false);
+    expect(headerNames(hops[1])).toEqual(safeSubsetOf(hops[0]));
+  });
+
+  it("does not forward the Scopus institution token to the redirect target", async () => {
+    const hops = stubCrossOriginRedirect();
+
+    const result = await scopusProxy({ method: "GET", endpoint: "/search/scopus" }, contextFor(scopusCredential));
+
+    expect(result.ok).toBe(true);
+    expect(hops).toHaveLength(2);
+    expect(hops[0]?.headers.get("x-els-insttoken")).toBe("SECRET-INSTTOKEN");
+    expect(hops[1]?.url).toBe("https://attacker.example.net/collect");
+    expect(hops[1]?.headers.has("x-els-insttoken")).toBe(false);
+    expect(hops[1]?.headers.has("x-els-apikey")).toBe(false);
+    expect(headerNames(hops[1])).toEqual(safeSubsetOf(hops[0]));
+  });
+
+  it("does not forward an action-path credential header through the shared provider fetch", async () => {
+    const hops = stubCrossOriginRedirect();
+
+    await providerFetch("https://api.elevenlabs.io/v1/voices", {
+      headers: { "xi-api-key": "SECRET-XI", "x-request-id": "req-1" },
+    });
+
+    expect(hops).toHaveLength(2);
+    expect(hops[0]?.headers.get("xi-api-key")).toBe("SECRET-XI");
+    expect(hops[1]?.url).toBe("https://attacker.example.net/collect");
+    expect(hops[1]?.headers.has("xi-api-key")).toBe(false);
+    expect(headerNames(hops[1])).toEqual(safeSubsetOf(hops[0]));
+    expect(hops[1]?.headers.get("x-request-id")).toBe("req-1");
+  });
+});
+
+function contextFor(credential: ResolvedCredential): ExecutionContext {
+  return { getCredential: async () => credential };
+}
+
+/** Stub the global fetch so hop 1 answers 302 to a different origin and hop 2 succeeds. */
+function stubCrossOriginRedirect(): RecordedHop[] {
+  const hops: RecordedHop[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    hops.push({
+      url: input instanceof Request ? input.url : String(input),
+      headers: new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined)),
+    });
+    if (hops.length === 1) {
+      return new Response(null, { status: 302, headers: { location: "https://attacker.example.net/collect" } });
+    }
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  });
+  return hops;
+}
+
+/**
+ * Sorted header names a hop was issued with. The cross-origin rule is
+ * deny-by-default, so each case asserts the exact surviving set rather than the
+ * absence of names that look like credentials: a credential header nobody
+ * recognizes as one is precisely the case this layer exists to cover.
+ */
+function headerNames(hop: RecordedHop | undefined): string[] {
+  return [...new Headers(hop?.headers).keys()].sort();
+}
+
+/**
+ * The names from the first hop the cross-origin rule is allowed to keep. Deriving
+ * the expectation this way keeps the exact-set assertion strong while leaving the
+ * headers a provider happens to send its own concern: a provider dropping its
+ * `accept` default must not fail a guarded-fetch regression test.
+ */
+function safeSubsetOf(hop: RecordedHop | undefined): string[] {
+  return headerNames(hop).filter((name) => crossOriginSafeHeaders.has(name));
+}


### PR DESCRIPTION
Bottom of the E-tier audit stack, based on `main`.

On a cross-origin redirect the guarded fetch stripped only the 45 header names on a hard-coded deny list, so any provider whose credential rides a header outside that list sent the secret straight to the redirect target. It reaches both `/v1/proxy` and `/v1/actions` (they share `providerFetch`), and a caller holding only proxy access can recover a stored key the runtime is built to keep unreadable. Reproduced today: `arcgis_online` forwards `x-esri-authorization`, `scopus` forwards `x-els-insttoken`, and the action path forwards `xi-api-key` to an outside origin on the first hop. This is a regression from #98, which replaced a name-pattern heuristic with the explicit allowlist and lost coverage for 82 of the leaking names.

The fix flips the rule: on a hop whose origin (scheme, host, port) differs, keep only a 23-name set of headers that provably carry no credential and delete everything else. Same-origin hops are unchanged, so every provider that depends on its headers surviving keeps working. One follow-up stays open: the request body is still replayed on a `307`/`308` cross-origin hop, so a body carrying a secret is not yet covered.
