### PR TITLE
fix(proxy): give defineProviderProxy a default request deadline

### DIFF
--- a/docs/runtime-api.md
+++ b/docs/runtime-api.md
@@ -288,6 +288,12 @@ stored credentials local and lets the provider proxy executor apply provider-spe
 Successful responses use the standard `/v1` success envelope with `data.status`, `data.headers`, and
 `data.data`.
 
+Most proxies run under the same 30 second per-request budget as actions, covering the upstream request
+and the response body read. A provider that does not answer in time returns HTTP 500 with `errorCode`
+`provider_error` and `data.status` 504. A minority of providers ship a hand-written proxy that keeps
+whatever budget it sets for itself, and most of those set none. Use the provider's asynchronous job
+endpoints for work that legitimately takes longer.
+
 Deployment and runtime proxy access is controlled by `OOMOL_CONNECT_ALLOWED_PROXIES` and
 `OOMOL_CONNECT_BLOCKED_PROXIES`; Action policy does not affect it. Persistent runtime tokens add an
 independent `allowedProxies` grant that can only narrow those rules. The requested provider must be

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -652,6 +652,26 @@ describe("defineProviderProxy request deadline", () => {
     return signals;
   }
 
+  // Headers arrive immediately; the body never enqueues. Erroring the stream on
+  // abort mirrors how fetch implementations propagate the request signal into
+  // an in-flight body read.
+  function stubStalledBodyFetch(): AbortSignal[] {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal("fetch", (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal ?? undefined;
+      if (signal) {
+        signals.push(signal);
+      }
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal?.addEventListener("abort", () => controller.error(signal.reason));
+        },
+      });
+      return Promise.resolve(new Response(body, { status: 200 }));
+    });
+    return signals;
+  }
+
   const hangingProxy = defineProviderProxy({
     service: "test_service",
     baseUrl: "https://api.example.com",
@@ -663,6 +683,39 @@ describe("defineProviderProxy request deadline", () => {
     vi.useFakeTimers();
     try {
       const signals = stubHangingFetch();
+      const pending = hangingProxy({ method: "GET", endpoint: "/items" }, executionContext);
+      let settled = false;
+      void pending.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(settled).toBe(true);
+      expect(signals[0]?.aborted).toBe(true);
+      await expect(pending).resolves.toEqual({
+        ok: false,
+        error: {
+          code: "provider_error",
+          message: "test_service request timed out",
+          details: { status: 504, details: undefined },
+        },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies the same budget to a response whose body stalls after headers arrive", async () => {
+    vi.useFakeTimers();
+    try {
+      const signals = stubStalledBodyFetch();
       const pending = hangingProxy({ method: "GET", endpoint: "/items" }, executionContext);
       let settled = false;
       void pending.then(() => {

--- a/src/providers/provider-runtime.test.ts
+++ b/src/providers/provider-runtime.test.ts
@@ -637,6 +637,109 @@ describe("provider egress SSRF guard", () => {
   });
 });
 
+describe("defineProviderProxy request deadline", () => {
+  function stubHangingFetch(): AbortSignal[] {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal("fetch", (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal ?? undefined;
+      if (signal) {
+        signals.push(signal);
+      }
+      return new Promise<never>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      });
+    });
+    return signals;
+  }
+
+  const hangingProxy = defineProviderProxy({
+    service: "test_service",
+    baseUrl: "https://api.example.com",
+    auth: { type: "bearer" },
+    skipDnsValidation: true,
+  });
+
+  it("fails a never-answering upstream at the default 30 second budget instead of hanging", async () => {
+    vi.useFakeTimers();
+    try {
+      const signals = stubHangingFetch();
+      const pending = hangingProxy({ method: "GET", endpoint: "/items" }, executionContext);
+      let settled = false;
+      void pending.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(settled).toBe(true);
+      expect(signals[0]?.aborted).toBe(true);
+      await expect(pending).resolves.toEqual({
+        ok: false,
+        error: {
+          code: "provider_error",
+          message: "test_service request timed out",
+          details: { status: 504, details: undefined },
+        },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Deliberate divergence from runProviderRequest, which reports any abort as "<label> request timed out".
+  it("maps a caller abort to internal_error rather than the timeout runProviderRequest would report", async () => {
+    vi.useFakeTimers();
+    try {
+      const signals = stubHangingFetch();
+      const controller = new AbortController();
+      const pending = hangingProxy(
+        { method: "GET", endpoint: "/items" },
+        { ...executionContext, signal: controller.signal },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      // The upstream request runs under the deadline's own signal, not the caller's.
+      expect(signals).toHaveLength(1);
+      expect(signals[0]).not.toBe(controller.signal);
+      controller.abort();
+
+      await expect(pending).resolves.toEqual({
+        ok: false,
+        error: {
+          code: "internal_error",
+          message: "provider request failed",
+        },
+      });
+      expect(signals[0]?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the deadline timer once the request completes", async () => {
+    vi.useFakeTimers();
+    try {
+      let answer: ((response: Response) => void) | undefined;
+      vi.stubGlobal("fetch", () => new Promise<Response>((resolve) => (answer = resolve)));
+      const pending = hangingProxy({ method: "GET", endpoint: "/items" }, executionContext);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(1);
+
+      answer?.(new Response(JSON.stringify({ id: 1 }), { status: 200 }));
+      await expect(pending).resolves.toMatchObject({ ok: true });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("provider runtime fetch", () => {
   it("maps transport failures to provider errors without exposing the native message", async () => {
     vi.stubGlobal("fetch", async () => {

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -560,30 +560,41 @@ export function defineProviderProxy(input: ProviderProxyDefinition): ProviderPro
         throw new ProviderRequestError(400, "endpoint must stay on the provider origin");
       }
 
-      const init: RequestInit = {
-        method: proxyInput.method,
-        headers,
-        signal: context.signal,
-      };
-      if (proxyInput.body !== undefined) {
-        init.body = typeof proxyInput.body === "string" ? proxyInput.body : JSON.stringify(proxyInput.body);
-        if (!headers.has("content-type") && typeof proxyInput.body !== "string") {
-          headers.set("content-type", "application/json");
+      const timeout = createProviderTimeout(context.signal);
+      try {
+        const init: RequestInit = {
+          method: proxyInput.method,
+          headers,
+          signal: timeout.signal,
+        };
+        if (proxyInput.body !== undefined) {
+          init.body = typeof proxyInput.body === "string" ? proxyInput.body : JSON.stringify(proxyInput.body);
+          if (!headers.has("content-type") && typeof proxyInput.body !== "string") {
+            headers.set("content-type", "application/json");
+          }
         }
-      }
 
-      const response = await egressFetch(url, init);
-      if (!response.ok) {
-        throw new ProviderRequestError(
-          response.status,
-          await readProviderProxyErrorMessage(response, `provider request failed with HTTP ${response.status}`),
-        );
-      }
+        const response = await egressFetch(url, init);
+        if (!response.ok) {
+          throw new ProviderRequestError(
+            response.status,
+            await readProviderProxyErrorMessage(response, `provider request failed with HTTP ${response.status}`),
+          );
+        }
 
-      return {
-        ok: true,
-        response: await readProviderProxyResponse(response),
-      };
+        return {
+          ok: true,
+          response: await readProviderProxyResponse(response),
+        };
+      } catch (error) {
+        // Only the local budget becomes the shared 504 timeout; a caller abort stays an abort.
+        if (error instanceof ProviderRequestError || !timeout.didTimeout()) {
+          throw error;
+        }
+        throw new ProviderRequestError(504, `${input.service} request timed out`);
+      } finally {
+        timeout.cleanup();
+      }
     } catch (error) {
       return toProviderProxyError(error, "provider request failed");
     }

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3308,6 +3308,41 @@ describe("ConnectServer", () => {
     });
   });
 
+  it("reports a provider proxy timeout as HTTP 500 with data.status 504", async () => {
+    const app = createTestServer([apiKeyProvider], {
+      providerLoader: new ProxyProviderLoader(async () => ({
+        // The failure defineProviderProxy returns once its per-request deadline fires.
+        ok: false,
+        error: {
+          code: "provider_error",
+          message: "example request timed out",
+          details: { status: 504, details: undefined },
+        },
+      })),
+    }).createApp();
+
+    await app.request("/api/connections/example", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authType: "api_key", values: { apiKey: "example-key" } }),
+    });
+
+    const response = await app.request("/v1/proxy/example", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: "/items", method: "GET" }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      message: "example request timed out",
+      data: { status: 504 },
+      errorCode: "provider_error",
+      meta: { service: "example" },
+    });
+  });
+
   it("applies stored runtime token proxy grants independently of action rules", async () => {
     const runtimeTokens = new RuntimeTokenService(new MemoryRuntimeTokenStore());
     const app = createTestServer([apiKeyProvider], {


### PR DESCRIPTION
Stacked on #462 (`fix/e2-proxy-signal-credential-memo`), part of the E-tier audit stack. Retargets to `main` once the branch below lands. #462 is a prerequisite: the deadline composes with the signal it threads.

A `defineProviderProxy` proxy had no request deadline at all, so a slow or stuck upstream held the request open until the platform's own limit fired (undici's 300s on Node, the Workers wall-clock on Cloudflare), ten times the 30s budget the same provider's actions get. This gives the shared proxy definition the same default 30s deadline, covering 653 of the 773 proxies.

Requests to `/v1/proxy/<service>` now give up after 30s and return a `provider_error` that says the request timed out. The budget covers the response body too, so a proxied download that takes longer than 30s now fails and should be fetched from the provider's direct URL instead. The sharpest thing to watch is a provider that declares a longer budget for the same upstream on its action path, `googledrive` at 300s most of all. A `timeoutMs` opt-out for the proxies that legitimately need longer is the natural follow-up.
