### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude Code looks for _CLAUDE.md_ at the repo root while the project instructions live in _AGENTS.md_. This adds a relative symlink so both files resolve to the same content, with nothing to keep in sync.
