### PR TITLE
feat(kuaidi100): add Kuaidi100 provider

### DIFF
--- a/src/providers/kuaidi100/actions.ts
+++ b/src/providers/kuaidi100/actions.ts
@@ -1,0 +1,203 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "kuaidi100";
+
+const trackingNumberSchema = s.nonEmptyString("The express tracking number (快递单号).");
+
+const timeEstimateCarrierSchema = s.stringEnum(
+  "The Kuaidi100 carrier code in lowercase: yuantong (圆通), zhongtong (中通), shunfeng (顺丰), shunfengkuaiyun (顺丰快运), jd (京东), jtexpress (极兔速递), shentong (申通), yunda (韵达), ems (EMS), kuayue (跨越), debangkuaidi (德邦快递), emsguoji (EMS国际件), youzhengguonei (邮政国内), youzhengguoji (国际包裹), zhaijisong (宅急送), zhimakaimen (芝麻开门), lianbangkuaidi (联邦快递), tiandihuayu (天地华宇), annengwuliu (安能快运), jinguangsudikuaijian (京广速递), jiayunmeiwuliu (加运美).",
+  [
+    "yuantong",
+    "zhongtong",
+    "shunfeng",
+    "shunfengkuaiyun",
+    "jd",
+    "jtexpress",
+    "shentong",
+    "yunda",
+    "ems",
+    "kuayue",
+    "debangkuaidi",
+    "emsguoji",
+    "youzhengguonei",
+    "youzhengguoji",
+    "zhaijisong",
+    "zhimakaimen",
+    "lianbangkuaidi",
+    "tiandihuayu",
+    "annengwuliu",
+    "jinguangsudikuaijian",
+    "jiayunmeiwuliu",
+  ],
+);
+
+const priceEstimateCarrierSchema = s.stringEnum(
+  "The Kuaidi100 carrier code in lowercase: shunfeng (顺丰), jd (京东), debangkuaidi (德邦快递), yuantong (圆通), zhongtong (中通), shentong (申通), yunda (韵达), ems (EMS).",
+  ["shunfeng", "jd", "debangkuaidi", "yuantong", "zhongtong", "shentong", "yunda", "ems"],
+);
+
+const orderTimeSchema = s.string(
+  "The order placement time in yyyy-MM-dd HH:mm:ss format, for example 2026-09-04 08:08:08. Defaults to the current time when omitted.",
+  { pattern: "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$" },
+);
+
+const expTypeSchema = s.nonEmptyString("The carrier business or product type, such as 标准快递.");
+
+const tipsSchema = s.string("An upstream notice, present when the call consumed the Kuaidi100 free daily quota.");
+
+const trajectoryEventSchema = s.object("One logistics trajectory event.", {
+  time: s.string("The event time in yyyy-MM-dd HH:mm:ss format."),
+  status: s.string("The event status, such as 揽收, 在途, or 已签收."),
+  context: s.string("The event description."),
+});
+
+const queryTraceOutputSchema = s.object(
+  "The Kuaidi100 logistics trajectory for a tracking number.",
+  {
+    kuaidiCom: s.string("The Kuaidi100 carrier code handling the shipment."),
+    kuaidiName: s.string("The carrier display name."),
+    kuaidiNum: s.string("The queried tracking number."),
+    state: s.string("The current shipment state, such as 在途 (in transit) or 已签收 (delivered)."),
+    fromTo: s.string("The shipment route in origin -> destination form."),
+    data: s.array("The logistics trajectory events.", trajectoryEventSchema),
+    tips: tipsSchema,
+  },
+  { optional: ["tips"] },
+);
+
+const autoNumberOutputSchema = s.object(
+  "The carriers that could own the tracking number.",
+  {
+    companies: s.array(
+      "The candidate carriers for the tracking number.",
+      s.object("One candidate carrier.", {
+        comCode: s.string("The Kuaidi100 carrier code."),
+        name: s.string("The carrier display name."),
+        lengthPre: s.string("The tracking number length the carrier uses."),
+      }),
+    ),
+    tips: tipsSchema,
+  },
+  { optional: ["tips"] },
+);
+
+const estimateTimeOutputSchema = s.object(
+  "The Kuaidi100 delivery time estimate.",
+  {
+    fromName: s.string("The normalized origin name."),
+    toName: s.string("The normalized destination name."),
+    orderTime: s.string("The order time the estimate is based on."),
+    arrivalTime: s.string("The estimated arrival time in yyyy-MM-dd HH:mm:ss format."),
+    deliveryExpendTime: s.string("The estimated total transit duration in days."),
+    remainTime: s.nullableInteger("The remaining transit time in hours, or null when it does not apply."),
+    expType: s.nullableString("The business or product type the estimate used."),
+    tips: tipsSchema,
+  },
+  { optional: ["tips"] },
+);
+
+const estimatePriceOutputSchema = s.object(
+  "The Kuaidi100 shipping price estimate.",
+  {
+    kuaidicom: s.string("The Kuaidi100 carrier code."),
+    kuaidiName: s.string("The carrier display name."),
+    from: s.string("The normalized sender address."),
+    to: s.string("The normalized recipient address."),
+    weight: s.string("The parcel weight in kilograms the estimate used."),
+    combos: s.array(
+      "The per-product price estimates.",
+      s.object("One product price estimate.", {
+        expType: s.string("The business or product type."),
+        price: s.string("The estimated shipping price in CNY."),
+        productName: s.nullableString("The product name when the carrier distinguishes products."),
+      }),
+    ),
+    tips: tipsSchema,
+  },
+  { optional: ["tips"] },
+);
+
+const estimateTimeInputProperties = {
+  kuaidi_com: timeEstimateCarrierSchema,
+  from_loc: s.nonEmptyString("The origin address, for example 广东省深圳市南山区."),
+  to_loc: s.nonEmptyString("The destination address, for example 北京市海淀区."),
+  order_time: orderTimeSchema,
+  exp_type: expTypeSchema,
+};
+
+export const kuaidi100Actions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "query_trace",
+    description:
+      "Query the real-time logistics trajectory for an express tracking number. The carrier is detected automatically.",
+    requiredScopes: [],
+    inputSchema: s.object(
+      "The tracking number whose trajectory should be queried.",
+      {
+        kuaidi_num: trackingNumberSchema,
+        phone: s.nonEmptyString(
+          "The sender or recipient phone number; required only for SF Express (顺丰) and ZTO (中通) shipments.",
+        ),
+      },
+      { optional: ["phone"] },
+    ),
+    outputSchema: queryTraceOutputSchema,
+    followUpActions: ["kuaidi100.estimate_time_with_logistic"],
+  }),
+  defineProviderAction(service, {
+    name: "auto_number",
+    description: "Detect the likely express carriers for a tracking number from its format.",
+    requiredScopes: [],
+    inputSchema: s.object("The tracking number to identify.", {
+      kuaidi_num: trackingNumberSchema,
+    }),
+    outputSchema: autoNumberOutputSchema,
+    followUpActions: ["kuaidi100.query_trace"],
+  }),
+  defineProviderAction(service, {
+    name: "estimate_time",
+    description:
+      "Estimate the delivery time for a shipment before it is sent, from the carrier, origin, destination, and optional order time and product type.",
+    requiredScopes: [],
+    inputSchema: s.object("The shipment whose delivery time should be estimated.", estimateTimeInputProperties, {
+      optional: ["order_time", "exp_type"],
+    }),
+    outputSchema: estimateTimeOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "estimate_time_with_logistic",
+    description:
+      "Estimate the remaining delivery time for an in-transit shipment from its existing logistics trajectory, usually the data returned by kuaidi100.query_trace.",
+    requiredScopes: [],
+    inputSchema: s.object(
+      "The in-transit shipment whose arrival time should be estimated.",
+      {
+        ...estimateTimeInputProperties,
+        logistic: s.array(
+          "The historical logistics trajectory events, usually the data returned by kuaidi100.query_trace.",
+          trajectoryEventSchema,
+          {
+            minItems: 1,
+          },
+        ),
+      },
+      { optional: ["order_time", "exp_type"] },
+    ),
+    outputSchema: estimateTimeOutputSchema,
+  }),
+  defineProviderAction(service, {
+    name: "estimate_price",
+    description: "Estimate the shipping price for a carrier, sender and recipient addresses, and parcel weight.",
+    requiredScopes: [],
+    inputSchema: s.object("The shipment whose price should be estimated.", {
+      kuaidi_com: priceEstimateCarrierSchema,
+      send_addr: s.nonEmptyString("The sender address, for example 北京市海淀区."),
+      rec_addr: s.nonEmptyString("The recipient address, for example 广东省深圳市南山区."),
+      weight: s.number("The parcel weight in kilograms.", { exclusiveMinimum: 0 }),
+    }),
+    outputSchema: estimatePriceOutputSchema,
+  }),
+];

