### PR TITLE
docs(cloudflare_r2): mark put_object as the relay fallback to presigned PUT

### DIFF
--- a/src/providers/cloudflare_r2/actions.ts
+++ b/src/providers/cloudflare_r2/actions.ts
@@ -303,7 +303,8 @@ export const cloudflareR2Actions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "put_object",
-    description: "Upload one R2 object from a public URL, plain text, or base64-encoded content.",
+    description:
+      "Upload one R2 object by relaying a public URL, plain text, or base64-encoded content through the connector. This is the fallback for OAuth connections and callers that cannot PUT directly; custom API token connections should prefer generate_presigned_url with method PUT so the bytes go straight to R2 without the connector size cap.",
     requiredScopes: [r2WriteScope],
     providerPermissions: [r2WritePermission],
     inputSchema: {
@@ -341,7 +342,7 @@ export const cloudflareR2Actions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "generate_presigned_url",
     description:
-      "Generate a pre-signed R2 URL for a single GET, PUT, or HEAD request. Requires a custom API token credential; OAuth connections cannot mint R2 S3 signatures.",
+      "Generate a pre-signed R2 URL for a single GET, PUT, or HEAD request so the caller transfers bytes directly with R2. Preferred over the put_object and download_object relays. Requires a custom API token credential; OAuth connections cannot mint R2 S3 signatures.",
     requiredScopes: [r2ReadScope, r2WriteScope],
     providerPermissions: [r2ReadPermission, r2WritePermission],
     inputSchema: s.object(


### PR DESCRIPTION
#390 settled on URL-first as the primary R2 transfer path, with the server-relayed `put_object` from #456 kept only as a fallback for OAuth connections and callers that cannot PUT directly. Its catalog description read as a peer of `generate_presigned_url`, so nothing told an agent which one to reach for first.

The `put_object` description now states the fallback role and points custom API token connections at `generate_presigned_url` with method PUT, and `generate_presigned_url` says it is preferred over the `put_object` and `download_object` relays. Descriptions only, no runtime change, and the regenerated catalog picks the new text up.

Refs #390
