### PR TITLE
fix(providers): accept valid empty resource responses

### DIFF
--- a/src/providers/confluence/executors.test.ts
+++ b/src/providers/confluence/executors.test.ts
@@ -79,6 +79,34 @@ describe("Confluence OAuth credentials", () => {
     ).rejects.toMatchObject({ status: 400, message: expect.stringContaining("multiple sites") });
   });
 
+  it("accepts a token without an accessible Confluence site", async () => {
+    const result = await credentialValidators.oauth2!(oauthCredential, {
+      fetcher: async () => Response.json([]),
+    });
+
+    expect(result).toEqual({
+      profile: {
+        accountId: "confluence",
+        displayName: "Confluence Cloud",
+        grantedScopes: [],
+      },
+      grantedScopes: [],
+      metadata: {
+        resourceCount: 0,
+        validationEndpoint: "/oauth/token/accessible-resources",
+      },
+    });
+  });
+
+  it("rejects malformed accessible-resource responses", async () => {
+    await expect(
+      credentialValidators.oauth2!(oauthCredential, { fetcher: async () => Response.json({}) }),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: "Confluence accessible-resources response must be an array",
+    });
+  });
+
   it("times out accessible-resource discovery", async () => {
     vi.useFakeTimers();
     const validation = credentialValidators.oauth2!(oauthCredential, {

--- a/src/providers/confluence/executors.test.ts
+++ b/src/providers/confluence/executors.test.ts
@@ -98,6 +98,18 @@ describe("Confluence OAuth credentials", () => {
     });
   });
 
+  it("accepts well-formed resources without Confluence product scopes", async () => {
+    const result = await credentialValidators.oauth2!(oauthCredential, {
+      fetcher: async () =>
+        Response.json([{ id: "cloud-123", url: "https://jira.atlassian.net", scopes: ["read:jira-work"] }]),
+    });
+
+    expect(result).toMatchObject({
+      profile: { accountId: "confluence", displayName: "Confluence Cloud" },
+      metadata: { resourceCount: 1 },
+    });
+  });
+
   it("rejects malformed accessible-resource responses", async () => {
     await expect(
       credentialValidators.oauth2!(oauthCredential, { fetcher: async () => Response.json({}) }),
@@ -105,6 +117,12 @@ describe("Confluence OAuth credentials", () => {
       status: 502,
       message: "Confluence accessible-resources response must be an array",
     });
+  });
+
+  it("rejects malformed accessible-resource entries", async () => {
+    await expect(
+      credentialValidators.oauth2!(oauthCredential, { fetcher: async () => Response.json([{}]) }),
+    ).rejects.toMatchObject({ status: 502, message: "Confluence accessible resource id is required." });
   });
 
   it("times out accessible-resource discovery", async () => {

--- a/src/providers/confluence/executors.ts
+++ b/src/providers/confluence/executors.ts
@@ -145,10 +145,18 @@ async function validateConfluenceOAuthCredential(
   const resources = readAccessibleResources(resourcesPayload);
   const resource = pickPrimaryResource(resources);
   if (!resource) {
-    throw new ProviderRequestError(
-      400,
-      "Confluence authorization does not include an accessible Confluence Cloud site",
-    );
+    return {
+      profile: {
+        accountId: "confluence",
+        displayName: "Confluence Cloud",
+        grantedScopes: [],
+      },
+      grantedScopes: [],
+      metadata: {
+        resourceCount: resources.length,
+        validationEndpoint: "/oauth/token/accessible-resources",
+      },
+    };
   }
 
   const cloudId = requiredString(resource.id, "cloudId", confluenceResponseError);

--- a/src/providers/confluence/executors.ts
+++ b/src/providers/confluence/executors.ts
@@ -261,6 +261,11 @@ function readAccessibleResources(payload: unknown): ConfluenceAccessibleResource
     if (!resource) {
       throw new ProviderRequestError(502, "Confluence accessible resource must be an object");
     }
+    requiredString(resource.id, "accessible resource id", confluenceResponseError);
+    requiredString(resource.url, "accessible resource URL", confluenceResponseError);
+    if (!optionalStringArray(resource.scopes)) {
+      throw confluenceResponseError("accessible resource scopes must be an array of strings");
+    }
     return resource;
   });
 }

--- a/src/providers/eversign/executors.test.ts
+++ b/src/providers/eversign/executors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+describe("Xodo Sign credential validation", () => {
+  it.each([
+    ["an empty business list", Response.json([])],
+    ["an empty response body", new Response(null, { status: 200 })],
+    [
+      "the documented no-businesses response",
+      Response.json({ success: false, error: { type: "no_businesses_found_for_user" } }),
+    ],
+  ])("accepts a valid API key with %s", async (_description, response) => {
+    const result = await credentialValidators.apiKey!(
+      { apiKey: "eversign-key", values: {} },
+      { fetcher: async () => response },
+    );
+
+    expect(result).toEqual({
+      profile: { accountId: "eversign", displayName: "Xodo Sign API Key" },
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl: "https://api.eversign.com",
+        validationEndpoint: "/business",
+        primaryBusinessId: undefined,
+        primaryBusinessName: undefined,
+        businessCount: 0,
+      },
+    });
+  });
+
+  it("keeps rejecting invalid API keys", async () => {
+    await expect(
+      credentialValidators.apiKey!(
+        { apiKey: "invalid-key", values: {} },
+        {
+          fetcher: async () =>
+            Response.json(
+              { success: false, error: { type: "invalid_access_key", message: "Invalid access key" } },
+              { status: 200 },
+            ),
+        },
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "Invalid access key" });
+  });
+});

--- a/src/providers/eversign/executors.ts
+++ b/src/providers/eversign/executors.ts
@@ -26,15 +26,15 @@ export const credentialValidators: CredentialValidators = {
     const { primary, businessCount } = await validateEversignCredential(input.apiKey, fetcher, signal);
     return {
       profile: {
-        accountId: String(primary.businessId),
-        displayName: primary.businessName || "Xodo Sign API Key",
+        accountId: primary ? String(primary.businessId) : "eversign",
+        displayName: primary?.businessName || "Xodo Sign API Key",
       },
       grantedScopes: [],
       metadata: {
         apiBaseUrl: eversignApiBaseUrl,
         validationEndpoint: eversignValidationPath,
-        primaryBusinessId: primary.businessId,
-        primaryBusinessName: primary.businessName,
+        primaryBusinessId: primary?.businessId,
+        primaryBusinessName: primary?.businessName,
         businessCount,
       },
     };

--- a/src/providers/eversign/runtime.ts
+++ b/src/providers/eversign/runtime.ts
@@ -25,7 +25,7 @@ export const eversignValidationPath = "/business";
 type EversignPhase = "validate" | "execute";
 
 interface EversignCredentialSummary {
-  primary: {
+  primary?: {
     businessId: number;
     businessName: string;
   };
@@ -222,11 +222,8 @@ export async function validateEversignCredential(
     signal,
     phase: "validate",
   });
-  const businesses = readResponseArray(payload, "business list").map(normalizeBusiness);
+  const businesses = (payload == null ? [] : readResponseArray(payload, "business list")).map(normalizeBusiness);
   const primary = businesses.find((business) => business.isPrimary) ?? businesses[0];
-  if (!primary) {
-    throw new ProviderRequestError(400, "Xodo Sign returned no businesses for this API key");
-  }
 
   return {
     primary,
@@ -265,6 +262,9 @@ async function requestEversignJson(input: {
       signal: timeout.signal,
     });
     const payload = await readEversignPayload(response);
+    if (response.ok && input.phase === "validate" && isNoBusinessesPayload(payload)) {
+      return [];
+    }
     if (!response.ok || isEversignErrorPayload(payload)) {
       throw mapEversignError(response.status, payload, input.phase);
     }
@@ -401,6 +401,12 @@ async function readEversignPayload(response: Response) {
 function isEversignErrorPayload(payload: unknown) {
   const body = optionalRecord(payload);
   return body?.success === false;
+}
+
+function isNoBusinessesPayload(payload: unknown) {
+  const body = optionalRecord(payload);
+  const error = body ? optionalRecord(body.error) : undefined;
+  return optionalString(error?.type) === "no_businesses_found_for_user";
 }
 
 function mapEversignError(status: number, payload: unknown, phase: EversignPhase) {

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -27,9 +27,27 @@ describe("Jira OAuth credential validation", () => {
     });
   });
 
+  it("accepts well-formed resources without Jira product scopes", async () => {
+    const result = await credentialValidators.oauth2!(credential, {
+      fetcher: async () =>
+        Response.json([{ id: "cloud-123", url: "https://docs.atlassian.net", scopes: ["read:me"] }]),
+    });
+
+    expect(result).toMatchObject({
+      profile: { accountId: "jira", displayName: "Jira Cloud" },
+      metadata: { resourceCount: 1 },
+    });
+  });
+
   it("rejects malformed accessible-resource responses", async () => {
     await expect(
       credentialValidators.oauth2!(credential, { fetcher: async () => Response.json({}) }),
     ).rejects.toMatchObject({ status: 502, message: "jira accessible-resources response must be an array" });
+  });
+
+  it("rejects malformed accessible-resource entries", async () => {
+    await expect(
+      credentialValidators.oauth2!(credential, { fetcher: async () => Response.json([{}]) }),
+    ).rejects.toMatchObject({ status: 502, message: "missing jira accessible resource id" });
   });
 });

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -1,0 +1,35 @@
+import type { ResolvedCredential } from "../../core/types.ts";
+
+import { describe, expect, it } from "vitest";
+import { credentialValidators } from "./executors.ts";
+
+const credential: Extract<ResolvedCredential, { authType: "oauth2" }> = {
+  authType: "oauth2",
+  accessToken: "jira-token",
+  tokenType: "Bearer",
+  profile: { accountId: "oauth2", displayName: "OAuth Credential", grantedScopes: [] },
+  metadata: {},
+};
+
+describe("Jira OAuth credential validation", () => {
+  it("accepts a token without an accessible Jira site", async () => {
+    const result = await credentialValidators.oauth2!(credential, {
+      fetcher: async () => Response.json([]),
+    });
+
+    expect(result).toEqual({
+      profile: { accountId: "jira", displayName: "Jira Cloud" },
+      grantedScopes: [],
+      metadata: {
+        resourceCount: 0,
+        validationEndpoint: "/oauth/token/accessible-resources",
+      },
+    });
+  });
+
+  it("rejects malformed accessible-resource responses", async () => {
+    await expect(
+      credentialValidators.oauth2!(credential, { fetcher: async () => Response.json({}) }),
+    ).rejects.toMatchObject({ status: 502, message: "jira accessible-resources response must be an array" });
+  });
+});

--- a/src/providers/jira/executors.test.ts
+++ b/src/providers/jira/executors.test.ts
@@ -29,8 +29,7 @@ describe("Jira OAuth credential validation", () => {
 
   it("accepts well-formed resources without Jira product scopes", async () => {
     const result = await credentialValidators.oauth2!(credential, {
-      fetcher: async () =>
-        Response.json([{ id: "cloud-123", url: "https://docs.atlassian.net", scopes: ["read:me"] }]),
+      fetcher: async () => Response.json([{ id: "cloud-123", url: "https://docs.atlassian.net", scopes: ["read:me"] }]),
     });
 
     expect(result).toMatchObject({

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -132,7 +132,17 @@ async function fetchJiraCurrentAccount(
   const resources = readAccessibleResources(accessibleResourcesPayload);
   const primaryResource = pickPrimaryResource(resources);
   if (!primaryResource) {
-    throw new ProviderRequestError(400, "jira authorization does not include an accessible Jira Cloud site");
+    return {
+      profile: {
+        accountId: "jira",
+        displayName: "Jira Cloud",
+      },
+      grantedScopes: [],
+      metadata: {
+        resourceCount: resources.length,
+        validationEndpoint: "/oauth/token/accessible-resources",
+      },
+    };
   }
 
   const cloudId = requireNonEmptyString(primaryResource.id, "jira cloudId");

--- a/src/providers/jira/executors.ts
+++ b/src/providers/jira/executors.ts
@@ -12,6 +12,7 @@ import {
   optionalInteger as asOptionalInteger,
   optionalRecord as asOptionalObject,
   optionalString as asOptionalString,
+  optionalStringArray,
 } from "../../core/cast.ts";
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
@@ -679,6 +680,11 @@ function readAccessibleResources(payload: unknown) {
     const record = asOptionalObject(item);
     if (!record) {
       throw new ProviderRequestError(502, "jira accessible resource must be an object");
+    }
+    requireNonEmptyString(record.id, "jira accessible resource id");
+    requireNonEmptyString(record.url, "jira accessible resource URL");
+    if (!optionalStringArray(record.scopes)) {
+      throw new ProviderRequestError(502, "jira accessible resource scopes must be an array of strings");
     }
     return record as JiraAccessibleResource;
   });

--- a/src/providers/workiz/executors.test.ts
+++ b/src/providers/workiz/executors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { workizActionHandlers } from "./runtime.ts";
+
+describe("Workiz list responses", () => {
+  it.each([
+    ["an empty response body", new Response(null, { status: 200 })],
+    ["a missing data field", Response.json({ flag: true })],
+    ["an empty data list", Response.json({ flag: true, data: [] })],
+  ])("normalizes %s to an empty list", async (_description, response) => {
+    const result = await workizActionHandlers.list_jobs({}, { apiKey: "workiz-key", fetcher: async () => response });
+
+    expect(result).toEqual({ jobs: [] });
+  });
+
+  it("rejects malformed non-empty list responses", async () => {
+    await expect(
+      workizActionHandlers.list_jobs(
+        {},
+        {
+          apiKey: "workiz-key",
+          fetcher: async () => Response.json({ data: "not-an-array" }),
+        },
+      ),
+    ).rejects.toMatchObject({ status: 502, message: "workiz response did not include a record list" });
+  });
+});

--- a/src/providers/workiz/runtime.ts
+++ b/src/providers/workiz/runtime.ts
@@ -80,9 +80,12 @@ async function request(path: string, context: ApiKeyProviderContext, phase: "val
   }
 }
 function records(payload: unknown) {
+  if (payload == null) return [];
   if (Array.isArray(payload)) return payload;
-  const data = optionalRecord(payload)?.data;
+  const body = optionalRecord(payload);
+  const data = body?.data;
   if (Array.isArray(data)) return data;
+  if (body && data === undefined) return [];
   throw new ProviderRequestError(502, "workiz response did not include a record list");
 }
 function unwrapData(value: unknown) {


### PR DESCRIPTION
## Summary

- accept Xodo Sign credentials when the business list is empty, the successful validation body is empty, or the API reports `no_businesses_found_for_user`
- accept Jira and Confluence OAuth tokens without an accessible cloud site while leaving site metadata unset
- normalize successful empty Workiz list responses and omitted `data` fields to empty arrays
- retain malformed-response and invalid-credential errors, with regression coverage for each provider

## Ablation

- scoped Xodo Sign empty-body normalization to credential validation instead of weakening every array-returning action
- kept Jira and Confluence non-array payloads as 502 responses
- kept Workiz non-empty malformed `data` values as 502 responses
- retained only the generic identity and metadata required before a provider resource is provisioned

## Issue tracking

#413 scope cleanup already landed in #417; this PR records the accepted audit outcome and leaves Strava private-data scopes unchanged.

Closes #413
Closes #480

## Test plan

- `npx vitest run src/providers/eversign/executors.test.ts src/providers/jira/executors.test.ts src/providers/confluence/executors.test.ts src/providers/workiz/executors.test.ts`
- `npx vitest run src/providers/provider-source-guards.clone-baseline.test.ts`
- `npm run fix-check`