### PR TITLE
refactor(runtime): drop undocumented x-oomol-connector-alias header

### DIFF
--- a/src/server/api/openapi.test.ts
+++ b/src/server/api/openapi.test.ts
@@ -149,7 +149,7 @@ describe("action execution OpenAPI", () => {
     expect(search.get.responses["404"]).toBeUndefined();
     expect(connectedApp.required).toEqual(expect.arrayContaining(["alias", "isDefault"]));
     expect(connectedApp.properties.alias?.description).toContain("connectionName");
-    expect(connectedApp.properties.alias?.description).not.toContain("x-oomol-connector-alias");
+    expect(connectedApp.properties.alias?.description).toContain("x-oo-connector-alias");
     expect(authenticatedApps.get.summary).toBe(
       "Return authenticated provider service IDs from the supplied candidates.",
     );

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -3192,7 +3192,7 @@ describe("ConnectServer", () => {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-oomol-connector-alias": "work",
+        "x-oo-connector-alias": "work",
       },
       body: JSON.stringify({ input: {} }),
     });
@@ -3229,7 +3229,7 @@ describe("ConnectServer", () => {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-oomol-connector-alias": "work",
+        "x-oo-connector-alias": "work",
       },
       body: JSON.stringify({
         endpoint: "/items",

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -1255,7 +1255,6 @@ function readConnectionName(context: Context, body?: Record<string, unknown>): s
   return (
     optionalString(body?.connectionName) ??
     optionalString(body?.alias) ??
-    optionalString(context.req.header("x-oomol-connector-alias")) ??
     optionalString(context.req.header("x-oo-connector-alias")) ??
     optionalString(context.req.query("connectionName")) ??
     optionalString(context.req.query("alias"))


### PR DESCRIPTION
`readConnectionName()` accepted `x-oomol-connector-alias` as a fallback next to `x-oo-connector-alias`, but only the latter is declared in the OpenAPI spec and in _docs/runtime-api.md_, and both spellings arrived in the same commit, so the extra one was never a migration path for an older client. This drops it so the header has a single name, and the OpenAPI test now asserts the documented name is present rather than the undocumented one being absent.

A caller that still sends only the old spelling now resolves to the default connection, the same as sending no alias at all.
