### PR TITLE
fix(appledb): guard lookup paths and match upstream build keys

### DIFF
--- a/src/providers/appledb/actions.ts
+++ b/src/providers/appledb/actions.ts
@@ -5,18 +5,26 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 
 const service = "appledb";
 
-const stringOrStringArray = s.union([s.string(), s.stringArray("String values returned by AppleDB.")]);
+const stringOrStringArray = s.union([s.string(), s.stringArray("String values returned by AppleDB.")], {
+  description: "One or more identifiers recorded by AppleDB.",
+});
 const partialDate = s.string({
   description: "A full or partial release date supplied by AppleDB.",
 });
-const partialDateOrArray = s.union([
-  partialDate,
-  s.array(partialDate, { description: "Release dates supplied by AppleDB." }),
-]);
+const partialDateOrArray = s.union(
+  [partialDate, s.array(partialDate, { description: "Release dates supplied by AppleDB." })],
+  { description: "Release date, or one date per variant, as YYYY, YYYY-MM, or YYYY-MM-DD." },
+);
 const colorSchema = s.object(
   {
     name: s.string({ description: "Color name." }),
-    hex: s.string({ description: "Color value as hexadecimal RGB without a leading hash." }),
+    hex: s.union(
+      [
+        s.string({ description: "Color value as hexadecimal RGB without a leading hash." }),
+        s.stringArray("Hexadecimal RGB values without a leading hash, one per tone."),
+      ],
+      { description: "Color value as hexadecimal RGB without a leading hash, or one value per tone." },
+    ),
     released: partialDate,
     discontinued: partialDate,
     key: s.string({ description: "AppleDB color key." }),
@@ -31,7 +39,7 @@ const deviceSchema = s.object(
   {
     key: s.string({ description: "Case-sensitive AppleDB device key used for exact lookup." }),
     name: s.string({ description: "Human-readable device name." }),
-    type: s.string({ description: "AppleDB device category, such as iPhone or Mac." }),
+    type: s.string({ description: "AppleDB device category, such as iPhone, iPad Pro, Apple Watch, or MacBook Pro." }),
     identifier: stringOrStringArray,
     alias: s.stringArray("Alternative device names."),
     model: stringOrStringArray,
@@ -63,7 +71,9 @@ const sourceLinkSchema = s.object(
     description: "A source link recorded by AppleDB.",
   },
 );
-const releaseLinkSchema = s.union([s.url("Release, enterprise, or security notes URL."), sourceLinkSchema]);
+const releaseLinkSchema = s.union([s.url("Release, enterprise, or security notes URL."), sourceLinkSchema], {
+  description: "Notes URL, or a link object when AppleDB tracks whether it is still active.",
+});
 const firmwareSourceSchema = s.object(
   {
     type: s.string({ description: "Firmware source type, such as ipsw, ota, recovery, pkg, or dmg." }),
@@ -85,17 +95,25 @@ const osBuildSchema = s.object(
     osStr: s.string({ description: "Marketing name of the operating system." }),
     osType: s.string({ description: "Stable AppleDB operating system type." }),
     version: s.string({ description: "Human-readable operating system version." }),
-    build: s.string({ description: "Apple build identifier." }),
+    build: s.nullableString(
+      "Apple build identifier; omitted or null for accessory and app firmware that has no build.",
+    ),
+    uniqueBuild: s.string({
+      description: "AppleDB build key that distinguishes simulator, RC, SDK, and shared builds; the build half of key.",
+    }),
     released: partialDate,
     beta: s.boolean({ description: "Whether this is a beta build." }),
     rc: s.boolean({ description: "Whether this is a release candidate." }),
     bsi: s.boolean({ description: "Whether this is a Background Security Improvement build." }),
     rsr: s.boolean({ description: "Whether this is a Rapid Security Response build." }),
     internal: s.boolean({ description: "Whether AppleDB marks this as an internal build." }),
-    signed: s.union([
-      s.boolean({ description: "Whether the build is signed for all supported devices." }),
-      s.stringArray("Device identifiers for which this build remains signed."),
-    ]),
+    signed: s.union(
+      [
+        s.boolean({ description: "Whether the build is signed for all supported devices." }),
+        s.stringArray("Device identifiers for which this build remains signed."),
+      ],
+      { description: "true when signed for every device, or the device identifiers still being signed." },
+    ),
     deviceMap: s.stringArray("Device identifiers supported by this build."),
     osMap: s.stringArray("Operating systems represented by this build."),
     notes: s.string({ description: "Additional AppleDB notes." }),
@@ -107,7 +125,7 @@ const osBuildSchema = s.object(
     }),
   },
   {
-    required: ["osStr", "version", "build"],
+    required: ["osStr", "version"],
     additionalProperties: true,
     description: "Community-maintained Apple operating system build metadata from AppleDB.",
   },
@@ -125,16 +143,22 @@ const deviceSearchResultSchema = s.object(
   },
   {
     required: ["key", "name", "type"],
-    additionalProperties: true,
     description: "A compact AppleDB device search result.",
   },
 );
 const osBuildSearchResultSchema = s.object(
   {
     key: s.string({ description: "AppleDB build key for get_os_build." }),
-    os: s.string({ description: "Operating system marketing name." }),
-    version: s.string({ description: "Human-readable version from the AppleDB firmware calendar." }),
-    build: s.string({ description: "Apple build identifier." }),
+    os: s.string({
+      description:
+        "AppleDB operating system name (osStr) for get_os_build; the iOS calendar also reports iPadOS, iPhone OS, and iPhone Software builds.",
+    }),
+    version: s.string({
+      description: "Version text from the calendar summary, such as 18.0, 18.1 beta 2, or 15.0 RC.",
+    }),
+    build: s.string({
+      description: "AppleDB build key for get_os_build; may carry a variant suffix such as -sim, -RC, or -SDK.",
+    }),
     released: s.string({ description: "Release date in YYYY-MM-DD form." }),
     summary: s.string({ description: "AppleDB calendar event summary." }),
     url: s.url("AppleDB page for this build."),
@@ -168,17 +192,32 @@ export const appledbActions: ActionDefinition[] = [
   defineProviderAction(service, {
     name: "search_devices",
     description: "Search AppleDB devices by name, key, identifier, model, board, or processor.",
-    inputSchema: searchInputSchema("Device search text, such as iPhone 16 Pro, iPhone17,1, or A3293."),
+    inputSchema: s.object(
+      {
+        query: s.nonWhitespaceString("Device search text, such as iPhone 16 Pro, iPhone17,1, or A3293."),
+        type: s.optional(
+          s.nonWhitespaceString(
+            "Optional case-insensitive AppleDB device category filter, matched exactly; examples: iPhone, iPad Pro, Apple Watch, MacBook Pro, Mac mini, AirPods.",
+          ),
+        ),
+        limit: resultLimitSchema,
+      },
+      { required: ["query"], description: "AppleDB device search input." },
+    ),
     outputSchema: searchOutputSchema("devices", deviceSearchResultSchema, "Matching AppleDB devices."),
     followUpActions: ["appledb.get_device"],
   }),
   defineProviderAction(service, {
     name: "get_os_build",
-    description: "Get an Apple operating system build by its marketing name and build identifier.",
+    description: "Get an Apple operating system build record by its AppleDB operating system name and build key.",
     inputSchema: s.object(
       {
-        os: s.nonWhitespaceString("Case-sensitive operating system marketing name, such as iOS or macOS."),
-        build: s.nonWhitespaceString("Apple build identifier, such as 22A3354."),
+        os: s.nonWhitespaceString(
+          "Case-sensitive AppleDB operating system name (osStr), such as iOS, iPadOS, macOS, or Mac OS X.",
+        ),
+        build: s.nonWhitespaceString(
+          "AppleDB build key: usually the Apple build identifier, such as 22A3354, but simulator, RC, and SDK variants carry suffixes such as 22A3351-sim or 22H355-RC, and accessory firmware uses its version. Pass the build returned by search_os_builds verbatim; use search_os_builds when a plain build identifier is not found.",
+        ),
         include_sources: s.optional(
           s.boolean({
             default: false,
@@ -192,10 +231,13 @@ export const appledbActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "search_os_builds",
-    description: "Search an AppleDB firmware calendar by version, build, device identifier, or release text.",
+    description:
+      "Search an AppleDB firmware calendar by version, build, device identifier, or release text; results are newest first.",
     inputSchema: s.object(
       {
-        os_type: s.nonWhitespaceString("Case-sensitive AppleDB OS type used in calendar URLs, such as iOS or macOS."),
+        os_type: s.nonWhitespaceString(
+          "Case-sensitive AppleDB OS type that names the calendar, such as iOS, macOS, watchOS, tvOS, visionOS, bridgeOS, or HomePod Software. iPadOS builds live in the iOS calendar and audioOS builds in the HomePod Software calendar; each result carries its own os for get_os_build.",
+        ),
         query: s.nonWhitespaceString("Search text, such as 18.0, 22A3354, or iPhone17,1."),
         limit: resultLimitSchema,
       },
@@ -205,17 +247,6 @@ export const appledbActions: ActionDefinition[] = [
     followUpActions: ["appledb.get_os_build"],
   }),
 ];
-
-function searchInputSchema(queryDescription: string): JsonSchema {
-  return s.object(
-    {
-      query: s.nonWhitespaceString(queryDescription),
-      type: s.optional(s.nonWhitespaceString("Optional case-insensitive AppleDB device category filter.")),
-      limit: resultLimitSchema,
-    },
-    { required: ["query"], description: "AppleDB device search input." },
-  );
-}
 
 function searchOutputSchema(resultKey: string, itemSchema: JsonSchema, description: string): JsonSchema {
   return s.object(

--- a/src/providers/appledb/runtime.test.ts
+++ b/src/providers/appledb/runtime.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { appledbActionHandlers } from "./runtime.ts";
 
+/** Four devices that match "A17" at every rank, deliberately out of rank order. */
+const rankedDevices = [
+  { key: "D", name: "Delta", type: "iPhone", model: ["xa17y"] },
+  { key: "B", name: "Bravo", type: "iPhone", model: ["A17 Pro"] },
+  { key: "A", name: "Alpha", type: "iPhone", soc: "A17" },
+  { key: "C", name: "Charlie", type: "iPhone", board: ["A17 Bionic"] },
+];
+
 describe("AppleDB runtime", () => {
   it("looks up a device with an encoded case-sensitive key", async () => {
     const requests: string[] = [];
@@ -15,52 +23,36 @@ describe("AppleDB runtime", () => {
     expect(result).toMatchObject({ key: "iPhone17,1", name: "iPhone 16 Pro" });
   });
 
-  it("ranks and bounds device search results", async () => {
-    const fetcher: typeof fetch = async () =>
-      Response.json([
-        {
-          key: "iPhone17,2",
-          name: "iPhone 16 Pro Max",
-          type: "iPhone",
-          identifier: ["iPhone17,2"],
-          model: ["A3295"],
-        },
-        {
-          key: "iPhone17,1",
-          name: "iPhone 16 Pro",
-          type: "iPhone",
-          identifier: ["iPhone17,1"],
-          model: ["A3293"],
-        },
-        {
-          key: "Case",
-          name: "iPhone 16 Pro Case",
-          type: "Accessory",
-          identifier: [],
-        },
-      ]);
+  it("orders device matches by exactness and reports omitted matches", async () => {
+    const fetcher: typeof fetch = async () => Response.json(rankedDevices);
 
-    const result = await appledbActionHandlers.search_devices(
-      { query: "iPhone17,1", type: "iphone", limit: 1 },
-      { fetcher },
-    );
+    const result = await appledbActionHandlers.search_devices({ query: "A17", limit: 2 }, { fetcher });
 
     expect(result).toEqual({
       devices: [
-        {
-          key: "iPhone17,1",
-          name: "iPhone 16 Pro",
-          type: "iPhone",
-          identifier: ["iPhone17,1"],
-          model: ["A3293"],
-          soc: undefined,
-          released: undefined,
-          discontinued: undefined,
-        },
+        { key: "A", name: "Alpha", type: "iPhone", soc: "A17" },
+        { key: "B", name: "Bravo", type: "iPhone", model: ["A17 Pro"] },
       ],
-      count: 1,
-      total_matches: 1,
-      truncated: false,
+      count: 2,
+      total_matches: 4,
+      truncated: true,
+    });
+  });
+
+  it("filters device matches by category", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json([...rankedDevices, { key: "E", name: "Echo", type: "Accessory", model: ["A17 Case"] }]);
+
+    const filtered = await appledbActionHandlers.search_devices({ query: "A17", type: "iphone" }, { fetcher });
+    const unfiltered = await appledbActionHandlers.search_devices({ query: "A17" }, { fetcher });
+
+    expect(filtered).toMatchObject({
+      devices: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "D" }],
+      total_matches: 4,
+    });
+    expect(unfiltered).toMatchObject({
+      devices: [{ key: "A" }, { key: "B" }, { key: "C" }, { key: "E" }, { key: "D" }],
+      total_matches: 5,
     });
   });
 
@@ -147,12 +139,191 @@ describe("AppleDB runtime", () => {
     });
   });
 
+  it("reads a version from a variant build summary", async () => {
+    const calendar = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:iPadOS 18.7.9 RC (22H355)",
+      "DTSTART;VALUE=DATE:20250915",
+      "UID:APPLEDB\\;FIRMWARE\\;iPadOS\\;22H355-RC",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 26.3 (a) (23D770890b)",
+      "DTSTART;VALUE=DATE:20260210",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;23D770890b",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetcher: typeof fetch = async () => new Response(calendar, { headers: { "content-type": "text/calendar" } });
+
+    const releaseCandidate = await appledbActionHandlers.search_os_builds(
+      { os_type: "iOS", query: "22H355-RC" },
+      { fetcher },
+    );
+    const rapidSecurityResponse = await appledbActionHandlers.search_os_builds(
+      { os_type: "iOS", query: "26.3 (a)" },
+      { fetcher },
+    );
+
+    expect(releaseCandidate).toMatchObject({
+      builds: [
+        {
+          key: "iPadOS;22H355-RC",
+          os: "iPadOS",
+          version: "18.7.9 RC",
+          build: "22H355-RC",
+          summary: "iPadOS 18.7.9 RC (22H355)",
+        },
+      ],
+      total_matches: 1,
+    });
+    expect(rapidSecurityResponse).toMatchObject({
+      builds: [{ key: "iOS;23D770890b", os: "iOS", version: "26.3 (a)", build: "23D770890b" }],
+      total_matches: 1,
+    });
+  });
+
+  it("does not match calendar boilerplate", async () => {
+    const calendar = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 18.0 (22A3354)",
+      "DTSTART;VALUE=DATE:20240916",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;22A3354",
+      "DESCRIPTION:iOS 18.0 (22A3354)\\n\\nSupported devices:\\niPhone16\\,1\\, iPhone17\\,1\\n\\nhttps://appledb.dev/firmware/iOS/22A3354",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetcher: typeof fetch = async () => new Response(calendar, { headers: { "content-type": "text/calendar" } });
+
+    const boilerplate = await appledbActionHandlers.search_os_builds(
+      { os_type: "iOS", query: "firmware" },
+      { fetcher },
+    );
+    const device = await appledbActionHandlers.search_os_builds({ os_type: "iOS", query: "iPhone17,1" }, { fetcher });
+
+    expect(boilerplate).toMatchObject({ builds: [], total_matches: 0 });
+    expect(device).toMatchObject({ total_matches: 1 });
+  });
+
+  it("returns newest builds first", async () => {
+    const calendar = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 18.0 (22A3354)",
+      "DTSTART;VALUE=DATE:20240916",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;22A3354",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 17.0 (21A329)",
+      "DTSTART;VALUE=DATE:20230918",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;21A329",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 26.0 (23A340)",
+      "DTSTART;VALUE=DATE:20250915",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;23A340",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetcher: typeof fetch = async () => new Response(calendar, { headers: { "content-type": "text/calendar" } });
+
+    const result = await appledbActionHandlers.search_os_builds({ os_type: "iOS", query: "iOS" }, { fetcher });
+
+    expect(result).toMatchObject({
+      builds: [
+        { build: "23A340", released: "2025-09-15" },
+        { build: "22A3354", released: "2024-09-16" },
+        { build: "21A329", released: "2023-09-18" },
+      ],
+      total_matches: 3,
+    });
+  });
+
+  it("ignores properties of nested calendar components", async () => {
+    const calendar = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "SUMMARY:iOS 18.0 (22A3354)",
+      "DTSTART;VALUE=DATE:20240916",
+      "UID:APPLEDB\\;FIRMWARE\\;iOS\\;22A3354",
+      "BEGIN:VALARM",
+      "ACTION:DISPLAY",
+      "TRIGGER:-PT1H",
+      "SUMMARY:Reminder",
+      "DESCRIPTION:Alarm text",
+      "END:VALARM",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetcher: typeof fetch = async () => new Response(calendar, { headers: { "content-type": "text/calendar" } });
+
+    const result = await appledbActionHandlers.search_os_builds({ os_type: "iOS", query: "22A3354" }, { fetcher });
+
+    expect(result).toMatchObject({
+      builds: [{ version: "18.0", summary: "iOS 18.0 (22A3354)" }],
+      total_matches: 1,
+    });
+  });
+
   it("preserves an AppleDB not-found status", async () => {
-    const fetcher: typeof fetch = async () => new Response("not found", { status: 404 });
+    const fetcher: typeof fetch = async () =>
+      new Response("<!DOCTYPE html><html><head><title>404</title></head><body>Not Found</body></html>", {
+        status: 404,
+        headers: { "content-type": "text/html" },
+      });
 
     await expect(appledbActionHandlers.get_device({ key: "missing" }, { fetcher })).rejects.toMatchObject({
       status: 404,
-      message: "not found",
+      message: "AppleDB has no record at /device/missing.json",
     });
+  });
+
+  it("reports a bot block as a provider error", async () => {
+    const fetcher: typeof fetch = async () =>
+      new Response("<!DOCTYPE html><html><body>Attention Required!</body></html>", {
+        status: 403,
+        headers: { "content-type": "text/html" },
+      });
+
+    await expect(appledbActionHandlers.get_device({ key: "iPhone17,1" }, { fetcher })).rejects.toMatchObject({
+      status: 502,
+      message: "AppleDB refused the request with HTTP 403",
+    });
+  });
+});
+
+describe("AppleDB path segments", () => {
+  const requests: string[] = [];
+  const fetcher: typeof fetch = async (input) => {
+    requests.push(String(input));
+    throw new Error("a rejected path must never reach AppleDB");
+  };
+
+  it.each([
+    [
+      "a device key that escapes the device prefix",
+      () => appledbActionHandlers.get_device({ key: "../ios/iOS;22A3354" }, { fetcher }),
+    ],
+    ["a device key with a path separator", () => appledbActionHandlers.get_device({ key: "a/b" }, { fetcher })],
+    [
+      "a build lookup whose operating system escapes the build prefix",
+      () => appledbActionHandlers.get_os_build({ os: "../device", build: "22A3354" }, { fetcher }),
+    ],
+    [
+      "a calendar named by a single dot segment",
+      () => appledbActionHandlers.search_os_builds({ os_type: ".", query: "x" }, { fetcher }),
+    ],
+    [
+      "a calendar named by a parent dot segment",
+      () => appledbActionHandlers.search_os_builds({ os_type: "..", query: "x" }, { fetcher }),
+    ],
+    [
+      "a calendar name with a path separator",
+      () => appledbActionHandlers.search_os_builds({ os_type: "iOS/..", query: "x" }, { fetcher }),
+    ],
+  ])("rejects %s", async (_description, lookUp) => {
+    await expect(lookUp()).rejects.toMatchObject({ status: 400 });
+    expect(requests).toEqual([]);
   });
 });

--- a/src/providers/appledb/runtime.ts
+++ b/src/providers/appledb/runtime.ts
@@ -1,12 +1,12 @@
-import type { ProviderActionHandlers, ProviderFetch } from "../provider-runtime.ts";
+import type { ProviderActionHandlers, ProviderFetch, ReadProviderJsonBodyOptions } from "../provider-runtime.ts";
 
 import { looseArray, objectArray, optionalBoolean, optionalInteger, optionalString } from "../../core/cast.ts";
 import { encodePathSegment } from "../../core/request.ts";
 import {
   ProviderRequestError,
+  providerInputError,
   providerResponseError,
   providerUserAgent,
-  readProviderErrorTextBody,
   readProviderJsonBody,
   readProviderTextBody,
   requiredInputString,
@@ -15,13 +15,36 @@ import {
 } from "../provider-runtime.ts";
 
 const appledbApiBaseUrl = "https://api.appledb.dev";
-const appledbJsonMaxBytes = 2 * 1024 * 1024;
-const appledbCalendarMaxBytes = 5 * 1024 * 1024;
+/**
+ * A per-key build file lists every OTA delta ever published for that build and
+ * only grows. The largest measured in 2026-09 is `/ios/iPadOS;23E261.json` at
+ * 1.43 MiB, and the cap applies before `sources` is dropped, so a compact
+ * result still has to read the whole file.
+ */
+const appledbJsonMaxBytes = 8 * 1024 * 1024;
+/**
+ * Calendars are served uncompressed and only ever gain events. The largest
+ * measured in 2026-09 is the macOS calendar at 3.86 MB.
+ */
+const appledbCalendarMaxBytes = 16 * 1024 * 1024;
+const appledbJsonBodyOptions: ReadProviderJsonBodyOptions = {
+  emptyBody: null,
+  invalidJsonMessage: "AppleDB returned invalid JSON.",
+  maxBytes: appledbJsonMaxBytes,
+};
 const defaultSearchLimit = 20;
+const appledbFirmwarePageUrlPattern = /https:\/\/appledb\.dev\/firmware\/[^\s]+/u;
 
 export interface AppleDbActionContext {
   fetcher: ProviderFetch;
   signal?: AbortSignal;
+}
+
+interface AppleDbRequest<T> {
+  /** Path under the AppleDB API origin, with every caller-supplied segment already guarded. */
+  path: string;
+  accept: string;
+  readBody: (response: Response) => Promise<T>;
 }
 
 interface RankedDevice {
@@ -38,6 +61,11 @@ interface AppleDbCalendarBuild {
   released: string;
   summary: string;
   url?: string;
+}
+
+/** A calendar build together with the lowercased text `search_os_builds` matches against. */
+interface CalendarSearchEntry {
+  build: AppleDbCalendarBuild;
   searchText: string;
 }
 
@@ -50,21 +78,29 @@ export const appledbActionHandlers: ProviderActionHandlers<
 > = {
   async get_device(input, context): Promise<unknown> {
     const key = requiredInputString(input.key, "key");
-    const payload = await requestAppleDbJson(`/device/${encodePathSegment(key)}.json`, context, appledbJsonMaxBytes);
+    const payload = await requestAppleDb(context, {
+      path: `/device/${appledbPathSegment(key, "key")}.json`,
+      accept: "application/json",
+      readBody: (response) => readProviderJsonBody(response, appledbJsonBodyOptions),
+    });
     return requiredResponseRecord(payload, "AppleDB device response");
   },
 
   async search_devices(input, context): Promise<unknown> {
-    const query = requiredInputString(input.query, "query").toLocaleLowerCase();
-    const type = optionalString(input.type)?.toLocaleLowerCase();
+    const query = requiredInputString(input.query, "query").toLowerCase();
+    const type = optionalString(input.type)?.toLowerCase();
     const limit = optionalInteger(input.limit) ?? defaultSearchLimit;
-    const payload = await requestAppleDbJson("/device/main.json", context, appledbJsonMaxBytes);
+    const payload = await requestAppleDb(context, {
+      path: "/device/main.json",
+      accept: "application/json",
+      readBody: (response) => readProviderJsonBody(response, appledbJsonBodyOptions),
+    });
     const devices = objectArray(payload, "AppleDB device search response", providerResponseError);
     const matches: RankedDevice[] = [];
 
     for (const device of devices) {
       const deviceType = optionalString(device.type);
-      if (type && deviceType?.toLocaleLowerCase() !== type) {
+      if (type && deviceType?.toLowerCase() !== type) {
         continue;
       }
       const rank = deviceMatchRank(device, query);
@@ -87,8 +123,11 @@ export const appledbActionHandlers: ProviderActionHandlers<
   async get_os_build(input, context): Promise<unknown> {
     const os = requiredInputString(input.os, "os");
     const build = requiredInputString(input.build, "build");
-    const key = `${os};${build}`;
-    const payload = await requestAppleDbJson(`/ios/${encodePathSegment(key)}.json`, context, appledbJsonMaxBytes);
+    const payload = await requestAppleDb(context, {
+      path: `/ios/${appledbPathSegment(`${os};${build}`, "os and build")}.json`,
+      accept: "application/json",
+      readBody: (response) => readProviderJsonBody(response, appledbJsonBodyOptions),
+    });
     const record = requiredResponseRecord(payload, "AppleDB operating system build response");
     if (optionalBoolean(input.include_sources) === true) {
       return record;
@@ -99,11 +138,21 @@ export const appledbActionHandlers: ProviderActionHandlers<
 
   async search_os_builds(input, context): Promise<unknown> {
     const osType = requiredInputString(input.os_type, "os_type");
-    const query = requiredInputString(input.query, "query").toLocaleLowerCase();
+    const query = requiredInputString(input.query, "query").toLowerCase();
     const limit = optionalInteger(input.limit) ?? defaultSearchLimit;
-    const calendar = await requestAppleDbCalendar(`/ios/${encodePathSegment(osType)}/main.ics`, context);
+    const calendar = await requestAppleDb(context, {
+      path: `/ios/${appledbPathSegment(osType, "os_type")}/main.ics`,
+      accept: "text/calendar",
+      readBody: (response) => readProviderTextBody(response, "AppleDB calendar response", appledbCalendarMaxBytes),
+    });
     const matches = parseAppleDbCalendar(calendar).filter((entry) => entry.searchText.includes(query));
-    const results = matches.slice(0, limit).map(({ searchText: _searchText, ...entry }) => entry);
+    // AppleDB publishes calendar events in neither ascending nor descending
+    // order, so the result limit would otherwise drop the newest builds.
+    matches.sort(
+      (left, right) =>
+        right.build.released.localeCompare(left.build.released) || left.build.key.localeCompare(right.build.key),
+    );
+    const results = matches.slice(0, limit).map((entry) => entry.build);
     return {
       builds: results,
       count: results.length,
@@ -113,47 +162,43 @@ export const appledbActionHandlers: ProviderActionHandlers<
   },
 };
 
-async function requestAppleDbJson(path: string, context: AppleDbActionContext, maxBytes: number): Promise<unknown> {
-  return runProviderRequest({ signal: context.signal, label: "AppleDB" }, async (signal) => {
-    const response = await context.fetcher(`${appledbApiBaseUrl}${path}`, {
-      headers: {
-        accept: "application/json",
-        "user-agent": providerUserAgent,
-      },
-      signal,
-    });
-    if (!response.ok) {
-      throw new ProviderRequestError(
-        response.status,
-        (await readProviderErrorTextBody(response, "AppleDB error response")) ||
-          `AppleDB request failed with HTTP ${response.status}`,
-      );
-    }
-    return readProviderJsonBody(response, {
-      emptyBody: null,
-      invalidJsonMessage: "AppleDB returned invalid JSON.",
-      maxBytes,
-    });
-  });
+/**
+ * AppleDB is served from static hosting that decodes %2F and collapses dot
+ * segments before resolving a file, so encoding alone cannot keep a lookup
+ * inside its /device/ or /ios/ prefix.
+ */
+function appledbPathSegment(value: string, fieldName: string): string {
+  if (value === "." || value === ".." || value.includes("/") || value.includes("\\")) {
+    throw providerInputError(`${fieldName} must not contain path separators or dot segments.`);
+  }
+  return encodePathSegment(value);
 }
 
-async function requestAppleDbCalendar(path: string, context: AppleDbActionContext): Promise<string> {
+async function requestAppleDb<T>(context: AppleDbActionContext, request: AppleDbRequest<T>): Promise<T> {
   return runProviderRequest({ signal: context.signal, label: "AppleDB" }, async (signal) => {
-    const response = await context.fetcher(`${appledbApiBaseUrl}${path}`, {
+    const response = await context.fetcher(`${appledbApiBaseUrl}${request.path}`, {
       headers: {
-        accept: "text/calendar",
+        accept: request.accept,
         "user-agent": providerUserAgent,
       },
       signal,
     });
     if (!response.ok) {
-      throw new ProviderRequestError(
-        response.status,
-        (await readProviderErrorTextBody(response, "AppleDB calendar error response")) ||
-          `AppleDB calendar request failed with HTTP ${response.status}`,
-      );
+      // AppleDB is a static site, so every error body is a full HTML error page
+      // rather than a message worth forwarding.
+      await response.body?.cancel().catch(() => undefined);
+      if (response.status === 404) {
+        throw new ProviderRequestError(404, `AppleDB has no record at ${request.path}`);
+      }
+      // AppleDB takes no credentials, so a 401 or 403 can only be a bot or WAF
+      // block; forwarding it would ask clients to reconnect an account that
+      // does not exist.
+      if (response.status === 401 || response.status === 403) {
+        throw new ProviderRequestError(502, `AppleDB refused the request with HTTP ${response.status}`);
+      }
+      throw new ProviderRequestError(response.status, `AppleDB request failed with HTTP ${response.status}`);
     }
-    return readProviderTextBody(response, "AppleDB calendar response", appledbCalendarMaxBytes);
+    return request.readBody(response);
   });
 }
 
@@ -174,7 +219,7 @@ function deviceMatchRank(device: Record<string, unknown>, query: string): number
     ...looseArray(device.soc).map(optionalString),
   ]
     .filter((value): value is string => value !== undefined)
-    .map((value) => value.toLocaleLowerCase());
+    .map((value) => value.toLowerCase());
 
   if (values.some((value) => value === query)) {
     return 0;
@@ -201,27 +246,40 @@ function compactDeviceSearchResult(device: Record<string, unknown>): Record<stri
   };
 }
 
-function parseAppleDbCalendar(calendar: string): AppleDbCalendarBuild[] {
+function parseAppleDbCalendar(calendar: string): CalendarSearchEntry[] {
   const lines = unfoldCalendarLines(calendar);
-  const builds: AppleDbCalendarBuild[] = [];
+  const entries: CalendarSearchEntry[] = [];
   let event: Record<string, string> | undefined;
+  // RFC 5545 lets a VEVENT hold nested components such as VALARM, whose own
+  // SUMMARY and DESCRIPTION describe the alarm rather than the build.
+  let nestedDepth = 0;
 
   for (const line of lines) {
     if (line === "BEGIN:VEVENT") {
       event = {};
+      nestedDepth = 0;
+      continue;
+    }
+    if (!event) {
       continue;
     }
     if (line === "END:VEVENT") {
-      if (event) {
-        const build = calendarEventToBuild(event);
-        if (build) {
-          builds.push(build);
-        }
+      const entry = calendarEventToEntry(event);
+      if (entry) {
+        entries.push(entry);
       }
       event = undefined;
       continue;
     }
-    if (!event) {
+    if (line.startsWith("BEGIN:")) {
+      nestedDepth += 1;
+      continue;
+    }
+    if (line.startsWith("END:")) {
+      nestedDepth = Math.max(0, nestedDepth - 1);
+      continue;
+    }
+    if (nestedDepth > 0) {
       continue;
     }
     const separatorIndex = line.indexOf(":");
@@ -232,7 +290,7 @@ function parseAppleDbCalendar(calendar: string): AppleDbCalendarBuild[] {
     event[property] = unescapeCalendarValue(line.slice(separatorIndex + 1));
   }
 
-  return builds;
+  return entries;
 }
 
 function unfoldCalendarLines(calendar: string): string[] {
@@ -247,7 +305,7 @@ function unfoldCalendarLines(calendar: string): string[] {
   return lines;
 }
 
-function calendarEventToBuild(event: Record<string, string>): AppleDbCalendarBuild | undefined {
+function calendarEventToEntry(event: Record<string, string>): CalendarSearchEntry | undefined {
   const uid = optionalString(event.UID);
   const summary = optionalString(event.SUMMARY);
   const released = calendarDate(optionalString(event.DTSTART));
@@ -263,24 +321,30 @@ function calendarEventToBuild(event: Record<string, string>): AppleDbCalendarBui
   if (!os || !build) {
     return undefined;
   }
-  const versionPrefix = `${os} `;
-  const versionSuffix = ` (${build})`;
-  const version =
-    summary.startsWith(versionPrefix) && summary.endsWith(versionSuffix)
-      ? summary.slice(versionPrefix.length, -versionSuffix.length)
-      : summary;
+  const version = calendarVersion(summary, os);
   const description = event.DESCRIPTION ?? "";
-  const url = description.match(/https:\/\/appledb\.dev\/firmware\/[^\s]+/u)?.[0];
+  const url = description.match(appledbFirmwarePageUrlPattern)?.[0];
   return {
-    key: `${os};${build}`,
-    os,
-    version,
-    build,
-    released,
-    summary,
-    url,
-    searchText: `${uid}\n${summary}\n${description}`.toLocaleLowerCase(),
+    build: { key: `${os};${build}`, os, version, build, released, summary, url },
+    // The UID prefix and the trailing AppleDB page URL are identical on every
+    // event, so indexing them would make queries such as "firmware" or "https"
+    // match the whole calendar.
+    searchText: [os, version, build, summary, url ? description.replace(url, "") : description]
+      .join("\n")
+      .toLowerCase(),
   };
+}
+
+/**
+ * Read the version out of a calendar summary. AppleDB writes the summary as
+ * `<osStr> <version>` plus the plain Apple build in parentheses, while the UID
+ * carries the build key, which may add a `-RC`, `-sim`, or `-SDK` suffix or be
+ * a bare version for accessory firmware, so the build cannot be matched against
+ * the summary directly.
+ */
+function calendarVersion(summary: string, os: string): string {
+  const withoutOs = summary.startsWith(`${os} `) ? summary.slice(os.length + 1) : summary;
+  return withoutOs.replace(/\s*\([^()]*\)$/u, "") || withoutOs;
 }
 
 function calendarDate(value: string | undefined): string | undefined {


### PR DESCRIPTION
Follow-up to #473 with the fixes from reviewing it against live api.appledb.dev data and the upstream littlebyteorg/appledb schemas and calendar generator. Every item below was reproduced through the real executor before the change and verified again after it.

- Path guard: api.appledb.dev decodes `%2F` and collapses dot segments before resolving a file, so `encodePathSegment` alone was not a barrier. `get_device` with the key `../ios/iOS;22A3354` returned an OS build record, and `search_os_builds` with the `os_type` `..` fetched the 10 MB aggregate calendar. Caller-supplied segments now reject `.`, `..`, and path separators with a 400 before anything is sent.
- Error mapping: every AppleDB error body is a GitHub Pages HTML page, and a 404 for a guessed key was echoing 9 KB of it into the error message. The message now names the missing path, and a 401 or 403 becomes 502 because a `no_auth` provider has no account for `authorization_failed` to reconnect.
- Response caps: per-key build files carry every OTA delta and already reach 1.43 MiB (71% of the 2 MiB cap, which applies before `sources` is dropped), the macOS calendar is 3.86 MB (74% of 5 MiB), and both only grow. They move to 8 MiB and 16 MiB.
- Calendar search: the UID carries the AppleDB build key (`uniqueBuild`, such as `22H355-RC`) while the summary prints the plain Apple build, so `version` fell back to the whole summary on 45% of real events. It is now the summary minus the OS prefix and the trailing parenthetical. Results are sorted newest first because the .ics is unordered and the default limit was dropping the latest builds, the constant UID prefix and page URL are no longer indexed (queries such as "firmware" matched every event), and nested VALARM properties no longer overwrite the event.
- Schemas: the lookup key is `osStr;uniqueBuild` and 5419 records have no `build` at all, so `build` leaves the required list and becomes nullable, `uniqueBuild` is declared, the `build` and `os_type` descriptions say what the key really is, dual-tone colors may carry an array of `hex` values, union fields get descriptions, and the `type` examples drop "Mac", which is not an AppleDB category (it has MacBook Pro, iMac, Mac mini, and so on).
- `toLocaleLowerCase()` becomes `toLowerCase()` so matching does not depend on the host locale.

The test file grows from 6 to 18 cases covering ranking and truncation, the type filter, variant summaries, boilerplate queries, ordering, nested components, the error mapping, and path rejection. `npm run generate:catalog` changes no tracked file.

Refs #473
