### PR TITLE
feat: add AppleDB provider

### DIFF
--- a/src/providers/appledb/actions.ts
+++ b/src/providers/appledb/actions.ts
@@ -1,0 +1,233 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "appledb";
+
+const stringOrStringArray = s.union([s.string(), s.stringArray("String values returned by AppleDB.")]);
+const partialDate = s.string({
+  description: "A full or partial release date supplied by AppleDB.",
+});
+const partialDateOrArray = s.union([
+  partialDate,
+  s.array(partialDate, { description: "Release dates supplied by AppleDB." }),
+]);
+const colorSchema = s.object(
+  {
+    name: s.string({ description: "Color name." }),
+    hex: s.string({ description: "Color value as hexadecimal RGB without a leading hash." }),
+    released: partialDate,
+    discontinued: partialDate,
+    key: s.string({ description: "AppleDB color key." }),
+  },
+  {
+    optional: ["hex", "released", "discontinued", "key"],
+    additionalProperties: true,
+    description: "A device color recorded by AppleDB.",
+  },
+);
+const deviceSchema = s.object(
+  {
+    key: s.string({ description: "Case-sensitive AppleDB device key used for exact lookup." }),
+    name: s.string({ description: "Human-readable device name." }),
+    type: s.string({ description: "AppleDB device category, such as iPhone or Mac." }),
+    identifier: stringOrStringArray,
+    alias: s.stringArray("Alternative device names."),
+    model: stringOrStringArray,
+    board: stringOrStringArray,
+    soc: stringOrStringArray,
+    arch: s.string({ description: "Processor architecture." }),
+    released: partialDateOrArray,
+    discontinued: partialDateOrArray,
+    colors: s.array(colorSchema, { description: "Known device colors." }),
+    internal: s.boolean({ description: "Whether AppleDB marks this as an internal device." }),
+    group: s.boolean({ description: "Whether this record represents a device group." }),
+  },
+  {
+    required: ["key", "name", "type"],
+    additionalProperties: true,
+    description: "Community-maintained Apple device metadata from AppleDB.",
+  },
+);
+const sourceLinkSchema = s.object(
+  {
+    url: s.url("Firmware or release resource URL."),
+    active: s.boolean({ description: "Whether AppleDB currently considers the URL active." }),
+    decryptionKey: s.string({ description: "Decryption key when the source requires one." }),
+    catalog: s.string({ description: "Apple software catalog associated with the URL." }),
+  },
+  {
+    required: ["url", "active"],
+    additionalProperties: true,
+    description: "A source link recorded by AppleDB.",
+  },
+);
+const releaseLinkSchema = s.union([s.url("Release, enterprise, or security notes URL."), sourceLinkSchema]);
+const firmwareSourceSchema = s.object(
+  {
+    type: s.string({ description: "Firmware source type, such as ipsw, ota, recovery, pkg, or dmg." }),
+    deviceMap: s.stringArray("Device identifiers supported by this source."),
+    boardMap: s.stringArray("Board identifiers supported by this source."),
+    osMap: s.stringArray("Operating systems supported by this source."),
+    size: s.integer({ minimum: 0, description: "Source size in bytes when known." }),
+    links: s.array(sourceLinkSchema, { description: "Download links for this source." }),
+  },
+  {
+    required: ["type", "links"],
+    additionalProperties: true,
+    description: "A firmware or software download source recorded by AppleDB.",
+  },
+);
+const osBuildSchema = s.object(
+  {
+    key: s.string({ description: "Case-sensitive AppleDB operating system build key." }),
+    osStr: s.string({ description: "Marketing name of the operating system." }),
+    osType: s.string({ description: "Stable AppleDB operating system type." }),
+    version: s.string({ description: "Human-readable operating system version." }),
+    build: s.string({ description: "Apple build identifier." }),
+    released: partialDate,
+    beta: s.boolean({ description: "Whether this is a beta build." }),
+    rc: s.boolean({ description: "Whether this is a release candidate." }),
+    bsi: s.boolean({ description: "Whether this is a Background Security Improvement build." }),
+    rsr: s.boolean({ description: "Whether this is a Rapid Security Response build." }),
+    internal: s.boolean({ description: "Whether AppleDB marks this as an internal build." }),
+    signed: s.union([
+      s.boolean({ description: "Whether the build is signed for all supported devices." }),
+      s.stringArray("Device identifiers for which this build remains signed."),
+    ]),
+    deviceMap: s.stringArray("Device identifiers supported by this build."),
+    osMap: s.stringArray("Operating systems represented by this build."),
+    notes: s.string({ description: "Additional AppleDB notes." }),
+    releaseNotes: releaseLinkSchema,
+    enterpriseNotes: releaseLinkSchema,
+    securityNotes: s.nullable(releaseLinkSchema),
+    sources: s.array(firmwareSourceSchema, {
+      description: "Firmware and software sources, included only when include_sources is true.",
+    }),
+  },
+  {
+    required: ["osStr", "version", "build"],
+    additionalProperties: true,
+    description: "Community-maintained Apple operating system build metadata from AppleDB.",
+  },
+);
+const deviceSearchResultSchema = s.object(
+  {
+    key: s.string({ description: "AppleDB device key for get_device." }),
+    name: s.string({ description: "Human-readable device name." }),
+    type: s.string({ description: "AppleDB device category." }),
+    identifier: stringOrStringArray,
+    model: stringOrStringArray,
+    soc: stringOrStringArray,
+    released: partialDateOrArray,
+    discontinued: partialDateOrArray,
+  },
+  {
+    required: ["key", "name", "type"],
+    additionalProperties: true,
+    description: "A compact AppleDB device search result.",
+  },
+);
+const osBuildSearchResultSchema = s.object(
+  {
+    key: s.string({ description: "AppleDB build key for get_os_build." }),
+    os: s.string({ description: "Operating system marketing name." }),
+    version: s.string({ description: "Human-readable version from the AppleDB firmware calendar." }),
+    build: s.string({ description: "Apple build identifier." }),
+    released: s.string({ description: "Release date in YYYY-MM-DD form." }),
+    summary: s.string({ description: "AppleDB calendar event summary." }),
+    url: s.url("AppleDB page for this build."),
+  },
+  {
+    required: ["key", "os", "version", "build", "released", "summary"],
+    description: "A compact AppleDB operating system build search result.",
+  },
+);
+const resultLimitSchema = s.optional(
+  s.integer({
+    minimum: 1,
+    maximum: 100,
+    default: 20,
+    description: "Maximum number of matches to return.",
+  }),
+);
+
+export const appledbActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_device",
+    description: "Get an Apple device record by its case-sensitive AppleDB key, such as iPhone17,1.",
+    inputSchema: s.object(
+      {
+        key: s.nonWhitespaceString("Case-sensitive AppleDB device key, usually a hardware identifier."),
+      },
+      { required: ["key"], description: "Exact AppleDB device lookup input." },
+    ),
+    outputSchema: deviceSchema,
+  }),
+  defineProviderAction(service, {
+    name: "search_devices",
+    description: "Search AppleDB devices by name, key, identifier, model, board, or processor.",
+    inputSchema: searchInputSchema("Device search text, such as iPhone 16 Pro, iPhone17,1, or A3293."),
+    outputSchema: searchOutputSchema("devices", deviceSearchResultSchema, "Matching AppleDB devices."),
+    followUpActions: ["appledb.get_device"],
+  }),
+  defineProviderAction(service, {
+    name: "get_os_build",
+    description: "Get an Apple operating system build by its marketing name and build identifier.",
+    inputSchema: s.object(
+      {
+        os: s.nonWhitespaceString("Case-sensitive operating system marketing name, such as iOS or macOS."),
+        build: s.nonWhitespaceString("Apple build identifier, such as 22A3354."),
+        include_sources: s.optional(
+          s.boolean({
+            default: false,
+            description: "Include firmware and software download sources; false keeps the result compact.",
+          }),
+        ),
+      },
+      { required: ["os", "build"], description: "Exact AppleDB operating system build lookup input." },
+    ),
+    outputSchema: osBuildSchema,
+  }),
+  defineProviderAction(service, {
+    name: "search_os_builds",
+    description: "Search an AppleDB firmware calendar by version, build, device identifier, or release text.",
+    inputSchema: s.object(
+      {
+        os_type: s.nonWhitespaceString("Case-sensitive AppleDB OS type used in calendar URLs, such as iOS or macOS."),
+        query: s.nonWhitespaceString("Search text, such as 18.0, 22A3354, or iPhone17,1."),
+        limit: resultLimitSchema,
+      },
+      { required: ["os_type", "query"], description: "AppleDB operating system build search input." },
+    ),
+    outputSchema: searchOutputSchema("builds", osBuildSearchResultSchema, "Matching AppleDB builds."),
+    followUpActions: ["appledb.get_os_build"],
+  }),
+];
+
+function searchInputSchema(queryDescription: string): JsonSchema {
+  return s.object(
+    {
+      query: s.nonWhitespaceString(queryDescription),
+      type: s.optional(s.nonWhitespaceString("Optional case-insensitive AppleDB device category filter.")),
+      limit: resultLimitSchema,
+    },
+    { required: ["query"], description: "AppleDB device search input." },
+  );
+}
+
+function searchOutputSchema(resultKey: string, itemSchema: JsonSchema, description: string): JsonSchema {
+  return s.object(
+    {
+      [resultKey]: s.array(itemSchema, { description }),
+      count: s.integer({ minimum: 0, description: "Number of matches returned." }),
+      total_matches: s.integer({ minimum: 0, description: "Number of matches before applying the result limit." }),
+      truncated: s.boolean({ description: "Whether additional matches were omitted by the result limit." }),
+    },
+    {
+      required: [resultKey, "count", "total_matches", "truncated"],
+      description: "Bounded AppleDB search results.",
+    },
+  );
+}

