### PR TITLE
test: cover the D1 marketplace store and local transit backend

### DIFF
--- a/src/server/files/transit-files.test.ts
+++ b/src/server/files/transit-files.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, readdir, rm, unlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TransitFileError } from "./transit-file-store.ts";
+import { TransitFileService } from "./transit-files.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("TransitFileService", () => {
+  it("treats an expired file as not found and removes it with its side-car", async () => {
+    const { rootDir, service } = await createService();
+    const read = await service.create(new File(["expired read"], "read.pdf", { type: "application/pdf" }));
+    const response = await service.create(new File(["expired response"], "response.txt", { type: "text/plain" }));
+    await expire(rootDir, read.fileId, response.fileId);
+
+    // One call per file id: the expiry branch unlinks before it throws, so a second read of the same id
+    // would land in the missing-file branch instead. The class matters because connect-server maps the
+    // response by `instanceof TransitFileError`.
+    const expired = await service.read(read.fileId).catch((error: unknown) => error);
+    expect(expired).toBeInstanceOf(TransitFileError);
+    expect(expired).toMatchObject({ status: 404, code: "file_not_found" });
+    await expect(service.response(response.fileId)).rejects.toMatchObject({ status: 404, code: "file_not_found" });
+
+    // Both removal paths must agree: no orphan .meta.json is left behind.
+    await expect(readdir(rootDir)).resolves.toEqual([]);
+  });
+
+  it("sweeps expired files and their side-cars while keeping live uploads", async () => {
+    const { rootDir, service } = await createService();
+    const expired = await service.create(new File(["old"], "old.txt", { type: "text/plain" }));
+    const live = await service.create(new File(["new"], "new.txt", { type: "text/plain" }));
+    await expire(rootDir, expired.fileId);
+
+    await service.cleanupExpired();
+
+    await expect(readdir(rootDir).then((names) => names.sort())).resolves.toEqual([
+      live.fileId,
+      `${live.fileId}.meta.json`,
+    ]);
+    await expect(service.read(live.fileId).then((stored) => stored.file.text())).resolves.toBe("new");
+  });
+
+  it("falls back to the file id and the extension mime type when the side-car is missing or malformed", async () => {
+    const { rootDir, service } = await createService();
+    const missing = await service.create(new File(["no side-car"], "invoice.pdf", { type: "application/pdf" }));
+    const malformed = await service.create(new File(["broken side-car"], "notes.md", { type: "text/markdown" }));
+    await unlink(join(rootDir, `${missing.fileId}.meta.json`));
+    await writeFile(join(rootDir, `${malformed.fileId}.meta.json`), "{");
+
+    await expect(service.read(missing.fileId)).resolves.toMatchObject({
+      name: missing.fileId,
+      mimeType: "application/pdf",
+      sizeBytes: 11,
+    });
+    await expect(service.read(malformed.fileId)).resolves.toMatchObject({
+      name: malformed.fileId,
+      mimeType: "text/markdown",
+    });
+  });
+
+  it("deletes a stored file with its side-car and reports an unknown id as no deletion", async () => {
+    const { rootDir, service } = await createService();
+    const upload = await service.create(new File(["bye"], "bye.txt", { type: "text/plain" }));
+
+    await expect(service.delete(upload.fileId)).resolves.toBe(true);
+    await expect(readdir(rootDir)).resolves.toEqual([]);
+    await expect(service.delete(upload.fileId)).resolves.toBe(false);
+    await expect(service.delete(`${"a".repeat(32)}.txt`)).resolves.toBe(false);
+  });
+});
+
+async function createService(): Promise<{ rootDir: string; service: TransitFileService }> {
+  const root = await mkdtemp(join(tmpdir(), "connect-transit-files-"));
+  roots.push(root);
+  const rootDir = join(root, "files");
+  return {
+    rootDir,
+    service: new TransitFileService({
+      rootDir,
+      publicOrigin: "http://localhost:3000",
+      ttlSeconds: 60,
+      maxBytes: 1024 * 1024,
+    }),
+  };
+}
+
+/** Backdate the stored bytes past the TTL, the way a file that has been sitting on disk ages out. */
+async function expire(rootDir: string, ...fileIds: string[]): Promise<void> {
+  const old = new Date(Date.now() - 120_000);
+  await Promise.all(fileIds.map((fileId) => utimes(join(rootDir, fileId), old, old)));
+}

--- a/src/server/files/transit-files.ts
+++ b/src/server/files/transit-files.ts
@@ -132,6 +132,7 @@ export class TransitFileService implements IStagedTransitFileService {
     }
     if (Date.now() - stats.mtimeMs > this.ttlMs) {
       await unlink(path).catch(() => undefined);
+      await unlink(metadataPath(path)).catch(() => undefined);
       throw new TransitFileError(404, "file_not_found", "Transit file was not found.");
     }
 

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -1,12 +1,14 @@
 import type { RuntimeActionHttpResult } from "../api/runtime-api.ts";
 import type { D1DatabaseBinding, D1PreparedStatementBinding } from "../cloudflare/cloudflare-bindings.ts";
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { AesGcmSecretCodec } from "../secrets/secret-codec.ts";
 import { D1RuntimeDatabase } from "./d1-runtime-store.ts";
 import { RuntimeTokenService } from "./runtime-token-service.ts";
+
+const migrationDirectory = new URL("../../../migrations/", import.meta.url);
 
 const githubProfile = {
   accountId: "github:octocat",
@@ -504,6 +506,76 @@ describe("D1RuntimeDatabase", () => {
     });
     await expect(database.runLogStore.get("run-2")).resolves.toMatchObject({ id: "run-2" });
   });
