### PR TITLE
feat(dingtalk): add DingTalk MCP provider

### DIFF
--- a/src/providers/dingtalk_mcp/actions.ts
+++ b/src/providers/dingtalk_mcp/actions.ts
@@ -1,0 +1,59 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "dingtalk_mcp";
+
+const toolAnnotationsSchema = s.looseObject("MCP behavior hints supplied by the connected DingTalk server.", {
+  title: s.optional(s.string("A human-readable title for the tool.")),
+  readOnlyHint: s.optional(s.boolean("Whether the tool is expected not to modify DingTalk data.")),
+  destructiveHint: s.optional(s.boolean("Whether the tool may perform a destructive DingTalk operation.")),
+  idempotentHint: s.optional(s.boolean("Whether repeating the same call is expected to have no additional effect.")),
+  openWorldHint: s.optional(s.boolean("Whether the tool may interact with entities outside DingTalk.")),
+});
+
+const mcpToolSummarySchema = s.object(
+  "A tool currently exposed by the connected DingTalk MCP endpoint.",
+  {
+    name: s.nonEmptyString("The exact DingTalk MCP tool name to pass to call_tool."),
+    description: s.string("The current tool description supplied by DingTalk MCP."),
+    annotations: toolAnnotationsSchema,
+    inputSchema: s.looseObject("The current JSON Schema for the tool arguments, supplied by DingTalk MCP."),
+  },
+  { optional: ["description", "annotations"] },
+);
+
+export const dingTalkMcpActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_tools",
+    description:
+      "Discover the current tools, behavior annotations, and live input schemas exposed by this DingTalk MCP connection.",
+    requiredScopes: [],
+    followUpActions: ["dingtalk_mcp.call_tool"],
+    inputSchema: s.object("No input is required.", {}),
+    outputSchema: s.object("The current DingTalk MCP tool catalog.", {
+      tools: s.array("Tools currently exposed by this DingTalk MCP connection.", mcpToolSummarySchema),
+    }),
+  }),
+  defineProviderAction(service, {
+    name: "call_tool",
+    description:
+      "Call a current DingTalk MCP tool with JSON arguments. Discover the tool first and confirm the user's intent because the endpoint may expose actions that send, overwrite, cancel, or delete DingTalk data.",
+    requiredScopes: [],
+    followUpActions: ["dingtalk_mcp.list_tools"],
+    inputSchema: s.object(
+      "Input for invoking one current DingTalk MCP tool.",
+      {
+        toolName: s.nonEmptyString("The exact tool name returned by list_tools."),
+        arguments: s.looseObject("JSON arguments matching the inputSchema returned for the selected tool."),
+      },
+      { optional: ["arguments"] },
+    ),
+    outputSchema: s.object("The normalized result returned by the DingTalk MCP tool.", {
+      result: s.unknown(
+        "The tool result. Structured MCP content is returned directly; otherwise the MCP content envelope is preserved.",
+      ),
+    }),
+  }),
+];

