### PR TITLE
fix(proxy): thread the request signal and memoize credentials

### DIFF
--- a/src/connection-service.test.ts
+++ b/src/connection-service.test.ts
@@ -974,6 +974,55 @@ describe("ConnectionService", () => {
       profile: { accountId: "example-account" },
     });
   });
+
+  it("resolves each service credential once per forConnection scope", async () => {
+    const store = new MemoryConnectionStore();
+    const service = createService([apiKeyProvider, customCredentialProvider], { store });
+    await store.set("uptimerobot", "default", {
+      authType: "api_key",
+      apiKey: "monitor-key",
+      values: { apiKey: "monitor-key", accountId: "account-1" },
+      profile: testProfile,
+      metadata: {},
+    });
+    await store.set("database", "default", {
+      authType: "custom_credential",
+      values: { host: "db.example.com", password: "secret" },
+      profile: testProfile,
+      metadata: {},
+    });
+    const get = vi.spyOn(store, "get");
+
+    const connection = service.forConnection();
+    await expect(connection.getCredential("uptimerobot")).resolves.toMatchObject({ apiKey: "monitor-key" });
+    await expect(connection.getCredential("uptimerobot")).resolves.toMatchObject({ apiKey: "monitor-key" });
+    expect(get).toHaveBeenCalledTimes(1);
+
+    await expect(connection.getCredential("database")).resolves.toMatchObject({
+      values: { host: "db.example.com" },
+    });
+    expect(get).toHaveBeenCalledTimes(2);
+
+    // A fresh scope is a fresh request: it must read the store again rather than serve a stale credential.
+    await expect(service.forConnection().getCredential("uptimerobot")).resolves.toMatchObject({
+      apiKey: "monitor-key",
+    });
+    expect(get).toHaveBeenCalledTimes(3);
+  });
+
+  it("replays a failed credential resolution without reading the store again", async () => {
+    const store = new MemoryConnectionStore();
+    const service = createService([apiKeyProvider], { store });
+    const get = vi.spyOn(store, "get");
+
+    const connection = service.forConnection("missing");
+    const first = await connection.getCredential("uptimerobot").catch((error: unknown) => error);
+    const second = await connection.getCredential("uptimerobot").catch((error: unknown) => error);
+
+    expect(first).toMatchObject({ code: "connection_not_found" });
+    expect(second).toBe(first);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
 });
 
 interface CreateServiceOptions {

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -280,9 +280,26 @@ export class ConnectionService {
     return this.supportsAuth(provider, "no_auth") ? { authType: "no_auth" } : undefined;
   }
 
+  /**
+   * Return a per-request credential scope for one connection name.
+   *
+   * The returned object resolves each service at most once and caches the
+   * promise, so a provider that asks twice - a credential-derived base URL plus
+   * an auth header, for example - costs one store read and one OAuth refresh
+   * check. Caching the promise rather than its value replays a rejection
+   * identically instead of retrying it.
+   */
   forConnection(connectionName?: string): Pick<ConnectionService, "getCredential"> {
+    const resolved = new Map<string, Promise<ResolvedCredential | undefined>>();
     return {
-      getCredential: (service: string) => this.getCredential(service, connectionName),
+      getCredential: (service: string) => {
+        let credential = resolved.get(service);
+        if (!credential) {
+          credential = this.getCredential(service, connectionName);
+          resolved.set(service, credential);
+        }
+        return credential;
+      },
     };
   }
 

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3260,6 +3260,54 @@ describe("ConnectServer", () => {
     });
   });
 