+
+  it("upserts the marketplace config and provider preferences", async () => {
+    const database = new D1RuntimeDatabase(new SqliteD1Database());
+
+    await expect(database.marketplaceStore.getConfig()).resolves.toBeUndefined();
+
+    await database.marketplaceStore.setConfig({
+      discoveryUrl: "https://marketplace.example.com/discovery",
+      apiKeyEncrypted: "encrypted-one",
+      enabled: false,
+      createdAt: "2026-06-30T00:00:00.000Z",
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    });
+    await database.marketplaceStore.setConfig({
+      discoveryUrl: "https://marketplace.example.com/discovery",
+      apiKeyEncrypted: "encrypted-two",
+      enabled: true,
+      createdAt: "2026-06-30T00:00:00.000Z",
+      updatedAt: "2026-06-30T00:00:05.000Z",
+    });
+
+    await expect(database.marketplaceStore.getConfig()).resolves.toEqual({
+      discoveryUrl: "https://marketplace.example.com/discovery",
+      apiKeyEncrypted: "encrypted-two",
+      enabled: true,
+      createdAt: "2026-06-30T00:00:00.000Z",
+      updatedAt: "2026-06-30T00:00:05.000Z",
+    });
+
+    await expect(database.marketplaceStore.listProviderPreferences()).resolves.toEqual([]);
+
+    await database.marketplaceStore.setProviderPreference({
+      service: "gmail",
+      enabled: true,
+      createdAt: "2026-06-30T00:00:00.000Z",
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    });
+    await database.marketplaceStore.setProviderPreference({
+      service: "gmail",
+      enabled: false,
+      createdAt: "2026-06-30T00:00:09.000Z",
+      updatedAt: "2026-06-30T00:00:09.000Z",
+    });
+    await database.marketplaceStore.setProviderPreference({
+      service: "abuseipdb",
+      enabled: true,
+      createdAt: "2026-06-30T00:00:02.000Z",
+      updatedAt: "2026-06-30T00:00:02.000Z",
+    });
+
+    // Ordered by service, and the second gmail write keeps createdAt while replacing enabled/updatedAt.
+    await expect(database.marketplaceStore.listProviderPreferences()).resolves.toEqual([
+      {
+        service: "abuseipdb",
+        enabled: true,
+        createdAt: "2026-06-30T00:00:02.000Z",
+        updatedAt: "2026-06-30T00:00:02.000Z",
+      },
+      {
+        service: "gmail",
+        enabled: false,
+        createdAt: "2026-06-30T00:00:00.000Z",
+        updatedAt: "2026-06-30T00:00:09.000Z",
+      },
+    ]);
+
+    await database.marketplaceStore.deleteConfig();
+    await expect(database.marketplaceStore.getConfig()).resolves.toBeUndefined();
+    await expect(database.marketplaceStore.listProviderPreferences()).resolves.toHaveLength(2);
+  });
 });
 
 function createRun(id: string, startedAt: string, actionId = "hackernews.get_top_stories", service = "hackernews") {
@@ -535,29 +607,15 @@ class SqliteD1Database implements D1DatabaseBinding {
   private readonly database = new DatabaseSync(":memory:");
 
   constructor() {
-    this.database.exec(readFileSync(new URL("../../../migrations/0001_runtime.sql", import.meta.url), "utf8"));
-    this.database.exec(readFileSync(new URL("../../../migrations/0002_run_service.sql", import.meta.url), "utf8"));
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0003_action_idempotency.sql", import.meta.url), "utf8"),
-    );
-    this.database.exec(readFileSync(new URL("../../../migrations/0004_action_run_audit.sql", import.meta.url), "utf8"));
-    this.database.exec(readFileSync(new URL("../../../migrations/0005_run_retention.sql", import.meta.url), "utf8"));
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0006_connection_identity.sql", import.meta.url), "utf8"),
-    );
-    this.database.exec(readFileSync(new URL("../../../migrations/0007_runtime_policy.sql", import.meta.url), "utf8"));
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0008_runtime_token_policy.sql", import.meta.url), "utf8"),
-    );
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0009_runtime_token_proxy.sql", import.meta.url), "utf8"),
-    );
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0010_connection_revision.sql", import.meta.url), "utf8"),
-    );
-    this.database.exec(
-      readFileSync(new URL("../../../migrations/0011_runtime_token_connection_scope.sql", import.meta.url), "utf8"),
-    );
+    // Derive the migration list the same way runSqliteMigrations does, so a new migration reaches the
+    // D1 harness on its own. The three lines stay duplicated here because sharing an owner would mean
+    // exporting from production code, which this test-only fix deliberately leaves alone.
+    const migrationFiles = readdirSync(migrationDirectory)
+      .filter((name) => /^\d+_.*\.sql$/.test(name))
+      .sort();
+    for (const file of migrationFiles) {
+      this.database.exec(readFileSync(new URL(file, migrationDirectory), "utf8"));
+    }
   }
 
   prepare(query: string): D1PreparedStatementBinding {


### PR DESCRIPTION
Stacked on #466 (`fix/e3-e14-timeout-predicate-mail-guard`), part of the E-tier audit stack. Retargets to `main` once the branch below lands.

The D1 test harness applied migrations by a hand-written list that stopped at `0011`, so `0012_marketplace.sql` never loaded and `D1MarketplaceStore` had no coverage, and every future migration would have been dropped the same silent way. The harness now derives the list from the migrations directory the way the sqlite harness does, with a marketplace round-trip test on top. This also adds the missing test for the default local transit file backend (TTL expiry, cleanup, sidecar fallback, deleting an unknown id) and unlinks the orphan `.meta.json` its expiry branch was leaving behind. Tests only, plus that one-line sidecar fix.