--- a/src/providers/dingtalk_mcp/definition.ts
+++ b/src/providers/dingtalk_mcp/definition.ts
@@ -1,0 +1,31 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { dingTalkMcpActions } from "./actions.ts";
+
+export const provider: ProviderDefinition = {
+  service: "dingtalk_mcp",
+  displayName: "DingTalk MCP",
+  description:
+    "Discover and call live DingTalk tools through an official DingTalk MCP marketplace service, such as DingTalk Docs, Calendar, or Contacts.",
+  categories: ["Communication", "Productivity", "Developer Tools"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "mcpUrl",
+          label: "MCP URL",
+          required: true,
+          inputType: "password",
+          secret: true,
+          placeholder: "https://mcp-gw.dingtalk.com/mserver/...",
+          description:
+            "The secret Streamable HTTP URL of one DingTalk MCP marketplace service. Open a service on the DingTalk MCP marketplace (https://aihub.dingtalk.com/#/mcp-market/mcp, DingTalk login required), click 获取 MCP Server 配置 (Get MCP Server config), and copy the URL. Each connection exposes one marketplace service. Official guide: https://open.dingtalk.com/document/development/mcp-square-introduction.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://www.dingtalk.com",
+  actions: dingTalkMcpActions,
+};

--- a/src/providers/dingtalk_mcp/executors.ts
+++ b/src/providers/dingtalk_mcp/executors.ts
@@ -1,0 +1,28 @@
+import type { CredentialValidators, ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+
+import { createProviderFetch, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import {
+  createDingTalkMcpContext,
+  dingTalkMcpActionHandlers,
+  toDingTalkMcpExecutionError,
+  validateDingTalkMcpCredential,
+} from "./runtime.ts";
+
+const service = "dingtalk_mcp";
+
+export const executors: ProviderExecutors = defineProviderExecutors({
+  service,
+  handlers: dingTalkMcpActionHandlers,
+  mapError: toDingTalkMcpExecutionError,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch) {
+    const credential = await requireCustomCredential(context, service);
+    return createDingTalkMcpContext(credential.values, fetcher, context.signal);
+  },
+  fallbackMessage: "DingTalk MCP request failed",
+});
+
+export const credentialValidators: CredentialValidators = {
+  customCredential(input, { fetcher, signal }) {
+    return validateDingTalkMcpCredential(input.values, createProviderFetch({ fetch: fetcher }), signal);
+  },
+};

--- a/src/providers/dingtalk_mcp/runtime.ts
+++ b/src/providers/dingtalk_mcp/runtime.ts
@@ -1,0 +1,284 @@
+import type { CredentialValidationResult, ExecutionResult } from "../../core/types.ts";
+import type { ProviderActionHandlers } from "../provider-runtime.ts";
+import type { ProviderFetch, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { Client } from "@modelcontextprotocol/client";
+
+import { UnauthorizedError } from "@modelcontextprotocol/client";
+import { SdkHttpError } from "@modelcontextprotocol/client";
+import { ProtocolError, SdkError, SdkErrorCode } from "@modelcontextprotocol/client";
+import { createHash } from "node:crypto";
+import { optionalRecord, requiredString } from "../../core/cast.ts";
+import { assertPublicHttpUrl } from "../../core/request.ts";
+import { withMcpClient } from "../mcp-client.ts";
+import {
+  isAbortLikeError,
+  providerUserAgent,
+  ProviderRequestError,
+  toProviderExecutionError,
+} from "../provider-runtime.ts";
+
+const dingTalkMcpHost = "mcp-gw.dingtalk.com";
+
+interface DingTalkMcpContext {
+  endpoint: URL;
+  fetcher: ProviderFetch;
+  signal?: AbortSignal;
+}
+
+type DingTalkMcpRequestPhase = "validate" | "execute";
+type DingTalkMcpToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+export const dingTalkMcpActionHandlers: ProviderActionHandlers<
+  "dingtalk_mcp",
+  ProviderRuntimeHandler<DingTalkMcpContext>
+> = {
+  list_tools(_input, context) {
+    return listDingTalkMcpTools(context);
+  },
+  call_tool(input, context) {
+    return callDingTalkMcpTool(context, input);
+  },
+};
+
+export function createDingTalkMcpContext(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): DingTalkMcpContext {
+  return {
+    endpoint: normalizeDingTalkMcpEndpoint(values.mcpUrl),
+    fetcher,
+    signal,
+  };
+}
+
+function normalizeDingTalkMcpEndpoint(value: unknown): URL {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ProviderRequestError(400, "DingTalk MCP Server URL is required");
+  }
+
+  let endpoint: URL;
+  try {
+    endpoint = new URL(value.trim());
+  } catch {
+    throw new ProviderRequestError(400, "DingTalk MCP Server URL must be a valid URL");
+  }
+
+  if (
+    endpoint.protocol !== "https:" ||
+    endpoint.hostname !== dingTalkMcpHost ||
+    (endpoint.port !== "" && endpoint.port !== "443")
+  ) {
+    throw new ProviderRequestError(400, `DingTalk MCP Server URL must use https://${dingTalkMcpHost}`);
+  }
+  if (endpoint.username || endpoint.password) {
+    throw new ProviderRequestError(400, "DingTalk MCP Server URL must not include username or password");
+  }
+
+  endpoint = assertPublicHttpUrl(endpoint.toString(), {
+    fieldName: "mcpUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+  });
+  endpoint.hash = "";
+  return endpoint;
+}
+
+export async function validateDingTalkMcpCredential(
+  values: Record<string, string>,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const context = createDingTalkMcpContext(values, fetcher, signal);
+  const tools = await withDingTalkMcpAuthRemap("validate", () => discoverDingTalkMcpTools(context));
+  if (tools.length === 0) {
+    throw new ProviderRequestError(502, "DingTalk MCP did not expose any tools for this account");
+  }
+
+  const credentialHash = createHash("sha256").update(context.endpoint.toString()).digest("hex").slice(0, 16);
+  return {
+    profile: {
+      accountId: `dingtalk_mcp:mcp:${credentialHash}`,
+      displayName: `DingTalk MCP · ${credentialHash.slice(-6)}`,
+    },
+    grantedScopes: [],
+    metadata: {
+      mcpHost: context.endpoint.hostname,
+      discoveredToolCount: tools.length,
+    },
+  };
+}
+
+async function listDingTalkMcpTools(context: DingTalkMcpContext): Promise<{
+  tools: Array<{
+    name: string;
+    description?: string;
+    annotations?: Record<string, unknown>;
+    inputSchema: Record<string, unknown>;
+  }>;
+}> {
+  return {
+    tools: await withDingTalkMcpAuthRemap("execute", () => discoverDingTalkMcpTools(context)),
+  };
+}
+
+async function callDingTalkMcpTool(
+  context: DingTalkMcpContext,
+  input: Record<string, unknown>,
+): Promise<{ result: unknown }> {
+  const toolName = requiredString(input.toolName, "toolName", (message) => new ProviderRequestError(400, message));
+  const argumentsValue = readToolArguments(input.arguments);
+  const result = await withDingTalkMcpAuthRemap("execute", () =>
+    withDingTalkMcpClient(context, async (client) => {
+      const toolResult = await client.callTool(
+        {
+          name: toolName,
+          arguments: argumentsValue,
+        },
+        {
+          signal: context.signal,
+        },
+      );
+      return normalizeDingTalkMcpToolResult(toolName, toolResult);
+    }),
+  );
+  return { result };
+}
+
+async function discoverDingTalkMcpTools(context: DingTalkMcpContext): Promise<
+  Array<{
+    name: string;
+    description?: string;
+    annotations?: Record<string, unknown>;
+    inputSchema: Record<string, unknown>;
+  }>
+> {
+  return withDingTalkMcpClient(context, async (client) => {
+    const result = await client.listTools(
+      {},
+      {
+        signal: context.signal,
+      },
+    );
+    return result.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      annotations: tool.annotations,
+      inputSchema: tool.inputSchema,
+    }));
+  });
+}
+
+async function withDingTalkMcpClient<T>(context: DingTalkMcpContext, run: (client: Client) => Promise<T>): Promise<T> {
+  const headers = new Headers();
+  headers.set("user-agent", providerUserAgent);
+  return withMcpClient(
+    {
+      endpoint: context.endpoint,
+      transport: "streamable_http",
+      fetcher: context.fetcher,
+      headers,
+      redirect: "error",
+      signal: context.signal,
+      mapError: mapDingTalkMcpError,
+    },
+    run,
+  );
+}
+
+function readToolArguments(value: unknown): Record<string, unknown> {
+  if (value === undefined) {
+    return {};
+  }
+  const argumentsValue = optionalRecord(value);
+  if (!argumentsValue) {
+    throw new ProviderRequestError(400, "arguments must be a JSON object");
+  }
+  return argumentsValue;
+}
+
+function normalizeDingTalkMcpToolResult(toolName: string, result: DingTalkMcpToolResult): unknown {
+  if ("content" in result && result.isError) {
+    throw new ProviderRequestError(
+      502,
+      `DingTalk MCP tool ${toolName} returned an error: ${formatDingTalkMcpToolContent(result)}`,
+      result,
+    );
+  }
+  if ("toolResult" in result) {
+    return result;
+  }
+  return result.structuredContent ?? result;
+}
+
+function formatDingTalkMcpToolContent(result: DingTalkMcpToolResult): string {
+  const content = "content" in result && Array.isArray(result.content) ? result.content : [];
+  const text = content
+    .map((item) => {
+      if (item.type === "text") {
+        return item.text;
+      }
+      if (item.type === "resource") {
+        return "text" in item.resource ? item.resource.text : item.resource.uri;
+      }
+      if (item.type === "resource_link") {
+        return item.uri;
+      }
+      return item.type;
+    })
+    .filter(Boolean)
+    .join("; ");
+
+  return text.slice(0, 300) || "empty error content";
+}
+
+function mapDingTalkMcpError(error: unknown): ProviderRequestError {
+  if (error instanceof ProviderRequestError) {
+    return error;
+  }
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(401, "DingTalk MCP URL is invalid or expired", error);
+  }
+  if (error instanceof SdkHttpError) {
+    const status = error.status;
+    return new ProviderRequestError(
+      status === 401 || status === 403
+        ? 401
+        : status === 429
+          ? 429
+          : status && status >= 400 && status < 500
+            ? 400
+            : 502,
+      `DingTalk MCP request failed: ${error.message}`,
+      error,
+    );
+  }
+  if (error instanceof SdkError && error.code === SdkErrorCode.RequestTimeout) {
+    return new ProviderRequestError(504, "DingTalk MCP request timed out", error);
+  }
+  if (error instanceof ProtocolError) {
+    return new ProviderRequestError(502, `DingTalk MCP request failed: ${error.message}`, error);
+  }
+  if (isAbortLikeError(error)) {
+    return new ProviderRequestError(504, "DingTalk MCP request timed out", error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `DingTalk MCP request failed: ${error.message}` : "DingTalk MCP request failed",
+    error,
+  );
+}
+
+async function withDingTalkMcpAuthRemap<T>(phase: DingTalkMcpRequestPhase, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof ProviderRequestError && error.status === 401) {
+      throw new ProviderRequestError(phase === "validate" ? 400 : 401, "DingTalk MCP URL is invalid or expired", error);
+    }
+    throw error;
+  }
+}
+
+export function toDingTalkMcpExecutionError(error: unknown): ExecutionResult {
+  return toProviderExecutionError(error, "DingTalk MCP request failed");
+}


### PR DESCRIPTION
## Summary

Adds a `dingtalk_mcp` provider bridging DingTalk's hosted MCP marketplace services over streamable HTTP, modeled after `wecom_mcp`.

Two generic actions:
- `dingtalk_mcp.list_tools` — discover the connection's live tools, annotations, and input schemas
- `dingtalk_mcp.call_tool` — invoke a tool with JSON arguments

Credential: a single secret `mcpUrl`, copied from a service detail page on the DingTalk MCP marketplace (获取 MCP Server 配置). The endpoint is pinned to `https://mcp-gw.dingtalk.com` and SSRF-guarded via `assertPublicHttpUrl` with DNS validation on. Each connection exposes one marketplace service (DingTalk Docs, Calendar, Contacts, AI Table, …).

## References

- DingTalk MCP marketplace: https://aihub.dingtalk.com/#/mcp-market/mcp
- Official guide: https://open.dingtalk.com/document/development/mcp-square-introduction

## Verification

- `npm run generate:catalog` — registries and catalog regenerated
- `npm run fix-check` — lint, format, and typecheck pass
- Provider guard tests (clone-baseline, basic-auth) and the full provider suite pass (946 tests)
- No provider-local tests added: request mapping is covered by the central loader tests, per repo convention