### PR TITLE
feat: ship OpenConnector as a nibrun binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 # PR quality gates for OOMOL Connect, run serially in a single job:
 #   1) Lint (oxlint + oxfmt)  ->  2) Typecheck (build)  ->  3) Unit tests (vitest)
+#   ->  4) Standalone binary build and smoke test
 # Serial keeps it simple and fail-fast: dependencies install once and a failing
 # earlier step short-circuits the rest. Also runs on pushes to main so the default
 # branch stays green and the npm cache stays warm for PR runs.
@@ -10,10 +11,11 @@ on:
     branches: [main]
   pull_request:
 
-# Cancel superseded runs for the same ref (e.g. new push to an open PR).
+# Cancel superseded PR runs. Main builds publish a rolling release, so they must
+# finish rather than being interrupted by a newer push during asset replacement.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least privilege: this job only reads the repository.
 permissions:
@@ -60,6 +62,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
+
       # Runs postinstall codegen (provider registry + catalog).
       - name: Install dependencies
         run: npm ci
@@ -78,3 +85,85 @@ jobs:
       # 3) Unit tests (vitest): covers src and the web workspace.
       - name: Run tests (vitest)
         run: npm test
+
+      # 4) Exercise the production packaging boundary on the Linux runner that
+      # matches the published artifact's target.
+      - name: Build nibrun binary
+        run: npm run build:binary
+
+      - name: Smoke test nibrun binary
+        env:
+          NIBRUN_DATA_DIR: ${{ runner.temp }}/open-connector-binary-smoke-test
+          NIBRUN_HOSTNAME: open-connector-ci.invalid
+          NIBRUN_HTTP_PORT: "3900"
+        run: |
+          set -euo pipefail
+          log_file="${RUNNER_TEMP}/open-connector-binary-smoke-test.log"
+          ./dist/open-connector-linux-x64 >"$log_file" 2>&1 &
+          server_pid=$!
+          cleanup() {
+            kill -TERM "$server_pid" 2>/dev/null || true
+            wait "$server_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for _ in {1..20}; do
+            if curl --fail --silent http://127.0.0.1:3900/health; then
+              exit 0
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              cat "$log_file"
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+          cat "$log_file"
+          echo "Standalone binary did not become healthy within 10 seconds"
+          exit 1
+
+  publish-nibrun:
+    name: Publish nibrun binary
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build binary
+        run: npm run build:binary
+
+      - name: Publish rolling release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view nibrun-latest >/dev/null 2>&1; then
+            gh release upload nibrun-latest dist/open-connector-linux-x64 --clobber
+            gh release edit nibrun-latest \
+              --notes "Built from ${GITHUB_SHA}. This asset is replaced after every successful build on main."
+          else
+            gh release create nibrun-latest dist/open-connector-linux-x64 \
+              --title "nibrun deployment" \
+              --prerelease \
+              --notes "Built from ${GITHUB_SHA}. This asset is replaced after every successful build on main."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/providers/action-contracts.generated.ts
 .DS_Store
 *.log
 *.tsbuildinfo
+*.bun-build
 data/
 
 # Local Xero OAuth app credentials (never commit)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ OpenConnector is an open-source connector gateway for AI agents and an alternati
 Connect user app accounts once, then expose a shared catalog of 1,000+ providers and 10,000+
 prebuilt Actions to agents and applications.
 
+<p align="center">
+  <a href="https://app.nibrun.com/deploy?name=open-connector&amp;binary=https%3A%2F%2Fgithub.com%2Foomol-lab%2Fopen-connector%2Freleases%2Fdownload%2Fnibrun-latest%2Fopen-connector-linux-x64&amp;port=3000&amp;env=OOMOL_CONNECT_ENCRYPTION_KEY&amp;env=OOMOL_CONNECT_ADMIN_TOKEN&amp;env=OOMOL_CONNECT_RUNTIME_TOKEN"><img src="https://nibrun.com/button.svg" alt="Deploy on nibrun"></a>
+</p>
+
 <table>
   <tr>
     <td width="33.33%" align="center"><img src="assets/deployment-options/oomol.svg" alt="OOMOL" width="140"></td>
@@ -273,6 +277,7 @@ Issues and pull requests are welcome.
 - [Instagram OAuth and Actions](docs/instagram-oauth.md)
 - [Runtime API and MCP](docs/runtime-api.md)
 - [Fly.io deployment](docs/fly-io.md)
+- [Standalone binary and nibrun deployment](docs/single-binary.md)
 - [Cloudflare deployment](docs/cloudflare.md)
 - [Docker image (GHCR)](docs/docker-ghcr.md)
 - [Configuration](docs/configuration.md)

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -1,0 +1,50 @@
+# Standalone Binary
+
+OpenConnector can be packaged as one Linux x86-64 glibc executable. The generated provider catalog,
+SQLite migrations, and built web console are embedded in the executable and materialized under a
+replaceable hidden directory inside the runtime data directory on startup. The directory is removed
+on a graceful shutdown and reused on restart, so hard-killed processes cannot leave accumulating
+copies in the operating system's temporary filesystem.
+
+Build it from a clean checkout with a current Node.js release, npm, and Bun:
+
+```bash
+npm ci
+npm run build:binary
+```
+
+The output is `dist/open-connector-linux-x64`. It defaults to the normal local server settings. A
+public deployment should configure `OOMOL_CONNECT_ENCRYPTION_KEY`,
+`OOMOL_CONNECT_ADMIN_TOKEN`, and `OOMOL_CONNECT_RUNTIME_TOKEN` before exposing it publicly.
+
+On nibrun, the executable automatically:
+
+- listens on the assigned `NIBRUN_HTTP_PORT` at `0.0.0.0`;
+- stores SQLite, transit-file data, and materialized runtime assets under `NIBRUN_DATA_DIR`;
+- derives its OAuth and transit-file public origin from `https://$NIBRUN_HOSTNAME`.
+
+The platform-owned `NIBRUN_HTTP_PORT`, `NIBRUN_DATA_DIR`, and `NIBRUN_HOSTNAME` values take effect
+without deployment-specific wrappers. Explicit `PORT`, `HOST`, `OOMOL_CONNECT_DATA_DIR`, and
+`OOMOL_CONNECT_ORIGIN` values continue to override the corresponding defaults.
+
+The README deploy button uses the latest successful `main` build and asks for those secrets before
+creating an app. To build and deploy from a checkout instead, install and authenticate the CLI,
+then export secrets for the first deployment:
+
+```bash
+curl -fsSL https://nibrun.com/install.sh | sh
+nib login
+
+export OOMOL_CONNECT_ENCRYPTION_KEY="$(openssl rand -base64 32)"
+export OOMOL_CONNECT_ADMIN_TOKEN="$(openssl rand -base64 32)"
+export OOMOL_CONNECT_RUNTIME_TOKEN="$(openssl rand -base64 32)"
+
+npm run deploy:nibrun
+```
+
+Save all three values in a password manager before deploying. The command builds the binary and
+creates an OpenConnector app on its first run. Later runs find that app and update it without
+changing its environment.
+
+The encryption key must remain stable across redeployments. Losing it makes encrypted credentials
+in the persistent SQLite database unreadable.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "postinstall": "node scripts/ensure-generated.ts",
     "dev": "node scripts/dev-local.ts",
     "build": "npm run typecheck",
+    "build:binary": "npm run generate:catalog && npm run build:web && bun scripts/build-binary.mjs",
+    "deploy:nibrun": "node scripts/deploy-nibrun.mjs",
     "build:web": "npm run build --workspace web",
     "dev:cloudflare": "npm run generate:catalog && npm run build:web && node scripts/copy-catalog-assets.ts && wrangler dev --config wrangler.local.jsonc",
     "deploy:cloudflare": "npm run generate:catalog && npm run build:web && node scripts/copy-catalog-assets.ts && wrangler deploy --config wrangler.local.jsonc --minify",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -1,0 +1,45 @@
+import { chmod, mkdir, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const root = process.cwd();
+const target = process.env.OPEN_CONNECTOR_BINARY_TARGET ?? "bun-linux-x64";
+const output = process.env.OPEN_CONNECTOR_BINARY_OUTPUT ?? join(root, "dist/open-connector-linux-x64");
+
+await mkdir(dirname(output), { recursive: true });
+await rm(output, { force: true });
+
+const result = await Bun.build({
+  entrypoints: [join(root, "src/server/index.ts")],
+  compile: {
+    target,
+    outfile: output,
+    assets: [join(root, "migrations"), join(root, "catalog"), join(root, "dist/web")],
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  // urllib only loads this optional peer when Aliyun OSS proxy mode is enabled;
+  // OpenConnector never enables that mode. Bun still tries to resolve the
+  // dormant require while bundling unless it is explicitly externalized.
+  external: ["proxy-agent"],
+  format: "esm",
+  minify: {
+    syntax: true,
+    whitespace: true,
+  },
+  naming: {
+    asset: "[dir]/[name].[ext]",
+  },
+  target: "bun",
+});
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}
+
+await chmod(output, 0o755);
+const bytes = (await stat(output)).size;
+console.log(`Built ${output} (${(bytes / 1024 / 1024).toFixed(1)} MiB)`);

--- a/scripts/deploy-nibrun.mjs
+++ b/scripts/deploy-nibrun.mjs
@@ -1,0 +1,104 @@
+import { spawnSync } from "node:child_process";
+
+const FAILURE_EXIT_CODE = 1;
+const APP_NAME = "open-connector";
+const APP_SLUG_PREFIX = `${APP_NAME}-`;
+const BINARY_FILE = "dist/open-connector-linux-x64";
+const DEFAULT_PORT = "3000";
+const REQUIRED_SECRETS = ["OOMOL_CONNECT_ENCRYPTION_KEY", "OOMOL_CONNECT_ADMIN_TOKEN", "OOMOL_CONNECT_RUNTIME_TOKEN"];
+
+function run(command, args, { capture = false } = {}) {
+  const result = spawnSync(command, args, {
+    encoding: capture ? "utf8" : undefined,
+    stdio: capture ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+
+  if (result.error?.code === "ENOENT") {
+    console.error(
+      [
+        `The required executable \`${command}\` was not found on PATH.`,
+        command === "nib"
+          ? "Install nibrun with `curl -fsSL https://nibrun.com/install.sh | sh`, then run `nib login`."
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+    process.exit(FAILURE_EXIT_CODE);
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? FAILURE_EXIT_CODE);
+  }
+  return result.stdout ?? "";
+}
+
+function nibJson(args) {
+  const serialized = run("nib", ["--json", ...args], { capture: true }).trim();
+  const lines = serialized.split("\n");
+  if (lines.length !== 1 || !lines[0]) {
+    unexpectedNibResponse(args);
+  }
+  try {
+    return JSON.parse(lines[0]);
+  } catch {
+    unexpectedNibResponse(args);
+  }
+}
+
+function unexpectedNibResponse(args) {
+  console.error(`nib --json ${args.join(" ")} returned an unexpected response; update nib and try again.`);
+  process.exit(FAILURE_EXIT_CODE);
+}
+
+const response = nibJson(["apps", "list"]);
+if (!Array.isArray(response.apps)) {
+  unexpectedNibResponse(["apps", "list"]);
+}
+
+const matchingApps = response.apps
+  .map((app) => app?.slug)
+  .filter((slug) => typeof slug === "string" && slug.startsWith(APP_SLUG_PREFIX));
+
+if (matchingApps.length > 1) {
+  console.error(
+    [
+      "Found multiple OpenConnector apps on nibrun:",
+      ...matchingApps.map((slug) => `  ${slug}`),
+      "",
+      "Deploy with `nib run` directly so the target is explicit.",
+    ].join("\n"),
+  );
+  process.exit(FAILURE_EXIT_CODE);
+}
+
+const [appSlug] = matchingApps;
+const target = appSlug ? ["--app", appSlug] : ["--name", APP_NAME];
+const secretArguments = [];
+
+if (!appSlug) {
+  const missingSecrets = REQUIRED_SECRETS.filter((name) => !process.env[name]);
+  if (missingSecrets.length > 0) {
+    console.error(
+      [
+        "The first deployment requires these environment variables:",
+        ...missingSecrets.map((name) => `  ${name}`),
+        "",
+        "Generate and save long random values before running this command again. For example:",
+        ...missingSecrets.map((name) => `  export ${name}="$(openssl rand -base64 32)"`),
+        "",
+        "The encryption key must remain available for as long as its persisted data is needed.",
+      ].join("\n"),
+    );
+    process.exit(FAILURE_EXIT_CODE);
+  }
+
+  for (const name of REQUIRED_SECRETS) {
+    secretArguments.push("--env", `${name}=${process.env[name]}`);
+  }
+}
+
+run("npm", ["run", "build:binary"]);
+run("nib", ["run", BINARY_FILE, ...target, "--port", DEFAULT_PORT, ...secretArguments]);

--- a/src/catalog-store.test.ts
+++ b/src/catalog-store.test.ts
@@ -1,8 +1,17 @@
 import type { ProviderSummaryDefinition } from "./catalog-store.ts";
 import type { ProviderDefinition } from "./core/types.ts";
 
-import { describe, expect, it } from "vitest";
-import { createCatalogStore, resolveExecutableActionIds } from "./catalog-store.ts";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCatalogStore, loadCatalog, resolveExecutableActionIds } from "./catalog-store.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
 
 describe("catalog store", () => {
   it("preserves optional provider descriptions without defaulting missing ones", () => {
@@ -87,6 +96,55 @@ describe("catalog store", () => {
 
     expect(catalog.executableActionIds).toEqual(new Set(["example.ping", "example.pong", "remote.ping"]));
     expect(catalog.actionsById.get("example.pong")?.execution.locallyExecutable).toBe(true);
+  });
+
+  it("loads action schemas lazily while preserving their JSON response shape", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-connector-catalog-store-"));
+    temporaryDirectories.push(root);
+    const catalogDir = join(root, "apps");
+    const providerPath = join(catalogDir, "example.json");
+    await mkdir(catalogDir, { recursive: true });
+    const provider = providerFixture("example", ["ping"]);
+    await writeFile(providerPath, JSON.stringify(provider));
+
+    const catalog = await loadCatalog(catalogDir, { executableServices: ["example"] });
+    provider.actions[0]!.inputSchema = { type: "object", properties: { lazy: { type: "boolean" } } };
+    await writeFile(providerPath, JSON.stringify(provider));
+
+    const action = catalog.actionsById.get("example.ping")!;
+    expect(action.inputSchema).toEqual({ type: "object", properties: { lazy: { type: "boolean" } } });
+    expect(JSON.parse(JSON.stringify(action))).toMatchObject({
+      id: "example.ping",
+      inputSchema: { type: "object", properties: { lazy: { type: "boolean" } } },
+      outputSchema: {},
+      execution: { locallyExecutable: true },
+    });
+    const [summary] = JSON.parse(catalog.providerSummariesJson) as ProviderSummaryDefinition[];
+    expect(summary?.actions[0]).not.toHaveProperty("inputSchema");
+    expect(summary?.actions[0]).not.toHaveProperty("outputSchema");
+  });
+
+  it("evicts least-recently-used schema files from the bounded cache", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-connector-catalog-cache-"));
+    temporaryDirectories.push(root);
+    const catalogDir = join(root, "apps");
+    await mkdir(catalogDir, { recursive: true });
+    const providers = Array.from({ length: 9 }, (_, index) => providerFixture(`service-${index}`, ["ping"]));
+    for (const provider of providers) {
+      provider.actions[0]!.inputSchema = { type: "object", description: "initial" };
+      await writeFile(join(catalogDir, `${provider.service}.json`), JSON.stringify(provider));
+    }
+
+    const catalog = await loadCatalog(catalogDir);
+    const firstAction = catalog.actionsById.get("service-0.ping")!;
+    expect(firstAction.inputSchema.description).toBe("initial");
+    providers[0]!.actions[0]!.inputSchema = { type: "object", description: "reloaded after eviction" };
+    await writeFile(join(catalogDir, "service-0.json"), JSON.stringify(providers[0]));
+
+    for (let index = 1; index < providers.length; index++) {
+      expect(catalog.actionsById.get(`service-${index}.ping`)!.inputSchema.description).toBe("initial");
+    }
+    expect(firstAction.inputSchema.description).toBe("reloaded after eviction");
   });
 });
 

--- a/src/catalog-store.ts
+++ b/src/catalog-store.ts
@@ -1,5 +1,6 @@
-import type { ActionDefinition, AuthType, ProviderDefinition, ProviderScenario } from "./core/types.ts";
+import type { ActionDefinition, AuthType, JsonSchema, ProviderDefinition, ProviderScenario } from "./core/types.ts";
 
+import { readFileSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { sortProviders } from "./core/catalog.ts";
@@ -78,6 +79,22 @@ export interface LoadCatalogOptions extends CreateCatalogStoreOptions {
   executableServices?: Iterable<string>;
 }
 
+interface ActionSchemas {
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema;
+}
+
+const actionSchemaSource = Symbol("catalog action schema source");
+const schemaCacheSize = 8;
+
+interface LazyActionDefinition extends ActionDefinition {
+  [actionSchemaSource]?: FileActionSchemaSource;
+}
+
+interface LazyRuntimeActionDefinition extends RuntimeActionDefinition {
+  [actionSchemaSource]: FileActionSchemaSource;
+}
+
 export function createCatalogStore(
   providers: ProviderDefinition[],
   options: CreateCatalogStoreOptions = {},
@@ -85,12 +102,17 @@ export function createCatalogStore(
   const sortedProviders = sortProviders(providers);
   const executableActions = new Set(options.executableActionIds ?? []);
   const runtimeProviders = sortedProviders.map((provider): RuntimeProviderDefinition => {
-    const actions = provider.actions.map(
-      (action): RuntimeActionDefinition => ({
+    const actions = provider.actions.map((action): RuntimeActionDefinition => {
+      const runtimeAction: RuntimeActionDefinition = {
         ...action,
         execution: createActionExecutionStatus(provider, action, executableActions),
-      }),
-    );
+      };
+      const source = (action as LazyActionDefinition)[actionSchemaSource];
+      if (source) {
+        attachLazyActionSchemas(runtimeAction, source);
+      }
+      return runtimeAction;
+    });
 
     return {
       ...provider,
@@ -136,29 +158,120 @@ function weakEtag(content: string): string {
 function toProviderSummary(provider: RuntimeProviderDefinition): ProviderSummaryDefinition {
   return {
     ...provider,
-    actions: provider.actions.map(({ inputSchema: _inputSchema, outputSchema: _outputSchema, ...action }) => action),
+    actions: provider.actions.map((action) => {
+      const summary: Record<string, unknown> = {};
+      for (const key of Object.keys(action)) {
+        if (key === "inputSchema" || key === "outputSchema") {
+          continue;
+        }
+        summary[key] = action[key as keyof RuntimeActionDefinition];
+      }
+      return summary as ActionSummaryDefinition;
+    }),
   };
 }
 
 /**
- * Load generated provider catalog files from disk.
+ * Load catalog metadata from disk while keeping the large action schemas
+ * file-backed and bounded by a small least-recently-used cache.
  */
 export async function loadCatalog(
   catalogDir: string = join(process.cwd(), "catalog/apps"),
   options: LoadCatalogOptions = {},
 ): Promise<CatalogStore> {
   const entries = await readdir(catalogDir, { withFileTypes: true });
-  const providers = await Promise.all(
-    entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-      .map(async (entry) => {
-        const content = await readFile(join(catalogDir, entry.name), "utf8");
-        return JSON.parse(content) as ProviderDefinition;
-      }),
-  );
+  const providers: ProviderDefinition[] = [];
+  const schemaLoader = new FileActionSchemaLoader(schemaCacheSize);
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+    const filePath = join(catalogDir, entry.name);
+    const content = await readFile(filePath, "utf8");
+    const provider = JSON.parse(content) as ProviderDefinition;
+    const source = new FileActionSchemaSource(filePath, schemaLoader);
+    providers.push({
+      ...provider,
+      actions: provider.actions.map((action) => createLazyActionDefinition(action, source)),
+    });
+  }
   return createCatalogStore(providers, {
     executableActionIds: resolveExecutableActionIds(providers, options),
   });
+}
+
+function createLazyActionDefinition(action: ActionDefinition, source: FileActionSchemaSource): ActionDefinition {
+  const { inputSchema: _inputSchema, outputSchema: _outputSchema, ...metadata } = action;
+  Object.defineProperty(metadata, actionSchemaSource, { value: source });
+  return metadata as ActionDefinition;
+}
+
+function attachLazyActionSchemas(action: RuntimeActionDefinition, source: FileActionSchemaSource): void {
+  Object.defineProperties(action, {
+    [actionSchemaSource]: { value: source },
+    inputSchema: { get: readLazyInputSchema, enumerable: true },
+    outputSchema: { get: readLazyOutputSchema, enumerable: true },
+  });
+}
+
+function readLazyInputSchema(this: LazyRuntimeActionDefinition): JsonSchema {
+  return this[actionSchemaSource].get(this.id).inputSchema;
+}
+
+function readLazyOutputSchema(this: LazyRuntimeActionDefinition): JsonSchema {
+  return this[actionSchemaSource].get(this.id).outputSchema;
+}
+
+class FileActionSchemaSource {
+  readonly filePath: string;
+  private readonly loader: FileActionSchemaLoader;
+
+  constructor(filePath: string, loader: FileActionSchemaLoader) {
+    this.filePath = filePath;
+    this.loader = loader;
+  }
+
+  get(actionId: string): ActionSchemas {
+    return this.loader.get(this.filePath, actionId);
+  }
+}
+
+class FileActionSchemaLoader {
+  private readonly cache = new Map<string, Map<string, ActionSchemas>>();
+  private readonly maxCachedFiles: number;
+
+  constructor(maxCachedFiles: number) {
+    this.maxCachedFiles = maxCachedFiles;
+  }
+
+  get(filePath: string, actionId: string): ActionSchemas {
+    let schemas = this.cache.get(filePath);
+    if (schemas) {
+      this.cache.delete(filePath);
+      this.cache.set(filePath, schemas);
+    } else {
+      const provider = JSON.parse(readFileSync(filePath, "utf8")) as ProviderDefinition;
+      schemas = new Map(
+        provider.actions.map((action) => [
+          action.id,
+          { inputSchema: action.inputSchema, outputSchema: action.outputSchema },
+        ]),
+      );
+      this.cache.set(filePath, schemas);
+      if (this.cache.size > this.maxCachedFiles) {
+        const oldestFile = this.cache.keys().next().value;
+        if (oldestFile) {
+          this.cache.delete(oldestFile);
+        }
+      }
+    }
+
+    const result = schemas.get(actionId);
+    if (!result) {
+      throw new Error(`Catalog action schemas not found for ${actionId} in ${filePath}`);
+    }
+    return result;
+  }
 }
 
 /** Resolve provider-level executable services into the exact action ids present in a loaded catalog. */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,13 +23,17 @@ import { S3TransitFileService } from "./files/s3-transit-files.ts";
 import { TransitFileService } from "./files/transit-files.ts";
 import { logger } from "./logger.ts";
 import { createSecretCodec } from "./secrets/secret-codec.ts";
+import { prepareServerAssets } from "./standalone-assets.ts";
 import { createNodeRuntimeDatabase } from "./storage/node-runtime-database.ts";
 import { DEFAULT_RUN_LIMIT } from "./storage/runtime-store.ts";
 
-const port = Number(process.env.PORT ?? 3000);
-const hostname = process.env.HOST ?? "127.0.0.1";
-const publicOrigin = process.env.OOMOL_CONNECT_ORIGIN ?? `http://localhost:${port}`;
-const dataDir = process.env.OOMOL_CONNECT_DATA_DIR ?? join(process.cwd(), "data");
+const nibrunPort = optionalEnv("NIBRUN_HTTP_PORT");
+const port = Number(process.env.PORT ?? nibrunPort ?? 3000);
+const nibrunHostname = optionalEnv("NIBRUN_HOSTNAME");
+const hostname = process.env.HOST ?? (nibrunHostname ? "0.0.0.0" : "127.0.0.1");
+const publicOrigin =
+  process.env.OOMOL_CONNECT_ORIGIN ?? (nibrunHostname ? `https://${nibrunHostname}` : `http://localhost:${port}`);
+const dataDir = process.env.OOMOL_CONNECT_DATA_DIR ?? optionalEnv("NIBRUN_DATA_DIR") ?? join(process.cwd(), "data");
 const transitFileTtlSeconds = readPositiveIntegerEnv("OOMOL_CONNECT_TRANSIT_FILE_TTL_SECONDS", 86_400);
 const transitFileMaxBytes = readPositiveIntegerEnv("OOMOL_CONNECT_TRANSIT_FILE_MAX_BYTES", 100 * 1024 * 1024);
 const runLimit = readPositiveIntegerEnv("OOMOL_CONNECT_RUN_LIMIT", DEFAULT_RUN_LIMIT);
@@ -45,6 +49,18 @@ try {
 }
 
 async function main(): Promise<void> {
+  await mkdir(dataDir, { recursive: true });
+  const assets = await prepareServerAssets({
+    materializationParentDirectory: dataDir,
+  });
+  try {
+    await runServer(assets);
+  } finally {
+    await assets.dispose();
+  }
+}
+
+async function runServer(assets: Awaited<ReturnType<typeof prepareServerAssets>>): Promise<void> {
   setPrivateNetworkAccessAllowed(parsePrivateNetworkAccessFlag(process.env.OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK));
   setEgressTrustedHosts(parseEgressTrustedHosts(process.env.OOMOL_CONNECT_EGRESS_TRUSTED_HOSTS));
 
@@ -64,15 +80,15 @@ async function main(): Promise<void> {
   });
   const allowedCustomOAuth = parseActionPolicyList(process.env.OOMOL_CONNECT_ALLOWED_CUSTOM_OAUTH);
 
-  await mkdir(dataDir, { recursive: true });
-  const staticRoot = await resolveStaticRoot(join(process.cwd(), "dist/web"));
-  const catalog = await loadCatalog(undefined, {
+  const staticRoot = await resolveStaticRoot(assets.staticRoot);
+  const catalog = await loadCatalog(assets.catalogDir, {
     executableServices: Object.keys(executorModules),
   });
   const runtimeDatabase = databaseUrl
     ? await createNodeRuntimeDatabase({
         backend: "postgresql",
         connectionString: databaseUrl,
+        migrationDirectory: assets.migrationDirectory ? join(assets.migrationDirectory, "postgresql") : undefined,
         logger,
         secretCodec,
         runLimit,
@@ -82,6 +98,7 @@ async function main(): Promise<void> {
     : await createNodeRuntimeDatabase({
         backend: "sqlite",
         path: join(dataDir, "connect.sqlite"),
+        migrationDirectory: assets.migrationDirectory,
         logger,
         secretCodec,
         runLimit,

--- a/src/server/standalone-assets.test.ts
+++ b/src/server/standalone-assets.test.ts
@@ -1,0 +1,93 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareServerAssets } from "./standalone-assets.ts";
+
+interface MutableRuntimeGlobal {
+  Bun?: unknown;
+}
+
+const runtimeGlobal = globalThis as typeof globalThis & MutableRuntimeGlobal;
+const originalBun = runtimeGlobal.Bun;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  if (originalBun === undefined) {
+    delete runtimeGlobal.Bun;
+  } else {
+    runtimeGlobal.Bun = originalBun;
+  }
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("standalone server assets", () => {
+  it("uses repository paths outside a standalone executable", async () => {
+    delete runtimeGlobal.Bun;
+
+    const assets = await prepareServerAssets({ root: "/workspace/open-connector" });
+
+    expect(assets).toMatchObject({
+      catalogDir: "/workspace/open-connector/catalog/apps",
+      staticRoot: "/workspace/open-connector/dist/web",
+    });
+    expect(assets.migrationDirectory).toBeUndefined();
+  });
+
+  it("replaces and cleans a fixed standalone materialization directory", async () => {
+    const parent = await temporaryDirectory();
+    const materializationDirectory = join(parent, ".open-connector-assets");
+    await mkdir(materializationDirectory, { recursive: true });
+    await writeFile(join(materializationDirectory, "stale.txt"), "left by a killed process");
+    await writeFile(join(parent, "persistent-data.txt"), "must not be deleted");
+    runtimeGlobal.Bun = {
+      isStandaloneExecutable: true,
+      embeddedFiles: [
+        namedBlob("/$bunfs/root/catalog/apps/example.json", '{"service":"example"}'),
+        namedBlob("/$bunfs/root/migrations/0001_runtime.sql", "select 1;"),
+        namedBlob("/$bunfs/root/dist/web/index.html", "<main>OpenConnector</main>"),
+      ],
+    };
+
+    const assets = await prepareServerAssets({ materializationParentDirectory: parent });
+
+    expect(assets).toMatchObject({
+      catalogDir: join(materializationDirectory, "catalog/apps"),
+      migrationDirectory: join(materializationDirectory, "migrations"),
+      staticRoot: join(materializationDirectory, "dist/web"),
+    });
+    await expect(access(join(materializationDirectory, "stale.txt"))).rejects.toThrow();
+    expect(await readFile(join(assets.catalogDir, "example.json"), "utf8")).toBe('{"service":"example"}');
+    expect(await readFile(join(assets.staticRoot, "index.html"), "utf8")).toBe("<main>OpenConnector</main>");
+
+    await assets.dispose();
+    await expect(access(materializationDirectory)).rejects.toThrow();
+    expect(await readFile(join(parent, "persistent-data.txt"), "utf8")).toBe("must not be deleted");
+  });
+
+  it("removes the materialization directory when no runtime assets are embedded", async () => {
+    const parent = await temporaryDirectory();
+    const materializationDirectory = join(parent, ".open-connector-assets");
+    runtimeGlobal.Bun = {
+      isStandaloneExecutable: true,
+      embeddedFiles: [namedBlob("/$bunfs/root/unrelated.txt", "ignored")],
+    };
+
+    await expect(prepareServerAssets({ materializationParentDirectory: parent })).rejects.toThrow(
+      "Standalone executable is missing required runtime assets: catalog, migrations, webConsole.",
+    );
+    await expect(access(materializationDirectory)).rejects.toThrow();
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "open-connector-standalone-assets-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function namedBlob(name: string, contents: string): Blob & { name: string } {
+  const blob = new Blob([contents]) as Blob & { name: string };
+  blob.name = name;
+  return blob;
+}

--- a/src/server/standalone-assets.ts
+++ b/src/server/standalone-assets.ts
@@ -1,0 +1,112 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+interface NamedBlob extends Blob {
+  name?: string;
+}
+
+interface BunRuntime {
+  isStandaloneExecutable?: boolean;
+  embeddedFiles?: readonly NamedBlob[];
+}
+
+export interface ServerAssetPaths {
+  catalogDir: string;
+  migrationDirectory?: string;
+  staticRoot: string;
+  dispose(): Promise<void>;
+}
+
+export interface PrepareServerAssetsOptions {
+  /** Filesystem root used by regular Node.js development and deployments. */
+  root?: string;
+  /** Parent directory for the fixed scratch directory owned by the standalone executable. */
+  materializationParentDirectory?: string;
+}
+
+/**
+ * Materialize assets carried by a Bun standalone executable into a replaceable
+ * runtime directory. The existing Node loaders can then keep using filesystem
+ * paths while the deployed artifact remains one binary.
+ */
+export async function prepareServerAssets(options: PrepareServerAssetsOptions = {}): Promise<ServerAssetPaths> {
+  const root = options.root ?? process.cwd();
+  const bun = (globalThis as typeof globalThis & { Bun?: BunRuntime }).Bun;
+  if (!bun?.isStandaloneExecutable) {
+    return {
+      catalogDir: join(root, "catalog/apps"),
+      staticRoot: join(root, "dist/web"),
+      dispose: async () => undefined,
+    };
+  }
+
+  const assetRoot = join(options.materializationParentDirectory ?? tmpdir(), ".open-connector-assets");
+  const embeddedFiles = bun.embeddedFiles ?? [];
+  const extracted = {
+    catalog: false,
+    migrations: false,
+    webConsole: false,
+  };
+
+  try {
+    // A deterministic directory prevents hard-killed processes from leaking a
+    // complete copy of the embedded assets on every restart.
+    await rm(assetRoot, { recursive: true, force: true });
+    await mkdir(assetRoot, { recursive: true });
+
+    for (const file of embeddedFiles) {
+      const relativePath = resolveEmbeddedPath(file.name);
+      if (!relativePath) {
+        continue;
+      }
+
+      const target = join(assetRoot, relativePath);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, new Uint8Array(await file.arrayBuffer()));
+      extracted.catalog ||= relativePath.startsWith("catalog/apps/") && relativePath.endsWith(".json");
+      extracted.migrations ||= relativePath.startsWith("migrations/") && relativePath.endsWith(".sql");
+      extracted.webConsole ||= relativePath === "dist/web/index.html";
+    }
+
+    const missingAssets = Object.entries(extracted)
+      .filter(([, present]) => !present)
+      .map(([name]) => name);
+    if (missingAssets.length > 0) {
+      throw new Error(`Standalone executable is missing required runtime assets: ${missingAssets.join(", ")}.`);
+    }
+
+    return {
+      catalogDir: join(assetRoot, "catalog/apps"),
+      migrationDirectory: join(assetRoot, "migrations"),
+      staticRoot: join(assetRoot, "dist/web"),
+      dispose: async () => {
+        await rm(assetRoot, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await rm(assetRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function resolveEmbeddedPath(name: string | undefined): string | undefined {
+  if (!name) {
+    return undefined;
+  }
+
+  const normalized = name.replaceAll("\\", "/");
+  for (const [prefix, destination] of [
+    ["migrations/", "migrations/"],
+    ["catalog/apps/", "catalog/apps/"],
+    ["dist/web/", "dist/web/"],
+    ["web/", "dist/web/"],
+  ] as const) {
+    const index = normalized.lastIndexOf(prefix);
+    if (index >= 0) {
+      const path = `${destination}${normalized.slice(index + prefix.length)}`;
+      return path.includes("../") ? undefined : path;
+    }
+  }
+  return undefined;
+}

--- a/src/server/storage/node-runtime-database.ts
+++ b/src/server/storage/node-runtime-database.ts
@@ -20,11 +20,13 @@ interface CommonOptions {
 interface SqliteOptions extends CommonOptions {
   backend: "sqlite";
   path: string;
+  migrationDirectory?: string | URL;
 }
 
 interface PostgresOptions extends CommonOptions {
   backend: "postgresql";
   connectionString: string;
+  migrationDirectory?: string | URL;
   poolMax?: number;
   connectionTimeoutMs?: number;
 }

--- a/src/server/storage/postgres-migrations.ts
+++ b/src/server/storage/postgres-migrations.ts
@@ -2,6 +2,7 @@ import type { RuntimeLogger } from "../../core/types.ts";
 import type { Pool, PoolClient } from "pg";
 
 import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 
 const migrationDirectory = new URL("../../../migrations/postgresql/", import.meta.url);
 const migrationLockNamespace = 1_326_382_671;
@@ -86,8 +87,11 @@ export async function migratePostgresDatabase(options: PostgresMigrationOptions)
   }
 }
 
-export async function assertPostgresSchemaReady(pool: Pool): Promise<void> {
-  const migrations = readPostgresMigrations();
+export async function assertPostgresSchemaReady(
+  pool: Pool,
+  directory: string | URL = migrationDirectory,
+): Promise<void> {
+  const migrations = readPostgresMigrations(directory);
   const relation = await pool.query<{ name: string | null }>("select to_regclass($1) as name", ["runtime_migrations"]);
   if (!relation.rows[0]?.name) {
     throw new Error(
@@ -104,13 +108,13 @@ export async function assertPostgresSchemaReady(pool: Pool): Promise<void> {
   }
 }
 
-function readPostgresMigrations(): PostgresMigration[] {
-  return readdirSync(migrationDirectory)
+function readPostgresMigrations(directory: string | URL = migrationDirectory): PostgresMigration[] {
+  return readdirSync(directory)
     .filter((name) => /^\d+_.*\.sql$/.test(name))
     .sort()
     .map((name) => ({
       name,
-      sql: readFileSync(new URL(name, migrationDirectory), "utf8"),
+      sql: readFileSync(typeof directory === "string" ? join(directory, name) : new URL(name, directory), "utf8"),
     }));
 }
 

--- a/src/server/storage/postgres-runtime-store.test.ts
+++ b/src/server/storage/postgres-runtime-store.test.ts
@@ -2,6 +2,9 @@ import type { RuntimeActionHttpResult } from "../api/runtime-api.ts";
 
 import { PGlite } from "@electric-sql/pglite";
 import { PGLiteSocketServer } from "@electric-sql/pglite-socket";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Pool } from "pg";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { AesGcmSecretCodec } from "../secrets/secret-codec.ts";
@@ -62,6 +65,21 @@ describe("PostgreSQL migrations with PGlite", () => {
         new Date().toISOString(),
       ]);
       await expect(assertPostgresSchemaReady(pool)).resolves.toBeUndefined();
+
+      const customMigrationDirectory = await mkdtemp(join(tmpdir(), "open-connector-postgres-migrations-"));
+      try {
+        await writeFile(join(customMigrationDirectory, "9998_standalone.sql"), "select 1;");
+        await expect(assertPostgresSchemaReady(pool, customMigrationDirectory)).rejects.toThrow(
+          "Missing migrations: 9998_standalone.sql",
+        );
+        await pool.query("insert into runtime_migrations (name, applied_at) values ($1, $2)", [
+          "9998_standalone.sql",
+          new Date().toISOString(),
+        ]);
+        await expect(assertPostgresSchemaReady(pool, customMigrationDirectory)).resolves.toBeUndefined();
+      } finally {
+        await rm(customMigrationDirectory, { recursive: true, force: true });
+      }
     } finally {
       await pool.end();
     }

--- a/src/server/storage/postgres-runtime-store.ts
+++ b/src/server/storage/postgres-runtime-store.ts
@@ -41,6 +41,7 @@ export interface PostgresRuntimeDatabaseOptions {
   logger?: RuntimeLogger;
   runLimit?: number;
   secretCodec?: ISecretCodec;
+  migrationDirectory?: string | URL;
   poolMax?: number;
   connectionTimeoutMs?: number;
 }
@@ -86,7 +87,7 @@ export class PostgresRuntimeDatabase implements RuntimeDatabase {
     });
 
     try {
-      await assertPostgresSchemaReady(pool);
+      await assertPostgresSchemaReady(pool, options.migrationDirectory);
       return new PostgresRuntimeDatabase(pool, options);
     } catch (error) {
       await pool.end();

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -21,6 +21,7 @@ import type { IRunLogStore, RunLog, RunLogListInput, RunLogPage, RunLogWriteResu
 import type { IRuntimeTokenStore, RuntimeTokenRecord } from "./runtime-token-service.ts";
 
 import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
@@ -42,6 +43,7 @@ export interface SqliteRuntimeDatabaseOptions {
   logger?: RuntimeLogger;
   runLimit?: number;
   secretCodec?: ISecretCodec;
+  migrationDirectory?: string | URL;
 }
 
 interface SecretJsonInput {
@@ -95,7 +97,7 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
   constructor(filename: string, options: SqliteRuntimeDatabaseOptions = {}) {
     this.database = new DatabaseSync(filename);
     this.secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
-    this.initialize(options.logger);
+    this.initialize(options.logger, options.migrationDirectory);
     this.connectionStore = new SqliteConnectionStore(this.database, this.secretCodec);
     this.oauthClientConfigStore = new SqliteOAuthClientConfigStore(this.database, this.secretCodec);
     this.oauthStateStore = new SqliteOAuthStateStore(this.database, this.secretCodec);
@@ -156,9 +158,9 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
     `);
   }
 
-  private initialize(logger?: RuntimeLogger): void {
+  private initialize(logger?: RuntimeLogger, directory?: string | URL): void {
     this.database.exec("pragma journal_mode = wal;");
-    runSqliteMigrations(this.database, logger);
+    runSqliteMigrations(this.database, logger, directory);
   }
 }
 
@@ -648,7 +650,11 @@ function insertRun(database: DatabaseSync, run: RunLog): void {
     );
 }
 
-function runSqliteMigrations(database: DatabaseSync, logger?: RuntimeLogger): void {
+function runSqliteMigrations(
+  database: DatabaseSync,
+  logger?: RuntimeLogger,
+  directory: string | URL = migrationDirectory,
+): void {
   const startedAt = Date.now();
   database.exec(`
     create table if not exists runtime_migrations (
@@ -662,7 +668,7 @@ function runSqliteMigrations(database: DatabaseSync, logger?: RuntimeLogger): vo
       .all()
       .map((row) => readString(row, "name")),
   );
-  const migrationFiles = readdirSync(migrationDirectory)
+  const migrationFiles = readdirSync(directory)
     .filter((name) => /^\d+_.*\.sql$/.test(name))
     .sort();
   let newlyAppliedCount = 0;
@@ -675,7 +681,10 @@ function runSqliteMigrations(database: DatabaseSync, logger?: RuntimeLogger): vo
     const migrationStartedAt = Date.now();
     logger?.info({ migration: file }, "sqlite migration started");
     try {
-      const sql = readFileSync(new URL(file, migrationDirectory), "utf8");
+      const sql = readFileSync(
+        typeof directory === "string" ? join(directory, file) : new URL(file, directory),
+        "utf8",
+      );
       runInTransaction(database, () => {
         database.exec(sql);
         database


### PR DESCRIPTION
## Problem

OpenConnector currently needs a Node.js checkout to self-host. A nibrun deployment needs one executable that stays within the 256 MiB memory limit, preserves runtime data across updates, and does not leak extracted assets until the volume fills.

## What this changes

- Builds one Linux x86-64 glibc executable with Bun, embedding the generated provider catalog, database migrations, and web console.
- Materializes embedded assets into one owned, replaceable directory under NIBRUN_DATA_DIR; SQLite and PostgreSQL both consume the extracted migration tree.
- Reads NIBRUN_HTTP_PORT, NIBRUN_DATA_DIR, and NIBRUN_HOSTNAME directly while preserving explicit OpenConnector overrides.
- Keeps action schemas file-backed behind a bounded LRU cache so the 1,462-provider catalog fits comfortably within the platform memory budget.
- Adds a repeatable CLI deployment command and a README deploy button backed by the upstream rolling release.
- Builds and boots the real Linux artifact in pull-request CI, then publishes it only after successful main-branch checks.

## Verification

- npm run fix-check
- npm test: 177 files passed, 1 skipped; 1,725 tests passed, 4 skipped
- npm run build:binary: produced a 157.3 MiB Linux x86-64 ELF
- Live nibrun deployment reached a healthy state under the 256 MiB plan without accumulating restart-time asset copies

## Operational notes

Public deployments require stable OOMOL_CONNECT_ENCRYPTION_KEY, OOMOL_CONNECT_ADMIN_TOKEN, and OOMOL_CONNECT_RUNTIME_TOKEN values. Losing the encryption key makes persisted encrypted credentials unreadable.