### PR TITLE
chore: symlink claude add-provider skill to codex skill

### DIFF
--- a/.claude/skills/add-provider
+++ b/.claude/skills/add-provider
@@ -1,0 +1,1 @@
+../../.codex/skills/add-provider


### PR DESCRIPTION
Claude Code discovers project skills under _.claude/skills/_, while the add-provider skill lives in _.codex/skills/_ where Codex reads it. A relative symlink exposes the same SKILL.md to both tools with one owner, the same pattern _CLAUDE.md_ already uses to point at _AGENTS.md_. The two directories sit at the same depth, so the relative links inside the skill to _AGENTS.md_ and _CONTRIBUTING.md_ still resolve from the new path.