--- a/src/providers/appledb/definition.ts
+++ b/src/providers/appledb/definition.ts
@@ -1,0 +1,19 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { appledbActions } from "./actions.ts";
+
+const service = "appledb";
+
+/**
+ * AppleDB provider backed by its community-maintained public data API.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "AppleDB",
+  description: "Community-maintained Apple device, operating system, firmware, and signing data.",
+  categories: ["Developer Tools", "Data"],
+  authTypes: ["no_auth"],
+  auth: [{ type: "no_auth" }],
+  homepageUrl: "https://appledb.dev",
+  actions: appledbActions,
+};

--- a/src/providers/appledb/executors.ts
+++ b/src/providers/appledb/executors.ts
@@ -1,0 +1,19 @@
+import type { ProviderExecutors } from "../../core/types.ts";
+import type { AppleDbActionContext } from "./runtime.ts";
+
+import { defineProviderExecutors } from "../provider-runtime.ts";
+import { appledbActionHandlers } from "./runtime.ts";
+
+const service = "appledb";
+
+export const executors: ProviderExecutors = defineProviderExecutors<AppleDbActionContext>({
+  service,
+  handlers: appledbActionHandlers,
+  skipDnsValidation: true,
+  createContext(context, fetcher): AppleDbActionContext {
+    return {
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});

--- a/src/providers/appledb/runtime.test.ts
+++ b/src/providers/appledb/runtime.test.ts
@@ -64,6 +64,28 @@ describe("AppleDB runtime", () => {
     });
   });
 
+  it("searches string-valued device fields", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json([
+        {
+          key: "AirPods1,1-left",
+          name: "AirPods (1st generation), left",
+          type: "AirPods",
+          identifier: ["AirPods1,1-left"],
+          soc: "W1",
+        },
+      ]);
+
+    const result = await appledbActionHandlers.search_devices({ query: "W1" }, { fetcher });
+
+    expect(result).toMatchObject({
+      devices: [{ key: "AirPods1,1-left", soc: "W1" }],
+      count: 1,
+      total_matches: 1,
+      truncated: false,
+    });
+  });
+
   it("omits build sources by default and includes them on request", async () => {
     const requests: string[] = [];
     const fetcher: typeof fetch = async (input) => {

--- a/src/providers/appledb/runtime.test.ts
+++ b/src/providers/appledb/runtime.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { appledbActionHandlers } from "./runtime.ts";
+
+describe("AppleDB runtime", () => {
+  it("looks up a device with an encoded case-sensitive key", async () => {
+    const requests: string[] = [];
+    const fetcher: typeof fetch = async (input) => {
+      requests.push(String(input));
+      return Response.json({ key: "iPhone17,1", name: "iPhone 16 Pro", type: "iPhone" });
+    };
+
+    const result = await appledbActionHandlers.get_device({ key: "iPhone17,1" }, { fetcher });
+
+    expect(requests).toEqual(["https://api.appledb.dev/device/iPhone17%2C1.json"]);
+    expect(result).toMatchObject({ key: "iPhone17,1", name: "iPhone 16 Pro" });
+  });
+
+  it("ranks and bounds device search results", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json([
+        {
+          key: "iPhone17,2",
+          name: "iPhone 16 Pro Max",
+          type: "iPhone",
+          identifier: ["iPhone17,2"],
+          model: ["A3295"],
+        },
+        {
+          key: "iPhone17,1",
+          name: "iPhone 16 Pro",
+          type: "iPhone",
+          identifier: ["iPhone17,1"],
+          model: ["A3293"],
+        },
+        {
+          key: "Case",
+          name: "iPhone 16 Pro Case",
+          type: "Accessory",
+          identifier: [],
+        },
+      ]);
+
+    const result = await appledbActionHandlers.search_devices(
+      { query: "iPhone17,1", type: "iphone", limit: 1 },
+      { fetcher },
+    );
+
+    expect(result).toEqual({
+      devices: [
+        {
+          key: "iPhone17,1",
+          name: "iPhone 16 Pro",
+          type: "iPhone",
+          identifier: ["iPhone17,1"],
+          model: ["A3293"],
+          soc: undefined,
+          released: undefined,
+          discontinued: undefined,
+        },
+      ],
+      count: 1,
+      total_matches: 1,
+      truncated: false,
+    });
+  });
+
+  it("omits build sources by default and includes them on request", async () => {
+    const requests: string[] = [];
+    const fetcher: typeof fetch = async (input) => {
+      requests.push(String(input));
+      return Response.json({
+        key: "iOS;22A3354",
+        osStr: "iOS",
+        version: "18.0",
+        build: "22A3354",
+        sources: [{ type: "ipsw", links: [{ url: "https://example.com/restore.ipsw", active: true }] }],
+      });
+    };
+
+    const compact = await appledbActionHandlers.get_os_build({ os: "iOS", build: "22A3354" }, { fetcher });
+    const complete = await appledbActionHandlers.get_os_build(
+      { os: "iOS", build: "22A3354", include_sources: true },
+      { fetcher },
+    );
+
+    expect(requests).toEqual([
+      "https://api.appledb.dev/ios/iOS%3B22A3354.json",
+      "https://api.appledb.dev/ios/iOS%3B22A3354.json",
+    ]);
+    expect(compact).not.toHaveProperty("sources");
+    expect(complete).toHaveProperty("sources");
+  });
+
+  it("searches folded AppleDB calendar events by version and device identifier", async () => {
+    const calendar = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 18.0 (22A3354)",
+      "DTSTART;VALUE=DATE:20240916",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;22A3354",
+      "DESCRIPTION:iOS 18.0 (22A3354)\\n\\nSupported devices:\\niPhone16\\,1\\, iPho",
+      " ne17\\,1\\n\\nhttps://appledb.dev/firmware/iOS/22A3354",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetcher: typeof fetch = async () => new Response(calendar, { headers: { "content-type": "text/calendar" } });
+
+    const result = await appledbActionHandlers.search_os_builds({ os_type: "iOS", query: "iPhone17,1" }, { fetcher });
+
+    expect(result).toEqual({
+      builds: [
+        {
+          key: "iOS;22A3354",
+          os: "iOS",
+          version: "18.0",
+          build: "22A3354",
+          released: "2024-09-16",
+          summary: "iOS 18.0 (22A3354)",
+          url: "https://appledb.dev/firmware/iOS/22A3354",
+        },
+      ],
+      count: 1,
+      total_matches: 1,
+      truncated: false,
+    });
+  });
+
+  it("preserves an AppleDB not-found status", async () => {
+    const fetcher: typeof fetch = async () => new Response("not found", { status: 404 });
+
+    await expect(appledbActionHandlers.get_device({ key: "missing" }, { fetcher })).rejects.toMatchObject({
+      status: 404,
+      message: "not found",
+    });
+  });
+});

--- a/src/providers/appledb/runtime.ts
+++ b/src/providers/appledb/runtime.ts
@@ -163,10 +163,14 @@ function deviceMatchRank(device: Record<string, unknown>, query: string): number
     optionalString(device.name),
     optionalString(device.type),
     optionalString(device.arch),
+    optionalString(device.identifier),
     ...looseArray(device.identifier).map(optionalString),
     ...looseArray(device.alias).map(optionalString),
+    optionalString(device.model),
     ...looseArray(device.model).map(optionalString),
+    optionalString(device.board),
     ...looseArray(device.board).map(optionalString),
+    optionalString(device.soc),
     ...looseArray(device.soc).map(optionalString),
   ]
     .filter((value): value is string => value !== undefined)

--- a/src/providers/appledb/runtime.ts
+++ b/src/providers/appledb/runtime.ts
@@ -1,0 +1,296 @@
+import type { ProviderActionHandlers, ProviderFetch } from "../provider-runtime.ts";
+
+import { looseArray, objectArray, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
+import {
+  ProviderRequestError,
+  providerResponseError,
+  providerUserAgent,
+  readProviderErrorTextBody,
+  readProviderJsonBody,
+  readProviderTextBody,
+  requiredInputString,
+  requiredResponseRecord,
+  runProviderRequest,
+} from "../provider-runtime.ts";
+
+const appledbApiBaseUrl = "https://api.appledb.dev";
+const appledbJsonMaxBytes = 2 * 1024 * 1024;
+const appledbCalendarMaxBytes = 5 * 1024 * 1024;
+const defaultSearchLimit = 20;
+
+export interface AppleDbActionContext {
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+interface RankedDevice {
+  device: Record<string, unknown>;
+  rank: number;
+  name: string;
+}
+
+interface AppleDbCalendarBuild {
+  key: string;
+  os: string;
+  version: string;
+  build: string;
+  released: string;
+  summary: string;
+  url?: string;
+  searchText: string;
+}
+
+/**
+ * AppleDB handlers for exact device/build lookup and bounded catalog search.
+ */
+export const appledbActionHandlers: ProviderActionHandlers<
+  "appledb",
+  (input: Record<string, unknown>, context: AppleDbActionContext) => Promise<unknown>
+> = {
+  async get_device(input, context): Promise<unknown> {
+    const key = requiredInputString(input.key, "key");
+    const payload = await requestAppleDbJson(`/device/${encodePathSegment(key)}.json`, context, appledbJsonMaxBytes);
+    return requiredResponseRecord(payload, "AppleDB device response");
+  },
+
+  async search_devices(input, context): Promise<unknown> {
+    const query = requiredInputString(input.query, "query").toLocaleLowerCase();
+    const type = optionalString(input.type)?.toLocaleLowerCase();
+    const limit = optionalInteger(input.limit) ?? defaultSearchLimit;
+    const payload = await requestAppleDbJson("/device/main.json", context, appledbJsonMaxBytes);
+    const devices = objectArray(payload, "AppleDB device search response", providerResponseError);
+    const matches: RankedDevice[] = [];
+
+    for (const device of devices) {
+      const deviceType = optionalString(device.type);
+      if (type && deviceType?.toLocaleLowerCase() !== type) {
+        continue;
+      }
+      const rank = deviceMatchRank(device, query);
+      const name = optionalString(device.name);
+      if (rank !== undefined && name && optionalString(device.key) && deviceType) {
+        matches.push({ device, rank, name });
+      }
+    }
+
+    matches.sort((left, right) => left.rank - right.rank || left.name.localeCompare(right.name));
+    const results = matches.slice(0, limit).map(({ device }) => compactDeviceSearchResult(device));
+    return {
+      devices: results,
+      count: results.length,
+      total_matches: matches.length,
+      truncated: matches.length > results.length,
+    };
+  },
+
+  async get_os_build(input, context): Promise<unknown> {
+    const os = requiredInputString(input.os, "os");
+    const build = requiredInputString(input.build, "build");
+    const key = `${os};${build}`;
+    const payload = await requestAppleDbJson(`/ios/${encodePathSegment(key)}.json`, context, appledbJsonMaxBytes);
+    const record = requiredResponseRecord(payload, "AppleDB operating system build response");
+    if (optionalBoolean(input.include_sources) === true) {
+      return record;
+    }
+    const { sources: _sources, ...compactRecord } = record;
+    return compactRecord;
+  },
+
+  async search_os_builds(input, context): Promise<unknown> {
+    const osType = requiredInputString(input.os_type, "os_type");
+    const query = requiredInputString(input.query, "query").toLocaleLowerCase();
+    const limit = optionalInteger(input.limit) ?? defaultSearchLimit;
+    const calendar = await requestAppleDbCalendar(`/ios/${encodePathSegment(osType)}/main.ics`, context);
+    const matches = parseAppleDbCalendar(calendar).filter((entry) => entry.searchText.includes(query));
+    const results = matches.slice(0, limit).map(({ searchText: _searchText, ...entry }) => entry);
+    return {
+      builds: results,
+      count: results.length,
+      total_matches: matches.length,
+      truncated: matches.length > results.length,
+    };
+  },
+};
+
+async function requestAppleDbJson(path: string, context: AppleDbActionContext, maxBytes: number): Promise<unknown> {
+  return runProviderRequest({ signal: context.signal, label: "AppleDB" }, async (signal) => {
+    const response = await context.fetcher(`${appledbApiBaseUrl}${path}`, {
+      headers: {
+        accept: "application/json",
+        "user-agent": providerUserAgent,
+      },
+      signal,
+    });
+    if (!response.ok) {
+      throw new ProviderRequestError(
+        response.status,
+        (await readProviderErrorTextBody(response, "AppleDB error response")) ||
+          `AppleDB request failed with HTTP ${response.status}`,
+      );
+    }
+    return readProviderJsonBody(response, {
+      emptyBody: null,
+      invalidJsonMessage: "AppleDB returned invalid JSON.",
+      maxBytes,
+    });
+  });
+}
+
+async function requestAppleDbCalendar(path: string, context: AppleDbActionContext): Promise<string> {
+  return runProviderRequest({ signal: context.signal, label: "AppleDB" }, async (signal) => {
+    const response = await context.fetcher(`${appledbApiBaseUrl}${path}`, {
+      headers: {
+        accept: "text/calendar",
+        "user-agent": providerUserAgent,
+      },
+      signal,
+    });
+    if (!response.ok) {
+      throw new ProviderRequestError(
+        response.status,
+        (await readProviderErrorTextBody(response, "AppleDB calendar error response")) ||
+          `AppleDB calendar request failed with HTTP ${response.status}`,
+      );
+    }
+    return readProviderTextBody(response, "AppleDB calendar response", appledbCalendarMaxBytes);
+  });
+}
+
+function deviceMatchRank(device: Record<string, unknown>, query: string): number | undefined {
+  const values = [
+    optionalString(device.key),
+    optionalString(device.name),
+    optionalString(device.type),
+    optionalString(device.arch),
+    ...looseArray(device.identifier).map(optionalString),
+    ...looseArray(device.alias).map(optionalString),
+    ...looseArray(device.model).map(optionalString),
+    ...looseArray(device.board).map(optionalString),
+    ...looseArray(device.soc).map(optionalString),
+  ]
+    .filter((value): value is string => value !== undefined)
+    .map((value) => value.toLocaleLowerCase());
+
+  if (values.some((value) => value === query)) {
+    return 0;
+  }
+  if (values.some((value) => value.startsWith(query))) {
+    return 1;
+  }
+  if (values.some((value) => value.includes(query))) {
+    return 2;
+  }
+  return undefined;
+}
+
+function compactDeviceSearchResult(device: Record<string, unknown>): Record<string, unknown> {
+  return {
+    key: device.key,
+    name: device.name,
+    type: device.type,
+    identifier: device.identifier,
+    model: device.model,
+    soc: device.soc,
+    released: device.released,
+    discontinued: device.discontinued,
+  };
+}
+
+function parseAppleDbCalendar(calendar: string): AppleDbCalendarBuild[] {
+  const lines = unfoldCalendarLines(calendar);
+  const builds: AppleDbCalendarBuild[] = [];
+  let event: Record<string, string> | undefined;
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      event = {};
+      continue;
+    }
+    if (line === "END:VEVENT") {
+      if (event) {
+        const build = calendarEventToBuild(event);
+        if (build) {
+          builds.push(build);
+        }
+      }
+      event = undefined;
+      continue;
+    }
+    if (!event) {
+      continue;
+    }
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex < 1) {
+      continue;
+    }
+    const property = line.slice(0, separatorIndex).split(";", 1)[0]!;
+    event[property] = unescapeCalendarValue(line.slice(separatorIndex + 1));
+  }
+
+  return builds;
+}
+
+function unfoldCalendarLines(calendar: string): string[] {
+  const lines: string[] = [];
+  for (const line of calendar.replaceAll("\r\n", "\n").split("\n")) {
+    if ((line.startsWith(" ") || line.startsWith("\t")) && lines.length > 0) {
+      lines[lines.length - 1] += line.slice(1);
+    } else {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+function calendarEventToBuild(event: Record<string, string>): AppleDbCalendarBuild | undefined {
+  const uid = optionalString(event.UID);
+  const summary = optionalString(event.SUMMARY);
+  const released = calendarDate(optionalString(event.DTSTART));
+  if (!uid || !summary || !released) {
+    return undefined;
+  }
+  const uidParts = uid.split(";");
+  if (uidParts.length < 4 || uidParts[0] !== "APPLEDB" || uidParts[1] !== "FIRMWARE") {
+    return undefined;
+  }
+  const os = optionalString(uidParts[2]);
+  const build = optionalString(uidParts.slice(3).join(";"));
+  if (!os || !build) {
+    return undefined;
+  }
+  const versionPrefix = `${os} `;
+  const versionSuffix = ` (${build})`;
+  const version =
+    summary.startsWith(versionPrefix) && summary.endsWith(versionSuffix)
+      ? summary.slice(versionPrefix.length, -versionSuffix.length)
+      : summary;
+  const description = event.DESCRIPTION ?? "";
+  const url = description.match(/https:\/\/appledb\.dev\/firmware\/[^\s]+/u)?.[0];
+  return {
+    key: `${os};${build}`,
+    os,
+    version,
+    build,
+    released,
+    summary,
+    url,
+    searchText: `${uid}\n${summary}\n${description}`.toLocaleLowerCase(),
+  };
+}
+
+function calendarDate(value: string | undefined): string | undefined {
+  if (!value || !/^\d{8}$/u.test(value)) {
+    return undefined;
+  }
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+function unescapeCalendarValue(value: string): string {
+  return value.replace(/\\([nN,;\\])/gu, (_match, escaped: string) => {
+    if (escaped === "n" || escaped === "N") {
+      return "\n";
+    }
+    return escaped;
+  });
+}


### PR DESCRIPTION
## Summary

- add a locally executable, no-auth AppleDB provider
- add exact device and OS build lookup actions
- add bounded device and firmware-calendar search actions
- keep firmware sources opt-in and bound upstream response sizes
- route all AppleDB egress through the shared guarded provider fetch

## Actions

- appledb.get_device
- appledb.search_devices
- appledb.get_os_build
- appledb.search_os_builds

## Verification

- npm run generate:catalog
- npm run fix-check
- npm test
- live smoke test against api.appledb.dev