### PR TITLE
feat(app_store_connect): add App Store Connect provider

### DIFF
--- a/examples/local-http/README.md
+++ b/examples/local-http/README.md
@@ -29,6 +29,16 @@ first.
 NOTION_TOKEN=secret_... node examples/local-http/notion.ts
 ```
 
+Run App Store Connect with an API key created in App Store Connect. Pass the `.p8` file by path, or
+inline its PEM contents. Omit `APP_STORE_CONNECT_ISSUER_ID` when you use an Individual API Key.
+
+```bash
+APP_STORE_CONNECT_KEY_ID=2X9R4HXF34 \
+APP_STORE_CONNECT_ISSUER_ID=57246542-96fe-1a63-e053-0824d011072a \
+APP_STORE_CONNECT_PRIVATE_KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_2X9R4HXF34.p8 \
+node examples/local-http/app_store_connect.ts
+```
+
 Prepare Gmail OAuth with your own Google OAuth app:
 
 ```bash

--- a/examples/local-http/README.md
+++ b/examples/local-http/README.md
@@ -29,8 +29,10 @@ first.
 NOTION_TOKEN=secret_... node examples/local-http/notion.ts
 ```
 
-Run App Store Connect with an API key created in App Store Connect. Pass the `.p8` file by path, or
-inline its PEM contents. Omit `APP_STORE_CONNECT_ISSUER_ID` when you use an Individual API Key.
+Run App Store Connect with an API key created in App Store Connect. Pass the `.p8` file through
+`APP_STORE_CONNECT_PRIVATE_KEY_PATH`, or inline its PEM contents through
+`APP_STORE_CONNECT_PRIVATE_KEY`. Omit `APP_STORE_CONNECT_ISSUER_ID` when you use an Individual API
+Key.
 
 ```bash
 APP_STORE_CONNECT_KEY_ID=2X9R4HXF34 \

--- a/examples/local-http/app_store_connect.ts
+++ b/examples/local-http/app_store_connect.ts
@@ -1,0 +1,57 @@
+// App Store Connect API docs: https://developer.apple.com/documentation/appstoreconnectapi
+// Create a key under Users and Access > Integrations > App Store Connect API, or generate an
+// Individual API Key from your user profile and leave APP_STORE_CONNECT_ISSUER_ID unset.
+
+import { readFileSync } from "node:fs";
+import { adminHeaders, fetchJson, runtimeHeaders } from "./client.ts";
+
+interface ActionResult<T> {
+  data: T;
+}
+
+const keyId = process.env.APP_STORE_CONNECT_KEY_ID;
+const issuerId = process.env.APP_STORE_CONNECT_ISSUER_ID;
+const privateKeyPath = process.env.APP_STORE_CONNECT_PRIVATE_KEY_PATH;
+
+if (!keyId) {
+  console.log("Set APP_STORE_CONNECT_KEY_ID to run this example.");
+  process.exit(0);
+}
+
+const privateKey = privateKeyPath ? readFileSync(privateKeyPath, "utf8") : process.env.APP_STORE_CONNECT_PRIVATE_KEY;
+if (!privateKey) {
+  console.log("Set APP_STORE_CONNECT_PRIVATE_KEY or APP_STORE_CONNECT_PRIVATE_KEY_PATH to run this example.");
+  process.exit(0);
+}
+
+await fetchJson("http://localhost:3000/api/connections/app_store_connect", {
+  method: "PUT",
+  headers: adminHeaders({ "content-type": "application/json" }),
+  body: JSON.stringify({ authType: "custom_credential", values: { keyId, issuerId, privateKey } }),
+});
+
+const apps = await fetchJson<ActionResult<{ apps: Array<{ id: string; name: string | null }> }>>(
+  "http://localhost:3000/v1/actions/app_store_connect.list_apps",
+  {
+    method: "POST",
+    headers: runtimeHeaders({ "content-type": "application/json" }),
+    body: JSON.stringify({ input: { limit: 5 } }),
+  },
+);
+
+console.log(JSON.stringify(apps, null, 2));
+
+const firstApp = apps.data.apps[0];
+if (!firstApp) {
+  console.log("The key can see no apps, so there are no builds to list.");
+  process.exit(0);
+}
+
+console.log(`Listing builds for ${firstApp.name ?? firstApp.id}:`);
+const builds = await fetchJson("http://localhost:3000/v1/actions/app_store_connect.list_builds", {
+  method: "POST",
+  headers: runtimeHeaders({ "content-type": "application/json" }),
+  body: JSON.stringify({ input: { appId: firstApp.id, limit: 5, sort: "-uploadedDate" } }),
+});
+
+console.log(JSON.stringify(builds, null, 2));