--- a/src/providers/kuaidi100/actions.ts
+++ b/src/providers/kuaidi100/actions.ts
@@ -48,11 +48,21 @@ const expTypeSchema = s.nonEmptyString("The carrier business or product type, su
 
 const tipsSchema = s.string("An upstream notice, present when the call consumed the Kuaidi100 free daily quota.");
 
-const trajectoryEventSchema = s.object("One logistics trajectory event.", {
+const trajectoryEventSchema = s.requiredObject("One logistics trajectory event.", {
   time: s.string("The event time in yyyy-MM-dd HH:mm:ss format."),
   status: s.string("The event status, such as 揽收, 在途, or 已签收."),
   context: s.string("The event description."),
 });
+
+const logisticEventSchema = s.object(
+  "One historical logistics trajectory event.",
+  {
+    time: s.string("The event time in yyyy-MM-dd HH:mm:ss format."),
+    context: s.string("The event description."),
+    status: s.string("The event status, such as 揽收, 在途, or 已签收."),
+  },
+  { optional: ["status"] },
+);
 
 const queryTraceOutputSchema = s.object(
   "The Kuaidi100 logistics trajectory for a tracking number.",
@@ -73,7 +83,7 @@ const autoNumberOutputSchema = s.object(
   {
     companies: s.array(
       "The candidate carriers for the tracking number.",
-      s.object("One candidate carrier.", {
+      s.requiredObject("One candidate carrier.", {
         comCode: s.string("The Kuaidi100 carrier code."),
         name: s.string("The carrier display name."),
         lengthPre: s.string("The tracking number length the carrier uses."),
@@ -109,7 +119,7 @@ const estimatePriceOutputSchema = s.object(
     weight: s.string("The parcel weight in kilograms the estimate used."),
     combos: s.array(
       "The per-product price estimates.",
-      s.object("One product price estimate.", {
+      s.requiredObject("One product price estimate.", {
         expType: s.string("The business or product type."),
         price: s.string("The estimated shipping price in CNY."),
         productName: s.nullableString("The product name when the carrier distinguishes products."),
@@ -139,7 +149,7 @@ export const kuaidi100Actions: ActionDefinition[] = [
       {
         kuaidi_num: trackingNumberSchema,
         phone: s.nonEmptyString(
-          "The sender or recipient phone number; required only for SF Express (顺丰) and ZTO (中通) shipments.",
+          "The sender or recipient phone number; required only for SF Express (顺丰), SF Freight (顺丰快运), and ZTO (中通) shipments.",
         ),
       },
       { optional: ["phone"] },
@@ -151,7 +161,7 @@ export const kuaidi100Actions: ActionDefinition[] = [
     name: "auto_number",
     description: "Detect the likely express carriers for a tracking number from its format.",
     requiredScopes: [],
-    inputSchema: s.object("The tracking number to identify.", {
+    inputSchema: s.requiredObject("The tracking number to identify.", {
       kuaidi_num: trackingNumberSchema,
     }),
     outputSchema: autoNumberOutputSchema,
@@ -178,7 +188,7 @@ export const kuaidi100Actions: ActionDefinition[] = [
         ...estimateTimeInputProperties,
         logistic: s.array(
           "The historical logistics trajectory events, usually the data returned by kuaidi100.query_trace.",
-          trajectoryEventSchema,
+          logisticEventSchema,
           {
             minItems: 1,
           },
@@ -192,7 +202,7 @@ export const kuaidi100Actions: ActionDefinition[] = [
     name: "estimate_price",
     description: "Estimate the shipping price for a carrier, sender and recipient addresses, and parcel weight.",
     requiredScopes: [],
-    inputSchema: s.object("The shipment whose price should be estimated.", {
+    inputSchema: s.requiredObject("The shipment whose price should be estimated.", {
       kuaidi_com: priceEstimateCarrierSchema,
       send_addr: s.nonEmptyString("The sender address, for example 北京市海淀区."),
       rec_addr: s.nonEmptyString("The recipient address, for example 广东省深圳市南山区."),

--- a/src/providers/kuaidi100/definition.ts
+++ b/src/providers/kuaidi100/definition.ts
@@ -1,0 +1,23 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { kuaidi100Actions } from "./actions.ts";
+
+const service = "kuaidi100";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "Kuaidi100",
+  categories: ["Productivity", "Location"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "KUAIDI100_API_KEY",
+      description:
+        "Kuaidi100 (快递100) authorization key sent as the key query parameter. Find it in the Kuaidi100 API console under 授权参数: https://api.kuaidi100.com/manager/v2/query/overview.",
+    },
+  ],
+  homepageUrl: "https://api.kuaidi100.com/product/mcp",
+  actions: kuaidi100Actions,
+};

--- a/src/providers/kuaidi100/executors.ts
+++ b/src/providers/kuaidi100/executors.ts
@@ -1,0 +1,23 @@
+import type { CredentialValidators, ProviderExecutors, ProviderProxyExecutor } from "../../core/types.ts";
+
+import { defineApiKeyProviderExecutors, defineProviderProxy } from "../provider-runtime.ts";
+import { kuaidi100ActionHandlers, kuaidi100ApiBaseUrl, validateKuaidi100Credential } from "./runtime.ts";
+
+const service = "kuaidi100";
+
+export const executors: ProviderExecutors = defineApiKeyProviderExecutors(service, kuaidi100ActionHandlers, {
+  skipDnsValidation: true,
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: kuaidi100ApiBaseUrl,
+  auth: { type: "api_key_query", name: "key" },
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async apiKey(input, { fetcher, signal }) {
+    return validateKuaidi100Credential(input.apiKey, fetcher, signal);
+  },
+};

--- a/src/providers/kuaidi100/runtime.test.ts
+++ b/src/providers/kuaidi100/runtime.test.ts
@@ -37,7 +37,6 @@ describe("Kuaidi100 provider runtime", () => {
       state: "已签收",
       fromTo: "广东省深圳市南山区 -> 北京市海淀区",
       data: [{ time: "2026-09-01 12:43:35", status: "揽收", context: "快件已揽收" }],
-      tips: undefined,
     });
   });
 
@@ -77,6 +76,67 @@ describe("Kuaidi100 provider runtime", () => {
     expect(output).toMatchObject({ arrivalTime: "2026-09-03 16:00:00", remainTime: null, expType: null });
   });
 
+  it("omits the status key of a trajectory event that carries no status", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      const logistic = JSON.parse(url.searchParams.get("logistic")!) as Array<Record<string, string>>;
+      expect(logistic).toEqual([
+        { time: "2026-09-01 12:43:35", context: "快件已揽收" },
+        { time: "2026-09-02 08:48:27", context: "运输中", status: "在途" },
+      ]);
+      expect(Object.keys(logistic[0]!)).toEqual(["time", "context"]);
+      return Response.json({
+        fromName: "广东深圳市南山区",
+        toName: "北京朝阳区",
+        orderTime: "2026-09-01 08:08:08",
+        arrivalTime: "2026-09-03 16:00:00",
+        deliveryExpendTime: "2",
+        remainTime: null,
+        expType: null,
+      });
+    });
+
+    const output = await kuaidi100ActionHandlers.estimate_time_with_logistic(
+      {
+        kuaidi_com: "yuantong",
+        from_loc: "广东省深圳市南山区",
+        to_loc: "北京市海淀区",
+        logistic: [
+          { time: "2026-09-01 12:43:35", context: "快件已揽收" },
+          { time: "2026-09-02 08:48:27", context: "运输中", status: "在途" },
+        ],
+      },
+      context(fetcher),
+    );
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(output).toMatchObject({ arrivalTime: "2026-09-03 16:00:00" });
+  });
+
+  it("keeps a non-null remainTime as an integer for numeric and string upstream values", async () => {
+    const estimate = (remainTime: unknown) =>
+      vi.fn<typeof fetch>(async () =>
+        Response.json({
+          fromName: "广东深圳市南山区",
+          toName: "北京朝阳区",
+          orderTime: "2026-09-01 08:08:08",
+          arrivalTime: "2026-09-03 16:00:00",
+          deliveryExpendTime: "2",
+          remainTime,
+          expType: "标准快递",
+        }),
+      );
+    const input = { kuaidi_com: "yuantong", from_loc: "广东省深圳市南山区", to_loc: "北京市海淀区" };
+
+    await expect(kuaidi100ActionHandlers.estimate_time(input, context(estimate(57)))).resolves.toMatchObject({
+      remainTime: 57,
+      expType: "标准快递",
+    });
+    await expect(kuaidi100ActionHandlers.estimate_time(input, context(estimate("12")))).resolves.toMatchObject({
+      remainTime: 12,
+    });
+  });
+
   it("maps an embedded 401 envelope to 401 when executing", async () => {
     const fetcher = vi.fn<typeof fetch>(async () =>
       Response.json({ code: "401", message: "用户鉴权失败", result: false }),
@@ -108,6 +168,35 @@ describe("Kuaidi100 provider runtime", () => {
     ).rejects.toMatchObject({ status: 502, message: "预估价格|快递公司参数异常：未查到指定快递公司" });
   });
 
+  it("maps a numeric envelope code the same way as a string one", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ code: 400, message: "快递单号不能为空", result: false }),
+    );
+
+    await expect(kuaidi100ActionHandlers.query_trace({ kuaidi_num: "x" }, context(fetcher))).rejects.toMatchObject({
+      status: 400,
+      message: "快递单号不能为空",
+    });
+  });
+
+  it("maps non-2xx responses without echoing the upstream body", async () => {
+    const gateway = vi.fn<typeof fetch>(
+      async () =>
+        new Response("<html>502 Bad Gateway</html>", { status: 502, headers: { "content-type": "text/html" } }),
+    );
+    const error = (await kuaidi100ActionHandlers
+      .auto_number({ kuaidi_num: "123" }, context(gateway))
+      .catch((reason: unknown) => reason)) as Error & { status: number };
+    expect(error.status).toBe(502);
+    expect(error.message).not.toContain("html");
+
+    const throttled = vi.fn<typeof fetch>(async () => Response.json({ message: "too many requests" }, { status: 429 }));
+    await expect(kuaidi100ActionHandlers.auto_number({ kuaidi_num: "123" }, context(throttled))).rejects.toMatchObject({
+      status: 429,
+      message: "too many requests",
+    });
+  });
+
   it("maps an embedded 401 envelope to 400 when validating a credential", async () => {
     const fetcher = vi.fn<typeof fetch>(async () =>
       Response.json({ code: "401", message: "用户鉴权失败", result: false }),
@@ -117,6 +206,12 @@ describe("Kuaidi100 provider runtime", () => {
       status: 400,
       message: "用户鉴权失败",
     });
+  });
+
+  it("maps a bare HTTP 401 to 400 when validating a credential", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => new Response("", { status: 401 }));
+
+    await expect(validateKuaidi100Credential("bad-key", fetcher)).rejects.toMatchObject({ status: 400 });
   });
 
   it("validates a credential through the autoNumber endpoint", async () => {

--- a/src/providers/kuaidi100/runtime.test.ts
+++ b/src/providers/kuaidi100/runtime.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { kuaidi100ActionHandlers, kuaidi100ApiBaseUrl, validateKuaidi100Credential } from "./runtime.ts";
+
+const context = (fetcher: typeof fetch) => ({ apiKey: "test-key", fetcher });
+
+describe("Kuaidi100 provider runtime", () => {
+  it("queries a trajectory with the key and JSON format query parameters", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.origin + url.pathname).toBe(`${kuaidi100ApiBaseUrl}/queryTrace`);
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        kuaidiNum: "YT0000000000000",
+        phone: "13800138000",
+        key: "test-key",
+        responseFormat: "json",
+      });
+      return Response.json({
+        kuaidiCom: "yuantong",
+        kuaidiName: "圆通速递",
+        kuaidiNum: "YT0000000000000",
+        state: "已签收",
+        fromTo: "广东省深圳市南山区 -> 北京市海淀区",
+        data: [{ time: "2026-09-01 12:43:35", status: "揽收", context: "快件已揽收" }],
+      });
+    });
+
+    const output = await kuaidi100ActionHandlers.query_trace(
+      { kuaidi_num: "YT0000000000000", phone: "13800138000" },
+      context(fetcher),
+    );
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(output).toEqual({
+      kuaidiCom: "yuantong",
+      kuaidiName: "圆通速递",
+      kuaidiNum: "YT0000000000000",
+      state: "已签收",
+      fromTo: "广东省深圳市南山区 -> 北京市海淀区",
+      data: [{ time: "2026-09-01 12:43:35", status: "揽收", context: "快件已揽收" }],
+      tips: undefined,
+    });
+  });
+
+  it("encodes in-transit trajectory events as the logistic JSON parameter", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/stdio/estimateTimeWithLogistic");
+      expect(JSON.parse(url.searchParams.get("logistic")!)).toEqual([
+        { time: "2026-09-01 12:43:35", context: "快件已揽收", status: "揽收" },
+        { time: "2026-09-02 08:48:27", context: "运输中", status: "在途" },
+      ]);
+      return Response.json({
+        fromName: "广东深圳市南山区",
+        toName: "北京朝阳区",
+        orderTime: "2026-09-01 08:08:08",
+        arrivalTime: "2026-09-03 16:00:00",
+        deliveryExpendTime: "2",
+        remainTime: null,
+        expType: null,
+      });
+    });
+
+    const output = await kuaidi100ActionHandlers.estimate_time_with_logistic(
+      {
+        kuaidi_com: "yuantong",
+        from_loc: "广东省深圳市南山区",
+        to_loc: "北京市海淀区",
+        order_time: "2026-09-01 08:08:08",
+        logistic: [
+          { time: "2026-09-01 12:43:35", context: "快件已揽收", status: "揽收" },
+          { time: "2026-09-02 08:48:27", context: "运输中", status: "在途" },
+        ],
+      },
+      context(fetcher),
+    );
+
+    expect(output).toMatchObject({ arrivalTime: "2026-09-03 16:00:00", remainTime: null, expType: null });
+  });
+
+  it("maps an embedded 401 envelope to 401 when executing", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ code: "401", message: "用户鉴权失败", result: false }),
+    );
+
+    await expect(kuaidi100ActionHandlers.auto_number({ kuaidi_num: "123" }, context(fetcher))).rejects.toMatchObject({
+      status: 401,
+      message: "用户鉴权失败",
+    });
+  });
+
+  it("maps embedded 400 and 500 envelopes to input and provider errors", async () => {
+    const badInput = vi.fn<typeof fetch>(async () =>
+      Response.json({ code: "400", message: "快递单号不能为空", result: false }),
+    );
+    await expect(kuaidi100ActionHandlers.query_trace({ kuaidi_num: "x" }, context(badInput))).rejects.toMatchObject({
+      status: 400,
+      message: "快递单号不能为空",
+    });
+
+    const upstream = vi.fn<typeof fetch>(async () =>
+      Response.json({ code: "500", message: "预估价格|快递公司参数异常：未查到指定快递公司", result: false }),
+    );
+    await expect(
+      kuaidi100ActionHandlers.estimate_price(
+        { kuaidi_com: "yuantong", send_addr: "北京市海淀区", rec_addr: "广东省深圳市南山区", weight: 1 },
+        context(upstream),
+      ),
+    ).rejects.toMatchObject({ status: 502, message: "预估价格|快递公司参数异常：未查到指定快递公司" });
+  });
+
+  it("maps an embedded 401 envelope to 400 when validating a credential", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ code: "401", message: "用户鉴权失败", result: false }),
+    );
+
+    await expect(validateKuaidi100Credential("bad-key", fetcher)).rejects.toMatchObject({
+      status: 400,
+      message: "用户鉴权失败",
+    });
+  });
+
+  it("validates a credential through the autoNumber endpoint", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (request) => {
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/stdio/autoNumber");
+      expect(url.searchParams.get("key")).toBe("good-key");
+      return Response.json({ data: [{ comCode: "shunfeng", lengthPre: "15", name: "顺丰速运" }] });
+    });
+
+    const result = await validateKuaidi100Credential("good-key", fetcher);
+
+    expect(result.profile?.displayName).toBe("Kuaidi100 API Key");
+    expect(result.metadata?.apiBaseUrl).toBe(kuaidi100ApiBaseUrl);
+  });
+});

--- a/src/providers/kuaidi100/runtime.ts
+++ b/src/providers/kuaidi100/runtime.ts
@@ -1,0 +1,228 @@
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type {
+  ApiKeyProviderContext,
+  ProviderActionHandlers,
+  ProviderFetch,
+  ProviderRuntimeHandler,
+} from "../provider-runtime.ts";
+
+import {
+  nullableInteger,
+  nullableString,
+  objectArray,
+  optionalNumberLike,
+  optionalString,
+  requiredString,
+} from "../../core/cast.ts";
+import {
+  ProviderRequestError,
+  providerInputError,
+  providerResponseError,
+  providerUserAgent,
+  readProviderJson,
+  requiredInputString,
+  requiredResponseRecord,
+  runProviderRequest,
+  setSearchParams,
+} from "../provider-runtime.ts";
+
+export const kuaidi100ApiBaseUrl = "https://api.kuaidi100.com/stdio";
+
+const kuaidi100ValidationMethod = "autoNumber";
+
+type Kuaidi100Phase = "validate" | "execute";
+type Kuaidi100ActionHandler = ProviderRuntimeHandler<ApiKeyProviderContext>;
+type Kuaidi100Query = Record<string, string | undefined>;
+
+export const kuaidi100ActionHandlers: ProviderActionHandlers<"kuaidi100", Kuaidi100ActionHandler> = {
+  async query_trace(input, context) {
+    const payload = await requestKuaidi100(
+      "queryTrace",
+      {
+        kuaidiNum: requiredInputString(input.kuaidi_num, "kuaidi_num"),
+        phone: optionalString(input.phone),
+      },
+      context,
+      "execute",
+    );
+    return normalizeQueryTrace(payload);
+  },
+  async auto_number(input, context) {
+    const payload = await requestKuaidi100(
+      "autoNumber",
+      { kuaidiNum: requiredInputString(input.kuaidi_num, "kuaidi_num") },
+      context,
+      "execute",
+    );
+    return normalizeAutoNumber(payload);
+  },
+  async estimate_time(input, context) {
+    const payload = await requestKuaidi100("estimateTime", readEstimateTimeQuery(input), context, "execute");
+    return normalizeEstimateTime(payload);
+  },
+  async estimate_time_with_logistic(input, context) {
+    const payload = await requestKuaidi100(
+      "estimateTimeWithLogistic",
+      { ...readEstimateTimeQuery(input), logistic: JSON.stringify(readLogisticEvents(input.logistic)) },
+      context,
+      "execute",
+    );
+    return normalizeEstimateTime(payload);
+  },
+  async estimate_price(input, context) {
+    const payload = await requestKuaidi100(
+      "estimatePrice",
+      {
+        kuaidicom: requiredInputString(input.kuaidi_com, "kuaidi_com"),
+        sendAddr: requiredInputString(input.send_addr, "send_addr"),
+        recAddr: requiredInputString(input.rec_addr, "rec_addr"),
+        weight: readWeight(input.weight),
+      },
+      context,
+      "execute",
+    );
+    return normalizeEstimatePrice(payload);
+  },
+};
+
+export async function validateKuaidi100Credential(
+  apiKey: string,
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  await requestKuaidi100(
+    kuaidi100ValidationMethod,
+    { kuaidiNum: "SF1234567890123" },
+    { apiKey, fetcher, signal },
+    "validate",
+  );
+
+  return {
+    profile: { displayName: "Kuaidi100 API Key" },
+    grantedScopes: [],
+    metadata: {
+      apiBaseUrl: kuaidi100ApiBaseUrl,
+      validationEndpoint: `/${kuaidi100ValidationMethod}`,
+    },
+  };
+}
+
+async function requestKuaidi100(
+  apiMethod: string,
+  query: Kuaidi100Query,
+  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
+  phase: Kuaidi100Phase,
+): Promise<Record<string, unknown>> {
+  return runProviderRequest({ signal: context.signal, label: "Kuaidi100" }, async (signal) => {
+    const url = new URL(`${kuaidi100ApiBaseUrl}/${apiMethod}`);
+    setSearchParams(url, { ...query, key: context.apiKey, responseFormat: "json" });
+    const response = await context.fetcher(url, {
+      headers: {
+        accept: "application/json",
+        "user-agent": providerUserAgent,
+      },
+      signal,
+    });
+    // Kuaidi100 answers business errors with HTTP 200 and a { code, message, result: false } envelope.
+    return assertKuaidi100Success(await readProviderJson<unknown>(response, "Kuaidi100"), phase);
+  });
+}
+
+function assertKuaidi100Success(payload: unknown, phase: Kuaidi100Phase): Record<string, unknown> {
+  const record = requiredResponseRecord(payload, "Kuaidi100 response");
+  const code = optionalString(record.code);
+  if (code === undefined && record.result !== false) {
+    return record;
+  }
+
+  const message = optionalString(record.message) ?? "Kuaidi100 request failed";
+  if (code === "401" || code === "403") {
+    throw new ProviderRequestError(phase === "validate" ? 400 : Number(code), message);
+  }
+  if (code === "400" || code === "429") {
+    throw new ProviderRequestError(Number(code), message);
+  }
+  throw providerResponseError(message);
+}
+
+function readEstimateTimeQuery(input: Record<string, unknown>): Kuaidi100Query {
+  return {
+    kuaidicom: requiredInputString(input.kuaidi_com, "kuaidi_com"),
+    from: requiredInputString(input.from_loc, "from_loc"),
+    to: requiredInputString(input.to_loc, "to_loc"),
+    orderTime: optionalString(input.order_time),
+    expType: optionalString(input.exp_type),
+  };
+}
+
+function readWeight(value: unknown): string {
+  const weight = optionalNumberLike(value);
+  if (weight === undefined || weight <= 0) {
+    throw providerInputError("weight must be a positive number.");
+  }
+  return String(weight);
+}
+
+function readLogisticEvents(value: unknown): Array<Record<string, string>> {
+  return objectArray(value, "logistic", providerInputError).map((event, index) => ({
+    time: requiredInputString(event.time, `logistic[${index}].time`),
+    context: requiredInputString(event.context, `logistic[${index}].context`),
+    status: requiredInputString(event.status, `logistic[${index}].status`),
+  }));
+}
+
+function normalizeQueryTrace(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    kuaidiCom: requiredString(payload.kuaidiCom, "kuaidiCom", providerResponseError),
+    kuaidiName: requiredString(payload.kuaidiName, "kuaidiName", providerResponseError),
+    kuaidiNum: requiredString(payload.kuaidiNum, "kuaidiNum", providerResponseError),
+    state: requiredString(payload.state, "state", providerResponseError),
+    fromTo: requiredString(payload.fromTo, "fromTo", providerResponseError),
+    data: objectArray(payload.data, "data", providerResponseError).map((event, index) => ({
+      time: requiredString(event.time, `data[${index}].time`, providerResponseError),
+      status: requiredString(event.status, `data[${index}].status`, providerResponseError),
+      context: requiredString(event.context, `data[${index}].context`, providerResponseError),
+    })),
+    tips: optionalString(payload.tips),
+  };
+}
+
+function normalizeAutoNumber(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    companies: objectArray(payload.data, "data", providerResponseError).map((company, index) => ({
+      comCode: requiredString(company.comCode, `data[${index}].comCode`, providerResponseError),
+      name: requiredString(company.name, `data[${index}].name`, providerResponseError),
+      lengthPre: requiredString(company.lengthPre, `data[${index}].lengthPre`, providerResponseError),
+    })),
+    tips: optionalString(payload.tips),
+  };
+}
+
+function normalizeEstimateTime(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    fromName: requiredString(payload.fromName, "fromName", providerResponseError),
+    toName: requiredString(payload.toName, "toName", providerResponseError),
+    orderTime: requiredString(payload.orderTime, "orderTime", providerResponseError),
+    arrivalTime: requiredString(payload.arrivalTime, "arrivalTime", providerResponseError),
+    deliveryExpendTime: requiredString(payload.deliveryExpendTime, "deliveryExpendTime", providerResponseError),
+    remainTime: nullableInteger(payload.remainTime) ?? null,
+    expType: nullableString(payload.expType) ?? null,
+    tips: optionalString(payload.tips),
+  };
+}
+
+function normalizeEstimatePrice(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    kuaidicom: requiredString(payload.kuaidicom, "kuaidicom", providerResponseError),
+    kuaidiName: requiredString(payload.kuaidiName, "kuaidiName", providerResponseError),
+    from: requiredString(payload.from, "from", providerResponseError),
+    to: requiredString(payload.to, "to", providerResponseError),
+    weight: requiredString(payload.weight, "weight", providerResponseError),
+    combos: objectArray(payload.combos, "combos", providerResponseError).map((combo, index) => ({
+      expType: requiredString(combo.expType, `combos[${index}].expType`, providerResponseError),
+      price: requiredString(combo.price, `combos[${index}].price`, providerResponseError),
+      productName: nullableString(combo.productName) ?? null,
+    })),
+    tips: optionalString(payload.tips),
+  };
+}

