### PR TITLE
fix(providers): reach eight dead timeout branches, guard mail switch

### DIFF
--- a/src/mail/imap-smtp/runtime.test.ts
+++ b/src/mail/imap-smtp/runtime.test.ts
@@ -1,6 +1,8 @@
 import type { MailActionName } from "./actions.ts";
 import type { MailProtocol } from "./protocol.ts";
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { neteaseMailRuntimeConfig } from "../../providers/netease_mail/config.ts";
 import { ProviderRequestError } from "../../providers/provider-runtime.ts";
@@ -76,6 +78,19 @@ describe("IMAP/SMTP mail runtime", () => {
     expect(error).toBeInstanceOf(ProviderRequestError);
     expect((error as ProviderRequestError).status).toBe(500);
     expect((error as ProviderRequestError).message).toBe("Unsupported mail action: archive_email");
+  });
+
+  // The case above only proves the default clause throws. What keeps a new mail
+  // action from ever reaching it is the `never` assignment, which the compiler
+  // rejects when a name skips the switch, and no test can observe a compile
+  // error the repo has no type-test harness for. Read the clause instead.
+  it("keeps the compile-time exhaustiveness guard on the mail dispatch switch", () => {
+    const source = readFileSync(fileURLToPath(new URL("runtime.ts", import.meta.url)), "utf8");
+
+    expect(
+      source,
+      "executeMailAction's default clause must assign actionName to a never binding; without it a mail action added without a case compiles and returns an empty success",
+    ).toMatch(/default:[\s\S]{0,600}?:\s*never\s*=\s*actionName;/);
   });
 
   it.each(["@qq.com", "user@", "user@@qq.com", "user name@qq.com"])(

--- a/src/mail/imap-smtp/runtime.test.ts
+++ b/src/mail/imap-smtp/runtime.test.ts
@@ -59,15 +59,13 @@ describe("IMAP/SMTP mail runtime", () => {
   });
 
   it("fails a mail action that has no dispatch branch instead of reporting an empty success", async () => {
-    const protocol = { listFolders: vi.fn(async () => []) } as unknown as MailProtocol;
-
     const error = await executeMailAction(
       "archive_email" as MailActionName,
       {},
       {
         values: { email: "user@qq.com", authorizationCode },
         fetcher: fetch,
-        protocol,
+        protocol: {} as unknown as MailProtocol,
         config: qqMailRuntimeConfig,
       },
     ).then(

--- a/src/mail/imap-smtp/runtime.test.ts
+++ b/src/mail/imap-smtp/runtime.test.ts
@@ -1,7 +1,9 @@
+import type { MailActionName } from "./actions.ts";
 import type { MailProtocol } from "./protocol.ts";
 
 import { describe, expect, it, vi } from "vitest";
 import { neteaseMailRuntimeConfig } from "../../providers/netease_mail/config.ts";
+import { ProviderRequestError } from "../../providers/provider-runtime.ts";
 import { qqMailRuntimeConfig } from "../../providers/qq_mail/config.ts";
 import { createMailActions } from "./actions.ts";
 import { MailProtocolError } from "./errors.ts";
@@ -54,6 +56,28 @@ describe("IMAP/SMTP mail runtime", () => {
       imapHost: "imap.qq.com",
       smtpHost: "smtp.qq.com",
     });
+  });
+
+  it("fails a mail action that has no dispatch branch instead of reporting an empty success", async () => {
+    const protocol = { listFolders: vi.fn(async () => []) } as unknown as MailProtocol;
+
+    const error = await executeMailAction(
+      "archive_email" as MailActionName,
+      {},
+      {
+        values: { email: "user@qq.com", authorizationCode },
+        fetcher: fetch,
+        protocol,
+        config: qqMailRuntimeConfig,
+      },
+    ).then(
+      () => undefined,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    expect((error as ProviderRequestError).status).toBe(500);
+    expect((error as ProviderRequestError).message).toBe("Unsupported mail action: archive_email");
   });
 
   it.each(["@qq.com", "user@", "user@@qq.com", "user name@qq.com"])(

--- a/src/mail/imap-smtp/runtime.ts
+++ b/src/mail/imap-smtp/runtime.ts
@@ -440,6 +440,14 @@ export async function executeMailAction(
           await prepared.cleanup();
         }
       }
+      default: {
+        // A mail action name without a branch would otherwise fall off the
+        // switch and resolve to undefined, which the runtime reports as an
+        // empty success. The never assignment makes the compiler reject the
+        // next action name that skips this switch.
+        const unreachable: never = actionName;
+        throw new ProviderRequestError(500, `Unsupported mail action: ${String(unreachable)}`);
+      }
     }
   } catch (error) {
     throw mapProtocolError(error, "execute", context.config);

--- a/src/mail/imap-smtp/runtime.ts
+++ b/src/mail/imap-smtp/runtime.ts
@@ -445,8 +445,8 @@ export async function executeMailAction(
         // switch and resolve to undefined, which the runtime reports as an
         // empty success. The never assignment makes the compiler reject the
         // next action name that skips this switch.
-        const unreachable: never = actionName;
-        throw new ProviderRequestError(500, `Unsupported mail action: ${String(unreachable)}`);
+        const exhaustiveActionName: never = actionName;
+        throw new ProviderRequestError(500, `Unsupported mail action: ${exhaustiveActionName}`);
       }
     }
   } catch (error) {

--- a/src/providers/abuseipdb/executors.ts
+++ b/src/providers/abuseipdb/executors.ts
@@ -5,6 +5,7 @@ import { isIP } from "node:net";
 import { nullableString, optionalBoolean, optionalInteger, optionalRecord, optionalString } from "../../core/cast.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -235,7 +236,7 @@ async function requestAbuseipdbJson<T>(input: {
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (isAbortError(error)) {
+    if (isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "AbuseIPDB request timed out");
     }
     throw new ProviderRequestError(
@@ -508,10 +509,6 @@ function serializeStringList(value: unknown): string | undefined {
     .filter((item) => item !== "");
 
   return values.length > 0 ? values.join(",") : undefined;
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function isRateLimitLike402Message(message: string): boolean {

--- a/src/providers/appdrag/executors.ts
+++ b/src/providers/appdrag/executors.ts
@@ -12,6 +12,7 @@ import {
   createProviderFetch,
   createProviderProxyUrl,
   defineApiKeyProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerInputError,
   ProviderRequestError,
@@ -273,7 +274,7 @@ async function requestAppdrag(
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "AppDrag request timed out");
     }
 
@@ -370,8 +371,4 @@ function inferResponseFormat(body: unknown): "empty" | "json" | "text" {
     return "text";
   }
   return "json";
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/datadog/executors.ts
+++ b/src/providers/datadog/executors.ts
@@ -13,6 +13,7 @@ import { compactObject, optionalBoolean, optionalNumber, optionalRecord, optiona
 import {
   createProviderProxyUrl,
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyHeaders,
   providerFetch,
   ProviderRequestError,
@@ -392,7 +393,7 @@ async function datadogRequestJson(
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (isAbortError(error)) {
+    if (isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "Datadog request timed out");
     }
     throw new ProviderRequestError(
@@ -558,8 +559,4 @@ function booleanQuery(value: unknown): string | undefined {
 function numberQuery(value: unknown): string | undefined {
   const numberValue = optionalNumber(value);
   return numberValue === undefined ? undefined : String(numberValue);
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/flowiseai/executors.ts
+++ b/src/providers/flowiseai/executors.ts
@@ -5,6 +5,7 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import { assertPublicHttpUrl } from "../../core/request.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   providerUserAgent,
   ProviderRequestError,
   requireApiKeyCredential,
@@ -169,7 +170,7 @@ async function requestFlowiseJson(input: FlowiseaiRequestInput): Promise<unknown
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "FlowiseAI request timed out", error);
     }
 
@@ -447,8 +448,4 @@ function readChatflowType(value: unknown): FlowiseaiChatflowType {
 
 function stringifyRecordValues(input: Record<string, unknown>): Record<string, string> {
   return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, value == null ? "" : String(value)]));
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }

--- a/src/providers/fluxguard/executors.ts
+++ b/src/providers/fluxguard/executors.ts
@@ -6,6 +6,7 @@ import { compactObject, optionalRecord, optionalString } from "../../core/cast.t
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requiredInputString,
@@ -240,7 +241,7 @@ async function requestFluxguardJson(context: FluxguardActionContext, input: Flux
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "Fluxguard request timed out", error);
     }
 
@@ -431,10 +432,6 @@ function readFirstString(record: Record<string, unknown>, keys: string[]): strin
     }
   }
   return null;
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({

--- a/src/providers/forem/executors.ts
+++ b/src/providers/forem/executors.ts
@@ -10,6 +10,7 @@ import { compactObject, optionalRawString, optionalRecord, optionalString } from
 import {
   defineProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requireApiKeyCredential,
@@ -284,7 +285,7 @@ async function requestForemJson<T>(context: ForemActionContext, input: ForemRequ
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "Forem request timed out", error);
     }
 
@@ -519,10 +520,6 @@ function assertCommentTarget(input: Record<string, unknown>): void {
   if (hasArticleId === hasPodcastEpisodeId) {
     throw new ProviderRequestError(400, "exactly one of articleId or podcastEpisodeId is required");
   }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
 }
 
 async function foremProxyBaseUrl(context: ExecutionContext, service: string): Promise<string> {

--- a/src/providers/fuxin/executors.ts
+++ b/src/providers/fuxin/executors.ts
@@ -22,6 +22,7 @@ import {
 import { assertPublicHttpUrl, readBoundedResponseBytes } from "../../core/request.ts";
 import {
   defineProviderExecutors,
+  isAbortLikeError,
   normalizeProviderProxyEndpoint,
   normalizeProviderProxyHeaders,
   normalizeProviderProxyQuery,
@@ -1074,7 +1075,7 @@ async function fetchFuxinSource(
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "failed to fetch multipart source: request timed out", error);
     }
     const message = error instanceof Error ? error.message : "failed to fetch multipart source";
@@ -1151,7 +1152,7 @@ async function sendFuxinRequest(url: URL, input: FuxinRequestInput): Promise<Res
       signal,
     });
   } catch (error) {
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, `fuxin ${input.path} request timed out`, error);
     }
     const message = error instanceof Error ? error.message : "fuxin request failed";
@@ -1511,8 +1512,4 @@ function setOptionalFormDataNumber(formData: FormData, key: string, value: numbe
   if (value !== undefined) {
     formData.set(key, String(value));
   }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }

--- a/src/providers/gamma/executors.ts
+++ b/src/providers/gamma/executors.ts
@@ -7,6 +7,7 @@ import { compactJson } from "../../core/request.ts";
 import {
   defineApiKeyProviderExecutors,
   defineProviderProxy,
+  isAbortLikeError,
   ProviderRequestError,
   providerUserAgent,
   requiredInputString,
@@ -319,7 +320,7 @@ async function gammaRequest(input: GammaRequestInput): Promise<unknown> {
     if (error instanceof ProviderRequestError) {
       throw error;
     }
-    if (timeoutSignal.aborted && isAbortError(error)) {
+    if (timeoutSignal.aborted && isAbortLikeError(error)) {
       throw new ProviderRequestError(504, "Gamma request timed out", error);
     }
     const message = error instanceof Error ? `Gamma request failed: ${error.message}` : "Gamma request failed";
@@ -467,10 +468,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     globalThis.setTimeout(resolve, ms);
   });
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
 }
 
 export const proxy: ProviderProxyExecutor = defineProviderProxy({

--- a/src/providers/openweather_api/executors.ts
+++ b/src/providers/openweather_api/executors.ts
@@ -114,7 +114,7 @@ export const openweatherApiActionHandlers: ProviderActionHandlers<"openweather_a
     return executeGetStationMeasurements(input, context);
   },
   get_weather_triggers() {
-    throw new ProviderRequestError(410, retiredWeatherTriggersMessage);
+    throw new ProviderRequestError(400, retiredWeatherTriggersMessage);
   },
 };
 

--- a/src/providers/provider-runtime.retired-actions.test.ts
+++ b/src/providers/provider-runtime.retired-actions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { openweatherApiActionHandlers } from "./openweather_api/executors.ts";
+import { ProviderRequestError } from "./provider-runtime.ts";
+
+// An action the upstream API retired is a caller error, and the runtime derives
+// the outward HTTP status from the error code alone: `RuntimeStatus` in
+// src/server/api/runtime-api.ts has no 410, so a 410 raised here would survive
+// only as a misleading `data.status`. Sub-500 statuses report as invalid_input
+// with HTTP 400, so 400 is the status this branch has to raise.
+
+describe("provider retired actions", () => {
+  it("reports the retired OpenWeather weather-triggers action with a status the runtime can express", async () => {
+    const error = await Promise.resolve()
+      .then(() =>
+        openweatherApiActionHandlers.get_weather_triggers(
+          {},
+          {
+            apiKey: "test-key",
+            fetcher: () => Promise.reject(new Error("the retired action must not reach the network")),
+          },
+        ),
+      )
+      .then(
+        () => undefined,
+        (reason: unknown) => reason,
+      );
+
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    expect((error as ProviderRequestError).status).toBe(400);
+    expect((error as ProviderRequestError).message).toBe(
+      "OpenWeather retired Weather Triggers API on August 1, 2025; this action is no longer available.",
+    );
+  });
+});

--- a/src/providers/provider-runtime.timeout-residual.test.ts
+++ b/src/providers/provider-runtime.timeout-residual.test.ts
@@ -4,12 +4,11 @@ import { datadogActionHandlers } from "./datadog/executors.ts";
 import { gammaActionHandlers } from "./gamma/executors.ts";
 import { ProviderRequestError } from "./provider-runtime.ts";
 
-/**
- * `AbortSignal.timeout()` aborts with a `TimeoutError`, not an `AbortError`, so
- * a provider whose timeout branch only recognizes `AbortError` reports its own
- * budget expiry as a generic upstream failure. These cases pin the timeout
- * branch of the providers that used to carry such a predicate.
- */
+// `AbortSignal.timeout()` aborts with a `TimeoutError`, not an `AbortError`, so
+// a provider whose timeout branch only recognizes `AbortError` reports its own
+// budget expiry as a generic upstream failure. These cases pin the timeout
+// branch of the providers that used to carry such a predicate.
+
 function timeoutAbortError(): DOMException {
   return new DOMException("The operation was aborted due to timeout", "TimeoutError");
 }

--- a/src/providers/provider-runtime.timeout-residual.test.ts
+++ b/src/providers/provider-runtime.timeout-residual.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { abuseipdbActionHandlers } from "./abuseipdb/executors.ts";
+import { datadogActionHandlers } from "./datadog/executors.ts";
+import { gammaActionHandlers } from "./gamma/executors.ts";
+import { ProviderRequestError } from "./provider-runtime.ts";
+
+/**
+ * `AbortSignal.timeout()` aborts with a `TimeoutError`, not an `AbortError`, so
+ * a provider whose timeout branch only recognizes `AbortError` reports its own
+ * budget expiry as a generic upstream failure. These cases pin the timeout
+ * branch of the providers that used to carry such a predicate.
+ */
+function timeoutAbortError(): DOMException {
+  return new DOMException("The operation was aborted due to timeout", "TimeoutError");
+}
+
+async function caught(promise: Promise<unknown>): Promise<ProviderRequestError> {
+  const error = await promise.then(
+    () => undefined,
+    (reason: unknown) => reason,
+  );
+  expect(error).toBeInstanceOf(ProviderRequestError);
+  return error as ProviderRequestError;
+}
+
+describe("provider timeout branches", () => {
+  it("reports an AbuseIPDB timeout as 504 rather than a generic failure", async () => {
+    const error = await caught(
+      abuseipdbActionHandlers.blacklist(
+        {},
+        {
+          apiKey: "test-key",
+          fetcher: () => Promise.reject(timeoutAbortError()),
+        },
+      ),
+    );
+
+    expect(error.status).toBe(504);
+    expect(error.message).toBe("AbuseIPDB request timed out");
+  });
+
+  it("reports a Datadog timeout as 504 rather than a generic failure", async () => {
+    const error = await caught(
+      datadogActionHandlers.list_monitors(
+        {},
+        {
+          baseUrl: "https://api.datadoghq.com",
+          apiKey: "test-key",
+          applicationKey: "test-app-key",
+          fetcher: () => Promise.reject(timeoutAbortError()),
+        },
+      ),
+    );
+
+    expect(error.status).toBe(504);
+    expect(error.message).toBe("Datadog request timed out");
+  });
+
+  it("reports a Gamma request that outruns a real AbortSignal.timeout budget as 504", async () => {
+    const error = await caught(
+      gammaActionHandlers.wait_for_generation(
+        { generationId: "gen-1", timeoutSeconds: 0.005 },
+        {
+          apiKey: "test-key",
+          async fetcher(_url, init) {
+            const signal = init?.signal;
+            if (!signal) {
+              throw new Error("gamma must pass an abort signal to the fetcher");
+            }
+            await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
+            throw signal.reason;
+          },
+        },
+      ),
+    );
+
+    expect(error.status).toBe(504);
+    expect(error.message).toBe("Gamma request timed out");
+  });
+});

--- a/src/providers/provider-runtime.timeout-residual.test.ts
+++ b/src/providers/provider-runtime.timeout-residual.test.ts
@@ -7,7 +7,9 @@ import { ProviderRequestError } from "./provider-runtime.ts";
 // `AbortSignal.timeout()` aborts with a `TimeoutError`, not an `AbortError`, so
 // a provider whose timeout branch only recognizes `AbortError` reports its own
 // budget expiry as a generic upstream failure. These cases pin the timeout
-// branch of the providers that used to carry such a predicate.
+// branch of the providers that used to carry such a predicate, and the 502 that
+// an ordinary transport failure still has to produce, so a guard widened to
+// match every error is caught here rather than mislabeling every failure.
 
 function timeoutAbortError(): DOMException {
   return new DOMException("The operation was aborted due to timeout", "TimeoutError");
@@ -38,6 +40,21 @@ describe("provider timeout branches", () => {
     expect(error.message).toBe("AbuseIPDB request timed out");
   });
 
+  it("still reports a non-abort AbuseIPDB failure as 502", async () => {
+    const error = await caught(
+      abuseipdbActionHandlers.blacklist(
+        {},
+        {
+          apiKey: "test-key",
+          fetcher: () => Promise.reject(new TypeError("fetch failed")),
+        },
+      ),
+    );
+
+    expect(error.status).toBe(502);
+    expect(error.message).toBe("AbuseIPDB request failed: fetch failed");
+  });
+
   it("reports a Datadog timeout as 504 rather than a generic failure", async () => {
     const error = await caught(
       datadogActionHandlers.list_monitors(
@@ -53,6 +70,23 @@ describe("provider timeout branches", () => {
 
     expect(error.status).toBe(504);
     expect(error.message).toBe("Datadog request timed out");
+  });
+
+  it("still reports a non-abort Datadog failure as 502", async () => {
+    const error = await caught(
+      datadogActionHandlers.list_monitors(
+        {},
+        {
+          baseUrl: "https://api.datadoghq.com",
+          apiKey: "test-key",
+          applicationKey: "test-app-key",
+          fetcher: () => Promise.reject(new TypeError("fetch failed")),
+        },
+      ),
+    );
+
+    expect(error.status).toBe(502);
+    expect(error.message).toBe("Datadog request failed: fetch failed");
   });
 
   it("reports a Gamma request that outruns a real AbortSignal.timeout budget as 504", async () => {

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -10,9 +10,11 @@ import { describe, expect, it } from "vitest";
 // when a provider grows an `AbortError`-only check again, which the
 // private-to-OSS sync has repeatedly done. Both a named predicate (declared as a
 // function or as an arrow constant, in the same file or a sibling of the same
-// provider directory) and an inline `error.name === "AbortError"` test count. A
-// check disjoined with the timeout signal's own `.aborted` flag stays reachable
-// and is therefore allowed.
+// provider directory) and an inline `error.name === "AbortError"` test count.
+// Only a branch that reports a timeout, by status 504 or by message, is read as
+// the timeout branch, so a provider that tells a caller cancellation apart from
+// a timeout keeps its `AbortError` test. A check disjoined with the timeout
+// signal's own `.aborted` flag stays reachable and is therefore allowed.
 
 const providersDir = fileURLToPath(new URL(".", import.meta.url));
 const repoDir = fileURLToPath(new URL("../..", import.meta.url));
@@ -20,11 +22,18 @@ const abortNameComparison = /name\s*===\s*"AbortError"/;
 const predicateDeclaration =
   /(?:function\s+([A-Za-z_$][\w$]*)\s*\(|const\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]*)?=\s*(?:async\s+)?[(<])/g;
 const requestHelperBody = /\b(?:await|fetch|throw)\b/;
+const timeoutBranch = /\b504\b|timed out/i;
 const declarationWindowChars = 2000;
 const predicateBodyChars = 500;
 const conditionWindowLines = 3;
+const branchWindowLines = 6;
 
 interface PredicateBody {
+  text: string;
+  end: number;
+}
+
+interface EnclosingCondition {
   text: string;
   end: number;
 }
@@ -121,7 +130,7 @@ function abortChecks(source: string): AbortChecks {
 }
 
 /** Join the lines around `index` that make up the enclosing condition, so a wrapped disjunction is read as one. */
-function enclosingCondition(lines: string[], index: number): string {
+function enclosingCondition(lines: string[], index: number): EnclosingCondition {
   let first = index;
   while (first > 0 && index - first < conditionWindowLines && !/\bif\s*\(/.test(lines[first] as string)) {
     first -= 1;
@@ -130,7 +139,28 @@ function enclosingCondition(lines: string[], index: number): string {
   while (last < lines.length - 1 && last - index < conditionWindowLines && !/\)\s*\{/.test(lines[last] as string)) {
     last += 1;
   }
-  return lines.slice(first, last + 1).join("\n");
+  return { text: lines.slice(first, last + 1).join("\n"), end: last };
+}
+
+/** Read the branch a condition ending on `line` guards, so it can be told apart from a non-timeout branch. */
+function guardedBranch(lines: string[], line: number): string {
+  const branch: string[] = [];
+  let braces = 0;
+  for (let index = line; index < lines.length && index - line <= branchWindowLines; index += 1) {
+    const text = lines[index] as string;
+    branch.push(text);
+    for (const char of text) {
+      if (char === "{") {
+        braces += 1;
+      } else if (char === "}") {
+        braces -= 1;
+        if (braces === 0) {
+          return branch.join("\n");
+        }
+      }
+    }
+  }
+  return branch.join("\n");
 }
 
 function findDeadTimeoutGuards(file: ProviderSource, names: string[]): string[] {
@@ -149,10 +179,15 @@ function findDeadTimeoutGuards(file: ProviderSource, names: string[]): string[] 
       return;
     }
     const condition = enclosingCondition(lines, index);
-    if (!callsPredicate && condition.includes('"TimeoutError"')) {
+    if (!callsPredicate && condition.text.includes('"TimeoutError"')) {
       return;
     }
-    if (condition.includes("||") && condition.includes(".aborted")) {
+    if (condition.text.includes("||") && condition.text.includes(".aborted")) {
+      return;
+    }
+    if (!timeoutBranch.test(guardedBranch(lines, condition.end))) {
+      // Not the timeout branch. An `AbortError` test that reports something else,
+      // a caller cancellation for instance, stays reachable and stays correct.
       return;
     }
     dead.push(`${relative(repoDir, file.path)}:${index + 1}`);

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -1,0 +1,69 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `AbortSignal.timeout()` aborts with a `TimeoutError`, so a provider that
+ * matches only `"AbortError"` has a dead timeout branch. The shared
+ * `isAbortLikeError` accepts both names; this guard fails when a provider grows
+ * its own `AbortError`-only predicate again, which the private-to-OSS sync has
+ * repeatedly done. A call disjoined with the timeout signal's own `.aborted`
+ * flag stays reachable and is therefore allowed.
+ */
+const providersDir = fileURLToPath(new URL(".", import.meta.url));
+const repoDir = fileURLToPath(new URL("../..", import.meta.url));
+const functionDeclaration = /function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)[^{}]*\{([^{}]*)\}/g;
+
+function listSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(path));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function abortOnlyPredicateNames(source: string): string[] {
+  const names: string[] = [];
+  for (const match of source.matchAll(functionDeclaration)) {
+    const body = match[2] ?? "";
+    if (body.includes('"AbortError"') && !body.includes('"TimeoutError"')) {
+      names.push(match[1] as string);
+    }
+  }
+  return names;
+}
+
+function findDeadTimeoutGuards(path: string): string[] {
+  const source = readFileSync(path, "utf8");
+  if (!source.includes("AbortSignal.timeout")) {
+    return [];
+  }
+  const names = abortOnlyPredicateNames(source);
+  if (names.length === 0) {
+    return [];
+  }
+  const dead: string[] = [];
+  source.split("\n").forEach((line, index) => {
+    if (line.trimStart().startsWith("function ") || /\.aborted\s*\|\|/.test(line)) {
+      return;
+    }
+    if (names.some((name) => line.includes(`${name}(`))) {
+      dead.push(`${relative(repoDir, path)}:${index + 1}`);
+    }
+  });
+  return dead;
+}
+
+describe("provider abort predicates", () => {
+  it("never guards a timeout branch on AbortError alone", () => {
+    const dead = listSourceFiles(providersDir).flatMap(findDeadTimeoutGuards);
+
+    expect(dead).toEqual([]);
+  });
+});

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -19,8 +19,11 @@ import { describe, expect, it } from "vitest";
 const providersDir = fileURLToPath(new URL(".", import.meta.url));
 const repoDir = fileURLToPath(new URL("../..", import.meta.url));
 const abortNameComparison = /name\s*===\s*"AbortError"/;
+// The `const` arm reads a return-type annotation that itself contains `=>`, and
+// its initializer arm accepts a single-parameter arrow written without
+// parentheses, so `const isAbortError = error => ...` is still resolved by name.
 const predicateDeclaration =
-  /(?:function\s+([A-Za-z_$][\w$]*)\s*\(|const\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]*)?=\s*(?:async\s+)?[(<])/g;
+  /(?:function\s+([A-Za-z_$][\w$]*)\s*\(|const\s+([A-Za-z_$][\w$]*)\s*(?::(?:[^=;]|=>)*)?=\s*(?:async\s+)?(?:[(<]|[A-Za-z_$][\w$]*\s*=>))/g;
 const requestHelperBody = /\b(?:await|fetch|throw)\b/;
 const timeoutBranch = /\b504\b|timed out/i;
 const declarationWindowChars = 2000;
@@ -167,11 +170,16 @@ function guardedBranch(lines: string[], line: number): string {
   return branch.join("\n");
 }
 
+/** Escape a captured predicate name, so a `$` in it stays a literal instead of anchoring the call pattern. */
+function escapeRegExp(text: string): string {
+  return text.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
 function findDeadTimeoutGuards(file: ProviderSource, names: string[]): string[] {
   if (names.length === 0 && !file.source.includes('"AbortError"')) {
     return [];
   }
-  const calls = names.map((name) => new RegExp(`\\b${name}\\s*\\(`));
+  const calls = names.map((name) => new RegExp(String.raw`(?<![\w$])${escapeRegExp(name)}\s*\(`));
   const lines = file.source.split("\n");
   const dead: string[] = [];
   lines.forEach((line, index) => {

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -3,17 +3,36 @@ import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-/**
- * `AbortSignal.timeout()` aborts with a `TimeoutError`, so a provider that
- * matches only `"AbortError"` has a dead timeout branch. The shared
- * `isAbortLikeError` accepts both names; this guard fails when a provider grows
- * its own `AbortError`-only predicate again, which the private-to-OSS sync has
- * repeatedly done. A call disjoined with the timeout signal's own `.aborted`
- * flag stays reachable and is therefore allowed.
- */
+// `AbortSignal.timeout()` aborts with a `TimeoutError`, never an `AbortError`,
+// so a timeout branch that recognizes only `AbortError` is dead and the provider
+// reports its own budget expiry as a generic upstream failure. The shared
+// `isAbortLikeError` in provider-runtime.ts accepts both names. This guard fails
+// when a provider grows an `AbortError`-only check again, which the
+// private-to-OSS sync has repeatedly done. Both a named predicate (declared as a
+// function or as an arrow constant, in the same file or a sibling of the same
+// provider directory) and an inline `error.name === "AbortError"` test count. A
+// check disjoined with the timeout signal's own `.aborted` flag stays reachable
+// and is therefore allowed.
+
 const providersDir = fileURLToPath(new URL(".", import.meta.url));
 const repoDir = fileURLToPath(new URL("../..", import.meta.url));
-const functionDeclaration = /function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)[^{}]*\{([^{}]*)\}/g;
+const abortNameComparison = /name\s*===\s*"AbortError"/;
+const predicateDeclaration =
+  /(?:function\s+([A-Za-z_$][\w$]*)\s*\(|const\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]*)?=\s*(?:async\s+)?[(<])/g;
+const requestHelperBody = /\b(?:await|fetch|throw)\b/;
+const declarationWindowChars = 2000;
+const predicateBodyChars = 500;
+const conditionWindowLines = 3;
+
+interface PredicateBody {
+  text: string;
+  end: number;
+}
+
+interface AbortChecks {
+  names: string[];
+  coveredLines: Set<number>;
+}
 
 function listSourceFiles(dir: string): string[] {
   const files: string[] = [];
@@ -28,42 +47,145 @@ function listSourceFiles(dir: string): string[] {
   return files;
 }
 
-function abortOnlyPredicateNames(source: string): string[] {
-  const names: string[] = [];
-  for (const match of source.matchAll(functionDeclaration)) {
-    const body = match[2] ?? "";
-    if (body.includes('"AbortError"') && !body.includes('"TimeoutError"')) {
-      names.push(match[1] as string);
+/** Read the body of the declaration starting at index 0 of `window`, following either a block or a concise arrow. */
+function readBody(window: string): PredicateBody | undefined {
+  let parens = 0;
+  for (let index = 0; index < window.length; index += 1) {
+    const char = window[index];
+    if (char === "(") {
+      parens += 1;
+    } else if (char === ")") {
+      parens -= 1;
+    } else if (parens > 0) {
+      continue;
+    } else if (char === "{") {
+      let braces = 0;
+      for (let end = index; end < window.length; end += 1) {
+        if (window[end] === "{") {
+          braces += 1;
+        } else if (window[end] === "}") {
+          braces -= 1;
+          if (braces === 0) {
+            return { text: window.slice(index, end + 1), end: end + 1 };
+          }
+        }
+      }
+      return undefined;
+    } else if (char === "=" && window[index + 1] === ">") {
+      const rest = window.slice(index + 2);
+      if (rest.trimStart().startsWith("{")) {
+        continue;
+      }
+      const semicolon = rest.indexOf(";");
+      return semicolon < 0 ? undefined : { text: rest.slice(0, semicolon), end: index + 2 + semicolon };
+    } else if (char === ";") {
+      return undefined;
     }
   }
-  return names;
+  return undefined;
 }
 
-function findDeadTimeoutGuards(path: string): string[] {
+/** Collect the file's `AbortError`-only predicate names and the lines that any abort predicate body occupies. */
+function abortChecks(source: string): AbortChecks {
+  const names: string[] = [];
+  const coveredLines = new Set<number>();
+  if (!source.includes('"AbortError"')) {
+    return { names, coveredLines };
+  }
+  for (const match of source.matchAll(predicateDeclaration)) {
+    const name = match[1] ?? match[2];
+    const body = readBody(source.slice(match.index, match.index + declarationWindowChars));
+    if (name === undefined || body === undefined || !abortNameComparison.test(body.text)) {
+      continue;
+    }
+    if (body.text.length > predicateBodyChars || requestHelperBody.test(body.text)) {
+      // A request helper that tests the name inline, not a predicate to resolve by name.
+      continue;
+    }
+    const first = source.slice(0, match.index).split("\n").length - 1;
+    const last = first + source.slice(match.index, match.index + body.end).split("\n").length - 1;
+    for (let line = first; line <= last; line += 1) {
+      coveredLines.add(line);
+    }
+    if (!body.text.includes('"TimeoutError"')) {
+      names.push(name);
+    }
+  }
+  return { names, coveredLines };
+}
+
+/** Join the lines around `index` that make up the enclosing condition, so a wrapped disjunction is read as one. */
+function enclosingCondition(lines: string[], index: number): string {
+  let first = index;
+  while (first > 0 && index - first < conditionWindowLines && !/\bif\s*\(/.test(lines[first] as string)) {
+    first -= 1;
+  }
+  let last = index;
+  while (last < lines.length - 1 && last - index < conditionWindowLines && !/\)\s*\{/.test(lines[last] as string)) {
+    last += 1;
+  }
+  return lines.slice(first, last + 1).join("\n");
+}
+
+function findDeadTimeoutGuards(path: string, names: string[]): string[] {
   const source = readFileSync(path, "utf8");
-  if (!source.includes("AbortSignal.timeout")) {
+  if (names.length === 0 && !source.includes('"AbortError"')) {
     return [];
   }
-  const names = abortOnlyPredicateNames(source);
-  if (names.length === 0) {
-    return [];
-  }
+  const lines = source.split("\n");
+  const checks = abortChecks(source);
+  const predicateNames = [...new Set([...names, ...checks.names])];
   const dead: string[] = [];
-  source.split("\n").forEach((line, index) => {
-    if (line.trimStart().startsWith("function ") || /\.aborted\s*\|\|/.test(line)) {
+  lines.forEach((line, index) => {
+    if (checks.coveredLines.has(index)) {
       return;
     }
-    if (names.some((name) => line.includes(`${name}(`))) {
-      dead.push(`${relative(repoDir, path)}:${index + 1}`);
+    const callsPredicate = predicateNames.some((name) => new RegExp(`\\b${name}\\s*\\(`).test(line));
+    if (!callsPredicate && !abortNameComparison.test(line)) {
+      return;
     }
+    const condition = enclosingCondition(lines, index);
+    if (!callsPredicate && condition.includes('"TimeoutError"')) {
+      return;
+    }
+    if (condition.includes("||") && condition.includes(".aborted")) {
+      return;
+    }
+    dead.push(`${relative(repoDir, path)}:${index + 1}`);
   });
   return dead;
 }
 
+/** Group the provider sources by provider directory, so a predicate imported from a sibling file is still resolved. */
+function groupByProvider(files: string[]): string[][] {
+  const groups = new Map<string, string[]>();
+  for (const file of files) {
+    const key = relative(providersDir, file).split(/[\\/]/)[0] as string;
+    const group = groups.get(key);
+    if (group === undefined) {
+      groups.set(key, [file]);
+    } else {
+      group.push(file);
+    }
+  }
+  return [...groups.values()];
+}
+
 describe("provider abort predicates", () => {
   it("never guards a timeout branch on AbortError alone", () => {
-    const dead = listSourceFiles(providersDir).flatMap(findDeadTimeoutGuards);
+    const dead: string[] = [];
+    for (const group of groupByProvider(listSourceFiles(providersDir))) {
+      const sources = group.map((file) => readFileSync(file, "utf8"));
+      if (!sources.some((source) => source.includes("AbortSignal.timeout"))) {
+        continue;
+      }
+      const names = sources.flatMap((source) => abortChecks(source).names);
+      dead.push(...group.flatMap((file) => findDeadTimeoutGuards(file, names)));
+    }
 
-    expect(dead).toEqual([]);
+    expect(
+      dead,
+      "these timeout guards match AbortError only, so AbortSignal.timeout never reaches them; call isAbortLikeError from provider-runtime.ts instead",
+    ).toEqual([]);
   });
 });

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -27,6 +27,10 @@ const declarationWindowChars = 2000;
 const predicateBodyChars = 500;
 const conditionWindowLines = 3;
 const branchWindowLines = 6;
+// 62 provider directories reach the scan today; a floor well under that fails
+// loudly if the timeout idiom or the directory layout moves and the scan quietly
+// stops covering anything.
+const minimumScannedProviders = 20;
 
 interface PredicateBody {
   text: string;
@@ -213,11 +217,13 @@ function groupByProvider(files: string[]): string[][] {
 describe("provider abort predicates", () => {
   it("never guards a timeout branch on AbortError alone", () => {
     const dead: string[] = [];
+    let scanned = 0;
     for (const group of groupByProvider(listSourceFiles(providersDir))) {
       const sources = group.map((path) => ({ path, source: readFileSync(path, "utf8") }));
       if (!sources.some((entry) => entry.source.includes("AbortSignal.timeout"))) {
         continue;
       }
+      scanned += 1;
       const files: ProviderSource[] = sources.map((entry) => ({ ...entry, checks: abortChecks(entry.source) }));
       const names = [...new Set(files.flatMap((file) => file.checks.names))];
       dead.push(...files.flatMap((file) => findDeadTimeoutGuards(file, names)));
@@ -227,5 +233,9 @@ describe("provider abort predicates", () => {
       dead,
       "these timeout guards match AbortError only, so AbortSignal.timeout never reaches them; call isAbortLikeError from provider-runtime.ts instead",
     ).toEqual([]);
+    expect(
+      scanned,
+      "no provider directory reached the scan, so this guard protects nothing; check that providers still call AbortSignal.timeout and that the scan root still points at src/providers",
+    ).toBeGreaterThan(minimumScannedProviders);
   });
 });

--- a/src/providers/provider-source-guards.abort-predicate.test.ts
+++ b/src/providers/provider-source-guards.abort-predicate.test.ts
@@ -34,6 +34,12 @@ interface AbortChecks {
   coveredLines: Set<number>;
 }
 
+interface ProviderSource {
+  path: string;
+  source: string;
+  checks: AbortChecks;
+}
+
 function listSourceFiles(dir: string): string[] {
   const files: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -47,11 +53,11 @@ function listSourceFiles(dir: string): string[] {
   return files;
 }
 
-/** Read the body of the declaration starting at index 0 of `window`, following either a block or a concise arrow. */
-function readBody(window: string): PredicateBody | undefined {
+/** Read the body of the declaration starting at index 0 of `declaration`, either a block or a concise arrow. */
+function readBody(declaration: string): PredicateBody | undefined {
   let parens = 0;
-  for (let index = 0; index < window.length; index += 1) {
-    const char = window[index];
+  for (let index = 0; index < declaration.length; index += 1) {
+    const char = declaration[index];
     if (char === "(") {
       parens += 1;
     } else if (char === ")") {
@@ -60,19 +66,19 @@ function readBody(window: string): PredicateBody | undefined {
       continue;
     } else if (char === "{") {
       let braces = 0;
-      for (let end = index; end < window.length; end += 1) {
-        if (window[end] === "{") {
+      for (let end = index; end < declaration.length; end += 1) {
+        if (declaration[end] === "{") {
           braces += 1;
-        } else if (window[end] === "}") {
+        } else if (declaration[end] === "}") {
           braces -= 1;
           if (braces === 0) {
-            return { text: window.slice(index, end + 1), end: end + 1 };
+            return { text: declaration.slice(index, end + 1), end: end + 1 };
           }
         }
       }
       return undefined;
-    } else if (char === "=" && window[index + 1] === ">") {
-      const rest = window.slice(index + 2);
+    } else if (char === "=" && declaration[index + 1] === ">") {
+      const rest = declaration.slice(index + 2);
       if (rest.trimStart().startsWith("{")) {
         continue;
       }
@@ -127,20 +133,18 @@ function enclosingCondition(lines: string[], index: number): string {
   return lines.slice(first, last + 1).join("\n");
 }
 
-function findDeadTimeoutGuards(path: string, names: string[]): string[] {
-  const source = readFileSync(path, "utf8");
-  if (names.length === 0 && !source.includes('"AbortError"')) {
+function findDeadTimeoutGuards(file: ProviderSource, names: string[]): string[] {
+  if (names.length === 0 && !file.source.includes('"AbortError"')) {
     return [];
   }
-  const lines = source.split("\n");
-  const checks = abortChecks(source);
-  const predicateNames = [...new Set([...names, ...checks.names])];
+  const calls = names.map((name) => new RegExp(`\\b${name}\\s*\\(`));
+  const lines = file.source.split("\n");
   const dead: string[] = [];
   lines.forEach((line, index) => {
-    if (checks.coveredLines.has(index)) {
+    if (file.checks.coveredLines.has(index)) {
       return;
     }
-    const callsPredicate = predicateNames.some((name) => new RegExp(`\\b${name}\\s*\\(`).test(line));
+    const callsPredicate = calls.some((call) => call.test(line));
     if (!callsPredicate && !abortNameComparison.test(line)) {
       return;
     }
@@ -151,7 +155,7 @@ function findDeadTimeoutGuards(path: string, names: string[]): string[] {
     if (condition.includes("||") && condition.includes(".aborted")) {
       return;
     }
-    dead.push(`${relative(repoDir, path)}:${index + 1}`);
+    dead.push(`${relative(repoDir, file.path)}:${index + 1}`);
   });
   return dead;
 }
@@ -175,12 +179,13 @@ describe("provider abort predicates", () => {
   it("never guards a timeout branch on AbortError alone", () => {
     const dead: string[] = [];
     for (const group of groupByProvider(listSourceFiles(providersDir))) {
-      const sources = group.map((file) => readFileSync(file, "utf8"));
-      if (!sources.some((source) => source.includes("AbortSignal.timeout"))) {
+      const sources = group.map((path) => ({ path, source: readFileSync(path, "utf8") }));
+      if (!sources.some((entry) => entry.source.includes("AbortSignal.timeout"))) {
         continue;
       }
-      const names = sources.flatMap((source) => abortChecks(source).names);
-      dead.push(...group.flatMap((file) => findDeadTimeoutGuards(file, names)));
+      const files: ProviderSource[] = sources.map((entry) => ({ ...entry, checks: abortChecks(entry.source) }));
+      const names = [...new Set(files.flatMap((file) => file.checks.names))];
+      dead.push(...files.flatMap((file) => findDeadTimeoutGuards(file, names)));
     }
 
     expect(


### PR DESCRIPTION
Stacked on #465 (`fix/e8-e9-auth-error-status`), part of the E-tier audit stack. Retargets to `main` once the branch below lands.

A timeout on eight providers (`abuseipdb`, `appdrag`, `datadog`, `flowiseai`, `fluxguard`, `forem`, `fuxin`, `gamma`) was reported as a generic upstream failure because their guard matched only `AbortError`, while `AbortSignal.timeout` raises `TimeoutError`, leaving the timeout branch dead. They now use the shared `isAbortLikeError` (which matches both), and a source guard fails CI if any provider pairs `AbortSignal.timeout` with an `AbortError`-only predicate, since the sync keeps re-adding that shape.

Two smaller fixes ride along. `executeMailAction`'s dispatch switch gains a `never` default so a mail action added later cannot ship as a silent `ok: true` no-op. And `openweather_api`'s retired-triggers action stops raising a 410, a status the runtime cannot express, in favor of 400. The timeout change is visible only in the message text and `data.status` (504 instead of 502), the outward HTTP status is unchanged.
