### PR TITLE
feat(mqtt): support Alibaba Cloud device authentication

### DIFF
--- a/src/providers/mqtt/actions.ts
+++ b/src/providers/mqtt/actions.ts
@@ -6,6 +6,12 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 const service = "mqtt";
 const qosSchema = s.integer("MQTT quality of service level.", { minimum: 0, maximum: 2 });
 const protocolVersionSchema = s.stringEnum("MQTT protocol version used for the connection.", ["3.1.1", "5.0"]);
+const aliyunRuntimeDeviceCredentialSchemas = {
+  aliyunDeviceAccessKeyId: s.nonEmptyString(
+    "Alibaba Cloud device AccessKey ID. Provide it together with aliyunDeviceAccessKeySecret when the connection is configured for runtime device credentials.",
+  ),
+  aliyunDeviceAccessKeySecret: s.nonEmptyString("Alibaba Cloud device AccessKey secret used to sign the Client ID."),
+};
 
 export const mqttActions: ActionDefinition[] = [
   defineProviderAction(service, {
@@ -19,8 +25,11 @@ export const mqttActions: ActionDefinition[] = [
         payloadEncoding: s.stringEnum("How to decode payload before publishing it.", ["utf8", "base64"]),
         qos: qosSchema,
         retain: s.boolean("Whether the broker should retain this message for future subscribers."),
+        ...aliyunRuntimeDeviceCredentialSchemas,
       },
-      { optional: ["payloadEncoding", "qos", "retain"] },
+      {
+        optional: ["payloadEncoding", "qos", "retain", "aliyunDeviceAccessKeyId", "aliyunDeviceAccessKeySecret"],
+      },
     ),
     outputSchema: s.object("The completed MQTT publish operation.", {
       topic: s.string("Topic the message was published to."),
@@ -44,8 +53,18 @@ export const mqttActions: ActionDefinition[] = [
         timeoutSeconds: s.integer("Maximum time to wait for messages before returning.", { minimum: 1, maximum: 30 }),
         maxMessages: s.integer("Maximum number of messages to collect before returning.", { minimum: 1, maximum: 100 }),
         payloadEncoding: s.stringEnum("How received message payloads should be returned.", ["utf8", "base64"]),
+        ...aliyunRuntimeDeviceCredentialSchemas,
       },
-      { optional: ["qos", "timeoutSeconds", "maxMessages", "payloadEncoding"] },
+      {
+        optional: [
+          "qos",
+          "timeoutSeconds",
+          "maxMessages",
+          "payloadEncoding",
+          "aliyunDeviceAccessKeyId",
+          "aliyunDeviceAccessKeySecret",
+        ],
+      },
     ),
     outputSchema: s.object("Messages observed during the bounded subscription window.", {
       messages: s.array(

--- a/src/providers/mqtt/definition.ts
+++ b/src/providers/mqtt/definition.ts
@@ -33,6 +33,16 @@ export const provider: ProviderDefinition = {
           description: "Optional MQTT CONNECT username configured by the broker operator.",
         },
         {
+          key: "clientId",
+          label: "Client ID",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "GID_example@@@device-1",
+          description:
+            "Optional fixed MQTT Client ID. When omitted, each action uses a random Client ID. Alibaba Cloud device credentials require GroupID@@@DeviceID.",
+        },
+        {
           key: "password",
           label: "Password",
           inputType: "password",
@@ -50,6 +60,35 @@ export const provider: ProviderDefinition = {
           secret: false,
           placeholder: "3.1.1",
           description: "MQTT protocol version. Use 3.1.1 by default, or enter 5.0 when the broker supports MQTT 5.",
+        },
+        {
+          key: "aliyunInstanceId",
+          label: "Alibaba Cloud Instance ID",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "mqtt-xxxxxxxx",
+          description:
+            "Alibaba Cloud ApsaraMQ instance ID for unique-certificate-per-device authentication. Configure it with a Client ID, then either save both device access key fields or pass them to each action.",
+        },
+        {
+          key: "aliyunDeviceAccessKeyId",
+          label: "Alibaba Cloud Device AccessKey ID",
+          inputType: "password",
+          required: false,
+          secret: true,
+          placeholder: "device-access-key-id",
+          description:
+            "Optional Alibaba Cloud device AccessKey ID. Leave both device key fields empty to provide them at action runtime.",
+        },
+        {
+          key: "aliyunDeviceAccessKeySecret",
+          label: "Alibaba Cloud Device AccessKey Secret",
+          inputType: "password",
+          required: false,
+          secret: true,
+          placeholder: "device-access-key-secret",
+          description: "Optional Alibaba Cloud device AccessKey secret used to sign the Client ID.",
         },
       ],
     },

--- a/src/providers/mqtt/mqtt-action-coverage.md
+++ b/src/providers/mqtt/mqtt-action-coverage.md
@@ -13,7 +13,9 @@ Implemented actions:
 
 - `receive_messages` is not a durable consumer. Non-retained messages published between action calls are missed.
 - MQTT 3.1.1 is the default. MQTT 5.0 is explicit; the provider does not reconnect with another protocol version after a failed handshake.
-- Raw `mqtt://` and `mqtts://` transport, persistent sessions, background subscriptions, workflow triggers, offline inboxes, mTLS, custom certificate authorities, and cloud-vendor signing are deferred.
+- A fixed Client ID is optional. When it is omitted, every action keeps using a new random Client ID.
+- Alibaba Cloud ApsaraMQ unique-certificate-per-device authentication is supported with saved or per-action device credentials. Other cloud-vendor signing schemes are deferred.
+- Raw `mqtt://` and `mqtts://` transport, persistent sessions, background subscriptions, workflow triggers, offline inboxes, mTLS, and custom certificate authorities are deferred.
 - Private-network brokers require a self-hosted runtime with `OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK` enabled. Cloudflare Workers cannot route to LAN brokers.
 
 ## Transport Safety

--- a/src/providers/mqtt/runtime.test.ts
+++ b/src/providers/mqtt/runtime.test.ts
@@ -3,9 +3,13 @@ import type { IClientOptions, MqttClient } from "mqtt";
 
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { openMqttClient } from "./runtime.ts";
+import { createMqttActionHandlers, createMqttContext, openMqttClient, validateMqttCredential } from "./runtime.ts";
 
 class FakeMqttClient extends EventEmitter {
+  public publishAsync(): Promise<void> {
+    return Promise.resolve();
+  }
+
   public endAsync(): Promise<void> {
     return Promise.resolve();
   }
@@ -47,5 +51,124 @@ describe("MQTT guarded WebSocket handoff", () => {
     );
     expect(guardedOptions?.allowPrivateNetwork).toBeTypeOf("function");
     expect(mqttOptions).toMatchObject({ forceNativeWebSocket: true, protocolVersion: 5, reconnectPeriod: 0 });
+    expect(mqttOptions?.clientId).toMatch(/^oomol-connect-/);
+  });
+
+  it("passes a configured Client ID through without changing the generic MQTT credentials", async () => {
+    const socket = new FakeWebSocket();
+    const client = new FakeMqttClient();
+    let mqttOptions: IClientOptions | undefined;
+    const connect = vi.fn((_url: string, options: IClientOptions) => {
+      mqttOptions = options;
+      options.createWebsocket?.(_url, ["mqtt"], options);
+      queueMicrotask(() => client.emit("connect"));
+      return client as unknown as MqttClient;
+    });
+
+    await openMqttClient(
+      {
+        websocketUrl: "wss://broker.example.com/mqtt",
+        clientId: "fixed-client",
+        username: "mqtt-user",
+        password: "mqtt-password",
+        protocolVersion: "3.1.1",
+      },
+      undefined,
+      { connect, openWebSocket: vi.fn(async () => socket) },
+    );
+
+    expect(mqttOptions).toMatchObject({
+      clientId: "fixed-client",
+      username: "mqtt-user",
+      password: "mqtt-password",
+      protocolVersion: 4,
+    });
+  });
+});
+
+describe("Alibaba Cloud MQTT device credentials", () => {
+  it("derives the documented CONNECT username and HMAC-SHA1 password from saved credentials", async () => {
+    let openedCredential: unknown;
+    const handlers = createMqttActionHandlers({
+      openClient: async (credential) => {
+        openedCredential = credential;
+        return new FakeMqttClient() as unknown as MqttClient;
+      },
+    });
+    const context = createMqttContext({
+      websocketUrl: "wss://example.mqtt.aliyuncs.com/mqtt",
+      clientId: "GID_Test@@@0001",
+      aliyunInstanceId: "mqtt-xxxxx",
+      aliyunDeviceAccessKeyId: "YYYYY",
+      aliyunDeviceAccessKeySecret: "XXXXX",
+    });
+
+    await handlers.publish_message({ topic: "test", payload: "hello" }, context);
+
+    expect(openedCredential).toMatchObject({
+      clientId: "GID_Test@@@0001",
+      username: "DeviceCredential|YYYYY|mqtt-xxxxx",
+      password: "vI009IZJZVGRwBwZvnbwjfuXxVM=",
+    });
+  });
+
+  it("defers validation when device credentials are intentionally supplied by each action", async () => {
+    const openClient = vi.fn();
+
+    await expect(
+      validateMqttCredential(
+        {
+          websocketUrl: "wss://example.mqtt.aliyuncs.com/mqtt",
+          clientId: "GID_Test@@@0001",
+          aliyunInstanceId: "mqtt-xxxxx",
+        },
+        undefined,
+        openClient,
+      ),
+    ).resolves.toMatchObject({ metadata: { protocolVersion: "3.1.1" } });
+    expect(openClient).not.toHaveBeenCalled();
+  });
+
+  it("signs the Client ID with device credentials supplied to an action", async () => {
+    let openedCredential: unknown;
+    const handlers = createMqttActionHandlers({
+      openClient: async (credential) => {
+        openedCredential = credential;
+        return new FakeMqttClient() as unknown as MqttClient;
+      },
+    });
+    const context = createMqttContext({
+      websocketUrl: "wss://example.mqtt.aliyuncs.com/mqtt",
+      clientId: "GID_Test@@@0001",
+      aliyunInstanceId: "mqtt-xxxxx",
+    });
+
+    await handlers.publish_message(
+      {
+        topic: "test",
+        payload: "hello",
+        aliyunDeviceAccessKeyId: "YYYYY",
+        aliyunDeviceAccessKeySecret: "XXXXX",
+      },
+      context,
+    );
+
+    expect(openedCredential).toMatchObject({
+      username: "DeviceCredential|YYYYY|mqtt-xxxxx",
+      password: "vI009IZJZVGRwBwZvnbwjfuXxVM=",
+    });
+  });
+
+  it("accepts runtime device credentials only as a complete pair", async () => {
+    const handlers = createMqttActionHandlers({ openClient: vi.fn() });
+    const context = createMqttContext({
+      websocketUrl: "wss://example.mqtt.aliyuncs.com/mqtt",
+      clientId: "GID_Test@@@0001",
+      aliyunInstanceId: "mqtt-xxxxx",
+    });
+
+    await expect(
+      handlers.publish_message({ topic: "test", payload: "hello", aliyunDeviceAccessKeyId: "YYYYY" }, context),
+    ).rejects.toThrow("aliyunDeviceAccessKeyId and aliyunDeviceAccessKeySecret must be provided together");
   });
 });

--- a/src/providers/mqtt/runtime.ts
+++ b/src/providers/mqtt/runtime.ts
@@ -5,7 +5,7 @@ import type { IClientOptions, IClientPublishOptions, IClientSubscribeOptions, IP
 
 import mqtt from "mqtt";
 import { Buffer } from "node:buffer";
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { optionalInteger, optionalString } from "../../core/cast.ts";
 import { openGuardedWebSocket } from "../../core/guarded-websocket.ts";
 import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
@@ -18,6 +18,7 @@ type MqttActionHandler = (input: Record<string, unknown>, context: MqttActionCon
 
 interface MqttCredential {
   websocketUrl: string;
+  clientId?: string;
   username?: string;
   password?: string;
   protocolVersion: MqttProtocolVersion;
@@ -42,6 +43,9 @@ export interface MqttConnectionDependencies {
 }
 
 export interface MqttActionContext extends MqttCredential {
+  aliyunInstanceId?: string;
+  aliyunDeviceAccessKeyId?: string;
+  aliyunDeviceAccessKeySecret?: string;
   signal?: AbortSignal;
 }
 
@@ -69,7 +73,7 @@ export function createMqttActionHandlers(
       const payload = decodePayload(requirePresentString(input.payload, "payload"), payloadEncoding);
       const qos = readQos(input.qos);
       const retain = input.retain === true;
-      const client = await dependencies.openClient(context, context.signal);
+      const client = await dependencies.openClient(resolveMqttActionCredential(input, context), context.signal);
       try {
         const publishOptions: IClientPublishOptions = { qos, retain };
         await withAbort(
@@ -95,7 +99,7 @@ export function createMqttActionHandlers(
       const timeoutSeconds = readBoundedInteger(input.timeoutSeconds, "timeoutSeconds", 10, 1, 30);
       const maxMessages = readBoundedInteger(input.maxMessages, "maxMessages", 1, 1, 100);
       const payloadEncoding = readPayloadEncoding(input.payloadEncoding);
-      const client = await dependencies.openClient(context, context.signal);
+      const client = await dependencies.openClient(resolveMqttActionCredential(input, context), context.signal);
       try {
         const result = await receiveMessages(client, {
           topicFilter,
@@ -117,16 +121,89 @@ export function createMqttContext(values: Record<string, string>, signal?: Abort
   const websocketUrl = normalizeWebSocketUrl(values.websocketUrl);
   const username = optionalString(values.username);
   const password = optionalString(values.password);
+  const clientId = optionalString(values.clientId);
+  const aliyunInstanceId = optionalString(values.aliyunInstanceId);
+  const aliyunDeviceAccessKeyId = optionalString(values.aliyunDeviceAccessKeyId);
+  const aliyunDeviceAccessKeySecret = optionalString(values.aliyunDeviceAccessKeySecret);
   if (password && !username) {
     throw new ProviderRequestError(400, "username is required when password is configured");
   }
-  return {
+  const credential: MqttActionContext = {
     websocketUrl,
+    clientId,
     username,
     password,
+    aliyunInstanceId,
+    aliyunDeviceAccessKeyId,
+    aliyunDeviceAccessKeySecret,
     protocolVersion: readProtocolVersion(values.protocolVersion),
     signal,
   };
+  validateAliyunCredentialFields(credential);
+  return credential;
+}
+
+function resolveMqttActionCredential(input: Record<string, unknown>, context: MqttActionContext): MqttCredential {
+  const runtimeAccessKeyId = optionalString(input.aliyunDeviceAccessKeyId);
+  const runtimeAccessKeySecret = optionalString(input.aliyunDeviceAccessKeySecret);
+  if (Boolean(runtimeAccessKeyId) !== Boolean(runtimeAccessKeySecret)) {
+    throw new ProviderRequestError(
+      400,
+      "aliyunDeviceAccessKeyId and aliyunDeviceAccessKeySecret must be provided together",
+    );
+  }
+  if (!context.aliyunInstanceId) {
+    if (runtimeAccessKeyId) {
+      throw new ProviderRequestError(
+        400,
+        "runtime Alibaba Cloud device credentials require aliyunInstanceId in the MQTT connection",
+      );
+    }
+    return context;
+  }
+  if (context.aliyunDeviceAccessKeyId && runtimeAccessKeyId) {
+    throw new ProviderRequestError(400, "runtime device credentials cannot override saved device credentials");
+  }
+  const deviceAccessKeyId = context.aliyunDeviceAccessKeyId ?? runtimeAccessKeyId;
+  const deviceAccessKeySecret = context.aliyunDeviceAccessKeySecret ?? runtimeAccessKeySecret;
+  if (!deviceAccessKeyId || !deviceAccessKeySecret) {
+    throw new ProviderRequestError(
+      400,
+      "aliyunDeviceAccessKeyId and aliyunDeviceAccessKeySecret are required for this MQTT action",
+    );
+  }
+  const clientId = context.clientId!;
+  return {
+    websocketUrl: context.websocketUrl,
+    clientId,
+    username: `DeviceCredential|${deviceAccessKeyId}|${context.aliyunInstanceId}`,
+    password: createHmac("sha1", deviceAccessKeySecret).update(clientId, "utf8").digest("base64"),
+    protocolVersion: context.protocolVersion,
+  };
+}
+
+function validateAliyunCredentialFields(credential: MqttActionContext): void {
+  const hasAccessKeyId = Boolean(credential.aliyunDeviceAccessKeyId);
+  const hasAccessKeySecret = Boolean(credential.aliyunDeviceAccessKeySecret);
+  if (hasAccessKeyId !== hasAccessKeySecret) {
+    throw new ProviderRequestError(
+      400,
+      "aliyunDeviceAccessKeyId and aliyunDeviceAccessKeySecret must be configured together",
+    );
+  }
+  if (!credential.aliyunInstanceId && (hasAccessKeyId || hasAccessKeySecret)) {
+    throw new ProviderRequestError(400, "aliyunInstanceId is required for Alibaba Cloud device credentials");
+  }
+  if (!credential.aliyunInstanceId) return;
+  if (!credential.clientId) {
+    throw new ProviderRequestError(400, "clientId is required for Alibaba Cloud device credentials");
+  }
+  if (credential.username || credential.password) {
+    throw new ProviderRequestError(
+      400,
+      "username and password cannot be combined with Alibaba Cloud device credentials",
+    );
+  }
 }
 
 export async function validateMqttCredential(
@@ -135,8 +212,11 @@ export async function validateMqttCredential(
   openClient: MqttActionDependencies["openClient"] = openMqttClient,
 ): Promise<CredentialValidationResult> {
   const context = createMqttContext(values, signal);
-  const client = await openClient(context, context.signal);
-  await closeMqttClient(client);
+  if (context.aliyunDeviceAccessKeyId || !context.aliyunInstanceId) {
+    const credential = resolveMqttActionCredential({}, context);
+    const client = await openClient(credential, context.signal);
+    await closeMqttClient(client);
+  }
   const url = new URL(context.websocketUrl);
   return {
     profile: {
@@ -165,7 +245,7 @@ export async function openMqttClient(
   let handedOff = false;
   const options: IClientOptions = {
     clean: true,
-    clientId: `oomol-connect-${randomUUID()}`,
+    clientId: credential.clientId ?? `oomol-connect-${randomUUID()}`,
     connectTimeout: 15_000,
     forceNativeWebSocket: true,
     protocolVersion: credential.protocolVersion === "5.0" ? 5 : 4,

--- a/src/server/actions/run-log-summary.test.ts
+++ b/src/server/actions/run-log-summary.test.ts
@@ -8,6 +8,8 @@ describe("summarizeForRunLog", () => {
         cookies: [{ name: "session", value: "cookie-secret" }],
         headers: { authorization: "Basic dXNlcjpwYXNz" },
         accessKey: "access-secret",
+        aliyunDeviceAccessKeyId: "device-key-id",
+        aliyunDeviceAccessKeySecret: "device-key-secret",
         token: "abc.def.ghi",
         temporaryUrl: "https://user:pass@example.com/file?token=secret#fragment",
       }),
@@ -15,6 +17,8 @@ describe("summarizeForRunLog", () => {
       cookies: "[redacted]",
       headers: "[redacted]",
       accessKey: "[redacted]",
+      aliyunDeviceAccessKeyId: "[redacted]",
+      aliyunDeviceAccessKeySecret: "[redacted]",
       token: "[redacted]",
       temporaryUrl: "[redacted-url]",
     });


### PR DESCRIPTION
## Summary

- support an optional fixed MQTT Client ID while preserving the random default
- support Alibaba Cloud ApsaraMQ unique-certificate-per-device authentication with saved or per-action credentials
- derive the documented `DeviceCredential|AccessKeyId|InstanceId` username and Base64 HMAC-SHA1 password
- keep Alibaba Cloud fields namespaced and verify action-run redaction

## Compatibility

Generic MQTT username/password authentication is unchanged. Connections without `clientId` continue to receive a fresh `oomol-connect-*` Client ID for every action.

## Verification

- `npm run fix-check`
- `npx vitest run src/providers/mqtt/runtime.test.ts src/server/actions/run-log-summary.test.ts src/server/actions/action-runner.test.ts`

Fixes #483