--- a/src/providers/kuaidi100/runtime.ts
+++ b/src/providers/kuaidi100/runtime.ts
@@ -7,11 +7,13 @@ import type {
 } from "../provider-runtime.ts";
 
 import {
-  nullableInteger,
-  nullableString,
   objectArray,
+  optionalIntegerOrNull,
   optionalNumberLike,
+  optionalRecord,
+  optionalScalarString,
   optionalString,
+  optionalStringOrNull,
   requiredString,
 } from "../../core/cast.ts";
 import {
@@ -19,7 +21,7 @@ import {
   providerInputError,
   providerResponseError,
   providerUserAgent,
-  readProviderJson,
+  readProviderJsonBody,
   requiredInputString,
   requiredResponseRecord,
   runProviderRequest,
@@ -123,24 +125,33 @@ async function requestKuaidi100(
       },
       signal,
     });
+    const payload = await readProviderJsonBody(response, {
+      emptyBody: {},
+      invalidJsonMessage: "Kuaidi100 returned an invalid JSON response",
+    });
+    const record = optionalRecord(payload);
     // Kuaidi100 answers business errors with HTTP 200 and a { code, message, result: false } envelope.
-    return assertKuaidi100Success(await readProviderJson<unknown>(response, "Kuaidi100"), phase);
+    const code = optionalScalarString(record?.code);
+    if (code !== undefined || record?.result === false) {
+      throwKuaidi100Error(Number(code), optionalString(record?.message) ?? "Kuaidi100 request failed", phase);
+    }
+    if (!response.ok) {
+      throwKuaidi100Error(
+        response.status,
+        optionalString(record?.message) ?? `Kuaidi100 request failed with HTTP ${response.status}`,
+        phase,
+      );
+    }
+    return requiredResponseRecord(payload, "Kuaidi100 response");
   });
 }
 