+  it("propagates HTTP request cancellation to provider proxy execution", async () => {
+    const controller = new AbortController();
+    let proxyStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      proxyStarted = resolve;
+    });
+    let proxySignal: AbortSignal | undefined;
+    const app = createTestServer([apiKeyProvider], {
+      providerLoader: new ProxyProviderLoader(async (_input, context) => {
+        proxySignal = context.signal;
+        proxyStarted?.();
+        await new Promise<void>((_resolve, reject) => {
+          if (!context.signal) {
+            reject(new Error("proxy request signal missing"));
+            return;
+          }
+          context.signal.addEventListener("abort", () => reject(new Error("proxy request aborted")), { once: true });
+        });
+        return { ok: true, response: { status: 200, headers: {}, data: {} } };
+      }),
+    }).createApp();
+
+    await app.request("/api/connections/example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authType: "api_key", values: { apiKey: "example-key" } }),
+    });
+
+    const responsePromise = app.fetch(
+      new Request("http://localhost/v1/proxy/example", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ endpoint: "/items", method: "GET" }),
+        signal: controller.signal,
+      }),
+    );
+    await started;
+    controller.abort();
+    const response = await responsePromise;
+
+    expect(proxySignal?.aborted).toBe(true);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      errorCode: "internal_error",
+    });
+  });
+
   it("applies stored runtime token proxy grants independently of action rules", async () => {
     const runtimeTokens = new RuntimeTokenService(new MemoryRuntimeTokenStore());
     const app = createTestServer([apiKeyProvider], {

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -690,6 +690,7 @@ export class ConnectServer {
       input: body,
       connectionName: readConnectionName(context, body),
       policy,
+      signal: context.req.raw.signal,
     });
     if (result.ok) {
       return writeRuntimeSuccess(context, result.response);

--- a/src/server/proxy/proxy-runner.test.ts
+++ b/src/server/proxy/proxy-runner.test.ts
@@ -430,6 +430,106 @@ describe("ProxyRunner", () => {
     expect(connections.forConnection).toHaveBeenCalledWith("work");
   });
 
+  it("threads the caller abort signal into the proxy execution context", async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+    const proxy: ProviderProxyExecutor = vi.fn(async (_input, context): Promise<ProxyExecutionResult> => {
+      seenSignal = context.signal;
+      return { ok: true, response: { status: 200, headers: {}, data: null } };
+    });
+    const runner = createRunner({ providerLoader: new TestProviderLoader(proxy) });
+
+    await expect(
+      runner.run({
+        service: "example",
+        input: { endpoint: "/items", method: "GET" },
+        policy: openPolicy,
+        signal: controller.signal,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(seenSignal).toBe(controller.signal);
+    expect(seenSignal?.aborted).toBe(false);
+  });
+
+  it("hands the proxy executor an already aborted signal when the caller aborted first", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let aborted: boolean | undefined;
+    const proxy: ProviderProxyExecutor = vi.fn(async (_input, context): Promise<ProxyExecutionResult> => {
+      aborted = context.signal?.aborted;
+      return { ok: true, response: { status: 200, headers: {}, data: null } };
+    });
+    const runner = createRunner({ providerLoader: new TestProviderLoader(proxy) });
+
+    await runner.run({
+      service: "example",
+      input: { endpoint: "/items", method: "GET" },
+      policy: openPolicy,
+      signal: controller.signal,
+    });
+    expect(aborted).toBe(true);
+  });
+
+  // An aborted proxy request must settle on the existing failure envelope rather than hang. This is the
+  // shape a hand-written proxy produces: it lets the abort propagate, so the runner catches a rejection.
+  it("surfaces an abort raised during proxy execution as a stable runtime failure", async () => {
+    const controller = new AbortController();
+    const proxy: ProviderProxyExecutor = vi.fn(async (_input, context): Promise<ProxyExecutionResult> => {
+      controller.abort();
+      context.signal?.throwIfAborted();
+      return { ok: true, response: { status: 200, headers: {}, data: null } };
+    });
+    const runner = createRunner({ providerLoader: new TestProviderLoader(proxy) });
+
+    await expect(
+      runner.run({
+        service: "example",
+        input: { endpoint: "/items", method: "GET" },
+        policy: openPolicy,
+        signal: controller.signal,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: 500,
+      errorCode: "internal_error",
+      message: "Proxy request failed unexpectedly.",
+      meta: { service: "example" },
+    });
+  });
+
+  // The shape most proxies produce: defineProviderProxy catches the abort and reports it as an error
+  // result, so a cancelled request lands on mapProxyErrorStatus's fall-through rather than the 500 above.
+  it("maps an abort a proxy executor reports as an error result onto the existing 400 envelope", async () => {
+    const controller = new AbortController();
+    const proxy: ProviderProxyExecutor = vi.fn(async (_input, context): Promise<ProxyExecutionResult> => {
+      controller.abort();
+      try {
+        context.signal?.throwIfAborted();
+        return { ok: true, response: { status: 200, headers: {}, data: null } };
+      } catch {
+        // What toProviderProxyError builds for an error that is not a ProviderRequestError.
+        return { ok: false, error: { code: "internal_error", message: "provider request failed" } };
+      }
+    });
+    const runner = createRunner({ providerLoader: new TestProviderLoader(proxy) });
+
+    await expect(
+      runner.run({
+        service: "example",
+        input: { endpoint: "/items", method: "GET" },
+        policy: openPolicy,
+        signal: controller.signal,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: 400,
+      errorCode: "internal_error",
+      message: "provider request failed",
+      data: null,
+      meta: { service: "example" },
+    });
+  });
+
   it("passes HEAD requests through to provider proxy executors", async () => {
     const proxy: ProviderProxyExecutor = vi.fn(
       async (): Promise<ProxyExecutionResult> => ({

--- a/src/server/proxy/proxy-runner.ts
+++ b/src/server/proxy/proxy-runner.ts
@@ -23,6 +23,8 @@ export interface RunProxyInput {
   input: unknown;
   connectionName?: string;
   policy: ActionPolicySnapshot;
+  /** Cancellation signal from the HTTP request, handed to the provider proxy executor. */
+  signal?: AbortSignal;
 }
 
 export type ProxyRunResult =
@@ -125,8 +127,10 @@ export class ProxyRunner {
         };
       }
       this.options.logger?.info(logContext, "proxy request started");
+      const credentials = this.options.connections.forConnection(input.connectionName);
       const result = await executor(request.input, {
-        ...this.options.connections.forConnection(input.connectionName),
+        getCredential: credentials.getCredential,
+        signal: input.signal,
       });
       const durationMs = Date.now() - startedAtMs;
       if (result.ok) {


### PR DESCRIPTION
Stacked on #461 (`fix/e1-redirect-header-leak`), part of the E-tier audit stack. Retargets to `main` once the branch below lands.

Proxy executors read `context.signal` to cancel their upstream fetch (151 references across 131 providers), but `ProxyRunner` never put a signal in the context, so every one of them was `undefined` and a `/v1/proxy` request could not be aborted when the caller went away. The same accessor also re-resolved the credential on every call, costing a second store read and OAuth refresh check per request where the action path resolves once. This threads `context.req.raw.signal` into the executor context the way the action route already does, and memoizes the per-request credential by caching the promise so a `ConnectionError` still replays identically.

The response contract is unchanged, but the provider side of an abandoned request now behaves differently: a non-idempotent proxy call the caller gives up on is torn down mid-flight and may be left partially applied, where before it always ran to completion.
