### PR TITLE
feat(provider): add official ClickUp MCP

### DIFF
--- a/.codex/skills/add-provider/SKILL.md
+++ b/.codex/skills/add-provider/SKILL.md
@@ -42,6 +42,7 @@ Before writing code, pick the closest current provider and follow its current im
 - `src/providers/avoma` or `src/providers/attention`: API key provider with `executors.ts` as credential wiring and provider logic in `runtime.ts`.
 - `src/providers/github`: provider supporting both OAuth and API key through one bearer-token runtime context.
 - `src/providers/gmail`: OAuth-only provider with credential validation and resource-specific runtime helpers.
+- `src/providers/sunsama_mcp` or `src/providers/clickup_mcp`: remote MCP providers using a manually registered public OAuth client and PKCE.
 - `src/providers/benchmark_email`, `src/providers/clickhouse`, or `src/providers/dataforseo`: custom credentials or user-configured API base URLs.
 - `src/providers/baselinker`, `src/providers/iqair_airvisual`, or `src/providers/autotask`: provider proxy support and endpoint guards.
 - `src/providers/http-json-runtime.ts`: shared helper for simple JSON HTTP providers when the provider does not need a richer local protocol.
@@ -102,6 +103,10 @@ Map provider auth to this repository's public credential types:
 - `oauth2`: configure public authorization URL, token URL, scopes, redirect path behavior if required by current types, token auth method, and static authorization params.
 
 Open-source users bring their own credentials and OAuth applications. Provider code should validate and use those credentials through the shared runtime interfaces instead of assuming an external credential service.
+
+Dynamic client registration endpoints do not authorize the runtime to register OAuth clients automatically. Treat registration as developer setup: describe the registration request in `clientSetup`, let the developer register the runtime's displayed callback URL, and accept the returned `client_id` through the existing OAuth client configuration. For a public client, use `tokenEndpointAuthMethod: "none"`, enable PKCE when required, and tell the developer to leave Client Secret empty. See `src/providers/clickup_mcp/definition.ts` and `src/providers/sunsama_mcp/definition.ts`.
+
+Verify RFC 8707 resource indicators independently at the authorization and token endpoints. Discovery metadata saying resource indicators are supported does not prove the token request requires one. Use `authorizationParams` for an authorization URL parameter; do not extend the shared token flow unless a real code exchange shows the token endpoint needs additional fields.
 
 Add `credentialValidators` in `executors.ts` when the provider can cheaply verify credentials and return a useful `CredentialProfile`. Use a stable account id and readable display name when the provider exposes them.
 