-function assertKuaidi100Success(payload: unknown, phase: Kuaidi100Phase): Record<string, unknown> {
-  const record = requiredResponseRecord(payload, "Kuaidi100 response");
-  const code = optionalString(record.code);
-  if (code === undefined && record.result !== false) {
-    return record;
+function throwKuaidi100Error(status: number, message: string, phase: Kuaidi100Phase): never {
+  if (status === 400 || status === 429) {
+    throw new ProviderRequestError(status, message);
   }
-
-  const message = optionalString(record.message) ?? "Kuaidi100 request failed";
-  if (code === "401" || code === "403") {
-    throw new ProviderRequestError(phase === "validate" ? 400 : Number(code), message);
-  }
-  if (code === "400" || code === "429") {
-    throw new ProviderRequestError(Number(code), message);
+  if (status === 401 || status === 403) {
+    throw new ProviderRequestError(phase === "validate" ? 400 : status, message);
   }
   throw providerResponseError(message);
 }
@@ -163,11 +174,12 @@ function readWeight(value: unknown): string {
   return String(weight);
 }
 
-function readLogisticEvents(value: unknown): Array<Record<string, string>> {
+// `status` is optional upstream; JSON.stringify drops it from the serialized event when absent.
+function readLogisticEvents(value: unknown): Array<Record<string, string | undefined>> {
   return objectArray(value, "logistic", providerInputError).map((event, index) => ({
     time: requiredInputString(event.time, `logistic[${index}].time`),
     context: requiredInputString(event.context, `logistic[${index}].context`),
-    status: requiredInputString(event.status, `logistic[${index}].status`),
+    status: optionalString(event.status),
   }));
 }
 
@@ -205,8 +217,8 @@ function normalizeEstimateTime(payload: Record<string, unknown>): Record<string,
     orderTime: requiredString(payload.orderTime, "orderTime", providerResponseError),
     arrivalTime: requiredString(payload.arrivalTime, "arrivalTime", providerResponseError),
     deliveryExpendTime: requiredString(payload.deliveryExpendTime, "deliveryExpendTime", providerResponseError),
-    remainTime: nullableInteger(payload.remainTime) ?? null,
-    expType: nullableString(payload.expType) ?? null,
+    remainTime: optionalIntegerOrNull(payload.remainTime),
+    expType: optionalStringOrNull(payload.expType),
     tips: optionalString(payload.tips),
   };
 }
@@ -221,7 +233,7 @@ function normalizeEstimatePrice(payload: Record<string, unknown>): Record<string
     combos: objectArray(payload.combos, "combos", providerResponseError).map((combo, index) => ({
       expType: requiredString(combo.expType, `combos[${index}].expType`, providerResponseError),
       price: requiredString(combo.price, `combos[${index}].price`, providerResponseError),
-      productName: nullableString(combo.productName) ?? null,
+      productName: optionalStringOrNull(combo.productName),
     })),
     tips: optionalString(payload.tips),
   };


### PR DESCRIPTION
Add the [Kuaidi100 (快递100) MCP API](https://api.kuaidi100.com/product/mcp) as a provider, calling its `https://api.kuaidi100.com/stdio/<method>` HTTP JSON endpoints with the API key sent as the `key` query parameter.

Actions (all locally executable):

- `query_trace` — real-time logistics trajectory for a tracking number
- `auto_number` — detect likely carriers from the number format
- `estimate_time` — pre-shipment delivery time estimate
- `estimate_time_with_logistic` — in-transit arrival estimate from an existing trajectory
- `estimate_price` — shipping price estimate

Also includes the `key`-query proxy, credential validation via `autoNumber`, and runtime tests for the HTTP-200 `{code, message, result:false}` error envelope mapping. Parameter names, response shapes, and error envelopes were verified against the live API and the official reference implementation (https://github.com/kuaidi100-api/kuaidi100-MCP).

## Verification

- `npm run fix-check`, `npm test` (1797 tests)
- Live audit of all 5 endpoints: params accepted, response keys match, error envelopes mapped