### PR TITLE
fix(providers): build Basic authorization from UTF-8 bytes

### DIFF
--- a/src/providers/clickhelp/runtime.ts
+++ b/src/providers/clickhelp/runtime.ts
@@ -2,7 +2,12 @@ import type { ProviderActionHandlers } from "../provider-runtime.ts";
 import type { ClickhelpActionName } from "./actions.ts";
 
 import { compactObject, optionalRecord, optionalString, requiredString } from "../../core/cast.ts";
-import { createProviderTimeout, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  basicAuthorizationHeader,
+  createProviderTimeout,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 interface ApiKeyProviderActionInput {
   apiKey: string;
@@ -238,7 +243,7 @@ async function requestClickhelpJson(input: ClickhelpRequest) {
       method: input.method ?? "GET",
       headers: {
         accept: "application/json",
-        authorization: `Basic ${btoa(`${input.credential.login}:${input.credential.apiKey}`)}`,
+        authorization: basicAuthorizationHeader(`${input.credential.login}:${input.credential.apiKey}`),
         "content-type": "application/json",
         "user-agent": providerUserAgent,
       },

--- a/src/providers/dealroom/executors.ts
+++ b/src/providers/dealroom/executors.ts
@@ -1,7 +1,12 @@
 import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
 import type { ApiKeyProviderContext, ProviderActionHandlers, ProviderRuntimeHandler } from "../provider-runtime.ts";
 
-import { defineApiKeyProviderExecutors, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
+import {
+  basicAuthorizationHeader,
+  defineApiKeyProviderExecutors,
+  ProviderRequestError,
+  providerUserAgent,
+} from "../provider-runtime.ts";
 
 const service = "dealroom";
 const baseUrl = "https://api.dealroom.co/api/v1/";
@@ -65,7 +70,7 @@ async function request(path: string, body: Record<string, unknown>, context: Api
   const response = await context.fetcher(new URL(path, baseUrl), {
     method: "POST",
     headers: {
-      authorization: `Basic ${btoa(`${context.apiKey}:`)}`,
+      authorization: basicAuthorizationHeader(`${context.apiKey}:`),
       accept: "application/json",
       "content-type": "application/json",
       "user-agent": providerUserAgent,

--- a/src/providers/echotik/executors.ts
+++ b/src/providers/echotik/executors.ts
@@ -7,6 +7,7 @@ import type {
 
 import { requiredString } from "../../core/cast.ts";
 import {
+  basicAuthorizationHeader,
   defineProviderExecutors,
   defineProviderProxy,
   ProviderRequestError,
@@ -75,7 +76,7 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     const credential = await requireCustomCredential(context, service);
     const username = requiredCredential(credential.values.username, "username");
     const password = requiredCredential(credential.values.password, "password");
-    headers.set("authorization", `Basic ${btoa(`${username}:${password}`)}`);
+    headers.set("authorization", basicAuthorizationHeader(`${username}:${password}`));
   },
 });
 

--- a/src/providers/helpdesk/executors.ts
+++ b/src/providers/helpdesk/executors.ts
@@ -7,6 +7,7 @@ import type {
 import type { ProviderActionHandlers } from "../provider-runtime.ts";
 
 import {
+  basicAuthorizationHeader,
   defineProviderExecutors,
   defineProviderProxy,
   ProviderRequestError,
@@ -151,7 +152,7 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
       throw new ProviderRequestError(401, "Configure HelpDesk account ID and API key credentials first.");
     }
     headers.delete("x-connector-api-key");
-    headers.set("authorization", `Basic ${btoa(`${credential.values.accountId}:${credential.apiKey}`)}`);
+    headers.set("authorization", basicAuthorizationHeader(`${credential.values.accountId}:${credential.apiKey}`));
   },
 });
 

--- a/src/providers/mx/executors.ts
+++ b/src/providers/mx/executors.ts
@@ -7,6 +7,7 @@ import type {
 import type { MxContext } from "./runtime.ts";
 
 import {
+  basicAuthorizationHeader,
   defineProviderExecutors,
   defineProviderProxy,
   ProviderRequestError,
@@ -46,7 +47,7 @@ export const proxy: ProviderProxyExecutor = defineProviderProxy({
     if (!clientId) {
       throw new ProviderRequestError(401, "Configure MX client ID first.");
     }
-    headers.set("authorization", `Basic ${btoa(`${clientId}:${credential.apiKey}`)}`);
+    headers.set("authorization", basicAuthorizationHeader(`${clientId}:${credential.apiKey}`));
     headers.set("accept", "application/vnd.mx.api.v1+json");
     headers.set("accept-version", "v20250224");
   },

--- a/src/providers/provider-runtime.basic-auth.test.ts
+++ b/src/providers/provider-runtime.basic-auth.test.ts
@@ -1,11 +1,28 @@
 import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
 
 import { Buffer } from "node:buffer";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../core/guarded-fetch.ts";
+import { executors as clickhelpExecutors } from "./clickhelp/executors.ts";
+import { executors as dealroomExecutors } from "./dealroom/executors.ts";
 import { proxy as echotikProxy } from "./echotik/executors.ts";
+import { proxy as helpdeskProxy } from "./helpdesk/executors.ts";
+import { proxy as mxProxy } from "./mx/executors.ts";
 import { defineProviderProxy } from "./provider-runtime.ts";
+import { proxy as razorpayProxy } from "./razorpay/executors.ts";
+import { executors as stannpExecutors } from "./stannp/executors.ts";
+import { proxy as woocommerceProxy } from "./woocommerce/executors.ts";
+import { proxy as zendeskProxy } from "./zendesk/executors.ts";
+
+beforeEach(() => {
+  // The providers below reach the network through the guarded fetch, which
+  // resolves the target host unless the provider opts out. The stubbed fetch
+  // never leaves the process, so drop the DNS step.
+  setDefaultGuardedFetchDnsLookup(null);
+});
 
 afterEach(() => {
+  setDefaultGuardedFetchDnsLookup(undefined);
   vi.unstubAllGlobals();
 });
 
@@ -29,11 +46,11 @@ function sentAuthorization(calls: RecordedFetchCall[]): string | null {
   return new Headers(calls[0]?.init?.headers).get("authorization");
 }
 
-function apiKeyContext(apiKey: string): ExecutionContext {
+function apiKeyContext(apiKey: string, values: Record<string, string> = { apiKey }): ExecutionContext {
   const credential: ResolvedCredential = {
     authType: "api_key",
     apiKey,
-    values: { apiKey },
+    values,
     profile: { accountId: "acct", displayName: "Test", grantedScopes: [] },
     metadata: {},
   };
@@ -93,6 +110,107 @@ describe("api_key_basic proxy authorization", () => {
     expect(result.ok).toBe(true);
     expect(sentAuthorization(calls)).toBe(`Basic ${Buffer.from("密钥_key:", "utf8").toString("base64")}`);
   });
+});
+
+interface HandWrittenBasicCase {
+  readonly provider: string;
+  readonly composed: string;
+  readonly run: () => Promise<unknown>;
+}
+
+// Every provider that builds its own Basic header, with a distinct value per
+// field so the pair, its order, and its separator are all pinned. Folding these
+// sites onto `basicAuthorizationHeader` had to keep the composed credential
+// character for character; nothing else here asserts that.
+const handWrittenCases: HandWrittenBasicCase[] = [
+  {
+    provider: "clickhelp",
+    composed: "clickhelp-login:clickhelp-key",
+    run: () =>
+      clickhelpExecutors["clickhelp.list_projects"]!(
+        {},
+        apiKeyContext("clickhelp-key", { login: "clickhelp-login", portalUrl: "https://portal.example.com" }),
+      ),
+  },
+  {
+    provider: "dealroom",
+    composed: "dealroom-key:",
+    run: () => dealroomExecutors["dealroom.search_companies"]!({ keyword: "acme" }, apiKeyContext("dealroom-key")),
+  },
+  {
+    provider: "echotik",
+    composed: "echotik-user:echotik-password",
+    run: () =>
+      echotikProxy(
+        { method: "GET", endpoint: "/echotik/category/l1" },
+        customCredentialContext({ username: "echotik-user", password: "echotik-password" }),
+      ),
+  },
+  {
+    provider: "helpdesk",
+    composed: "helpdesk-account:helpdesk-key",
+    run: () =>
+      helpdeskProxy(
+        { method: "GET", endpoint: "/tickets" },
+        apiKeyContext("helpdesk-key", { accountId: "helpdesk-account" }),
+      ),
+  },
+  {
+    provider: "mx",
+    composed: "mx-client:mx-key",
+    run: () => mxProxy({ method: "GET", endpoint: "/users" }, apiKeyContext("mx-key", { clientId: "mx-client" })),
+  },
+  {
+    provider: "razorpay",
+    composed: "razorpay-key-id:razorpay-secret",
+    run: () =>
+      razorpayProxy(
+        { method: "GET", endpoint: "/payments" },
+        apiKeyContext("razorpay-secret", { keyId: "razorpay-key-id" }),
+      ),
+  },
+  {
+    provider: "stannp",
+    composed: "stannp-key:",
+    run: () => stannpExecutors["stannp.get_account_balance"]!({}, apiKeyContext("stannp-key", { region: "eu" })),
+  },
+  {
+    provider: "woocommerce",
+    composed: "woo-consumer-key:woo-consumer-secret",
+    run: () =>
+      woocommerceProxy(
+        { method: "GET", endpoint: "/products" },
+        customCredentialContext({
+          storeUrl: "https://store.example.com",
+          consumerKey: "woo-consumer-key",
+          consumerSecret: "woo-consumer-secret",
+        }),
+      ),
+  },
+  {
+    provider: "zendesk",
+    composed: "agent@example.com/token:zendesk-token",
+    run: () =>
+      zendeskProxy(
+        { method: "GET", endpoint: "/api/v2/tickets" },
+        apiKeyContext("zendesk-token", { email: "agent@example.com", subdomain: "example" }),
+      ),
+  },
+];
+
+describe("hand-written Basic credential composition", () => {
+  for (const { provider, composed, run } of handWrittenCases) {
+    it(`composes the ${provider} Basic credential from its own credential fields`, async () => {
+      const calls = captureFetchCalls();
+
+      // The stub answers every provider with the same body, so a handler may
+      // reject on the payload shape afterwards. The header is already sent by
+      // then, and the header is what this case pins.
+      await run().catch(() => undefined);
+
+      expect(sentAuthorization(calls)).toBe(`Basic ${Buffer.from(composed, "utf8").toString("base64")}`);
+    });
+  }
 });
 
 describe("hand-written Basic authorization headers", () => {

--- a/src/providers/provider-runtime.basic-auth.test.ts
+++ b/src/providers/provider-runtime.basic-auth.test.ts
@@ -9,10 +9,14 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function stubFetchOnce(): Array<{ url: string; init: RequestInit | undefined }> {
-  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
-  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
-    calls.push({ url: input instanceof Request ? input.url : String(input), init });
+interface RecordedFetchCall {
+  init: RequestInit | undefined;
+}
+
+function captureFetchCalls(): RecordedFetchCall[] {
+  const calls: RecordedFetchCall[] = [];
+  vi.stubGlobal("fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ init });
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -21,7 +25,7 @@ function stubFetchOnce(): Array<{ url: string; init: RequestInit | undefined }> 
   return calls;
 }
 
-function sentAuthorization(calls: Array<{ init: RequestInit | undefined }>): string | null {
+function sentAuthorization(calls: RecordedFetchCall[]): string | null {
   return new Headers(calls[0]?.init?.headers).get("authorization");
 }
 
@@ -58,11 +62,15 @@ describe("api_key_basic proxy authorization", () => {
   // three keys pin the ASCII case (must stay byte-identical), the Latin-1
   // representable case (wrong bytes before the fix), and the case `btoa` cannot
   // encode at all (a DOMException before the fix).
-  const keys = ["waka_ascii_key", "wäka_key_ü", "密钥_key"];
+  const keys = [
+    { label: "an ASCII", key: "waka_ascii_key" },
+    { label: "a Latin-1 representable", key: "wäka_key_ü" },
+    { label: "a non-Latin-1", key: "密钥_key" },
+  ];
 
-  for (const key of keys) {
-    it(`encodes the ${JSON.stringify(key)} API key as UTF-8 base64`, async () => {
-      const calls = stubFetchOnce();
+  for (const { label, key } of keys) {
+    it(`encodes ${label} API key as UTF-8 base64`, async () => {
+      const calls = captureFetchCalls();
 
       const result = await basicProxy({ method: "GET", endpoint: "/users/current" }, apiKeyContext(key));
 
@@ -78,7 +86,7 @@ describe("api_key_basic proxy authorization", () => {
       auth: { type: "api_key_basic", suffix: ":" },
       skipDnsValidation: true,
     });
-    const calls = stubFetchOnce();
+    const calls = captureFetchCalls();
 
     const result = await suffixProxy({ method: "GET", endpoint: "/users/current" }, apiKeyContext("密钥_key"));
 
@@ -89,7 +97,7 @@ describe("api_key_basic proxy authorization", () => {
 
 describe("hand-written Basic authorization headers", () => {
   it("encodes an echotik username and password as UTF-8 base64", async () => {
-    const calls = stubFetchOnce();
+    const calls = captureFetchCalls();
     const context = customCredentialContext({ username: "echo_user", password: "密码_pässwörd" });
 
     const result = await echotikProxy({ method: "GET", endpoint: "/echotik/category/l1" }, context);

--- a/src/providers/provider-runtime.basic-auth.test.ts
+++ b/src/providers/provider-runtime.basic-auth.test.ts
@@ -1,0 +1,100 @@
+import type { ExecutionContext, ResolvedCredential } from "../core/types.ts";
+
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxy as echotikProxy } from "./echotik/executors.ts";
+import { defineProviderProxy } from "./provider-runtime.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetchOnce(): Array<{ url: string; init: RequestInit | undefined }> {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: input instanceof Request ? input.url : String(input), init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return calls;
+}
+
+function sentAuthorization(calls: Array<{ init: RequestInit | undefined }>): string | null {
+  return new Headers(calls[0]?.init?.headers).get("authorization");
+}
+
+function apiKeyContext(apiKey: string): ExecutionContext {
+  const credential: ResolvedCredential = {
+    authType: "api_key",
+    apiKey,
+    values: { apiKey },
+    profile: { accountId: "acct", displayName: "Test", grantedScopes: [] },
+    metadata: {},
+  };
+  return { getCredential: async () => credential };
+}
+
+function customCredentialContext(values: Record<string, string>): ExecutionContext {
+  const credential: ResolvedCredential = {
+    authType: "custom_credential",
+    values,
+    profile: { accountId: "acct", displayName: "Test", grantedScopes: [] },
+    metadata: {},
+  };
+  return { getCredential: async () => credential };
+}
+
+describe("api_key_basic proxy authorization", () => {
+  const basicProxy = defineProviderProxy({
+    service: "test_service",
+    baseUrl: "https://api.example.com/v1/",
+    auth: { type: "api_key_basic" },
+    skipDnsValidation: true,
+  });
+
+  // RFC 7617 says the Basic credential is encoded from its UTF-8 bytes. These
+  // three keys pin the ASCII case (must stay byte-identical), the Latin-1
+  // representable case (wrong bytes before the fix), and the case `btoa` cannot
+  // encode at all (a DOMException before the fix).
+  const keys = ["waka_ascii_key", "wäka_key_ü", "密钥_key"];
+
+  for (const key of keys) {
+    it(`encodes the ${JSON.stringify(key)} API key as UTF-8 base64`, async () => {
+      const calls = stubFetchOnce();
+
+      const result = await basicProxy({ method: "GET", endpoint: "/users/current" }, apiKeyContext(key));
+
+      expect(result.ok).toBe(true);
+      expect(sentAuthorization(calls)).toBe(`Basic ${Buffer.from(key, "utf8").toString("base64")}`);
+    });
+  }
+
+  it("keeps the auth suffix inside the encoded credential", async () => {
+    const suffixProxy = defineProviderProxy({
+      service: "test_service",
+      baseUrl: "https://api.example.com/v1/",
+      auth: { type: "api_key_basic", suffix: ":" },
+      skipDnsValidation: true,
+    });
+    const calls = stubFetchOnce();
+
+    const result = await suffixProxy({ method: "GET", endpoint: "/users/current" }, apiKeyContext("密钥_key"));
+
+    expect(result.ok).toBe(true);
+    expect(sentAuthorization(calls)).toBe(`Basic ${Buffer.from("密钥_key:", "utf8").toString("base64")}`);
+  });
+});
+
+describe("hand-written Basic authorization headers", () => {
+  it("encodes an echotik username and password as UTF-8 base64", async () => {
+    const calls = stubFetchOnce();
+    const context = customCredentialContext({ username: "echo_user", password: "密码_pässwörd" });
+
+    const result = await echotikProxy({ method: "GET", endpoint: "/echotik/category/l1" }, context);
+
+    expect(result.ok).toBe(true);
+    expect(sentAuthorization(calls)).toBe(`Basic ${Buffer.from("echo_user:密码_pässwörd", "utf8").toString("base64")}`);
+  });
+});

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -442,6 +442,17 @@ export function normalizeProviderProxyHeaders(headersInput: unknown): Headers {
   return headers;
 }
 
+/**
+ * Build an HTTP Basic `authorization` header value from an already composed
+ * `user:password` credential. RFC 7617 encodes the credential from its UTF-8
+ * bytes, so this is the only correct way to build the header: `btoa` understands
+ * Latin-1 only, which silently sends the wrong bytes for accented credentials
+ * and throws on anything outside Latin-1.
+ */
+export function basicAuthorizationHeader(value: string): string {
+  return `Basic ${Buffer.from(value, "utf8").toString("base64")}`;
+}
+
 export interface ReadProviderProxyResponseOptions {
   maxBytes?: number;
 }
@@ -670,7 +681,7 @@ async function applyProviderProxyAuth(
     }
     case "api_key_basic": {
       const credential = await requireApiKeyCredential(context, input.service);
-      headers.set("authorization", `Basic ${btoa(`${credential.apiKey}${input.auth.suffix ?? ""}`)}`);
+      headers.set("authorization", basicAuthorizationHeader(`${credential.apiKey}${input.auth.suffix ?? ""}`));
       return credential;
     }
     case "api_key_authorization": {

--- a/src/providers/provider-runtime.ts
+++ b/src/providers/provider-runtime.ts
@@ -444,7 +444,8 @@ export function normalizeProviderProxyHeaders(headersInput: unknown): Headers {
 
 /**
  * Build an HTTP Basic `authorization` header value from an already composed
- * `user:password` credential. RFC 7617 encodes the credential from its UTF-8
+ * credential, usually `user:password` but also a bare API key or a key with a
+ * provider-specific suffix. RFC 7617 encodes the credential from its UTF-8
  * bytes, so this is the only correct way to build the header: `btoa` understands
  * Latin-1 only, which silently sends the wrong bytes for accented credentials
  * and throws on anything outside Latin-1.

--- a/src/providers/provider-source-guards.basic-auth.test.ts
+++ b/src/providers/provider-source-guards.basic-auth.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const providersDirectory = fileURLToPath(new URL(".", import.meta.url));
+const guardFile = fileURLToPath(import.meta.url);
+
+/**
+ * `btoa` is a browser-era Latin-1 encoder: it sends the wrong bytes for an
+ * accented credential and throws on anything outside Latin-1. Provider code
+ * must build Basic credentials with `basicAuthorizationHeader` instead. These
+ * two files base64 a binary string assembled byte by byte, which is Latin-1 by
+ * construction and has nothing to do with credentials, so the one call each of
+ * them makes is exempt. The exemption is the exact call text rather than the
+ * file, so a credential-bearing `btoa` added elsewhere in either file is still
+ * reported.
+ */
+const binaryStringAllowlist = new Map<string, string>([
+  ["gitea/runtime.ts", "return btoa(binary);"],
+  ["pi_hole/runtime.ts", "return btoa(binary);"],
+]);
+
+function listProviderSourceFiles(directory: string, prefix: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...listProviderSourceFiles(join(directory, entry.name), relativePath));
+    } else if (entry.name.endsWith(".ts")) {
+      files.push(relativePath);
+    }
+  }
+  return files;
+}
+
+function countOccurrences(source: string, needle: string): number {
+  let count = 0;
+  let index = source.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = source.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function readProviderSource(relativePath: string): string {
+  return readFileSync(join(providersDirectory, relativePath), "utf8");
+}
+
+describe("provider source guards", () => {
+  it("keeps btoa out of provider source outside the binary-string allowlist", () => {
+    const offenders = listProviderSourceFiles(providersDirectory, "").filter((relativePath) => {
+      if (join(providersDirectory, relativePath) === guardFile) {
+        return false;
+      }
+      const source = readProviderSource(relativePath);
+      const allowedCall = binaryStringAllowlist.get(relativePath);
+      const allowed = allowedCall === undefined ? 0 : countOccurrences(source, allowedCall);
+      return countOccurrences(source, "btoa(") > allowed;
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every allowlisted btoa call on its binary-string form", () => {
+    const stale = [...binaryStringAllowlist]
+      .filter(([relativePath, allowedCall]) => !readProviderSource(relativePath).includes(allowedCall))
+      .map(([relativePath]) => relativePath);
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/src/providers/razorpay/executors.ts
+++ b/src/providers/razorpay/executors.ts
@@ -7,6 +7,7 @@ import type {
 import type { ProviderFetch } from "../provider-runtime.ts";
 
 import {
+  basicAuthorizationHeader,
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
@@ -60,7 +61,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
 
     const url = createProviderProxyUrl(razorpayApiBaseUrl, input.endpoint, input.query);
     const headers = normalizeProviderProxyHeaders(input.headers);
-    headers.set("authorization", `Basic ${btoa(`${keyId}:${credential.apiKey}`)}`);
+    headers.set("authorization", basicAuthorizationHeader(`${keyId}:${credential.apiKey}`));
     headers.set("user-agent", providerUserAgent);
     if (!headers.has("accept")) {
       headers.set("accept", "application/json");

--- a/src/providers/stannp/runtime.ts
+++ b/src/providers/stannp/runtime.ts
@@ -4,6 +4,7 @@ import type { ProviderRuntimeHandler } from "../provider-runtime.ts";
 
 import { compactObject, optionalBoolean, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
+  basicAuthorizationHeader,
   createProviderTimeout,
   providerUserAgent,
   ProviderRequestError,
@@ -287,7 +288,7 @@ function buildStannpUrl(path: string, region: StannpRegion, query: Record<string
 
 function stannpHeaders(apiKey: string, extraHeaders?: HeadersInit): Record<string, string> {
   return {
-    authorization: `Basic ${btoa(`${apiKey}:`)}`,
+    authorization: basicAuthorizationHeader(`${apiKey}:`),
     accept: "application/json",
     "user-agent": providerUserAgent,
     ...Object.fromEntries(new Headers(extraHeaders).entries()),

--- a/src/providers/woocommerce/executors.ts
+++ b/src/providers/woocommerce/executors.ts
@@ -7,6 +7,7 @@ import type {
 
 import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
+  basicAuthorizationHeader,
   createProviderFetch,
   createProviderProxyUrl,
   defineProviderExecutors,
@@ -52,7 +53,7 @@ export const proxy: ProviderProxyExecutor = async (input, context) => {
     const headers = normalizeProviderProxyHeaders(input.headers);
     headers.set(
       "authorization",
-      `Basic ${btoa(`${credentialContext.consumerKey}:${credentialContext.consumerSecret}`)}`,
+      basicAuthorizationHeader(`${credentialContext.consumerKey}:${credentialContext.consumerSecret}`),
     );
     headers.set("user-agent", providerUserAgent);
 

--- a/src/providers/zendesk/executors.ts
+++ b/src/providers/zendesk/executors.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../core/types.ts";
 
 import {
+  basicAuthorizationHeader,
   createProviderProxyUrl,
   defineProviderExecutors,
   normalizeProviderProxyHeaders,
@@ -110,7 +111,7 @@ function buildProxyAuthorization(credential: Awaited<ReturnType<ExecutionContext
       credential.values.email ?? stringMetadata(credential.metadata.email),
       "Zendesk email is required",
     );
-    return `Basic ${btoa(`${email}/token:${credential.apiKey}`)}`;
+    return basicAuthorizationHeader(`${email}/token:${credential.apiKey}`);
   }
   throw new ProviderRequestError(401, "Configure zendesk credentials first.");
 }


### PR DESCRIPTION
Stacked on #463 (`fix/e2b-proxy-default-timeout`), part of the E-tier audit stack. Retargets to `main` once the branch below lands.

HTTP Basic auth was built with `btoa`, which only understands Latin-1, so a credential with any non-ASCII character was either encoded with the wrong bytes (the provider answers 401 and the user is told a correct credential is invalid) or could not be encoded at all (a `DOMException` surfaced as an opaque `internal_error`). RFC 7617 requires UTF-8. This adds a shared `basicAuthorizationHeader` that encodes with `Buffer.from(value, "utf8")`, routes the `api_key_basic` branch and nine hand-rolled provider sites through it, and adds a guard test that fails if any file under _src/providers/_ uses `btoa`, since the private-to-OSS sync keeps re-introducing it. ASCII credentials, the common case, send exactly the same bytes as before.
