### PR TITLE
chore(deps): update qs to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8405,9 +8405,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## Summary

- update the transitive `qs` dependency from 6.15.3 to 6.16.0
- resolve GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g

## Verification

- `npm run fix-check`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npm audit` (`0 vulnerabilities`)