--- a/src/providers/clickup_mcp/actions.ts
+++ b/src/providers/clickup_mcp/actions.ts
@@ -141,8 +141,7 @@ export const clickupMcpActions: ActionDefinition[] = [
     "Add a comment to a ClickUp task.",
     writeScope,
     {
-      entity_type: s.stringEnum("The type of ClickUp entity receiving the comment.", ["task", "list", "view"]),
-      entity_id: s.nonEmptyString("The target task, List, or view ID."),
+      entity_id: s.nonEmptyString("The target task ID."),
       comment_text: s.string("The comment text, with Markdown supported unless it contains a mention.", {
         minLength: 1,
         maxLength: 40_000,
@@ -153,7 +152,7 @@ export const clickupMcpActions: ActionDefinition[] = [
         pattern: "^\\d+$",
       }),
     },
-    ["comment_text"],
+    ["entity_id", "comment_text"],
   ),
   action(
     "send_chat_message",

--- a/src/providers/clickup_mcp/actions.ts
+++ b/src/providers/clickup_mcp/actions.ts
@@ -142,7 +142,7 @@ export const clickupMcpActions: ActionDefinition[] = [
     writeScope,
     {
       entity_id: s.nonEmptyString("The target task ID."),
-      comment_text: s.string("The comment text, with Markdown supported unless it contains a mention.", {
+      comment_text: s.string("The plain-text comment body.", {
         minLength: 1,
         maxLength: 40_000,
       }),

--- a/src/providers/clickup_mcp/actions.ts
+++ b/src/providers/clickup_mcp/actions.ts
@@ -1,0 +1,174 @@
+import type { ActionDefinition, JsonSchema } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "clickup_mcp";
+const readScope = ["read"];
+const writeScope = ["write"];
+const resultSchema = s.object("The ClickUp MCP tool response.", {
+  result: s.unknown("The normalized structured result, text, or MCP content returned by ClickUp."),
+});
+
+function action(
+  name: string,
+  description: string,
+  requiredScopes: string[],
+  properties: Record<string, JsonSchema>,
+  required: string[] = [],
+): ActionDefinition {
+  return defineProviderAction(service, {
+    name,
+    description,
+    requiredScopes,
+    inputSchema: s.object(`Arguments for the ClickUp MCP ${name} tool.`, properties, {
+      optional: Object.keys(properties).filter((key) => !required.includes(key)),
+    }),
+    outputSchema: resultSchema,
+  });
+}
+
+const taskReferenceFields: Record<string, JsonSchema> = {
+  task_id: s.nonEmptyString("The ClickUp task ID, including a custom ID when configured."),
+};
+
+export const clickupMcpActions: ActionDefinition[] = [
+  action(
+    "search_workspace",
+    "Search tasks, Lists, Folders, and Docs across the authorized ClickUp Workspaces.",
+    readScope,
+    {
+      keywords: s.nonEmptyString("Keywords to search for."),
+      count: s.number("The maximum number of results to return on this page."),
+      cursor: s.string("The cursor returned by the previous page."),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+  ),
+  action(
+    "get_task",
+    "Get one ClickUp task, optionally including normally summarized sections.",
+    readScope,
+    {
+      ...taskReferenceFields,
+      include: s.array(
+        "Sections to expand in the response.",
+        s.stringEnum("One task section.", [
+          "attachments",
+          "checklists",
+          "custom_fields",
+          "dependencies",
+          "description",
+          "linked_tasks",
+          "subtasks",
+          "watchers",
+        ]),
+      ),
+      expand_statuses: s.boolean("Whether to include the statuses available for this task's List."),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+    ["task_id"],
+  ),
+  action(
+    "get_workspace_hierarchy",
+    "Get the authorized ClickUp Workspace hierarchy of Spaces, Folders, and Lists.",
+    readScope,
+    {
+      cursor: s.string("The cursor returned by the previous page."),
+      limit: s.number("The maximum number of Spaces to return.", { minimum: 1, maximum: 50 }),
+      max_depth: s.stringEnum("The hierarchy depth: Spaces only, Folders, or Lists.", ["0", "1", "2"]),
+      space_ids: s.array("Only return these Space IDs.", s.nonEmptyString("One Space ID.")),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+  ),
+  action("get_workspace_members", "List members and guests in an authorized ClickUp Workspace.", readScope, {
+    workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+      pattern: "^\\d+$",
+    }),
+  }),
+  action(
+    "create_task",
+    "Create a task in a ClickUp List.",
+    writeScope,
+    {
+      name: s.nonEmptyString("The task name."),
+      list_id: s.nonEmptyString("The destination ClickUp List ID."),
+      markdown_description: s.string("The task description in Markdown."),
+      assignees: s.array("ClickUp user IDs to assign.", s.nonEmptyString("One user ID.")),
+      due_date: s.string("The due date as YYYY-MM-DD or YYYY-MM-DD HH:MM."),
+      start_date: s.string("The start date as YYYY-MM-DD or YYYY-MM-DD HH:MM."),
+      priority: s.stringEnum("The task priority.", ["urgent", "high", "normal", "low"]),
+      status: s.nonEmptyString("A status available in the destination List."),
+      tags: s.array("Existing tag names to apply.", s.nonEmptyString("One tag name.")),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+    ["name", "list_id"],
+  ),
+  action(
+    "update_task",
+    "Update the properties of an existing ClickUp task.",
+    writeScope,
+    {
+      ...taskReferenceFields,
+      name: s.nonEmptyString("The updated task name."),
+      markdown_description: s.string("The updated task description in Markdown."),
+      assignees: s.array("Replacement ClickUp user IDs.", s.nonEmptyString("One user ID.")),
+      due_date: s.string("The updated due date, or `none` to clear it."),
+      start_date: s.string("The updated start date, or `none` to clear it."),
+      priority: s.stringEnum("The updated task priority, or `none` to clear it.", [
+        "urgent",
+        "high",
+        "normal",
+        "low",
+        "none",
+      ]),
+      status: s.nonEmptyString("The updated task status."),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+    ["task_id"],
+  ),
+  action(
+    "create_task_comment",
+    "Add a comment to a ClickUp task.",
+    writeScope,
+    {
+      entity_type: s.stringEnum("The type of ClickUp entity receiving the comment.", ["task", "list", "view"]),
+      entity_id: s.nonEmptyString("The target task, List, or view ID."),
+      comment_text: s.string("The comment text, with Markdown supported unless it contains a mention.", {
+        minLength: 1,
+        maxLength: 40_000,
+      }),
+      reply_to_id: s.string("The parent comment ID when creating a threaded reply."),
+      notify_all: s.boolean("Whether to notify every assignee."),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+    ["comment_text"],
+  ),
+  action(
+    "send_chat_message",
+    "Send a message to a ClickUp Chat channel.",
+    writeScope,
+    {
+      channel_id: s.nonEmptyString("The ClickUp Chat channel ID."),
+      content: s.nonEmptyString("The message content."),
+      parent_message_id: s.string("The parent message ID when sending a threaded reply."),
+      type: s.stringEnum("The chat item type.", ["message", "post"]),
+      content_format: s.stringEnum("The content format.", ["text/md", "text/plain"]),
+      workspace_id: s.string("The Workspace ID when the connection authorizes multiple Workspaces.", {
+        pattern: "^\\d+$",
+      }),
+    },
+    ["channel_id", "content"],
+  ),
+];

--- a/src/providers/clickup_mcp/definition.ts
+++ b/src/providers/clickup_mcp/definition.ts
@@ -1,0 +1,35 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { clickupMcpActions } from "./actions.ts";
+
+const clickupMcpEndpoint = "https://mcp.clickup.com/mcp";
+
+/** ClickUp provider backed by ClickUp's official remote MCP server. */
+export const provider: ProviderDefinition = {
+  service: "clickup_mcp",
+  displayName: "ClickUp MCP",
+  description: "Search and manage ClickUp work through ClickUp's official remote MCP server.",
+  categories: ["Productivity"],
+  authTypes: ["oauth2"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://mcp.clickup.com/oauth/authorize",
+      tokenUrl: "https://mcp.clickup.com/oauth/token",
+      scopes: ["read", "write"],
+      tokenEndpointAuthMethod: "none",
+      pkce: { method: "S256" },
+      authorizationParams: { resource: clickupMcpEndpoint },
+      clientSetup: {
+        docsUrl: "https://developer.clickup.com/docs/connect-an-ai-assistant-to-clickups-mcp-server",
+        steps: [
+          "Copy the Callback URL shown below.",
+          'POST {"client_name":"Open Connector","redirect_uris":["<Callback URL>"],"grant_types":["authorization_code"],"response_types":["code"],"token_endpoint_auth_method":"none"} as JSON to https://mcp.clickup.com/oauth/register.',
+          "Copy the returned client_id into the Client ID field below and leave Client Secret empty.",
+        ],
+      },
+    },
+  ],
+  homepageUrl: "https://developer.clickup.com/docs/connect-an-ai-assistant-to-clickups-mcp-server",
+  actions: clickupMcpActions,
+};

--- a/src/providers/clickup_mcp/executors.ts
+++ b/src/providers/clickup_mcp/executors.ts
@@ -1,0 +1,113 @@
+import type { CredentialValidators, ProviderExecutors } from "../../core/types.ts";
+import type { OAuthProviderContext, ProviderActionSources, ProviderRuntimeHandler } from "../provider-runtime.ts";
+import type { Client } from "@modelcontextprotocol/client";
+
+import { ProtocolError, SdkHttpError, UnauthorizedError } from "@modelcontextprotocol/client";
+import { createHash } from "node:crypto";
+import { optionalString } from "../../core/cast.ts";
+import { withMcpClient } from "../mcp-client.ts";
+import {
+  defineOAuthProviderExecutors,
+  mapProviderActionSources,
+  providerUserAgent,
+  ProviderRequestError,
+} from "../provider-runtime.ts";
+
+const service = "clickup_mcp";
+const endpoint = "https://mcp.clickup.com/mcp";
+const requestTimeoutMs = 60_000;
+const toolsByAction: ProviderActionSources<typeof service, string> = {
+  search_workspace: "clickup_search",
+  get_task: "clickup_get_task",
+  get_workspace_hierarchy: "clickup_get_workspace_hierarchy",
+  get_workspace_members: "clickup_get_workspace_members",
+  create_task: "clickup_create_task",
+  update_task: "clickup_update_task",
+  create_task_comment: "clickup_create_comment",
+  send_chat_message: "clickup_send_chat_message",
+};
+
+const handlers = mapProviderActionSources(
+  service,
+  toolsByAction,
+  (_actionName, toolName): ProviderRuntimeHandler<OAuthProviderContext> =>
+    async (input, context) => {
+      const result = await withClickUpMcpClient(context, "execute", (client) =>
+        client.callTool({ name: toolName, arguments: input }, { timeout: requestTimeoutMs, signal: context.signal }),
+      );
+      if (!("toolResult" in result) && result.isError) {
+        throw new ProviderRequestError(502, `ClickUp MCP tool ${toolName} returned an error`, result);
+      }
+      if ("toolResult" in result) return { result };
+      if (result.structuredContent) return { result: result.structuredContent };
+      const text = result.content.find((item) => item.type === "text");
+      return { result: text?.type === "text" ? text.text : result.content };
+    },
+);
+
+export const executors: ProviderExecutors = defineOAuthProviderExecutors(service, handlers, {
+  skipDnsValidation: true,
+});
+
+export const credentialValidators: CredentialValidators = {
+  async oauth2(input, { fetcher, signal }) {
+    const tools = await withClickUpMcpClient(
+      { accessToken: input.accessToken, fetcher, signal },
+      "validate",
+      (client) => client.listTools({}, { timeout: requestTimeoutMs, signal }),
+    );
+    const available = new Set(tools.tools.map((tool) => tool.name));
+    if (!Object.values(toolsByAction).some((name) => available.has(name))) {
+      throw new ProviderRequestError(502, "ClickUp MCP did not expose any supported tools for this account");
+    }
+    const tokenHash = createHash("sha256").update(input.accessToken).digest("hex").slice(0, 16);
+    return {
+      profile: {
+        accountId: `clickup:mcp:${tokenHash}`,
+        displayName: `ClickUp MCP · ${tokenHash.slice(-6)}`,
+      },
+      grantedScopes: optionalString(input.metadata.scope)?.split(" ") ?? [],
+      metadata: { mcpEndpoint: endpoint, discoveredToolCount: tools.tools.length },
+    };
+  },
+};
+
+async function withClickUpMcpClient<T>(
+  context: Pick<OAuthProviderContext, "accessToken" | "fetcher" | "signal">,
+  phase: "validate" | "execute",
+  run: (client: Client) => Promise<T>,
+): Promise<T> {
+  return withMcpClient(
+    {
+      endpoint: new URL(endpoint),
+      transport: "streamable_http",
+      fetcher: context.fetcher,
+      headers: { authorization: `Bearer ${context.accessToken}`, "user-agent": providerUserAgent },
+      signal: context.signal,
+      mapError: (error) => mapClickUpMcpError(error, phase),
+    },
+    run,
+  );
+}
+
+function mapClickUpMcpError(error: unknown, phase: "validate" | "execute"): unknown {
+  if (error instanceof ProviderRequestError) return error;
+  if (error instanceof UnauthorizedError) {
+    return new ProviderRequestError(phase === "validate" ? 400 : 401, "ClickUp MCP credential is invalid or expired");
+  }
+  if (error instanceof SdkHttpError) {
+    const status = error.status;
+    if (status === 401 || status === 403) {
+      return new ProviderRequestError(phase === "validate" ? 400 : 401, "ClickUp MCP credential is invalid or expired");
+    }
+    return new ProviderRequestError(status === 429 ? 429 : 502, `ClickUp MCP request failed: ${error.message}`, error);
+  }
+  if (error instanceof ProtocolError) {
+    return new ProviderRequestError(502, `ClickUp MCP request failed: ${error.message}`, error);
+  }
+  return new ProviderRequestError(
+    502,
+    error instanceof Error ? `ClickUp MCP request failed: ${error.message}` : "ClickUp MCP request failed",
+    error,
+  );
+}

--- a/src/providers/clickup_mcp/executors.ts
+++ b/src/providers/clickup_mcp/executors.ts
@@ -3,7 +3,6 @@ import type { OAuthProviderContext, ProviderActionSources, ProviderRuntimeHandle
 import type { Client } from "@modelcontextprotocol/client";
 
 import { ProtocolError, SdkHttpError, UnauthorizedError } from "@modelcontextprotocol/client";
-import { createHash } from "node:crypto";
 import { optionalString } from "../../core/cast.ts";
 import { withMcpClient } from "../mcp-client.ts";
 import {
@@ -60,12 +59,7 @@ export const credentialValidators: CredentialValidators = {
     if (!Object.values(toolsByAction).some((name) => available.has(name))) {
       throw new ProviderRequestError(502, "ClickUp MCP did not expose any supported tools for this account");
     }
-    const tokenHash = createHash("sha256").update(input.accessToken).digest("hex").slice(0, 16);
     return {
-      profile: {
-        accountId: `clickup:mcp:${tokenHash}`,
-        displayName: `ClickUp MCP · ${tokenHash.slice(-6)}`,
-      },
       grantedScopes: optionalString(input.metadata.scope)?.split(" ") ?? [],
       metadata: { mcpEndpoint: endpoint, discoveredToolCount: tools.tools.length },
     };
@@ -100,7 +94,8 @@ function mapClickUpMcpError(error: unknown, phase: "validate" | "execute"): unkn
     if (status === 401 || status === 403) {
       return new ProviderRequestError(phase === "validate" ? 400 : 401, "ClickUp MCP credential is invalid or expired");
     }
-    return new ProviderRequestError(status === 429 ? 429 : 502, `ClickUp MCP request failed: ${error.message}`, error);
+    const providerStatus = 400 <= status && status < 500 ? status : 502;
+    return new ProviderRequestError(providerStatus, `ClickUp MCP request failed: ${error.message}`, error);
   }
   if (error instanceof ProtocolError) {
     return new ProviderRequestError(502, `ClickUp MCP request failed: ${error.message}`, error);


### PR DESCRIPTION
## Summary

- add an additive `clickup_mcp` provider backed by ClickUp's official remote MCP server
- support manually registered public OAuth clients with S256 PKCE and the MCP resource indicator on authorization
- expose eight policy-controlled named actions with schemas verified against a live authenticated `tools/list` response
- document manual dynamic client registration guidance in the add-provider skill

The existing REST-backed `clickup` provider remains unchanged.

## Live verification

- registered a public client for the local callback URL
- completed OAuth with `read write` scopes
- verified token exchange succeeds without repeating `resource` at the token endpoint
- verified `get_workspace_hierarchy`, `get_workspace_members`, and `search_workspace` against the local runtime
- verified credential persistence across server restarts
- did not execute write actions because no scratch List or task was designated

## Checks

- `npm run generate:catalog`
- `npm run fix-check`
- `npm test` (1847 passed, 4 skipped)
- `git diff --check`

Closes #504