--- a/src/providers/app_store_connect/actions.ts
+++ b/src/providers/app_store_connect/actions.ts
@@ -1,0 +1,856 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+import type { JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "app_store_connect";
+
+const contentPlatforms = ["IOS", "MAC_OS", "TV_OS", "VISION_OS"];
+/** Tester devices are the only records where App Store Connect reports a watchOS platform. */
+const devicePlatforms = ["IOS", "MAC_OS", "TV_OS", "WATCH_OS", "VISION_OS"];
+const buildProcessingStates = ["PROCESSING", "FAILED", "INVALID", "VALID"];
+const buildAudienceTypes = ["INTERNAL_ONLY", "APP_STORE_ELIGIBLE"];
+const betaReviewStates = ["WAITING_FOR_REVIEW", "IN_REVIEW", "REJECTED", "APPROVED"];
+const betaTesterStates = ["NOT_INVITED", "INVITED", "ACCEPTED", "INSTALLED", "REVOKED"];
+const betaInviteTypes = ["EMAIL", "PUBLIC_LINK"];
+const appStoreReviewTypes = ["APP_STORE", "NOTARIZATION"];
+const appStoreReleaseTypes = ["MANUAL", "AFTER_APPROVAL", "SCHEDULED"];
+const reviewResponseStates = ["PUBLISHED", "PENDING_PUBLISH"];
+const contentRightsDeclarations = ["DOES_NOT_USE_THIRD_PARTY_CONTENT", "USES_THIRD_PARTY_CONTENT"];
+const subscriptionStatusUrlVersions = ["V1", "V2"];
+const appVersionStates = [
+  "ACCEPTED",
+  "DEVELOPER_REJECTED",
+  "IN_REVIEW",
+  "INVALID_BINARY",
+  "METADATA_REJECTED",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "PREPARE_FOR_SUBMISSION",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_REVIEW",
+  "REJECTED",
+  "REPLACED_WITH_NEW_VERSION",
+  "WAITING_FOR_EXPORT_COMPLIANCE",
+  "WAITING_FOR_REVIEW",
+];
+const teamRoles = [
+  "ADMIN",
+  "FINANCE",
+  "ACCOUNT_HOLDER",
+  "SALES",
+  "MARKETING",
+  "APP_MANAGER",
+  "DEVELOPER",
+  "ACCESS_TO_REPORTS",
+  "CUSTOMER_SUPPORT",
+  "CREATE_APPS",
+  "CLOUD_MANAGED_DEVELOPER_ID",
+  "CLOUD_MANAGED_APP_DISTRIBUTION",
+  "GENERATE_INDIVIDUAL_KEYS",
+];
+
+// Apple's TestFlight capability for creating and editing beta groups and testers.
+const manageTestFlightRoles = ["Account Holder", "Admin", "App Manager"];
+// Apple's TestFlight capability for submitting builds to beta review and editing their test details.
+const manageTestFlightBuildsRoles = [...manageTestFlightRoles, "Developer"];
+// Apple's "View ratings and reviews" capability.
+const viewReviewsRoles = [...manageTestFlightBuildsRoles, "Marketing", "Sales", "Customer Support"];
+// Apple's "Reply to ratings and reviews" capability.
+const respondToReviewsRoles = [...manageTestFlightRoles, "Marketing", "Customer Support"];
+// Apple's Users and Access area, which only the account-wide roles can read.
+const usersAndAccessRoles = ["Account Holder", "Admin"];
+
+/** How this provider reports an attribute App Store Connect has no value for. */
+const absentAttributeNote =
+  "An attribute App Store Connect has no value for is returned as null, and older records may leave it out entirely.";
+
+const limitInput = s.integer("Maximum number of records to return on this page. App Store Connect allows up to 200.", {
+  minimum: 1,
+  maximum: 200,
+});
+const cursorInput = s.nonEmptyString(
+  "Opaque page cursor taken from the nextCursor value of a previous response for the same query.",
+);
+const nextCursorOutput = s.nullableString(
+  "Cursor to pass back as cursor for the next page, or null when this was the last page.",
+);
+const totalOutput = s.nullableInteger(
+  "Total number of records matching the query when App Store Connect reports one, otherwise null.",
+);
+
+const appResource = s.object(
+  `An app registered in App Store Connect. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the app."),
+    name: s.nullableString("App name shown on the App Store."),
+    bundleId: s.nullableString("Bundle identifier registered for the app."),
+    sku: s.nullableString("SKU chosen when the app record was created."),
+    primaryLocale: s.nullableString("Primary App Store locale, such as en-US."),
+    isOrEverWasMadeForKids: s.nullableBoolean("Whether the app is or has ever been part of the Kids category."),
+    contentRightsDeclaration: s.nullable(
+      s.stringEnum("Third-party content rights declared for the app.", contentRightsDeclarations),
+    ),
+    streamlinedPurchasingEnabled: s.nullableBoolean("Whether streamlined purchasing is enabled for the app."),
+    accessibilityUrl: s.nullableString("Accessibility information URL published with the app."),
+    subscriptionStatusUrl: s.nullableString("Production server-to-server subscription status URL."),
+    subscriptionStatusUrlVersion: s.nullable(
+      s.stringEnum("Version of the production subscription status URL.", subscriptionStatusUrlVersions),
+    ),
+    subscriptionStatusUrlForSandbox: s.nullableString("Sandbox server-to-server subscription status URL."),
+    subscriptionStatusUrlVersionForSandbox: s.nullable(
+      s.stringEnum("Version of the sandbox subscription status URL.", subscriptionStatusUrlVersions),
+    ),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+const appSummary = s.nullable(
+  s.object(
+    "The app a record belongs to, or null when App Store Connect did not return it.",
+    {
+      id: s.string("App Store Connect identifier for the app."),
+      name: s.nullableString("App name shown on the App Store."),
+      bundleId: s.nullableString("Bundle identifier registered for the app."),
+    },
+    { required: ["id"], additionalProperties: true },
+  ),
+);
+
+const preReleaseVersionSummary = s.nullable(
+  s.object(
+    "The prerelease version a build belongs to, or null when it was not returned.",
+    {
+      id: s.string("App Store Connect identifier for the prerelease version."),
+      version: s.nullableString("Marketing version string, such as 1.4.0."),
+      platform: s.nullable(s.stringEnum("Content platform the version targets.", contentPlatforms)),
+    },
+    { required: ["id"], additionalProperties: true },
+  ),
+);
+
+const betaReviewSubmissionFields = {
+  id: s.string("App Store Connect identifier for the beta app review submission."),
+  betaReviewState: s.nullable(s.stringEnum("State of the TestFlight beta review.", betaReviewStates)),
+  submittedDate: s.nullableString("When the build was submitted for beta review, as an ISO 8601 timestamp."),
+};
+
+const betaReviewSubmissionSummary = s.nullable(
+  s.object(
+    "The TestFlight beta review submission for a build, or null when there is none.",
+    betaReviewSubmissionFields,
+    { required: ["id"], additionalProperties: true },
+  ),
+);
+
+const buildCoreFields = {
+  id: s.string("App Store Connect identifier for the build."),
+  version: s.nullableString("Build number, such as 42."),
+  uploadedDate: s.nullableString("When the build finished uploading, as an ISO 8601 timestamp."),
+  expirationDate: s.nullableString("When the build stops being installable by testers."),
+  expired: s.nullableBoolean("Whether the build has expired for TestFlight."),
+  processingState: s.nullable(s.stringEnum("Processing state of the uploaded build.", buildProcessingStates)),
+  buildAudienceType: s.nullable(s.stringEnum("Distribution audience the build was uploaded for.", buildAudienceTypes)),
+  preReleaseVersion: preReleaseVersionSummary,
+};
+
+const buildResource = s.object(
+  `A build uploaded to App Store Connect. ${absentAttributeNote}`,
+  {
+    ...buildCoreFields,
+    minOsVersion: s.nullableString("Minimum OS version the build supports."),
+    lsMinimumSystemVersion: s.nullableString("Minimum macOS system version declared by the build."),
+    computedMinMacOsVersion: s.nullableString("Minimum macOS version App Store Connect computed for the build."),
+    computedMinVisionOsVersion: s.nullableString("Minimum visionOS version App Store Connect computed for the build."),
+    usesNonExemptEncryption: s.nullableBoolean("Whether the build declares non-exempt encryption."),
+    iconAssetToken: s.nullable(
+      s.looseObject("Template URL and pixel size of the build icon asset.", {
+        templateUrl: s.string("Template URL with width, height, and format placeholders."),
+        width: s.integer("Icon width in pixels."),
+        height: s.integer("Icon height in pixels."),
+      }),
+    ),
+  },
+  { required: ["id", "preReleaseVersion"], additionalProperties: true },
+);
+
+const buildWithReviewResource = s.object(
+  `A build with the related records requested alongside it. ${absentAttributeNote}`,
+  {
+    ...buildCoreFields,
+    betaAppReviewSubmission: betaReviewSubmissionSummary,
+    app: appSummary,
+  },
+  { required: ["id", "preReleaseVersion", "betaAppReviewSubmission", "app"], additionalProperties: true },
+);
+
+const preReleaseVersionResource = s.object(
+  `A prerelease version that groups TestFlight builds. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the prerelease version."),
+    version: s.nullableString("Marketing version string, such as 1.4.0."),
+    platform: s.nullable(s.stringEnum("Content platform the version targets.", contentPlatforms)),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+const betaGroupResource = s.object(
+  `A TestFlight beta group. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the beta group."),
+    name: s.nullableString("Group name shown in TestFlight."),
+    createdDate: s.nullableString("When the group was created, as an ISO 8601 timestamp."),
+    isInternalGroup: s.nullableBoolean("Whether the group is an internal group of team members."),
+    hasAccessToAllBuilds: s.nullableBoolean("Whether the group automatically receives every new build."),
+    publicLinkEnabled: s.nullableBoolean("Whether a public TestFlight link is enabled for the group."),
+    publicLinkId: s.nullableString("Identifier segment of the public TestFlight link."),
+    publicLink: s.nullableString("Full public TestFlight invitation link."),
+    publicLinkLimitEnabled: s.nullableBoolean("Whether the public link enforces a tester limit."),
+    publicLinkLimit: s.nullableInteger("Maximum number of testers who may join through the public link."),
+    feedbackEnabled: s.nullableBoolean("Whether testers can send feedback from TestFlight."),
+    iosBuildsAvailableForAppleSiliconMac: s.nullableBoolean("Whether iOS builds are offered to Apple silicon Macs."),
+    iosBuildsAvailableForAppleVision: s.nullableBoolean("Whether iOS builds are offered to Apple Vision Pro."),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+const betaTesterResource = s.object(
+  `A TestFlight beta tester. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the beta tester."),
+    email: s.nullableString("Email address the invitation was sent to."),
+    firstName: s.nullableString("Tester first name."),
+    lastName: s.nullableString("Tester last name."),
+    inviteType: s.nullable(s.stringEnum("How the tester was invited.", betaInviteTypes)),
+    state: s.nullable(s.stringEnum("Where the tester stands in the invitation flow.", betaTesterStates)),
+    appDevices: s.nullable(
+      s.array(
+        "Devices the tester has installed the app on.",
+        s.looseObject("One tester device.", {
+          model: s.string("Device model name."),
+          platform: s.stringEnum("Platform of the device.", devicePlatforms),
+          osVersion: s.string("Operating system version on the device."),
+          appBuildVersion: s.string("Build number installed on the device."),
+        }),
+      ),
+    ),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+const testNotesOutput = {
+  id: s.string("App Store Connect identifier for the beta build localization."),
+  locale: s.nullableString("Locale the test notes belong to, such as en-US."),
+  whatsNew: s.nullableString("Test notes shown to testers for this locale."),
+};
+
+const appStoreVersionResource = s.object(
+  `An App Store version of an app. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the version."),
+    platform: s.nullable(s.stringEnum("Content platform the version targets.", contentPlatforms)),
+    versionString: s.nullableString("Version string shown on the App Store, such as 1.4.0."),
+    appVersionState: s.nullable(s.stringEnum("Current review and release state.", appVersionStates)),
+    copyright: s.nullableString("Copyright line published with the version."),
+    reviewType: s.nullable(s.stringEnum("Review track the version goes through.", appStoreReviewTypes)),
+    releaseType: s.nullable(s.stringEnum("Release behaviour after approval.", appStoreReleaseTypes)),
+    earliestReleaseDate: s.nullableString("Earliest scheduled release time, as an ISO 8601 timestamp."),
+    downloadable: s.nullableBoolean("Whether the version is downloadable."),
+    createdDate: s.nullableString("When the version record was created, as an ISO 8601 timestamp."),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+const reviewResponseFields = {
+  id: s.string("App Store Connect identifier for the response."),
+  responseBody: s.nullableString("Text of the developer response."),
+  lastModifiedDate: s.nullableString("When the response was last changed, as an ISO 8601 timestamp."),
+  state: s.nullable(s.stringEnum("Publication state of the response.", reviewResponseStates)),
+};
+
+const reviewResponseSummary = s.nullable(
+  s.object("The developer response published for a review, or null when there is none.", reviewResponseFields, {
+    required: ["id"],
+    additionalProperties: true,
+  }),
+);
+
+const customerReviewResource = s.object(
+  `A customer review left on the App Store. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the review."),
+    rating: s.nullableInteger("Star rating from 1 to 5."),
+    title: s.nullableString("Review title."),
+    body: s.nullableString("Review text."),
+    reviewerNickname: s.nullableString("Nickname the reviewer publishes under."),
+    createdDate: s.nullableString("When the review was written, as an ISO 8601 timestamp."),
+    territory: s.nullableString("ISO 3166-1 alpha-3 storefront the review was written in, such as USA."),
+    response: reviewResponseSummary,
+  },
+  { required: ["id", "response"], additionalProperties: true },
+);
+
+const userResource = s.object(
+  `A member of the App Store Connect team. ${absentAttributeNote}`,
+  {
+    id: s.string("App Store Connect identifier for the user."),
+    username: s.nullableString("Apple Account email the user signs in with."),
+    firstName: s.nullableString("User first name."),
+    lastName: s.nullableString("User last name."),
+    roles: s.nullable(
+      s.array("Roles granted to the user.", s.stringEnum("An App Store Connect team role.", teamRoles)),
+    ),
+    allAppsVisible: s.nullableBoolean("Whether the user can see every app on the team."),
+    provisioningAllowed: s.nullableBoolean("Whether the user may manage certificates, identifiers, and profiles."),
+  },
+  { required: ["id"], additionalProperties: true },
+);
+
+function deletedOutput(description: string): Record<string, JsonSchema> {
+  return {
+    id: s.string(description),
+    deleted: s.boolean("Always true once App Store Connect confirmed the deletion."),
+  };
+}
+
+export const appStoreConnectActions: ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "list_apps",
+    description: "List the apps the API key can see, optionally filtered by bundle identifier, name, or SKU.",
+    inputSchema: s.object(
+      "Filters for browsing App Store Connect apps.",
+      {
+        bundleId: s.nonEmptyString("Return only the app with this exact bundle identifier."),
+        name: s.nonEmptyString("Return only apps with this exact name."),
+        sku: s.nonEmptyString("Return only the app with this exact SKU."),
+        sort: s.stringEnum("Sort order for the returned apps.", [
+          "name",
+          "-name",
+          "bundleId",
+          "-bundleId",
+          "sku",
+          "-sku",
+        ]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { optional: ["bundleId", "name", "sku", "sort", "limit", "cursor"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        apps: s.array("Apps returned for this page.", appResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of App Store Connect apps.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "get_app",
+    description: "Read one app record by its App Store Connect identifier.",
+    inputSchema: s.actionInput(
+      { appId: s.nonEmptyString("App Store Connect identifier of the app.") },
+      ["appId"],
+      "Identifies the app to read.",
+    ),
+    outputSchema: s.actionOutput({ app: appResource }, "The requested app."),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_builds",
+    description:
+      "List builds uploaded for one app, with the prerelease version each build belongs to. Filter by version, platform, processing state, or TestFlight review state.",
+    inputSchema: s.object(
+      "Filters for browsing the builds of one app.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app whose builds to list."),
+        version: s.nonEmptyString("Return only builds with this build number, such as 42."),
+        preReleaseVersion: s.nonEmptyString("Return only builds under this marketing version, such as 1.4.0."),
+        platform: s.stringEnum("Return only builds for this content platform.", contentPlatforms),
+        processingState: s.stringEnum("Return only builds in this processing state.", buildProcessingStates),
+        betaReviewState: s.stringEnum(
+          "Return only builds whose beta review submission is in this state.",
+          betaReviewStates,
+        ),
+        expired: s.boolean("Return only expired builds when true, or only unexpired builds when false."),
+        sort: s.stringEnum("Sort order for the returned builds.", [
+          "version",
+          "-version",
+          "uploadedDate",
+          "-uploadedDate",
+          "preReleaseVersion",
+          "-preReleaseVersion",
+        ]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { required: ["appId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        builds: s.array("Builds returned for this page.", buildResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of builds for one app.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "get_build",
+    description:
+      "Read one build together with its prerelease version, its TestFlight review submission, and the app it belongs to.",
+    inputSchema: s.actionInput(
+      { buildId: s.nonEmptyString("App Store Connect identifier of the build.") },
+      ["buildId"],
+      "Identifies the build to read.",
+    ),
+    outputSchema: s.actionOutput({ build: buildWithReviewResource }, "The requested build and its related records."),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_pre_release_versions",
+    description: "List the prerelease versions of one app, which group its TestFlight builds by marketing version.",
+    inputSchema: s.object(
+      "Filters for browsing prerelease versions.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app."),
+        platform: s.stringEnum("Return only prerelease versions for this content platform.", contentPlatforms),
+        version: s.nonEmptyString("Return only the prerelease version with this exact version string."),
+        sort: s.stringEnum("Sort order for the returned prerelease versions.", ["version", "-version"]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { required: ["appId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        preReleaseVersions: s.array("Prerelease versions returned for this page.", preReleaseVersionResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of prerelease versions.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_beta_groups",
+    description: "List the TestFlight groups of one app, including the public invitation link of each group.",
+    inputSchema: s.object(
+      "Filters for browsing TestFlight groups.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app."),
+        name: s.nonEmptyString("Return only the group with this exact name."),
+        isInternalGroup: s.boolean("Return only internal groups when true, or only external groups when false."),
+        publicLinkEnabled: s.boolean("Return only groups whose public link is enabled or disabled."),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { required: ["appId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        betaGroups: s.array("TestFlight groups returned for this page.", betaGroupResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of TestFlight groups.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "create_beta_group",
+    description: "Create a TestFlight group for an app, optionally enabling its public invitation link.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.object(
+      "The TestFlight group to create.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app the group belongs to."),
+        name: s.nonEmptyString("Group name shown in TestFlight."),
+        publicLinkEnabled: s.boolean("Enable a public TestFlight invitation link for the group."),
+        publicLinkLimitEnabled: s.boolean("Enforce a maximum number of testers joining through the public link."),
+        publicLinkLimit: s.positiveInteger("Maximum number of testers allowed to join through the public link."),
+        feedbackEnabled: s.boolean("Let testers send feedback from TestFlight."),
+        hasAccessToAllBuilds: s.boolean("Automatically give the group every new build of the app."),
+      },
+      { required: ["appId", "name"] },
+    ),
+    outputSchema: s.actionOutput({ betaGroup: betaGroupResource }, "The created TestFlight group."),
+  }),
+
+  defineProviderAction(service, {
+    name: "delete_beta_group",
+    description: "Delete a TestFlight group. Testers who only belonged to that group lose access to its builds.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.actionInput(
+      { betaGroupId: s.nonEmptyString("App Store Connect identifier of the TestFlight group.") },
+      ["betaGroupId"],
+      "Identifies the TestFlight group to delete.",
+    ),
+    outputSchema: s.actionOutput(
+      deletedOutput("App Store Connect identifier of the deleted TestFlight group."),
+      "Confirmation that the TestFlight group was deleted.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_beta_testers",
+    description: "List TestFlight testers, optionally narrowed to one app, group, or build.",
+    inputSchema: s.object(
+      "Filters for browsing TestFlight testers.",
+      {
+        email: s.email("Return only the tester with this exact email address."),
+        firstName: s.nonEmptyString("Return only testers with this exact first name."),
+        lastName: s.nonEmptyString("Return only testers with this exact last name."),
+        inviteType: s.stringEnum("Return only testers invited this way.", betaInviteTypes),
+        appId: s.nonEmptyString("Return only testers who have access to this app."),
+        betaGroupId: s.nonEmptyString("Return only testers who belong to this TestFlight group."),
+        buildId: s.nonEmptyString("Return only testers who were assigned this build individually."),
+        sort: s.stringEnum("Sort order for the returned testers.", [
+          "firstName",
+          "-firstName",
+          "lastName",
+          "-lastName",
+          "email",
+          "-email",
+          "inviteType",
+          "-inviteType",
+          "state",
+          "-state",
+        ]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      {
+        optional: [
+          "email",
+          "firstName",
+          "lastName",
+          "inviteType",
+          "appId",
+          "betaGroupId",
+          "buildId",
+          "sort",
+          "limit",
+          "cursor",
+        ],
+      },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        betaTesters: s.array("TestFlight testers returned for this page.", betaTesterResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of TestFlight testers.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "create_beta_tester",
+    description:
+      "Invite a TestFlight tester by email. App Store Connect only creates a tester that is assigned to something, so pass at least one of betaGroupIds or buildIds.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.object(
+      "The TestFlight tester to invite.",
+      {
+        email: s.email("Email address the TestFlight invitation is sent to."),
+        firstName: s.nonEmptyString("Tester first name."),
+        lastName: s.nonEmptyString("Tester last name."),
+        betaGroupIds: s.stringArray("TestFlight groups to add the tester to. Required unless buildIds is given.", {
+          minItems: 1,
+        }),
+        buildIds: s.stringArray("Builds to assign to the tester individually. Required unless betaGroupIds is given.", {
+          minItems: 1,
+        }),
+      },
+      { required: ["email"] },
+    ),
+    outputSchema: s.actionOutput({ betaTester: betaTesterResource }, "The invited TestFlight tester."),
+  }),
+
+  defineProviderAction(service, {
+    name: "delete_beta_tester",
+    description: "Remove a TestFlight tester from the team, revoking their access to every build and group.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.actionInput(
+      { betaTesterId: s.nonEmptyString("App Store Connect identifier of the TestFlight tester.") },
+      ["betaTesterId"],
+      "Identifies the TestFlight tester to remove.",
+    ),
+    outputSchema: s.actionOutput(
+      deletedOutput("App Store Connect identifier of the removed TestFlight tester."),
+      "Confirmation that the TestFlight tester was removed.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "add_beta_testers_to_group",
+    description: "Add existing TestFlight testers to one group so they receive the builds that group can install.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.object(
+      "The testers to add to a TestFlight group.",
+      {
+        betaGroupId: s.nonEmptyString("App Store Connect identifier of the TestFlight group."),
+        betaTesterIds: s.stringArray("Identifiers of the testers to add.", { minItems: 1 }),
+      },
+      { required: ["betaGroupId", "betaTesterIds"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        betaGroupId: s.string("The TestFlight group the testers were added to."),
+        betaTesterIds: s.stringArray("Identifiers of the testers that were added."),
+        added: s.boolean("Always true once App Store Connect confirmed the change."),
+      },
+      "Confirmation that the testers were added to the group.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "remove_beta_testers_from_group",
+    description:
+      "Remove testers from one TestFlight group. The testers stay on the team and keep access through their other groups.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.object(
+      "The testers to remove from a TestFlight group.",
+      {
+        betaGroupId: s.nonEmptyString("App Store Connect identifier of the TestFlight group."),
+        betaTesterIds: s.stringArray("Identifiers of the testers to remove.", { minItems: 1 }),
+      },
+      { required: ["betaGroupId", "betaTesterIds"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        betaGroupId: s.string("The TestFlight group the testers were removed from."),
+        betaTesterIds: s.stringArray("Identifiers of the testers that were removed."),
+        removed: s.boolean("Always true once App Store Connect confirmed the change."),
+      },
+      "Confirmation that the testers were removed from the group.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "add_build_to_beta_groups",
+    description: "Make one build available to TestFlight groups so their testers can install it.",
+    providerPermissions: manageTestFlightRoles,
+    inputSchema: s.object(
+      "The build to distribute and the groups that should receive it.",
+      {
+        buildId: s.nonEmptyString("App Store Connect identifier of the build."),
+        betaGroupIds: s.stringArray("Identifiers of the TestFlight groups to add the build to.", { minItems: 1 }),
+      },
+      { required: ["buildId", "betaGroupIds"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        buildId: s.string("The build that was distributed."),
+        betaGroupIds: s.stringArray("Identifiers of the groups the build was added to."),
+        added: s.boolean("Always true once App Store Connect confirmed the change."),
+      },
+      "Confirmation that the build was added to the groups.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "submit_build_for_beta_review",
+    description: "Submit a build for TestFlight beta review, which external groups require before they can install it.",
+    providerPermissions: manageTestFlightBuildsRoles,
+    inputSchema: s.actionInput(
+      { buildId: s.nonEmptyString("App Store Connect identifier of the build to submit.") },
+      ["buildId"],
+      "Identifies the build to submit for beta review.",
+    ),
+    outputSchema: s.actionOutput({ ...betaReviewSubmissionFields }, "The created beta app review submission."),
+  }),
+
+  defineProviderAction(service, {
+    name: "update_build_test_notes",
+    description:
+      'Set the "What to Test" notes a build shows testers in one locale. Updates the existing notes for that locale, or creates them when the locale has none yet.',
+    providerPermissions: manageTestFlightBuildsRoles,
+    inputSchema: s.object(
+      "The test notes to publish for one build and locale.",
+      {
+        buildId: s.nonEmptyString("App Store Connect identifier of the build."),
+        locale: s.nonEmptyString("TestFlight locale the notes are written in, such as en-US."),
+        whatsNew: s.nonEmptyString("Test notes shown to testers in that locale."),
+      },
+      { required: ["buildId", "locale", "whatsNew"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        ...testNotesOutput,
+        created: s.boolean("True when the locale had no notes yet and they were created."),
+      },
+      "The stored test notes for one build and locale.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_app_store_versions",
+    description: "List the App Store versions of one app, with the review and release state of each version.",
+    inputSchema: s.object(
+      "Filters for browsing the App Store versions of one app.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app."),
+        platform: s.stringEnum("Return only versions for this content platform.", contentPlatforms),
+        versionString: s.nonEmptyString("Return only the version with this exact version string."),
+        appVersionState: s.stringEnum("Return only versions in this review and release state.", appVersionStates),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { required: ["appId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        appStoreVersions: s.array("App Store versions returned for this page.", appStoreVersionResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of App Store versions.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "get_app_store_version",
+    description: "Read one App Store version by its App Store Connect identifier.",
+    inputSchema: s.actionInput(
+      { appStoreVersionId: s.nonEmptyString("App Store Connect identifier of the version.") },
+      ["appStoreVersionId"],
+      "Identifies the App Store version to read.",
+    ),
+    outputSchema: s.actionOutput({ appStoreVersion: appStoreVersionResource }, "The requested App Store version."),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_customer_reviews",
+    description:
+      "List the App Store reviews of one app together with the developer response published for each review.",
+    providerPermissions: viewReviewsRoles,
+    inputSchema: s.object(
+      "Filters for browsing the reviews of one app.",
+      {
+        appId: s.nonEmptyString("App Store Connect identifier of the app."),
+        rating: s.integer("Return only reviews with this star rating.", { minimum: 1, maximum: 5 }),
+        territory: s.nonEmptyString(
+          "Return only reviews written in this storefront, as an ISO 3166-1 alpha-3 code such as USA or DEU.",
+          { pattern: "^[A-Z]{3}$" },
+        ),
+        hasResponse: s.boolean("Return only reviews that already have a developer response, or only those without."),
+        sort: s.stringEnum("Sort order for the returned reviews.", [
+          "rating",
+          "-rating",
+          "createdDate",
+          "-createdDate",
+        ]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { required: ["appId"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        customerReviews: s.array("Reviews returned for this page.", customerReviewResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of App Store reviews.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "get_customer_review",
+    description: "Read one App Store review together with the developer response published for it.",
+    providerPermissions: viewReviewsRoles,
+    inputSchema: s.actionInput(
+      { customerReviewId: s.nonEmptyString("App Store Connect identifier of the review.") },
+      ["customerReviewId"],
+      "Identifies the review to read.",
+    ),
+    outputSchema: s.actionOutput({ customerReview: customerReviewResource }, "The requested App Store review."),
+  }),
+
+  defineProviderAction(service, {
+    name: "respond_to_customer_review",
+    description:
+      "Publish a developer response to an App Store review. App Store Connect treats this as an upsert: an existing response for the same review is replaced, and publication is asynchronous.",
+    providerPermissions: respondToReviewsRoles,
+    inputSchema: s.object(
+      "The response to publish for one review.",
+      {
+        customerReviewId: s.nonEmptyString("App Store Connect identifier of the review to respond to."),
+        responseBody: s.nonEmptyString("Text of the developer response."),
+      },
+      { required: ["customerReviewId", "responseBody"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        customerReviewResponse: s.object("The stored developer response.", reviewResponseFields, {
+          required: ["id"],
+          additionalProperties: true,
+        }),
+      },
+      "The published or updated developer response.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "delete_customer_review_response",
+    description: "Remove a published developer response from an App Store review.",
+    providerPermissions: respondToReviewsRoles,
+    inputSchema: s.actionInput(
+      { customerReviewResponseId: s.nonEmptyString("App Store Connect identifier of the developer response.") },
+      ["customerReviewResponseId"],
+      "Identifies the developer response to remove.",
+    ),
+    outputSchema: s.actionOutput(
+      deletedOutput("App Store Connect identifier of the removed developer response."),
+      "Confirmation that the developer response was removed.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "list_users",
+    description: "List the members of the App Store Connect team, with the roles granted to each of them.",
+    providerPermissions: usersAndAccessRoles,
+    inputSchema: s.object(
+      "Filters for browsing team members.",
+      {
+        roles: s.array(
+          "Return only users holding at least one of these roles.",
+          s.stringEnum("An App Store Connect team role.", teamRoles),
+          { minItems: 1 },
+        ),
+        username: s.nonEmptyString("Return only the user with this exact Apple Account email."),
+        visibleAppId: s.nonEmptyString("Return only users who can see this app."),
+        sort: s.stringEnum("Sort order for the returned users.", ["username", "-username", "lastName", "-lastName"]),
+        limit: limitInput,
+        cursor: cursorInput,
+      },
+      { optional: ["roles", "username", "visibleAppId", "sort", "limit", "cursor"] },
+    ),
+    outputSchema: s.actionOutput(
+      {
+        users: s.array("Team members returned for this page.", userResource),
+        nextCursor: nextCursorOutput,
+        total: totalOutput,
+      },
+      "A page of App Store Connect team members.",
+    ),
+  }),
+
+  defineProviderAction(service, {
+    name: "get_user",
+    description: "Read one App Store Connect team member by identifier.",
+    providerPermissions: usersAndAccessRoles,
+    inputSchema: s.actionInput(
+      { userId: s.nonEmptyString("App Store Connect identifier of the team member.") },
+      ["userId"],
+      "Identifies the team member to read.",
+    ),
+    outputSchema: s.actionOutput({ user: userResource }, "The requested team member."),
+  }),
+];

--- a/src/providers/app_store_connect/definition.ts
+++ b/src/providers/app_store_connect/definition.ts
@@ -1,0 +1,53 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { appStoreConnectActions } from "./actions.ts";
+
+const service = "app_store_connect";
+
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "App Store Connect",
+  description:
+    "Browse apps and App Store versions, run TestFlight distribution, answer App Store reviews, and read team members through Apple's App Store Connect API.",
+  categories: ["Developer Tools", "Productivity"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "keyId",
+          label: "Key ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "2X9R4HXF34",
+          description:
+            "The key identifier shown next to the API key in App Store Connect under Users and Access > Integrations > App Store Connect API (Team Keys), or on your user profile for an Individual API Key.",
+        },
+        {
+          key: "issuerId",
+          label: "Issuer ID",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "57246542-96fe-1a63-e053-0824d011072a",
+          description:
+            "The issuer ID printed above the team key list in App Store Connect. Required for team keys. Leave it empty for an Individual API Key, which is authenticated by the key alone.",
+        },
+        {
+          key: "privateKey",
+          label: "Private Key (.p8)",
+          inputType: "textarea",
+          required: true,
+          secret: true,
+          placeholder: "-----BEGIN PRIVATE KEY-----",
+          description:
+            "The full contents of the AuthKey_<KEYID>.p8 file downloaded when the key was created, a PKCS#8 PEM holding an EC P-256 key. Apple offers the download only once. Escaped \\n line breaks are accepted.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://appstoreconnect.apple.com/",
+  actions: appStoreConnectActions,
+};

--- a/src/providers/app_store_connect/executors.test.ts
+++ b/src/providers/app_store_connect/executors.test.ts
@@ -1,0 +1,459 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { exportPKCS8, generateKeyPair } from "jose";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { credentialValidators, executors, proxy } from "./executors.ts";
+
+const keyId = "2X9R4HXF34";
+const issuerId = "57246542-96fe-1a63-e053-0824d011072a";
+
+let values: Record<string, string>;
+let context: ExecutionContext;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair("ES256", { extractable: true });
+  values = { keyId, issuerId, privateKey: await exportPKCS8(privateKey) };
+  const credential: ResolvedCredential = {
+    authType: "custom_credential",
+    values,
+    profile: { accountId: issuerId, displayName: `App Store Connect key ${keyId}`, grantedScopes: [] },
+    metadata: {},
+  };
+  context = { getCredential: async () => credential };
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Record every outgoing request and answer each one from the given queue. */
+function stubFetch(responses: Array<() => Response>): Request[] {
+  const requests: Request[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push(input instanceof Request ? input : new Request(input, init));
+    const next = responses[requests.length - 1];
+    if (!next) {
+      throw new Error(`unexpected request ${requests.length}`);
+    }
+    return next();
+  });
+  return requests;
+}
+
+function errorResponse(status: number, errors: Array<Record<string, string>>): Response {
+  return Response.json({ errors }, { status });
+}
+
+describe("App Store Connect list pagination", () => {
+  it("reads the next cursor out of the absolute links.next URL", async () => {
+    const requests = stubFetch([
+      () =>
+        Response.json({
+          data: [{ type: "apps", id: "6446901002", attributes: { name: "Demo", bundleId: "com.example.demo" } }],
+          links: {
+            self: "https://api.appstoreconnect.apple.com/v1/apps?limit=1",
+            next: "https://api.appstoreconnect.apple.com/v1/apps?cursor=AoJ4g7mg6o4D.ANrJC88&limit=1",
+          },
+          meta: { paging: { total: 431, limit: 1 } },
+        }),
+    ]);
+
+    const result = await executors["app_store_connect.list_apps"]!({ limit: 1 }, context);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        apps: [{ id: "6446901002", name: "Demo", bundleId: "com.example.demo" }],
+        nextCursor: "AoJ4g7mg6o4D.ANrJC88",
+        total: 431,
+      },
+    });
+    expect(requests[0]?.url).toBe("https://api.appstoreconnect.apple.com/v1/apps?limit=1");
+    expect(requests[0]?.headers.get("authorization")?.startsWith("Bearer ")).toBe(true);
+  });
+
+  it("falls back to the bare paging cursor and reports an absent total as null", async () => {
+    stubFetch([
+      () =>
+        Response.json({
+          data: [],
+          links: { self: "https://api.appstoreconnect.apple.com/v1/apps" },
+          meta: { paging: { limit: 200, nextCursor: "BARE.CURSOR" } },
+        }),
+    ]);
+
+    const result = await executors["app_store_connect.list_apps"]!({}, context);
+
+    expect(result).toMatchObject({ ok: true, output: { apps: [], nextCursor: "BARE.CURSOR", total: null } });
+  });
+
+  it("passes a caller cursor straight back to App Store Connect", async () => {
+    const requests = stubFetch([
+      () => Response.json({ data: [], links: { self: "https://api.appstoreconnect.apple.com/v1/apps" } }),
+    ]);
+
+    await executors["app_store_connect.list_apps"]!({ cursor: "AoJ4g7mg6o4D.ANrJC88" }, context);
+
+    expect(new URL(requests[0]!.url).searchParams.get("cursor")).toBe("AoJ4g7mg6o4D.ANrJC88");
+  });
+});
+
+describe("App Store Connect error mapping", () => {
+  it("composes the message from the first error and counts the rest", async () => {
+    stubFetch([
+      () =>
+        errorResponse(404, [
+          { status: "404", code: "NOT_FOUND", title: "The resource does not exist", detail: "id 'missing' not found" },
+          { status: "404", code: "NOT_FOUND", title: "Another problem", detail: "second detail" },
+        ]),
+    ]);
+
+    const result = await executors["app_store_connect.get_app"]!({ appId: "missing" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_input",
+        // Apple's error code leads the message: it is the only part a caller can branch on.
+        message: "NOT_FOUND: The resource does not exist: id 'missing' not found (+1 more)",
+        details: { status: 404 },
+      },
+    });
+  });
+
+  it("keeps a title-only error message and the upstream status", async () => {
+    stubFetch([() => errorResponse(429, [{ status: "429", code: "RATE_LIMIT_EXCEEDED", title: "Too many requests" }])]);
+
+    const result = await executors["app_store_connect.list_apps"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "rate_limited", message: "RATE_LIMIT_EXCEEDED: Too many requests", details: { status: 429 } },
+    });
+  });
+
+  it.each([401, 403])("reports an upstream %i as an authorization failure while executing", async (status) => {
+    stubFetch([() => new Response("", { status })]);
+
+    const result = await executors["app_store_connect.list_apps"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "authorization_failed",
+        message: `App Store Connect request failed with HTTP ${status}`,
+        details: { status },
+      },
+    });
+  });
+
+  it("falls back to the status when the body is not JSON", async () => {
+    stubFetch([() => new Response("Not Acceptable", { status: 406, headers: { "content-type": "text/plain" } })]);
+
+    const result = await executors["app_store_connect.list_apps"]!({}, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: "App Store Connect request failed with HTTP 406" },
+    });
+  });
+});
+
+describe("App Store Connect credential validation", () => {
+  it("accepts a key that can list apps", async () => {
+    const result = await credentialValidators.customCredential!(
+      { values },
+      { fetcher: async () => Response.json({ data: [], links: { self: "https://api.appstoreconnect.apple.com" } }) },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: issuerId, displayName: `App Store Connect key ${keyId}` },
+      metadata: { keyId, issuerId, keyKind: "team" },
+    });
+  });
+
+  it("rejects a key that cannot list apps, because 403 also covers a revoked key", async () => {
+    await expect(
+      credentialValidators.customCredential!(
+        { values },
+        { fetcher: async () => errorResponse(403, [{ status: "403", code: "FORBIDDEN_ERROR", title: "Forbidden" }]) },
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message:
+        "App Store Connect authenticated the key but refused to list apps. Grant the key a role that can read apps (for example Developer, App Manager or Admin), and check that the key has not been revoked.",
+    });
+  });
+
+  it("reports a rejected key as a field error rather than a reconnect prompt", async () => {
+    await expect(
+      credentialValidators.customCredential!({ values }, { fetcher: async () => new Response("", { status: 401 }) }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "App Store Connect rejected the key. Check the Key ID, Issuer ID and private key.",
+    });
+  });
+
+  it("labels a key without an issuer as an individual key", async () => {
+    const result = await credentialValidators.customCredential!(
+      { values: { keyId, privateKey: values.privateKey! } },
+      { fetcher: async () => Response.json({ data: [], links: { self: "https://api.appstoreconnect.apple.com" } }) },
+    );
+
+    expect(result).toMatchObject({
+      profile: { accountId: keyId },
+      metadata: { keyKind: "individual", issuerId: null },
+    });
+  });
+});
+
+describe("App Store Connect no-content writes", () => {
+  it.each([202, 204])("accepts the documented %i answer when removing a tester", async (status) => {
+    stubFetch([() => new Response(null, { status })]);
+
+    const result = await executors["app_store_connect.delete_beta_tester"]!({ betaTesterId: "T1" }, context);
+
+    expect(result).toMatchObject({ ok: true, output: { id: "T1", deleted: true } });
+  });
+
+  it("refuses to report a deletion for any other success status", async () => {
+    // A redirect the guarded fetch rewrites to GET answers 200 with the tester
+    // still present, so "any 2xx" would report a deletion that never happened.
+    stubFetch([() => Response.json({ data: { type: "betaTesters", id: "T1" } })]);
+
+    const result = await executors["app_store_connect.delete_beta_tester"]!({ betaTesterId: "T1" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "provider_error",
+        message: "Removing the App Store Connect beta tester answered HTTP 200 instead of 202 or 204",
+      },
+    });
+  });
+
+  it("sends the linkage body on the relationship DELETE", async () => {
+    const requests = stubFetch([() => new Response(null, { status: 204 })]);
+
+    const result = await executors["app_store_connect.remove_beta_testers_from_group"]!(
+      { betaGroupId: "G1", betaTesterIds: ["T1", "T2"] },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: { betaGroupId: "G1", betaTesterIds: ["T1", "T2"], removed: true },
+    });
+    expect(requests[0]?.method).toBe("DELETE");
+    await expect(requests[0]!.json()).resolves.toEqual({
+      data: [
+        { type: "betaTesters", id: "T1" },
+        { type: "betaTesters", id: "T2" },
+      ],
+    });
+  });
+});
+
+describe("App Store Connect beta testers", () => {
+  it("refuses to invite a tester that is assigned to no group and no build", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executors["app_store_connect.create_beta_tester"]!({ email: "tester@example.com" }, context);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "betaGroupIds or buildIds must contain at least one identifier" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("App Store Connect test notes", () => {
+  const localization = {
+    type: "betaBuildLocalizations",
+    id: "L1",
+    attributes: { locale: "en-US", whatsNew: "Fixed a crash." },
+  };
+
+  it("patches the localization that already covers the locale", async () => {
+    const requests = stubFetch([
+      () =>
+        Response.json({
+          data: [{ type: "betaBuildLocalizations", id: "L1", attributes: { locale: "en-US", whatsNew: "Old." } }],
+          links: { self: "https://api.appstoreconnect.apple.com" },
+        }),
+      () => Response.json({ data: localization, links: { self: "https://api.appstoreconnect.apple.com" } }),
+    ]);
+
+    const result = await executors["app_store_connect.update_build_test_notes"]!(
+      { buildId: "B1", locale: "en-US", whatsNew: "Fixed a crash." },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: { id: "L1", locale: "en-US", whatsNew: "Fixed a crash.", created: false },
+    });
+    // The lookup asks the filterable collection for the one matching row rather
+    // than paging the localizations of the build.
+    const lookup = new URL(requests[0]!.url);
+    expect(lookup.pathname).toBe("/v1/betaBuildLocalizations");
+    expect(lookup.searchParams.get("filter[build]")).toBe("B1");
+    expect(lookup.searchParams.get("filter[locale]")).toBe("en-US");
+    expect(lookup.searchParams.get("limit")).toBe("1");
+    expect(requests[1]?.method).toBe("PATCH");
+    expect(requests[1]?.url).toBe("https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/L1");
+  });
+
+  it("rejects a build id that would collapse into a different path", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await executors["app_store_connect.update_build_test_notes"]!(
+      { buildId: "..", locale: "en-US", whatsNew: "Fixed a crash." },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "invalid_input", message: "buildId must not be . or ..", details: { status: 400 } },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("creates a localization when the locale has no notes yet", async () => {
+    const requests = stubFetch([
+      () => Response.json({ data: [], links: { self: "https://api.appstoreconnect.apple.com" } }),
+      () =>
+        Response.json(
+          { data: localization, links: { self: "https://api.appstoreconnect.apple.com" } },
+          { status: 201 },
+        ),
+    ]);
+
+    const result = await executors["app_store_connect.update_build_test_notes"]!(
+      { buildId: "B1", locale: "en-US", whatsNew: "Fixed a crash." },
+      context,
+    );
+
+    expect(result).toMatchObject({ ok: true, output: { id: "L1", created: true } });
+    expect(requests[1]?.method).toBe("POST");
+    expect(requests[1]?.url).toBe("https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations");
+    await expect(requests[1]!.json()).resolves.toMatchObject({
+      data: {
+        type: "betaBuildLocalizations",
+        attributes: { locale: "en-US", whatsNew: "Fixed a crash." },
+        relationships: { build: { data: { type: "builds", id: "B1" } } },
+      },
+    });
+  });
+});
+
+describe("App Store Connect included relationships", () => {
+  it("attaches the prerelease version each build belongs to", async () => {
+    const requests = stubFetch([
+      () =>
+        Response.json({
+          data: [
+            {
+              type: "builds",
+              id: "B1",
+              attributes: { version: "42", processingState: "VALID" },
+              relationships: { preReleaseVersion: { data: { type: "preReleaseVersions", id: "P1" } } },
+            },
+            { type: "builds", id: "B2", attributes: { version: "41" } },
+          ],
+          included: [{ type: "preReleaseVersions", id: "P1", attributes: { version: "1.4.0", platform: "IOS" } }],
+          links: { self: "https://api.appstoreconnect.apple.com" },
+        }),
+    ]);
+
+    const result = await executors["app_store_connect.list_builds"]!(
+      { appId: "A1", expired: false, platform: "IOS" },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        builds: [
+          { id: "B1", version: "42", preReleaseVersion: { id: "P1", version: "1.4.0", platform: "IOS" } },
+          { id: "B2", preReleaseVersion: null },
+        ],
+      },
+    });
+    const query = new URL(requests[0]!.url).searchParams;
+    expect(query.get("filter[app]")).toBe("A1");
+    expect(query.get("filter[expired]")).toBe("false");
+    expect(query.get("filter[preReleaseVersion.platform]")).toBe("IOS");
+    expect(query.get("include")).toBe("preReleaseVersion");
+  });
+});
+
+describe("App Store Connect app store versions", () => {
+  it("drops the deprecated appStoreState and usesIdfa attributes", async () => {
+    stubFetch([
+      () =>
+        Response.json({
+          data: [
+            {
+              type: "appStoreVersions",
+              id: "V1",
+              attributes: {
+                platform: "IOS",
+                versionString: "2.0.1",
+                appStoreState: "READY_FOR_SALE",
+                appVersionState: "READY_FOR_DISTRIBUTION",
+                earliestReleaseDate: null,
+                usesIdfa: null,
+              },
+            },
+          ],
+          links: { self: "https://api.appstoreconnect.apple.com" },
+        }),
+    ]);
+
+    const result = await executors["app_store_connect.list_app_store_versions"]!({ appId: "A1" }, context);
+
+    expect(result).toMatchObject({
+      ok: true,
+      output: {
+        appStoreVersions: [
+          { id: "V1", versionString: "2.0.1", appVersionState: "READY_FOR_DISTRIBUTION", earliestReleaseDate: null },
+        ],
+      },
+    });
+    // Apple deprecated both attributes, so the record must not carry them even
+    // though the attribute spread would otherwise pass them straight through.
+    expect(result).not.toHaveProperty("output.appStoreVersions.0.appStoreState");
+    expect(result).not.toHaveProperty("output.appStoreVersions.0.usesIdfa");
+  });
+});
+
+describe("App Store Connect proxy", () => {
+  it("signs the forwarded request", async () => {
+    const requests = stubFetch([() => Response.json({ data: [] })]);
+
+    const result = await proxy({ method: "GET", endpoint: "/v1/apps", query: { limit: "1" } }, context);
+
+    expect(result.ok).toBe(true);
+    expect(requests[0]?.url).toBe("https://api.appstoreconnect.apple.com/v1/apps?limit=1");
+    expect(requests[0]?.headers.get("authorization")?.startsWith("Bearer ")).toBe(true);
+  });
+
+  it.each([
+    ["/v1/../../etc/passwd", "endpoint must not contain path traversal segments"],
+    ["/v1\\apps", "endpoint must not contain path traversal segments"],
+    ["/etc/passwd", "endpoint is not supported for this provider"],
+    ["/.well-known/openid-configuration", "endpoint is not supported for this provider"],
+  ])("rejects %s before signing a token", async (endpoint, message) => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await proxy({ method: "GET", endpoint }, context);
+
+    expect(result).toMatchObject({ ok: false, error: { message } });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/providers/app_store_connect/executors.ts
+++ b/src/providers/app_store_connect/executors.ts
@@ -1,0 +1,86 @@
+import type {
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { AppStoreConnectContext } from "./runtime.ts";
+
+import { optionalString } from "../../core/cast.ts";
+import {
+  defineProviderExecutors,
+  defineProviderProxy,
+  providerProxyEndpointPrefixes,
+  requireCustomCredential,
+  requiredInputString,
+} from "../provider-runtime.ts";
+import { createAppStoreConnectAuthorization } from "./jwt.ts";
+import {
+  appStoreConnectActionHandlers,
+  appStoreConnectApiBaseUrl,
+  requestAppStoreConnectCredentialValidation,
+} from "./runtime.ts";
+
+const service = "app_store_connect";
+
+export const executors: ProviderExecutors = defineProviderExecutors<AppStoreConnectContext>({
+  service,
+  handlers: appStoreConnectActionHandlers,
+  // The API host is a hardcoded literal with no credential-derived component.
+  skipDnsValidation: true,
+  fallbackMessage: "App Store Connect request failed",
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<AppStoreConnectContext> {
+    const credential = await requireCustomCredential(context, service);
+    return {
+      authorization: createAppStoreConnectAuthorization(credential.values),
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
+
+export const credentialValidators: CredentialValidators = {
+  async customCredential(input, { fetcher, signal }) {
+    const keyId = requiredInputString(input.values.keyId, "keyId");
+    const issuerId = optionalString(input.values.issuerId);
+    await requestAppStoreConnectCredentialValidation({
+      authorization: createAppStoreConnectAuthorization(input.values),
+      fetcher,
+      signal,
+    });
+
+    return {
+      profile: {
+        // Team keys share one issuer across the team; an individual key has no
+        // issuer, so its own key id is the stable identity.
+        accountId: issuerId ?? keyId,
+        displayName: `App Store Connect key ${keyId}`,
+      },
+      // App Store Connect exposes no endpoint that reports the roles a key
+      // holds, so there is nothing to derive granted scopes from.
+      grantedScopes: [],
+      metadata: {
+        apiBaseUrl: appStoreConnectApiBaseUrl,
+        validationEndpoint: "/v1/apps",
+        keyId,
+        issuerId: issuerId ?? null,
+        keyKind: issuerId ? "team" : "individual",
+      },
+    };
+  },
+};
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: appStoreConnectApiBaseUrl,
+  // App Store Connect authenticates with a per-request signed JWT, which no
+  // shared proxy auth type covers, so the header is set here instead.
+  auth: { type: "none" },
+  skipDnsValidation: true,
+  allowedEndpoint: providerProxyEndpointPrefixes("/v1", "/v2", "/v3"),
+  async customizeRequest({ context, headers }) {
+    const credential = await requireCustomCredential(context, service);
+    const authorization = createAppStoreConnectAuthorization(credential.values);
+    headers.set("authorization", await authorization());
+  },
+});

--- a/src/providers/app_store_connect/jwt.test.ts
+++ b/src/providers/app_store_connect/jwt.test.ts
@@ -1,0 +1,85 @@
+import { exportPKCS8, generateKeyPair, jwtVerify } from "jose";
+import { describe, expect, it } from "vitest";
+import { ProviderRequestError } from "../provider-runtime.ts";
+import { createAppStoreConnectAuthorization } from "./jwt.ts";
+
+const keyId = "2X9R4HXF34";
+const issuerId = "57246542-96fe-1a63-e053-0824d011072a";
+
+async function createSigningKey(): Promise<{ pem: string; publicKey: CryptoKey }> {
+  const { privateKey, publicKey } = await generateKeyPair("ES256", { extractable: true });
+  return { pem: await exportPKCS8(privateKey), publicKey };
+}
+
+function readToken(header: string): string {
+  expect(header.startsWith("Bearer ")).toBe(true);
+  return header.slice("Bearer ".length);
+}
+
+describe("App Store Connect token signing", () => {
+  it("signs a team key token with the issuer claim", async () => {
+    const { pem, publicKey } = await createSigningKey();
+
+    const header = await createAppStoreConnectAuthorization({ keyId, issuerId, privateKey: pem })();
+
+    const { payload, protectedHeader } = await jwtVerify(readToken(header), publicKey);
+    expect(protectedHeader).toMatchObject({ alg: "ES256", kid: keyId, typ: "JWT" });
+    expect(payload.aud).toBe("appstoreconnect-v1");
+    expect(payload.iss).toBe(issuerId);
+    expect(payload.sub).toBeUndefined();
+    // Apple rejects a lifetime above 20 minutes, so the signer stays well below it.
+    expect((payload.exp as number) - (payload.iat as number)).toBe(600);
+  });
+
+  it("signs an individual key token with the fixed subject and no issuer", async () => {
+    const { pem, publicKey } = await createSigningKey();
+
+    const header = await createAppStoreConnectAuthorization({ keyId, privateKey: pem })();
+
+    const { payload, protectedHeader } = await jwtVerify(readToken(header), publicKey);
+    expect(protectedHeader.kid).toBe(keyId);
+    expect(payload.sub).toBe("user");
+    expect(payload.iss).toBeUndefined();
+    expect(payload.aud).toBe("appstoreconnect-v1");
+  });
+
+  it("accepts a private key pasted with escaped line breaks", async () => {
+    const { pem, publicKey } = await createSigningKey();
+    const escaped = pem.replaceAll("\n", "\\n");
+
+    const header = await createAppStoreConnectAuthorization({ keyId, issuerId, privateKey: escaped })();
+
+    await expect(jwtVerify(readToken(header), publicKey)).resolves.toBeDefined();
+  });
+
+  it("signs once and reuses the token for the rest of the run", async () => {
+    const { pem } = await createSigningKey();
+    const authorization = createAppStoreConnectAuthorization({ keyId, issuerId, privateKey: pem });
+
+    const [first, second] = await Promise.all([authorization(), authorization()]);
+
+    expect(first).toBe(second);
+  });
+
+  it("rejects a private key that is not a PEM block", () => {
+    expect(() => createAppStoreConnectAuthorization({ keyId, privateKey: "AuthKey_2X9R4HXF34" })).toThrow(
+      /privateKey/u,
+    );
+    try {
+      createAppStoreConnectAuthorization({ keyId, privateKey: "AuthKey_2X9R4HXF34" });
+      expect.unreachable("a non-PEM private key must be rejected");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderRequestError);
+      expect((error as ProviderRequestError).status).toBe(400);
+    }
+  });
+
+  it("rejects a PEM block that does not hold an EC P-256 key", async () => {
+    const authorization = createAppStoreConnectAuthorization({
+      keyId,
+      privateKey: "-----BEGIN PRIVATE KEY-----\nbm90LWEta2V5\n-----END PRIVATE KEY-----\n",
+    });
+
+    await expect(authorization()).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/src/providers/app_store_connect/jwt.ts
+++ b/src/providers/app_store_connect/jwt.ts
@@ -1,0 +1,79 @@
+import { importPKCS8, SignJWT } from "jose";
+import { optionalString } from "../../core/cast.ts";
+import { ProviderRequestError, requiredInputString } from "../provider-runtime.ts";
+
+/** The audience every App Store Connect token is signed for. */
+const appStoreConnectAudience = "appstoreconnect-v1";
+/**
+ * App Store Connect rejects a token whose `exp - iat` is more than 20 minutes.
+ * Ten minutes stays well inside that ceiling while covering an action that
+ * issues several requests.
+ */
+const tokenLifetimeSeconds = 600;
+const pkcs8Marker = "-----BEGIN PRIVATE KEY-----";
+
+interface AppStoreConnectKey {
+  keyId: string;
+  /** Present for a team key; an individual key has no issuer and signs with `sub: "user"`. */
+  issuerId: string | undefined;
+  privateKey: string;
+}
+
+/**
+ * Build the `Authorization` header value for one App Store Connect action run.
+ *
+ * The returned function signs the ES256 JWT on first use and reuses it for the
+ * rest of the run, so an action that issues several requests signs once. The
+ * token is never cached across runs, which would outlive the credential it was
+ * signed from.
+ */
+export function createAppStoreConnectAuthorization(values: Record<string, string>): () => Promise<string> {
+  const key = readAppStoreConnectKey(values);
+  let signed: Promise<string> | undefined;
+  return () => {
+    signed ??= signAuthorizationHeader(key);
+    return signed;
+  };
+}
+
+function readAppStoreConnectKey(values: Record<string, string>): AppStoreConnectKey {
+  const privateKey = requiredInputString(values.privateKey, "privateKey").replaceAll("\\n", "\n");
+  if (!privateKey.includes(pkcs8Marker)) {
+    throw new ProviderRequestError(
+      400,
+      "privateKey must be the PEM contents of the App Store Connect .p8 key file, starting with -----BEGIN PRIVATE KEY-----",
+    );
+  }
+
+  return {
+    keyId: requiredInputString(values.keyId, "keyId"),
+    issuerId: optionalString(values.issuerId),
+    privateKey,
+  };
+}
+
+async function signAuthorizationHeader(key: AppStoreConnectKey): Promise<string> {
+  const signingKey = await importAppStoreConnectKey(key.privateKey);
+  const issuedAt = Math.floor(Date.now() / 1000);
+  // A team key is identified by its issuer; an individual key has none and is
+  // identified by the fixed subject Apple documents for it.
+  const claims = key.issuerId === undefined ? { sub: "user" } : { iss: key.issuerId };
+  const token = await new SignJWT(claims)
+    .setProtectedHeader({ alg: "ES256", kid: key.keyId, typ: "JWT" })
+    .setAudience(appStoreConnectAudience)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(issuedAt + tokenLifetimeSeconds)
+    .sign(signingKey);
+  return `Bearer ${token}`;
+}
+
+async function importAppStoreConnectKey(privateKey: string): Promise<CryptoKey> {
+  try {
+    return await importPKCS8(privateKey, "ES256");
+  } catch {
+    throw new ProviderRequestError(
+      400,
+      "privateKey must be an EC P-256 private key in PKCS#8 PEM format, as downloaded from App Store Connect",
+    );
+  }
+}

--- a/src/providers/app_store_connect/runtime.ts
+++ b/src/providers/app_store_connect/runtime.ts
@@ -1,0 +1,815 @@
+import type { ProviderActionHandlers } from "../provider-runtime.ts";
+
+import {
+  booleanString,
+  compactObject,
+  looseArray,
+  optionalBoolean,
+  optionalInteger,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  rawStringOrNull,
+  recordOrEmpty,
+} from "../../core/cast.ts";
+import { encodePathSegment } from "../../core/request.ts";
+import {
+  providerInputError,
+  ProviderRequestError,
+  providerResponseError,
+  providerUserAgent,
+  readProviderJsonBody,
+  requiredInputString,
+  requiredResponseRecord,
+  runProviderRequest,
+  setSearchParams,
+} from "../provider-runtime.ts";
+
+export const appStoreConnectApiBaseUrl = "https://api.appstoreconnect.apple.com";
+
+/** Label used in the shared timeout and transport failure messages. */
+const providerLabel = "App Store Connect";
+
+/**
+ * Whether a failure happens while an action runs or while a credential is being
+ * verified. A rejected token is a field error on the connect form but a
+ * reconnect prompt during execution, so the two phases map 401 differently.
+ */
+type AppStoreConnectPhase = "execute" | "validate";
+
+export interface AppStoreConnectContext {
+  /** Resolves the `Bearer <ES256 JWT>` header value, signed once per action run. */
+  authorization: () => Promise<string>;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+interface AppStoreConnectRequest {
+  path: string;
+  method?: string;
+  query?: Record<string, string | undefined>;
+  body?: Record<string, unknown>;
+  phase?: AppStoreConnectPhase;
+}
+
+interface AppStoreConnectResponse {
+  status: number;
+  payload: unknown;
+}
+
+/** Included resources indexed by `<type>:<id>`, the linkage key JSON:API uses. */
+type IncludedResources = Map<string, Record<string, unknown>>;
+
+interface AppStoreConnectPage {
+  resources: Array<Record<string, unknown>>;
+  included: IncludedResources;
+  nextCursor: string | null;
+  total: number | null;
+}
+
+interface ListRequest {
+  path: string;
+  label: string;
+  query?: Record<string, string | undefined>;
+}
+
+type AppStoreConnectHandler = (input: Record<string, unknown>, context: AppStoreConnectContext) => Promise<unknown>;
+
+export const appStoreConnectActionHandlers: ProviderActionHandlers<"app_store_connect", AppStoreConnectHandler> = {
+  async list_apps(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/apps",
+      label: "App Store Connect app list",
+      query: {
+        "filter[bundleId]": optionalString(input.bundleId),
+        "filter[name]": optionalString(input.name),
+        "filter[sku]": optionalString(input.sku),
+        sort: optionalString(input.sort),
+      },
+    });
+    return {
+      apps: page.resources.map((resource) => normalizeResource(resource, "App Store Connect app")),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async get_app(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      path: `/v1/apps/${encodePathSegment(readAppStoreConnectId(input.appId, "appId"))}`,
+    });
+    return { app: normalizeResource(readResource(payload, "App Store Connect app"), "App Store Connect app") };
+  },
+
+  async list_builds(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/builds",
+      label: "App Store Connect build list",
+      query: {
+        "filter[app]": readAppStoreConnectId(input.appId, "appId"),
+        "filter[version]": optionalString(input.version),
+        "filter[preReleaseVersion.version]": optionalString(input.preReleaseVersion),
+        "filter[preReleaseVersion.platform]": optionalString(input.platform),
+        "filter[processingState]": optionalString(input.processingState),
+        "filter[betaAppReviewSubmission.betaReviewState]": optionalString(input.betaReviewState),
+        "filter[expired]": booleanString(input.expired),
+        sort: optionalString(input.sort),
+        include: "preReleaseVersion",
+      },
+    });
+    return {
+      builds: page.resources.map((resource) => ({
+        ...normalizeResource(resource, "App Store Connect build"),
+        preReleaseVersion: readPreReleaseVersionSummary(
+          readIncludedResource(resource, "preReleaseVersion", page.included),
+        ),
+      })),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async get_build(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      path: `/v1/builds/${encodePathSegment(readAppStoreConnectId(input.buildId, "buildId"))}`,
+      query: { include: "preReleaseVersion,betaAppReviewSubmission,app" },
+    });
+    const resource = readResource(payload, "App Store Connect build");
+    const included = indexIncludedResources(payload);
+    return {
+      build: {
+        ...normalizeResource(resource, "App Store Connect build"),
+        preReleaseVersion: readPreReleaseVersionSummary(readIncludedResource(resource, "preReleaseVersion", included)),
+        betaAppReviewSubmission: readBetaReviewSubmissionSummary(
+          readIncludedResource(resource, "betaAppReviewSubmission", included),
+        ),
+        app: readAppSummary(readIncludedResource(resource, "app", included)),
+      },
+    };
+  },
+
+  async list_pre_release_versions(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/preReleaseVersions",
+      label: "App Store Connect prerelease version list",
+      query: {
+        "filter[app]": readAppStoreConnectId(input.appId, "appId"),
+        "filter[platform]": optionalString(input.platform),
+        "filter[version]": optionalString(input.version),
+        sort: optionalString(input.sort),
+      },
+    });
+    return {
+      preReleaseVersions: page.resources.map((resource) =>
+        normalizeResource(resource, "App Store Connect prerelease version"),
+      ),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async list_beta_groups(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/betaGroups",
+      label: "App Store Connect beta group list",
+      query: {
+        "filter[app]": readAppStoreConnectId(input.appId, "appId"),
+        "filter[name]": optionalString(input.name),
+        "filter[isInternalGroup]": booleanString(input.isInternalGroup),
+        "filter[publicLinkEnabled]": booleanString(input.publicLinkEnabled),
+      },
+    });
+    return {
+      betaGroups: page.resources.map((resource) => normalizeResource(resource, "App Store Connect beta group")),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async create_beta_group(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: "/v1/betaGroups",
+      body: {
+        data: {
+          type: "betaGroups",
+          attributes: compactObject({
+            name: requiredInputString(input.name, "name"),
+            publicLinkEnabled: optionalBoolean(input.publicLinkEnabled),
+            publicLinkLimitEnabled: optionalBoolean(input.publicLinkLimitEnabled),
+            publicLinkLimit: optionalInteger(input.publicLinkLimit),
+            feedbackEnabled: optionalBoolean(input.feedbackEnabled),
+            hasAccessToAllBuilds: optionalBoolean(input.hasAccessToAllBuilds),
+          }),
+          relationships: { app: toOneLinkage("apps", readAppStoreConnectId(input.appId, "appId")) },
+        },
+      },
+    });
+    return {
+      betaGroup: normalizeResource(
+        readResource(payload, "App Store Connect beta group"),
+        "App Store Connect beta group",
+      ),
+    };
+  },
+
+  async delete_beta_group(input, context) {
+    const betaGroupId = readAppStoreConnectId(input.betaGroupId, "betaGroupId");
+    const response = await requestAppStoreConnect(context, {
+      method: "DELETE",
+      path: `/v1/betaGroups/${encodePathSegment(betaGroupId)}`,
+    });
+    assertNoContent(response, [204], "Deleting the App Store Connect beta group");
+    return { id: betaGroupId, deleted: true };
+  },
+
+  async list_beta_testers(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/betaTesters",
+      label: "App Store Connect beta tester list",
+      query: {
+        "filter[email]": optionalString(input.email),
+        "filter[firstName]": optionalString(input.firstName),
+        "filter[lastName]": optionalString(input.lastName),
+        "filter[inviteType]": optionalString(input.inviteType),
+        "filter[apps]": optionalString(input.appId),
+        "filter[betaGroups]": optionalString(input.betaGroupId),
+        "filter[builds]": optionalString(input.buildId),
+        sort: optionalString(input.sort),
+      },
+    });
+    return {
+      betaTesters: page.resources.map((resource) => normalizeResource(resource, "App Store Connect beta tester")),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async create_beta_tester(input, context) {
+    const betaGroupIds = optionalStringArray(input.betaGroupIds);
+    const buildIds = optionalStringArray(input.buildIds);
+    // App Store Connect only creates a tester that is assigned to something,
+    // and answers an unassigned create with a 409 the caller cannot act on.
+    if (!betaGroupIds?.length && !buildIds?.length) {
+      throw providerInputError("betaGroupIds or buildIds must contain at least one identifier");
+    }
+
+    const { payload } = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: "/v1/betaTesters",
+      body: {
+        data: {
+          type: "betaTesters",
+          attributes: compactObject({
+            email: requiredInputString(input.email, "email"),
+            firstName: optionalString(input.firstName),
+            lastName: optionalString(input.lastName),
+          }),
+          relationships: compactObject({
+            betaGroups: betaGroupIds?.length ? toManyLinkage("betaGroups", betaGroupIds) : undefined,
+            builds: buildIds?.length ? toManyLinkage("builds", buildIds) : undefined,
+          }),
+        },
+      },
+    });
+    return {
+      betaTester: normalizeResource(
+        readResource(payload, "App Store Connect beta tester"),
+        "App Store Connect beta tester",
+      ),
+    };
+  },
+
+  async delete_beta_tester(input, context) {
+    const betaTesterId = readAppStoreConnectId(input.betaTesterId, "betaTesterId");
+    const response = await requestAppStoreConnect(context, {
+      method: "DELETE",
+      path: `/v1/betaTesters/${encodePathSegment(betaTesterId)}`,
+    });
+    // Removing a tester is the one delete App Store Connect may answer
+    // asynchronously, so it documents 202 alongside 204.
+    assertNoContent(response, [202, 204], "Removing the App Store Connect beta tester");
+    return { id: betaTesterId, deleted: true };
+  },
+
+  async add_beta_testers_to_group(input, context) {
+    const betaGroupId = readAppStoreConnectId(input.betaGroupId, "betaGroupId");
+    const betaTesterIds = readIdentifierList(input.betaTesterIds, "betaTesterIds");
+    const response = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: `/v1/betaGroups/${encodePathSegment(betaGroupId)}/relationships/betaTesters`,
+      body: toManyLinkage("betaTesters", betaTesterIds),
+    });
+    assertNoContent(response, [204], "Adding testers to the App Store Connect beta group");
+    return { betaGroupId, betaTesterIds, added: true };
+  },
+
+  async remove_beta_testers_from_group(input, context) {
+    const betaGroupId = readAppStoreConnectId(input.betaGroupId, "betaGroupId");
+    const betaTesterIds = readIdentifierList(input.betaTesterIds, "betaTesterIds");
+    const response = await requestAppStoreConnect(context, {
+      method: "DELETE",
+      path: `/v1/betaGroups/${encodePathSegment(betaGroupId)}/relationships/betaTesters`,
+      body: toManyLinkage("betaTesters", betaTesterIds),
+    });
+    assertNoContent(response, [204], "Removing testers from the App Store Connect beta group");
+    return { betaGroupId, betaTesterIds, removed: true };
+  },
+
+  async add_build_to_beta_groups(input, context) {
+    const buildId = readAppStoreConnectId(input.buildId, "buildId");
+    const betaGroupIds = readIdentifierList(input.betaGroupIds, "betaGroupIds");
+    const response = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: `/v1/builds/${encodePathSegment(buildId)}/relationships/betaGroups`,
+      body: toManyLinkage("betaGroups", betaGroupIds),
+    });
+    assertNoContent(response, [204], "Adding the build to App Store Connect beta groups");
+    return { buildId, betaGroupIds, added: true };
+  },
+
+  async submit_build_for_beta_review(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: "/v1/betaAppReviewSubmissions",
+      body: {
+        data: {
+          type: "betaAppReviewSubmissions",
+          relationships: { build: toOneLinkage("builds", readAppStoreConnectId(input.buildId, "buildId")) },
+        },
+      },
+    });
+    return readBetaReviewSubmissionSummary(readResource(payload, "App Store Connect beta app review submission"));
+  },
+
+  async update_build_test_notes(input, context) {
+    const buildId = readAppStoreConnectId(input.buildId, "buildId");
+    const locale = requiredInputString(input.locale, "locale");
+    const whatsNew = requiredInputString(input.whatsNew, "whatsNew");
+    // The filterable collection answers with the single localization that
+    // covers this build and locale, so there is no page of locales to walk.
+    const existing = await requestAppStoreConnect(context, {
+      path: "/v1/betaBuildLocalizations",
+      query: { "filter[build]": buildId, "filter[locale]": locale, limit: "1" },
+    });
+    const localizationId = readLocalizationId(existing.payload);
+    if (localizationId) {
+      const { payload } = await requestAppStoreConnect(context, {
+        method: "PATCH",
+        path: `/v1/betaBuildLocalizations/${encodePathSegment(localizationId)}`,
+        body: { data: { type: "betaBuildLocalizations", id: localizationId, attributes: { whatsNew } } },
+      });
+      return { ...readTestNotes(readResource(payload, "App Store Connect beta build localization")), created: false };
+    }
+
+    const { payload } = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: "/v1/betaBuildLocalizations",
+      body: {
+        data: {
+          type: "betaBuildLocalizations",
+          attributes: { locale, whatsNew },
+          relationships: { build: toOneLinkage("builds", buildId) },
+        },
+      },
+    });
+    return { ...readTestNotes(readResource(payload, "App Store Connect beta build localization")), created: true };
+  },
+
+  async list_app_store_versions(input, context) {
+    const page = await listResources(context, input, {
+      path: `/v1/apps/${encodePathSegment(readAppStoreConnectId(input.appId, "appId"))}/appStoreVersions`,
+      label: "App Store Connect version list",
+      query: {
+        "filter[platform]": optionalString(input.platform),
+        "filter[versionString]": optionalString(input.versionString),
+        "filter[appVersionState]": optionalString(input.appVersionState),
+      },
+    });
+    return {
+      appStoreVersions: page.resources.map(normalizeAppStoreVersion),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async get_app_store_version(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      path: `/v1/appStoreVersions/${encodePathSegment(
+        readAppStoreConnectId(input.appStoreVersionId, "appStoreVersionId"),
+      )}`,
+    });
+    return { appStoreVersion: normalizeAppStoreVersion(readResource(payload, "App Store Connect version")) };
+  },
+
+  async list_customer_reviews(input, context) {
+    const rating = optionalInteger(input.rating);
+    const page = await listResources(context, input, {
+      path: `/v1/apps/${encodePathSegment(readAppStoreConnectId(input.appId, "appId"))}/customerReviews`,
+      label: "App Store Connect customer review list",
+      query: {
+        "filter[rating]": rating === undefined ? undefined : String(rating),
+        "filter[territory]": optionalString(input.territory),
+        "exists[publishedResponse]": booleanString(input.hasResponse),
+        sort: optionalString(input.sort),
+        include: "response",
+      },
+    });
+    return {
+      customerReviews: page.resources.map((resource) => ({
+        ...normalizeResource(resource, "App Store Connect customer review"),
+        response: readReviewResponseSummary(readIncludedResource(resource, "response", page.included)),
+      })),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async get_customer_review(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      path: `/v1/customerReviews/${encodePathSegment(readAppStoreConnectId(input.customerReviewId, "customerReviewId"))}`,
+      query: { include: "response" },
+    });
+    const resource = readResource(payload, "App Store Connect customer review");
+    return {
+      customerReview: {
+        ...normalizeResource(resource, "App Store Connect customer review"),
+        response: readReviewResponseSummary(
+          readIncludedResource(resource, "response", indexIncludedResources(payload)),
+        ),
+      },
+    };
+  },
+
+  async respond_to_customer_review(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      method: "POST",
+      path: "/v1/customerReviewResponses",
+      body: {
+        data: {
+          type: "customerReviewResponses",
+          attributes: { responseBody: requiredInputString(input.responseBody, "responseBody") },
+          relationships: {
+            review: toOneLinkage("customerReviews", readAppStoreConnectId(input.customerReviewId, "customerReviewId")),
+          },
+        },
+      },
+    });
+    const customerReviewResponse = readReviewResponseSummary(
+      readResource(payload, "App Store Connect customer review response"),
+    );
+    if (!customerReviewResponse) {
+      throw providerResponseError("App Store Connect did not return the created customer review response");
+    }
+
+    return { customerReviewResponse };
+  },
+
+  async delete_customer_review_response(input, context) {
+    const customerReviewResponseId = readAppStoreConnectId(input.customerReviewResponseId, "customerReviewResponseId");
+    const response = await requestAppStoreConnect(context, {
+      method: "DELETE",
+      path: `/v1/customerReviewResponses/${encodePathSegment(customerReviewResponseId)}`,
+    });
+    assertNoContent(response, [204], "Removing the App Store Connect customer review response");
+    return { id: customerReviewResponseId, deleted: true };
+  },
+
+  async list_users(input, context) {
+    const page = await listResources(context, input, {
+      path: "/v1/users",
+      label: "App Store Connect user list",
+      query: {
+        "filter[roles]": readCommaSeparatedList(input.roles),
+        "filter[username]": optionalString(input.username),
+        "filter[visibleApps]": optionalString(input.visibleAppId),
+        sort: optionalString(input.sort),
+      },
+    });
+    return {
+      users: page.resources.map((resource) => normalizeResource(resource, "App Store Connect user")),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
+  },
+
+  async get_user(input, context) {
+    const { payload } = await requestAppStoreConnect(context, {
+      path: `/v1/users/${encodePathSegment(readAppStoreConnectId(input.userId, "userId"))}`,
+    });
+    return { user: normalizeResource(readResource(payload, "App Store Connect user"), "App Store Connect user") };
+  },
+};
+
+/**
+ * Verify a configured key by asking for a single app.
+ *
+ * Both rejections are field errors on the connect form. A 401 means the token
+ * itself was refused. A 403 does not single out a narrow role: Apple answers it
+ * for a revoked key and a malformed token too, so a key that cannot read apps
+ * is reported as unusable rather than stored as a working connection.
+ */
+export async function requestAppStoreConnectCredentialValidation(context: AppStoreConnectContext): Promise<void> {
+  await requestAppStoreConnect(context, { path: "/v1/apps", query: { limit: "1" }, phase: "validate" });
+}
+
+async function listResources(
+  context: AppStoreConnectContext,
+  input: Record<string, unknown>,
+  request: ListRequest,
+): Promise<AppStoreConnectPage> {
+  const limit = optionalInteger(input.limit);
+  const { payload } = await requestAppStoreConnect(context, {
+    path: request.path,
+    query: {
+      ...request.query,
+      limit: limit === undefined ? undefined : String(limit),
+      cursor: optionalString(input.cursor),
+    },
+  });
+  return {
+    resources: readCollection(payload, request.label),
+    included: indexIncludedResources(payload),
+    nextCursor: readNextCursor(payload),
+    total: readTotal(payload),
+  };
+}
+
+async function requestAppStoreConnect(
+  context: AppStoreConnectContext,
+  input: AppStoreConnectRequest,
+): Promise<AppStoreConnectResponse> {
+  const url = new URL(`${appStoreConnectApiBaseUrl}${input.path}`);
+  setSearchParams(url, input.query ?? {});
+  return runProviderRequest({ signal: context.signal, label: providerLabel }, async (signal) => {
+    const headers = new Headers({
+      accept: "application/json",
+      authorization: await context.authorization(),
+      "user-agent": providerUserAgent,
+    });
+    if (input.body !== undefined) {
+      headers.set("content-type", "application/json");
+    }
+    const response = await context.fetcher(url, {
+      method: input.method ?? "GET",
+      headers,
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal,
+    });
+    const payload = await readPayload(response);
+    if (!response.ok) {
+      throw createAppStoreConnectError(response.status, payload, input.phase ?? "execute");
+    }
+    return { status: response.status, payload };
+  });
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return null;
+  }
+
+  return readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "App Store Connect returned a response that is not JSON",
+    // A 406 answer is plain text rather than JSON, so keep the text for the
+    // error message instead of failing to parse it.
+    invalidJsonFallback: (text) => text,
+  });
+}
+
+function createAppStoreConnectError(
+  status: number,
+  payload: unknown,
+  phase: AppStoreConnectPhase,
+): ProviderRequestError {
+  if (phase === "validate" && status === 401) {
+    return new ProviderRequestError(
+      400,
+      "App Store Connect rejected the key. Check the Key ID, Issuer ID and private key.",
+      payload,
+    );
+  }
+
+  if (phase === "validate" && status === 403) {
+    return new ProviderRequestError(
+      400,
+      "App Store Connect authenticated the key but refused to list apps. Grant the key a role that can read apps (for example Developer, App Manager or Admin), and check that the key has not been revoked.",
+      payload,
+    );
+  }
+
+  return new ProviderRequestError(status, readErrorMessage(status, payload), payload);
+}
+
+function readErrorMessage(status: number, payload: unknown): string {
+  const errors = looseArray(recordOrEmpty(payload).errors);
+  const first = optionalRecord(errors[0]);
+  // Apple's `code` is the only machine-readable discriminator in an error body,
+  // so it leads the message that reaches the caller.
+  const summary = [optionalString(first?.code), optionalString(first?.title), optionalString(first?.detail)]
+    .filter((part) => part !== undefined)
+    .join(": ");
+  if (!summary) {
+    return `App Store Connect request failed with HTTP ${status}`;
+  }
+
+  return errors.length > 1 ? `${summary} (+${errors.length - 1} more)` : summary;
+}
+
+function assertNoContent(response: AppStoreConnectResponse, allowedStatuses: readonly number[], label: string): void {
+  // A redirect the guarded fetch rewrites to GET can answer 200, so accepting
+  // any 2xx would report a resource as deleted while it still exists.
+  if (!allowedStatuses.includes(response.status)) {
+    throw providerResponseError(`${label} answered HTTP ${response.status} instead of ${allowedStatuses.join(" or ")}`);
+  }
+}
+
+function readResource(payload: unknown, label: string): Record<string, unknown> {
+  const envelope = requiredResponseRecord(payload, label);
+  return requiredResponseRecord(envelope.data, `${label} data`);
+}
+
+function readCollection(payload: unknown, label: string): Array<Record<string, unknown>> {
+  const envelope = requiredResponseRecord(payload, label);
+  return looseArray(envelope.data).map((item) => requiredResponseRecord(item, `${label} item`));
+}
+
+function normalizeResource(resource: Record<string, unknown>, label: string): Record<string, unknown> {
+  const id = optionalString(resource.id);
+  if (!id) {
+    throw providerResponseError(`${label} is missing an id`);
+  }
+
+  return { id, ...recordOrEmpty(resource.attributes) };
+}
+
+/**
+ * App Store Connect still returns `appStoreState` and `usesIdfa` on every
+ * version record, but both are deprecated: `appVersionState` replaces the
+ * release state, and the IDFA declaration moved to app privacy. Drop them so
+ * the attribute spread does not publish an answer callers should not branch on.
+ */
+function normalizeAppStoreVersion(resource: Record<string, unknown>): Record<string, unknown> {
+  const version = normalizeResource(resource, "App Store Connect version");
+  delete version.appStoreState;
+  delete version.usesIdfa;
+  return version;
+}
+
+function indexIncludedResources(payload: unknown): IncludedResources {
+  const included: IncludedResources = new Map();
+  for (const item of looseArray(recordOrEmpty(payload).included)) {
+    const resource = optionalRecord(item);
+    const key = linkageKey(resource);
+    if (resource && key) {
+      included.set(key, resource);
+    }
+  }
+  return included;
+}
+
+function readIncludedResource(
+  resource: Record<string, unknown>,
+  relationship: string,
+  included: IncludedResources,
+): Record<string, unknown> | undefined {
+  const key = linkageKey(optionalRecord(recordOrEmpty(recordOrEmpty(resource.relationships)[relationship]).data));
+  return key === undefined ? undefined : included.get(key);
+}
+
+function linkageKey(resource: Record<string, unknown> | undefined): string | undefined {
+  const type = optionalString(resource?.type);
+  const id = optionalString(resource?.id);
+  return type && id ? `${type}:${id}` : undefined;
+}
+
+/**
+ * The cursor for the next page. App Store Connect always publishes it inside
+ * the absolute `links.next` URL and only sometimes repeats it as a bare token
+ * in `meta.paging.nextCursor`.
+ */
+function readNextCursor(payload: unknown): string | null {
+  const next = optionalString(recordOrEmpty(recordOrEmpty(payload).links).next);
+  if (next) {
+    try {
+      const cursor = new URL(next).searchParams.get("cursor");
+      if (cursor) {
+        return cursor;
+      }
+    } catch {
+      // Fall through to the paging metadata when links.next is not a URL.
+    }
+  }
+
+  return optionalString(readPaging(payload).nextCursor) ?? null;
+}
+
+function readTotal(payload: unknown): number | null {
+  return optionalInteger(readPaging(payload).total) ?? null;
+}
+
+function readPaging(payload: unknown): Record<string, unknown> {
+  return recordOrEmpty(recordOrEmpty(recordOrEmpty(payload).meta).paging);
+}
+
+function readAppSummary(resource: Record<string, unknown> | undefined): Record<string, unknown> | null {
+  if (!resource) {
+    return null;
+  }
+
+  const app = normalizeResource(resource, "App Store Connect app");
+  return { id: app.id, name: rawStringOrNull(app.name), bundleId: rawStringOrNull(app.bundleId) };
+}
+
+function readPreReleaseVersionSummary(resource: Record<string, unknown> | undefined): Record<string, unknown> | null {
+  if (!resource) {
+    return null;
+  }
+
+  const version = normalizeResource(resource, "App Store Connect prerelease version");
+  return { id: version.id, version: rawStringOrNull(version.version), platform: rawStringOrNull(version.platform) };
+}
+
+function readBetaReviewSubmissionSummary(
+  resource: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (!resource) {
+    return null;
+  }
+
+  const submission = normalizeResource(resource, "App Store Connect beta app review submission");
+  return {
+    id: submission.id,
+    betaReviewState: rawStringOrNull(submission.betaReviewState),
+    submittedDate: rawStringOrNull(submission.submittedDate),
+  };
+}
+
+function readReviewResponseSummary(resource: Record<string, unknown> | undefined): Record<string, unknown> | null {
+  if (!resource) {
+    return null;
+  }
+
+  const response = normalizeResource(resource, "App Store Connect customer review response");
+  return {
+    id: response.id,
+    responseBody: rawStringOrNull(response.responseBody),
+    lastModifiedDate: rawStringOrNull(response.lastModifiedDate),
+    state: rawStringOrNull(response.state),
+  };
+}
+
+function readTestNotes(resource: Record<string, unknown>): Record<string, unknown> {
+  const localization = normalizeResource(resource, "App Store Connect beta build localization");
+  return {
+    id: localization.id,
+    locale: rawStringOrNull(localization.locale),
+    whatsNew: rawStringOrNull(localization.whatsNew),
+  };
+}
+
+function readLocalizationId(payload: unknown): string | undefined {
+  const localizations = readCollection(payload, "App Store Connect beta build localization list");
+  return optionalString(localizations[0]?.id);
+}
+
+/**
+ * Read a caller-supplied App Store Connect resource identifier.
+ *
+ * `.` and `..` are never identifiers, and the shared `encodePathSegment` leaves
+ * them for the URL parser to collapse: `buildId: ".."` would turn a build
+ * subresource path into the team-wide collection and let the action write to an
+ * unrelated build. Reject them while the id is read, so every identifier is
+ * guarded whether it ends up in a path, a filter, or a relationship linkage.
+ */
+function readAppStoreConnectId(value: unknown, fieldName: string): string {
+  const id = requiredInputString(value, fieldName);
+  if (id === "." || id === "..") {
+    throw providerInputError(`${fieldName} must not be . or ..`);
+  }
+
+  return id;
+}
+
+function readIdentifierList(value: unknown, fieldName: string): string[] {
+  const identifiers = optionalStringArray(value);
+  if (!identifiers?.length) {
+    throw providerInputError(`${fieldName} must contain at least one identifier`);
+  }
+
+  return identifiers;
+}
+
+function readCommaSeparatedList(value: unknown): string | undefined {
+  const values = optionalStringArray(value);
+  return values?.length ? values.join(",") : undefined;
+}
+
+function toOneLinkage(type: string, id: string): { data: { type: string; id: string } } {
+  return { data: { type, id } };
+}
+
+function toManyLinkage(type: string, ids: readonly string[]): { data: Array<{ type: string; id: string }> } {
+  return { data: ids.map((id) => ({ type, id })) };
+}


### PR DESCRIPTION
Adds an `app_store_connect` provider for Apple's App Store Connect API. Users bring an API key from App Store Connect (Key ID, Issuer ID, and the downloaded `.p8`), and the provider signs a short-lived ES256 JWT per action run with `jose`, so the same code runs on Node and Cloudflare Workers. Leaving the Issuer ID empty produces the `sub: "user"` token Apple requires for Individual API Keys. New code lives in _src/providers/app_store_connect/_ with a runnable example in _examples/local-http/app_store_connect.ts_.

What is in the box:

- 24 actions across apps, builds, pre-release versions, TestFlight groups and testers, beta review submission and test notes, App Store versions, customer reviews and responses, and team users. Every list takes `limit` and an opaque `cursor` and returns `nextCursor` and `total` from Apple's JSON:API envelope.
- A proxy over `/v1`, `/v2`, and `/v3` for everything the actions do not cover (sales reports, provisioning, Xcode Cloud), authenticated with the same per-request JWT through `customizeRequest`.
- Credential validation against `GET /v1/apps?limit=1`. Both 401 and 403 become a field error, since Apple documents 403 for revoked keys as well as for roles that cannot read apps. There is no whoami endpoint, so the profile is built from the Issuer ID or the Key ID.
- Resource ids reject `.` and `..` before they reach a path, and App Store version records drop the deprecated `appStoreState` and `usesIdfa` attributes that Apple still returns next to `appVersionState`.

Every action's path, parameters, enums, request bodies, and status codes were checked against Apple's OpenAPI 4.4.1 spec, and the read paths were exercised against the live API with a team key: list and get actions, cursor pagination, the 404 mapping, and the proxy guards. Apple returns an explicit `null` for attributes without a value, so the output schemas mark every attribute other than `id` as nullable. Write actions were not run against the live account. Tests cover the JWT claims for both key kinds, pagination, error mapping, the validator branches, the 202/204 handling for tester deletion, the PATCH-versus-POST branch of test notes, and the proxy endpoint guard. The sample Key ID and Issuer ID in the README and field placeholders are the ones from Apple's own token documentation.
