### PR TITLE
feat(connections): align personal connection management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Issues and pull requests are welcome.
 
 - [Quickstart](docs/quickstart.md)
 - [Developer tools](docs/sdk-cli.md)
+- [Programmatic connection management](docs/programmatic-connections.md)
 - [Gmail OAuth and SDK tutorial](docs/gmail-oauth-sdk.md)
 - [Instagram OAuth and Actions](docs/instagram-oauth.md)
 - [Runtime API and MCP](docs/runtime-api.md)

--- a/docs/programmatic-connections.md
+++ b/docs/programmatic-connections.md
@@ -1,0 +1,149 @@
+# Programmatic connections
+
+The `/v1/connections` and `/v1/connection-requests` endpoints provide personal connection
+management through the same HTTP paths and envelopes as OOMOL Hosted Connector. They support
+OAuth authorization, polling one authorization attempt, connection details, and synchronous
+API-key or custom-credential creation and replacement.
+
+## Authentication
+
+Use the local administrator bearer token (`OOMOL_CONNECT_ADMIN_TOKEN`) to manage connections.
+Execution-only runtime tokens and runtime JWTs do not grant management access. A fresh instance
+with neither administrator nor runtime authentication configured accepts local management
+requests without a token. Once runtime authentication is configured, configure an administrator
+token before using these endpoints.
+
+The open runtime has one administrator identity; its bearer token and authenticated console
+session act as that same identity. It does not require Hosted Team headers. Hosted deployments
+apply their own user and Team management permissions.
+
+`GET /v1/apps` remains execution discovery and applies execution access policies.
+`GET /v1/connections` returns the administrator's stored connections, including connections
+hidden from execution discovery. It excludes virtual no-auth and Marketplace entries.
+
+## Start and track OAuth
+
+Configure your provider's OAuth client through the console or `/api/oauth/configs/:service`
+first. The registered callback URL remains `/oauth/callback` on this runtime.
+
+```sh
+curl -sS -X POST http://localhost:3000/v1/connections/github/connect \
+  -H "Authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+The success envelope contains:
+
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "authorizationUrl": "https://github.com/login/oauth/authorize?...",
+    "stateHandle": "oauth-state-id",
+    "connectionRequestId": "request-id",
+    "status": "initiated",
+    "expiresAt": "2026-09-07T10:10:00.000Z"
+  },
+  "meta": {}
+}
+```
+
+Open `authorizationUrl` in a browser and save `connectionRequestId`. The state handle belongs
+to the OAuth callback and is not the result-query identifier.
+
+```sh
+curl -sS http://localhost:3000/v1/connection-requests/request-id \
+  -H "Authorization: Bearer $OOMOL_CONNECT_ADMIN_TOKEN"
+```
+
+The result's `data` has `connectionRequestId`, `service`, `status`, `appId`, `errorCode`,
+`errorMessage`, `expiresAt`, `createdAt`, and `updatedAt`. Creation and update times are Unix
+milliseconds; `expiresAt` is an ISO timestamp. `appId` and the error fields are nullable.
+
+| Status      | Meaning                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `initiated` | Authorization has not reached a terminal result. Poll again, for example after two seconds. |
+| `connected` | This attempt saved its connection. Use its exact `appId` and stop polling.                  |
+| `failed`    | Authorization failed or was denied. Inspect the safe error fields and stop polling.         |
+| `expired`   | The ten-minute authorization window elapsed without a terminal result.                      |
+
+A callback must begin before `expiresAt`. A callback already processing may finish after that
+time and change an expired view to a connected or failed result. Success and failure remain
+queryable until `expiresAt` plus 24 hours. Missing or expired-retention results return HTTP 404
+with `connection_request_not_found`. Results use `Cache-Control: private, no-store` and never
+include credentials or raw provider errors.
+
+Starting another request for the same provider supersedes earlier requests that have not
+started processing, returning `failed` with `request_superseded`. A callback already processing
+continues. Repeated callbacks do not overwrite terminal results.
+
+OAuth inputs can include:
+
+- `returnUri`: optional `http:`, `https:`, or `oomol:` URL. The callback adds `status` and `service`,
+  and safe `code` and `message` fields on failure.
+- `authorizationOptionIds`: provider-declared option IDs. GitHub and Slack expose selectable
+  provider-native scopes in their OAuth definitions. Required options are always included.
+  Omission preserves the configured scopes; unknown options or options on unsupported providers
+  return `invalid_input`. `requires` describes selection dependencies for clients; the server
+  preserves the explicitly selected options and required options.
+- `extra` and `secretExtra`: provider-declared OAuth configuration fields, merged for this
+  authorization attempt without changing the saved client configuration.
+
+## Inspect and reconnect
+
+```http
+GET /v1/connections
+GET /v1/connections?status=active
+GET /v1/connections/by-id/:appId
+POST /v1/connections/by-id/:appId/connect
+```
+
+A successful OAuth request records the outcome of that attempt. Query connection details for
+its current state. An expired OAuth credential with no refresh token reports `reauth_required`.
+
+Reconnection takes the same OAuth body and returns a new request ID. Success keeps the original
+`appId`. If the original connection is deleted or its credentials change during authorization,
+the stale callback fails instead of recreating it or overwriting the replacement.
+
+New connections receive distinct local aliases. Use the returned `alias` as the connection
+selector when executing actions. Existing local default-connection selection remains available.
+
+## API keys and custom credentials
+
+These operations validate and save credentials synchronously. They return the connection in the
+success envelope and do not require polling.
+
+```http
+POST /v1/connections/:service/connect/api-key
+POST /v1/connections/by-id/:appId/connect/api-key
+```
+
+Body: `{ "apiKey": "...", "extra": { "field": "value" }, "comment": "Optional note" }`.
+`extra` and `comment` are optional.
+
+```http
+POST /v1/connections/:service/connect/custom-credential
+POST /v1/connections/by-id/:appId/connect/custom-credential
+```
+
+Body: `{ "values": { "field": "value" }, "comment": "Optional note" }`.
+`comment` is optional; use `null` to clear an existing note. Replacement retains the connection
+ID, requires the existing credential type, and does not discard existing credentials when
+validation fails or a concurrent update wins.
+
+The OpenAPI document at `/openapi.json` describes the request and response envelopes. The local
+console's `/api/connections` and `/api/oauth/authorizations` endpoints continue to work.
+
+## Persistence
+
+Migration `0013_connection_requests.sql` stores authorization attempts on SQLite, PostgreSQL,
+and Cloudflare D1. SQLite applies it through the existing startup migrations. PostgreSQL and D1
+use their existing deployment migration commands; migrate before starting the new runtime.
+
+The pending OAuth snapshot uses the configured secret codec and participates in secret rotation.
+A connection write and its successful request result commit together. D1 uses transactional
+[`batch()`](https://developers.cloudflare.com/d1/worker-api/d1-database/#batch) for these writes;
+SQLite and PostgreSQL use their native transactions. Expired retained records are cleaned up
+when new requests are created.

--- a/migrations/0013_connection_requests.sql
+++ b/migrations/0013_connection_requests.sql
@@ -1,0 +1,17 @@
+create table connection_requests (
+  id text primary key,
+  owner text not null,
+  service text not null,
+  state text not null unique,
+  phase text not null check (phase in ('pending', 'processing', 'completed')),
+  status text not null check (status in ('initiated', 'connected', 'failed')),
+  value text,
+  app_id text,
+  error_code text,
+  error_message text,
+  expires_at text not null,
+  created_at bigint not null,
+  updated_at bigint not null
+);
+create index connection_requests_expires on connection_requests (expires_at);
+create index connection_requests_pending on connection_requests (owner, service) where phase = 'pending';

--- a/migrations/postgresql/0013_connection_requests.sql
+++ b/migrations/postgresql/0013_connection_requests.sql
@@ -1,0 +1,17 @@
+create table connection_requests (
+  id text primary key,
+  owner text not null,
+  service text not null,
+  state text not null unique,
+  phase text not null check (phase in ('pending', 'processing', 'completed')),
+  status text not null check (status in ('initiated', 'connected', 'failed')),
+  value text,
+  app_id text,
+  error_code text,
+  error_message text,
+  expires_at text not null,
+  created_at bigint not null,
+  updated_at bigint not null
+);
+create index connection_requests_expires on connection_requests (expires_at);
+create index connection_requests_pending on connection_requests (owner, service) where phase = 'pending';

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -36,13 +36,18 @@ export interface ConnectionSummary {
   marketplace?: { id: string; pricing: MarketplacePricing };
 }
 
-/**
- * Request body for local credential connections.
- */
+export interface ManagedConnectionSummary extends ConnectionSummary {
+  status: "active" | "reauth_required";
+  comment: string | null;
+}
+
+/** Request body for local credential connections. */
 export interface ConnectWithCredentialInput {
   connectionName?: string;
   values?: Record<string, unknown>;
   signal?: AbortSignal;
+  expectedConnection?: StoredConnection;
+  comment?: string | null;
 }
 
 export interface ConnectWithoutAuthInput {
@@ -338,11 +343,7 @@ export class ConnectionService {
         await this.validateApiKeyCredential(service, { apiKey, values }, input.signal),
       ),
     };
-    const connectionName = normalizeConnectionName(input.connectionName);
-    this.assertNotCancelled(input.signal);
-    const stored = await this.store.set(service, connectionName, credential);
-
-    return this.createStoredConnectionSummary(provider, stored.id, connectionName, credential);
+    return this.saveCredential(provider, credential, input);
   }
 
   async connectWithCustomCredential(service: string, input: ConnectWithCredentialInput): Promise<ConnectionSummary> {
@@ -368,11 +369,7 @@ export class ConnectionService {
         await this.validateCustomCredential(service, { values }, input.signal),
       ),
     };
-    const connectionName = normalizeConnectionName(input.connectionName);
-    this.assertNotCancelled(input.signal);
-    const stored = await this.store.set(service, connectionName, credential);
-
-    return this.createStoredConnectionSummary(provider, stored.id, connectionName, credential);
+    return this.saveCredential(provider, credential, input);
   }
 
   async setOAuthCredential(
@@ -381,27 +378,108 @@ export class ConnectionService {
     connectionNameInput?: string,
     signal?: AbortSignal,
   ): Promise<ConnectionSummary> {
+    let storedCredential: OAuthCredential;
+    try {
+      storedCredential = await this.prepareOAuthCredential(service, credential, signal);
+    } catch (error) {
+      if (!(error instanceof ConnectionError && error.code === "credential_verification_failed")) throw error;
+      // The legacy console flow keeps exchanged tokens when optional profile verification fails.
+      storedCredential = {
+        ...credential,
+        ...this.mergeCredentialRuntimeData(this.getAvailableProvider(service), "oauth2", credential, {}),
+      };
+    }
+    const connectionName = normalizeConnectionName(connectionNameInput);
+    const stored = await this.store.set(service, connectionName, storedCredential);
+    return this.createStoredConnectionSummary(
+      this.getAvailableProvider(service),
+      stored.id,
+      connectionName,
+      storedCredential,
+    );
+  }
+
+  async prepareOAuthCredential(
+    service: string,
+    credential: OAuthCredential,
+    signal?: AbortSignal,
+  ): Promise<OAuthCredential> {
     const provider = this.getAvailableProvider(service);
     if (!this.supportsAuth(provider, "oauth2")) {
       throw new ConnectionError("unsupported_auth_type", `${service} does not support oauth2.`);
     }
 
-    const connectionName = normalizeConnectionName(connectionNameInput);
-    let validation: CredentialValidationResult = {};
-    try {
-      validation = await this.validateOAuthCredential(service, credential, signal);
-    } catch (error) {
-      if (!(error instanceof ConnectionError && error.code === "credential_verification_failed")) {
-        throw error;
-      }
-    }
+    const validation = await this.validateOAuthCredential(service, credential, signal);
     this.assertNotCancelled(signal);
-    const storedCredential = {
+    return {
       ...credential,
       ...this.mergeCredentialRuntimeData(provider, "oauth2", credential, validation),
     };
-    const stored = await this.store.set(service, connectionName, storedCredential);
-    return this.createStoredConnectionSummary(provider, stored.id, connectionName, storedCredential);
+  }
+
+  async getStoredConnection(id: string): Promise<StoredConnection> {
+    const connection = (await this.store.list()).find((item) => item.id === id);
+    if (!connection) throw new ConnectionError("connection_not_found", "Connection not found.");
+    return connection;
+  }
+
+  async listManagedConnections(): Promise<ManagedConnectionSummary[]> {
+    return (await this.store.list()).map((stored) => this.createManagedConnectionSummary(stored));
+  }
+
+  async getManagedConnection(id: string): Promise<ManagedConnectionSummary> {
+    return this.createManagedConnectionSummary(await this.getStoredConnection(id));
+  }
+
+  private createManagedConnectionSummary(stored: StoredConnection): ManagedConnectionSummary {
+    const credential = stored.credential;
+    return {
+      status:
+        credential.authType === "oauth2" &&
+        credential.expiresAt &&
+        Date.parse(credential.expiresAt) <= Date.now() &&
+        !credential.refreshToken
+          ? "reauth_required"
+          : "active",
+      ...this.createConfiguredConnectionSummary(
+        this.getProvider(stored.service),
+        stored.id,
+        stored.connectionName,
+        credential,
+      ),
+      comment:
+        credential.authType !== "no_auth" && typeof credential.metadata.connectionComment === "string"
+          ? credential.metadata.connectionComment
+          : null,
+    };
+  }
+
+  private async saveCredential(
+    provider: ProviderDefinition,
+    credential: Exclude<ResolvedCredential, { authType: "no_auth" }>,
+    input: ConnectWithCredentialInput,
+  ): Promise<ConnectionSummary> {
+    const expected = input.expectedConnection;
+    const previousComment =
+      expected?.credential.authType !== "no_auth" ? expected?.credential.metadata.connectionComment : undefined;
+    if (input.comment !== undefined || previousComment !== undefined) {
+      credential.metadata.connectionComment = input.comment === undefined ? previousComment : input.comment;
+    }
+    this.assertNotCancelled(input.signal);
+    const stored = expected
+      ? await this.replaceCredential(expected, credential)
+      : await this.store.set(provider.service, normalizeConnectionName(input.connectionName), credential);
+    return this.createStoredConnectionSummary(provider, stored.id, stored.connectionName, credential);
+  }
+
+  private async replaceCredential(
+    expected: StoredConnection,
+    credential: ResolvedCredential,
+  ): Promise<StoredConnection> {
+    if (!(await this.store.updateCredential({ ...expected, credential }))) {
+      throw new ConnectionError("connection_changed", "The connection changed during authorization.");
+    }
+    return { ...expected, credential };
   }
 
   async disconnect(

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -435,10 +435,7 @@ export class ConnectionService {
     const credential = stored.credential;
     return {
       status:
-        credential.authType === "oauth2" &&
-        credential.expiresAt &&
-        Date.parse(credential.expiresAt) <= Date.now() &&
-        !credential.refreshToken
+        credential.authType === "oauth2" && !credential.refreshToken && isOAuthCredentialExpired(credential)
           ? "reauth_required"
           : "active",
       ...this.createConfiguredConnectionSummary(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -130,7 +130,7 @@ export type OAuth2AuthDefinition = {
   refreshTokenUrl?: string;
   /** OAuth scopes joined with spaces into the authorization URL `scope` parameter. */
   scopes: string[];
-  /** Optional per-connection scope choices shown by the local console. */
+  /** Selectable provider-native OAuth scopes for programmatic connections. */
   authorizationOptions?: OAuthAuthorizationOption[];
   /** Separator used when joining OAuth scopes. Defaults to a space. */
   scopeSeparator?: " " | ",";

--- a/src/oauth/oauth-flow-service.test.ts
+++ b/src/oauth/oauth-flow-service.test.ts
@@ -18,8 +18,14 @@ import { ConnectionService } from "../connection-service.ts";
 import { provider as slackProvider } from "../providers/slack/definition.ts";
 import { provider as slackbotProvider } from "../providers/slackbot/definition.ts";
 import { AesGcmSecretCodec } from "../server/secrets/secret-codec.ts";
+import { SqliteRuntimeDatabase } from "../server/storage/sqlite-runtime-store.ts";
 import { OAuthClientConfigService } from "./oauth-client-config-service.ts";
 import { OAuthFlowService } from "./oauth-flow-service.ts";
+
+const requestDatabases: SqliteRuntimeDatabase[] = [];
+afterEach(() => {
+  for (const database of requestDatabases.splice(0)) database.close();
+});
 
 const oauthProvider: ProviderDefinition = {
   service: "example",
@@ -895,6 +901,8 @@ function createServices(
   flow: OAuthFlowService;
   states: MemoryOAuthStateStore;
 } {
+  const requestDatabase = new SqliteRuntimeDatabase(":memory:");
+  requestDatabases.push(requestDatabase);
   const catalog = createCatalogStore(providers);
   const providerLoader = new EmptyProviderLoader(options.oauthRuntime);
   const connections = new ConnectionService({
@@ -917,6 +925,7 @@ function createServices(
       connections,
       providerLoader,
       states,
+      requests: requestDatabase.connectionRequestStore,
       stateMaxAgeMs: options.stateMaxAgeMs,
       secretCodec: options.secretCodec,
       isCustomClientConfigAllowed: (service) =>

--- a/src/oauth/oauth-flow-service.ts
+++ b/src/oauth/oauth-flow-service.ts
@@ -1,7 +1,12 @@
-import type { ConnectionService } from "../connection-service.ts";
+import type { StoredConnection, ConnectionService } from "../connection-service.ts";
 import type { OAuth2AuthDefinition } from "../core/types.ts";
 import type { IProviderLoader } from "../providers/provider-loader.ts";
 import type { ISecretCodec } from "../server/secrets/secret-codec-core.ts";
+import type {
+  ConnectionRequestStore,
+  PendingConnectionRequest,
+  ConnectionRequest,
+} from "../server/storage/connection-request-store.ts";
 import type {
   OAuthClientConfig,
   OAuthClientConfigInput,
@@ -10,6 +15,7 @@ import type {
 import type { OAuthTokenResult } from "./oauth-token.ts";
 
 import { createHash, randomBytes } from "node:crypto";
+import { ConnectionError } from "../connection-service.ts";
 import { providerFetch } from "../providers/provider-runtime.ts";
 import { requestAuthorizationCodeToken } from "./oauth-token.ts";
 
@@ -53,6 +59,7 @@ export interface OAuthFlowServiceOptions {
   connections: ConnectionService;
   providerLoader: IProviderLoader;
   states: IOAuthStateStore;
+  requests: ConnectionRequestStore;
   stateMaxAgeMs?: number;
   secretCodec?: ISecretCodec;
   isCustomClientConfigAllowed?: (service: string) => boolean;
@@ -76,6 +83,7 @@ export class OAuthFlowService {
   private readonly connections: ConnectionService;
   private readonly providerLoader: IProviderLoader;
   private readonly states: IOAuthStateStore;
+  private readonly requests: ConnectionRequestStore;
   private readonly stateMaxAgeMs: number;
   private readonly secretCodec?: ISecretCodec;
   private readonly isCustomClientConfigAllowed: (service: string) => boolean;
@@ -85,18 +93,106 @@ export class OAuthFlowService {
     this.connections = input.connections;
     this.providerLoader = input.providerLoader;
     this.states = input.states;
+    this.requests = input.requests;
     this.stateMaxAgeMs = input.stateMaxAgeMs ?? 15 * 60 * 1000;
     this.secretCodec = input.secretCodec;
     this.isCustomClientConfigAllowed = input.isCustomClientConfigAllowed ?? (() => false);
   }
 
   async startAuthorization(input: OAuthAuthorizationStartInput): Promise<OAuthAuthorizationStart> {
+    const { pending, authorizationUrl } = await this.prepareAuthorization(input);
+    await this.states.deleteCreatedBefore(new Date(Date.now() - this.stateMaxAgeMs).toISOString());
+    await this.states.set(pending);
+    return { authorizationUrl, state: pending.state };
+  }
+
+  async startConnectionRequest(input: OAuthConnectionRequestInput): Promise<OAuthConnectionRequestStart> {
+    validateReturnUri(input.returnUri);
+    const auth = this.clientConfigs.getOAuthDefinition(input.service);
+    let requestedScopes: string[] | undefined;
+    if (input.authorizationOptionIds !== undefined) {
+      if (!auth.authorizationOptions)
+        throw new OAuthFlowError("invalid_input", "This provider does not declare authorization options.");
+      const selected = new Set(input.authorizationOptionIds);
+      const unknown = [...selected].filter((id) => !auth.authorizationOptions!.some((option) => option.id === id));
+      if (unknown.length)
+        throw new OAuthFlowError("invalid_input", `Unknown OAuth authorization options: ${unknown.join(", ")}.`);
+      requestedScopes = auth.authorizationOptions
+        .filter((option) => option.required || selected.has(option.id))
+        .map((option) => option.id);
+    }
+    if (input.target && input.target.credential.authType !== "oauth2") {
+      throw new OAuthFlowError("unsupported_auth_type", "This connection does not use OAuth.");
+    }
+    const configured = await this.clientConfigs.getConfig(input.service);
+    if (!configured)
+      throw new OAuthFlowError("oauth_client_config_required", `Configure an OAuth client for ${input.service} first.`);
+    const config = this.clientConfigs.normalizeConfig(input.service, {
+      ...configured,
+      requestedScopes: requestedScopes ?? configured.requestedScopes,
+      extra: { ...configured.extra, ...input.extra },
+      secretExtra: { ...configured.secretExtra, ...input.secretExtra },
+    });
+    const connectionName = input.target?.connectionName ?? crypto.randomUUID();
+    const { pending, authorizationUrl } = await this.prepareAuthorization(
+      {
+        service: input.service,
+        connectionName,
+      },
+      config,
+    );
+    const request: PendingConnectionRequest = {
+      ...pending,
+      connectionName,
+      clientConfig: config,
+      connectionRequestId: crypto.randomUUID(),
+      owner: input.owner,
+      expiresAt: new Date(Date.parse(pending.createdAt) + 10 * 60_000).toISOString(),
+      returnUri: input.returnUri,
+      target: input.target ? { id: input.target.id, revision: input.target.revision } : undefined,
+    };
+    await this.requests.create(request);
+    return {
+      authorizationUrl,
+      stateHandle: pending.state,
+      connectionRequestId: request.connectionRequestId,
+      status: "initiated",
+      expiresAt: request.expiresAt,
+    };
+  }
+
+  async getConnectionRequest(id: string, owner: string): Promise<ConnectionRequest | undefined> {
+    return this.requests.get(id, owner);
+  }
+
+  async rejectAuthorization(state: string, denied: boolean): Promise<string | undefined> {
+    const pending = await this.requests.claim(state);
+    if (!pending) return undefined;
+    await this.requests.fail(
+      pending.connectionRequestId,
+      denied ? "invalid_input" : "provider_error",
+      denied ? "Authorization was denied." : "OAuth connection failed.",
+    );
+    return callbackReturnUri(
+      pending,
+      "error",
+      denied ? "invalid_input" : "provider_error",
+      denied ? "Authorization was denied." : "OAuth connection failed.",
+    );
+  }
+
+  private async prepareAuthorization(
+    input: OAuthAuthorizationStartInput,
+    requestConfig?: OAuthClientConfig,
+  ): Promise<{ pending: OAuthAuthorizationState; authorizationUrl: string }> {
     const { service, connectionName } = input;
     this.connections.assertProviderAvailable(service);
     const auth = this.clientConfigs.getOAuthDefinition(service);
-    const config = input.clientConfig
-      ? this.resolveCustomClientConfig(service, input.clientConfig)
-      : await this.clientConfigs.getConfig(service);
+    const config =
+      requestConfig ??
+      (input.clientConfig
+        ? this.resolveCustomClientConfig(service, input.clientConfig)
+        : await this.clientConfigs.getConfig(service));
     if (!config) {
       throw new OAuthFlowError("oauth_client_config_required", `Configure an OAuth client for ${service} first.`);
     }
@@ -104,13 +200,12 @@ export class OAuthFlowService {
     const now = new Date();
     const state = crypto.randomUUID();
     const pkceCodeVerifier = auth.pkce ? createPkceCodeVerifier() : undefined;
-    await this.states.deleteCreatedBefore(new Date(now.getTime() - this.stateMaxAgeMs).toISOString());
     const authorizationScopes = resolveAuthorizationScopes(
       auth,
       input.authorizationOptionIds,
       this.clientConfigs.getEffectiveScopes(service, config),
     );
-    await this.states.set({
+    const pending: OAuthAuthorizationState = {
       service,
       connectionName,
       state,
@@ -118,7 +213,7 @@ export class OAuthFlowService {
       pkceCodeVerifier,
       authorizationScopes: auth.authorizationOptions ? authorizationScopes : undefined,
       clientConfig: input.clientConfig ? config : undefined,
-    });
+    };
 
     const authorizationUrl = new URL(this.clientConfigs.resolveEndpointUrl(service, auth.authorizationUrl, config));
     for (const [key, value] of Object.entries(auth.authorizationParams ?? {})) {
@@ -146,85 +241,135 @@ export class OAuthFlowService {
 
     return {
       authorizationUrl: authorizationUrl.toString(),
-      state,
+      pending,
     };
   }
 
-  async completeAuthorization(input: OAuthAuthorizationCompleteInput): Promise<{ service: string; connected: true }> {
-    const pending = await this.states.take(input.state);
+  async completeAuthorization(
+    input: OAuthAuthorizationCompleteInput,
+  ): Promise<{ service: string; connected: true; returnUri?: string }> {
+    const request = await this.requests.claim(input.state);
+    const pending = request ?? (await this.states.take(input.state));
     if (!pending) {
       throw new OAuthFlowError("invalid_oauth_state", "OAuth state is missing or expired.");
     }
-    if (isExpiredOAuthState(pending, this.stateMaxAgeMs)) {
+    if (!request && isExpiredOAuthState(pending, this.stateMaxAgeMs)) {
       throw new OAuthFlowError("invalid_oauth_state", "OAuth state is missing or expired.");
     }
 
-    const auth = this.clientConfigs.getOAuthDefinition(pending.service);
-    const config = pending.clientConfig ?? (await this.clientConfigs.getConfig(pending.service));
-    if (!config) {
-      throw new OAuthFlowError(
-        "oauth_client_config_required",
-        `Configure an OAuth client for ${pending.service} first.`,
-      );
-    }
+    try {
+      const auth = this.clientConfigs.getOAuthDefinition(pending.service);
+      const config = pending.clientConfig ?? (await this.clientConfigs.getConfig(pending.service));
+      if (!config) {
+        throw new OAuthFlowError(
+          "oauth_client_config_required",
+          `Configure an OAuth client for ${pending.service} first.`,
+        );
+      }
 
-    const redirectUri = this.clientConfigs.expectedRedirectUri(pending.service);
-    const tokenUrl = this.clientConfigs.resolveEndpointUrl(pending.service, auth.tokenUrl, config);
-    const createError = (message: string): OAuthFlowError => new OAuthFlowError("oauth_token_exchange_failed", message);
-    const providerOAuth = await this.providerLoader.loadProviderOAuthRuntime?.(pending.service);
-    let tokenResponse: OAuthTokenResult;
-    if (providerOAuth?.exchangeCode) {
-      tokenResponse = await providerOAuth.exchangeCode({
-        code: input.code,
-        clientConfig: config,
-        redirectUri,
-        tokenUrl,
-        fetcher: providerFetch,
-        signal: input.signal,
-        createError,
-      });
-    } else {
-      tokenResponse = await requestAuthorizationCodeToken({
-        code: input.code,
-        state: pending.state,
-        clientId: config.clientId,
-        clientSecret: config.clientSecret,
-        redirectUri,
-        responseEnvelope: auth.tokenResponseEnvelope,
-        tokenRequestFields: auth.tokenRequestFields,
-        tokenEndpointAuthMethod: auth.tokenEndpointAuthMethod,
-        tokenRequestFormat: auth.tokenRequestFormat,
-        tokenUrl,
-        extraFields: createTokenExtraFields(pending, auth.tokenRequestCallbackParameters, input.callbackParameters),
-        signal: input.signal,
-        createError,
-      });
-    }
-    const refreshParameters = readCallbackParameters(auth.tokenRequestCallbackParameters, input.callbackParameters);
-    const oauthCredential = {
-      authType: "oauth2" as const,
-      ...tokenResponse,
-      profile: {
-        accountId: "oauth2",
-        displayName: "OAuth Credential",
-        grantedScopes: pending.authorizationScopes ?? [],
-      },
-      providerSecret:
-        Object.keys(refreshParameters).length > 0 ? { oauthRefreshParameters: refreshParameters } : undefined,
-      metadata: {
-        ...tokenResponse.metadata,
-        oauthClientId: config.clientId,
-        oauthClientExtra: config.extra,
-        oauthClientSecretExtra: config.secretExtra,
-        oauthClientConfig: pending.clientConfig ? config : undefined,
-      },
-    };
+      const redirectUri = this.clientConfigs.expectedRedirectUri(pending.service);
+      const tokenUrl = this.clientConfigs.resolveEndpointUrl(pending.service, auth.tokenUrl, config);
+      const createError = (message: string): OAuthFlowError =>
+        new OAuthFlowError("oauth_token_exchange_failed", message);
+      const providerOAuth = await this.providerLoader.loadProviderOAuthRuntime?.(pending.service);
+      let tokenResponse: OAuthTokenResult;
+      if (providerOAuth?.exchangeCode) {
+        tokenResponse = await providerOAuth.exchangeCode({
+          code: input.code,
+          clientConfig: config,
+          redirectUri,
+          tokenUrl,
+          fetcher: providerFetch,
+          signal: input.signal,
+          createError,
+        });
+      } else {
+        tokenResponse = await requestAuthorizationCodeToken({
+          code: input.code,
+          state: pending.state,
+          clientId: config.clientId,
+          clientSecret: config.clientSecret,
+          redirectUri,
+          responseEnvelope: auth.tokenResponseEnvelope,
+          tokenRequestFields: auth.tokenRequestFields,
+          tokenEndpointAuthMethod: auth.tokenEndpointAuthMethod,
+          tokenRequestFormat: auth.tokenRequestFormat,
+          tokenUrl,
+          extraFields: createTokenExtraFields(pending, auth.tokenRequestCallbackParameters, input.callbackParameters),
+          signal: input.signal,
+          createError,
+        });
+      }
+      const refreshParameters = readCallbackParameters(auth.tokenRequestCallbackParameters, input.callbackParameters);
+      const oauthCredential = {
+        authType: "oauth2" as const,
+        ...tokenResponse,
+        profile: {
+          accountId: "oauth2",
+          displayName: "OAuth Credential",
+          grantedScopes: request ? [] : (pending.authorizationScopes ?? []),
+        },
+        providerSecret:
+          Object.keys(refreshParameters).length > 0 ? { oauthRefreshParameters: refreshParameters } : undefined,
+        metadata: {
+          ...tokenResponse.metadata,
+          oauthClientId: config.clientId,
+          oauthClientExtra: config.extra,
+          oauthClientSecretExtra: config.secretExtra,
+          oauthClientConfig: pending.clientConfig ? config : undefined,
+        },
+      };
 
-    await this.connections.setOAuthCredential(pending.service, oauthCredential, pending.connectionName, input.signal);
-    return {
-      service: pending.service,
-      connected: true,
-    };
+      if (request) {
+        const credential = await this.connections.prepareOAuthCredential(
+          pending.service,
+          oauthCredential,
+          input.signal,
+        );
+        const granted = new Set(credential.profile.grantedScopes);
+        const missing = auth.authorizationOptions?.filter((option) => option.required && !granted.has(option.id)) ?? [];
+        if (missing.length)
+          throw new OAuthFlowError("scope_missing", "The provider did not grant required OAuth scopes.");
+        input.signal?.throwIfAborted();
+        const appId = await this.requests.complete(request, credential, input.signal);
+        if (!appId) {
+          if (request.target) {
+            try {
+              await this.connections.getStoredConnection(request.target.id);
+            } catch (error) {
+              if (error instanceof ConnectionError && error.code === "connection_not_found")
+                throw new OAuthFlowError("app_not_found", "App not found.");
+              throw error;
+            }
+          }
+          throw new OAuthFlowError("request_key_conflict", "The connection changed during authorization.");
+        }
+      } else {
+        await this.connections.setOAuthCredential(
+          pending.service,
+          oauthCredential,
+          pending.connectionName,
+          input.signal,
+        );
+      }
+      return {
+        service: pending.service,
+        connected: true,
+        ...(request?.returnUri ? { returnUri: callbackReturnUri(request, "success") } : {}),
+      };
+    } catch (error) {
+      if (request) {
+        const code =
+          error instanceof OAuthFlowError &&
+          ["app_not_found", "request_key_conflict", "scope_missing"].includes(error.code)
+            ? error.code
+            : "provider_error";
+        const message = "OAuth connection failed.";
+        await this.requests.fail(request.connectionRequestId, code, message);
+        throw new OAuthCallbackError(code, message, callbackReturnUri(request, "error", code, message), error);
+      }
+      throw error;
+    }
   }
 
   private resolveCustomClientConfig(service: string, input: OAuthClientConfigInput): OAuthClientConfig {
@@ -319,4 +464,59 @@ export class OAuthFlowError extends Error {
     super(message);
     this.code = code;
   }
+}
+
+export interface OAuthConnectionRequestInput {
+  service: string;
+  owner: string;
+  target?: StoredConnection;
+  returnUri?: string;
+  authorizationOptionIds?: string[];
+  extra?: Record<string, unknown>;
+  secretExtra?: Record<string, string>;
+}
+
+export interface OAuthConnectionRequestStart {
+  authorizationUrl: string;
+  stateHandle: string;
+  connectionRequestId: string;
+  status: "initiated";
+  expiresAt: string;
+}
+
+function validateReturnUri(value?: string): void {
+  if (!value) return;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new OAuthFlowError("invalid_input", "returnUri must be a valid URL.");
+  }
+  if (!["http:", "https:", "oomol:"].includes(url.protocol)) {
+    throw new OAuthFlowError("invalid_input", "returnUri scheme is not allowed.");
+  }
+}
+
+export class OAuthCallbackError extends OAuthFlowError {
+  readonly returnUri?: string;
+  constructor(code: string, message: string, returnUri: string | undefined, cause: unknown) {
+    super(code, message);
+    this.returnUri = returnUri;
+    this.cause = cause;
+  }
+}
+
+function callbackReturnUri(
+  pending: PendingConnectionRequest,
+  status: "success" | "error",
+  code?: string,
+  message?: string,
+): string | undefined {
+  if (!pending.returnUri) return undefined;
+  const url = new URL(pending.returnUri);
+  url.searchParams.set("status", status);
+  url.searchParams.set("service", pending.service);
+  if (code) url.searchParams.set("code", code);
+  if (message) url.searchParams.set("message", message);
+  return url.toString();
 }

--- a/src/providers/github/definition.ts
+++ b/src/providers/github/definition.ts
@@ -1,7 +1,14 @@
 import type { ProviderDefinition } from "../../core/types.ts";
 
 import { githubActions } from "./actions.ts";
-import { githubOAuthScopes } from "./scopes.ts";
+import {
+  githubOAuthScopes,
+  githubReadUserScope,
+  githubUserEmailScope,
+  githubRepoScope,
+  githubWorkflowScope,
+  githubDeleteRepoScope,
+} from "./scopes.ts";
 
 const service = "github";
 
@@ -22,6 +29,49 @@ export const provider: ProviderDefinition = {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: githubOAuthScopes,
+      authorizationOptions: [
+        {
+          id: githubReadUserScope,
+          label: "Account profile",
+          description: "Identify the connected GitHub account.",
+          required: true,
+          defaultSelected: true,
+          risk: "standard",
+        },
+        {
+          id: githubRepoScope,
+          label: "Repositories",
+          description: "Read and modify public and private repositories.",
+          required: false,
+          defaultSelected: true,
+          risk: "sensitive",
+        },
+        {
+          id: githubUserEmailScope,
+          label: "Email addresses",
+          description: "Read the account's email addresses.",
+          required: false,
+          defaultSelected: false,
+          risk: "sensitive",
+        },
+        {
+          id: githubWorkflowScope,
+          label: "Workflows",
+          description: "Update GitHub Actions workflow files.",
+          required: false,
+          defaultSelected: false,
+          risk: "sensitive",
+          requires: [githubRepoScope],
+        },
+        {
+          id: githubDeleteRepoScope,
+          label: "Delete repositories",
+          description: "Permanently delete repositories.",
+          required: false,
+          defaultSelected: false,
+          risk: "destructive",
+        },
+      ],
       tokenEndpointAuthMethod: "client_secret_post",
     },
     {

--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -5,6 +5,7 @@ import type { Context, MiddlewareHandler } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { isConsoleShellRequest } from "./console-paths.ts";
 import { jsonError } from "./http-utils.ts";
+import { writeRuntimeFailure } from "./runtime-api.ts";
 
 const bearerScheme = "bearer";
 const authCookieName = "oomol_connect_admin_session";
@@ -58,6 +59,19 @@ export function createLocalAuthMiddleware(options: LocalAuthOptions): Middleware
       return;
     }
 
+    if (
+      isConnectionManagementPath(context.req.path) &&
+      !adminToken &&
+      (runtimeToken ||
+        options.verifyRuntimeJwt ||
+        (options.hasRuntimeTokens ? await options.hasRuntimeTokens() : options.resolveRuntimeToken !== undefined))
+    ) {
+      return writeRuntimeFailure(context, {
+        status: 403,
+        errorCode: "forbidden",
+        message: "Configure an admin token to manage connections.",
+      });
+    }
     if (await hasValidToken(context, options, scope)) {
       if (scope === "admin") {
         await installAdminCookieForBearer(context, options);
@@ -79,6 +93,13 @@ export function createLocalAuthMiddleware(options: LocalAuthOptions): Middleware
       return;
     }
 
+    if (isConnectionManagementPath(context.req.path)) {
+      return writeRuntimeFailure(context, {
+        status: 401,
+        errorCode: "unauthorized",
+        message: "A valid administrator bearer token is required.",
+      });
+    }
     return jsonError(context, 401, "unauthorized", "A valid local bearer token is required.");
   };
 }
@@ -237,6 +258,7 @@ function normalizeToken(token: string | undefined): string | undefined {
 }
 
 function readAuthScope(path: string): AuthScope {
+  if (isConnectionManagementPath(path)) return "admin";
   return path === "/mcp" || path.startsWith("/mcp/") || path === "/v1" || path.startsWith("/v1/") ? "runtime" : "admin";
 }
 
@@ -281,4 +303,10 @@ function readBearerCredential(context: Context): string {
   }
 
   return authorization.slice(separator + 1);
+}
+
+function isConnectionManagementPath(path: string): boolean {
+  return (
+    path === "/v1/connections" || path.startsWith("/v1/connections/") || path.startsWith("/v1/connection-requests/")
+  );
 }

--- a/src/server/api/cache-policy.ts
+++ b/src/server/api/cache-policy.ts
@@ -16,6 +16,8 @@ export function getResponseCachePolicy(method: string, path: string, status: num
     };
   }
 
+  if (path.startsWith("/v1/connection-requests/")) return { cacheControl: "private, no-store" };
+
   if (isRuntimeResponsePath(path)) {
     return { cacheControl: "no-store" };
   }

--- a/src/server/api/connection-input.ts
+++ b/src/server/api/connection-input.ts
@@ -1,0 +1,34 @@
+import type { OAuthConnectionRequestInput } from "../../oauth/oauth-flow-service.ts";
+
+import { z } from "zod";
+
+export const oauthConnectionInput: z.ZodType<Omit<OAuthConnectionRequestInput, "owner" | "service" | "target">> =
+  z.object({
+    returnUri: z.string().optional(),
+    authorizationOptionIds: z.array(z.string().trim().min(1)).optional(),
+    extra: z.record(z.string(), z.unknown()).optional(),
+    secretExtra: z.record(z.string(), z.string().trim().min(1)).optional(),
+  });
+
+export const apiKeyConnectionInput: z.ZodType<{
+  apiKey: string;
+  extra?: Record<string, string>;
+  comment?: string | null;
+}> = z
+  .object({
+    apiKey: z.string(),
+    extra: z.record(z.string(), z.string()).optional(),
+    comment: z.string().nullable().optional(),
+  })
+  .strict();
+
+export const customConnectionInput: z.ZodType<{ values: Record<string, string>; comment?: string | null }> = z
+  .object({
+    values: z.record(z.string(), z.string()),
+    comment: z.string().nullable().optional(),
+  })
+  .strict();
+
+export const connectionStatusInput: z.ZodType<"active" | "reauth_required" | "error" | "disconnected" | undefined> = z
+  .enum(["active", "reauth_required", "error", "disconnected"])
+  .optional();

--- a/src/server/api/connection-routes.test.ts
+++ b/src/server/api/connection-routes.test.ts
@@ -3,8 +3,11 @@ import type { ProviderOAuthRuntime } from "../../oauth/oauth-token.ts";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCatalogStore } from "../../catalog-store.ts";
+import { requestAuthorizationCodeToken } from "../../oauth/oauth-token.ts";
 import { provider as githubProvider } from "../../providers/github/definition.ts";
 import { ProviderLoader } from "../../providers/provider-loader.ts";
+import { provider as slackProvider } from "../../providers/slack/definition.ts";
+import { slackCredentialValidators } from "../../providers/slack/runtime.ts";
 import { createConnectApp } from "../connect-app.ts";
 import { TransitFileService } from "../files/transit-files.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
@@ -34,6 +37,7 @@ const provider: ProviderDefinition = {
 const databases: SqliteRuntimeDatabase[] = [];
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
   for (const database of databases.splice(0)) database.close();
 });
 
@@ -305,11 +309,11 @@ it("does not save credentials when a callback is cancelled during token exchange
   );
 });
 
-it("reports current reauthorization needs separately from a successful request", async () => {
+it.each([-1000, 30_000])("reports reauthorization needs for an expiry offset of %i ms", async (offset) => {
   const { call, start } = await setup(async () => ({
     accessToken: "secret",
     tokenType: "Bearer",
-    expiresAt: new Date(Date.now() - 1000).toISOString(),
+    expiresAt: new Date(Date.now() + offset).toISOString(),
     metadata: {},
   }));
   const request = await start();
@@ -361,4 +365,47 @@ it("does not overwrite credentials when a synchronous replacement loses a valida
   expect(conflict.status).toBe(409);
   expect((await conflict.json()).errorCode).toBe("request_key_conflict");
   expect((await database.connectionStore.list())[0].credential).toMatchObject({ apiKey: "winner" });
+});
+
+it("connects Slack using granted scopes from the nested user token response", async () => {
+  const fetcher = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url === "https://slack.com/api/oauth.v2.user.access") {
+      return Response.json({
+        ok: true,
+        access_token: "xoxp-user-token",
+        token_type: "user",
+        authed_user: { id: "U12345", scope: "channels:read,users:read" },
+        team: { id: "T12345" },
+      });
+    }
+    expect(url).toBe("https://slack.com/api/auth.test");
+    return Response.json({ ok: true, user_id: "U12345", team_id: "T12345", team: "Workspace" });
+  });
+  vi.stubGlobal("fetch", fetcher);
+  const { call } = await setup(
+    async () =>
+      requestAuthorizationCodeToken({
+        clientId: "client",
+        clientSecret: "secret",
+        code: "code",
+        redirectUri: "http://localhost/oauth/callback",
+        tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+        tokenEndpointAuthMethod: "client_secret_post",
+        createError: (message) => new Error(message),
+      }),
+    {},
+    { ...slackProvider, service: "example", actions: [] },
+    slackCredentialValidators,
+  );
+  const started = await (await call("/v1/connections/example/connect", {})).json();
+  expect(started).toMatchObject({ success: true });
+  const request = started.data;
+  const callback = await call(`/oauth/callback?state=${request.stateHandle}&code=code`);
+  expect(callback.status).toBe(200);
+  const result = (await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data;
+  expect(result.status).toBe("connected");
+  const connection = (await (await call(`/v1/connections/by-id/${result.appId}`)).json()).data;
+  expect(connection.scopes).toEqual(["channels:read", "users:read"]);
+  expect(fetcher).toHaveBeenCalledTimes(2);
 });

--- a/src/server/api/connection-routes.test.ts
+++ b/src/server/api/connection-routes.test.ts
@@ -1,0 +1,364 @@
+import type { CredentialValidators, ProviderDefinition } from "../../core/types.ts";
+import type { ProviderOAuthRuntime } from "../../oauth/oauth-token.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCatalogStore } from "../../catalog-store.ts";
+import { provider as githubProvider } from "../../providers/github/definition.ts";
+import { ProviderLoader } from "../../providers/provider-loader.ts";
+import { createConnectApp } from "../connect-app.ts";
+import { TransitFileService } from "../files/transit-files.ts";
+import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
+import { SqliteRuntimeDatabase } from "../storage/sqlite-runtime-store.ts";
+
+const provider: ProviderDefinition = {
+  service: "example",
+  displayName: "Example",
+  categories: [],
+  authTypes: ["oauth2", "api_key", "custom_credential"],
+  auth: [
+    {
+      type: "oauth2",
+      authorizationUrl: "https://example.com/authorize",
+      tokenUrl: "https://example.com/token",
+      scopes: ["read"],
+      tokenEndpointAuthMethod: "client_secret_post",
+    },
+    { type: "api_key", label: "API key" },
+    {
+      type: "custom_credential",
+      fields: [{ key: "password", label: "Password", inputType: "password", required: true, secret: true }],
+    },
+  ],
+  actions: [],
+};
+const databases: SqliteRuntimeDatabase[] = [];
+afterEach(() => {
+  vi.useRealTimers();
+  for (const database of databases.splice(0)) database.close();
+});
+
+async function setup(
+  exchangeCode?: ProviderOAuthRuntime["exchangeCode"],
+  auth: { adminToken?: string; runtimeToken?: string } = {},
+  definition: ProviderDefinition = provider,
+  credentialValidators?: CredentialValidators,
+) {
+  const database = new SqliteRuntimeDatabase(":memory:");
+  databases.push(database);
+  await database.oauthClientConfigStore.set({
+    service: "example",
+    clientId: "client",
+    clientSecret: "secret",
+    extra: {},
+    secretExtra: {},
+  });
+  const { app } = await createConnectApp({
+    catalog: createCatalogStore([definition]),
+    runtimeDatabase: database,
+    providerLoader: new ProviderLoader({
+      example: async () => ({
+        executors: {},
+        credentialValidators,
+        oauth: {
+          exchangeCode:
+            exchangeCode ??
+            (async () => ({ accessToken: "access-secret", tokenType: "Bearer", metadata: { scope: "read" } })),
+        },
+      }),
+    }),
+    transitFiles: new TransitFileService({
+      rootDir: ".tmp/connection-tests",
+      publicOrigin: "http://localhost",
+      ttlSeconds: 60,
+      maxBytes: 1024,
+    }),
+    publicOrigin: "http://localhost",
+    secretCodec: new PlainTextSecretCodec(),
+    ...auth,
+  });
+  const call = async (path: string, body?: unknown, token = auth.adminToken) =>
+    app.request(path, {
+      method: body === undefined ? "GET" : "POST",
+      headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  const start = async () => (await (await call("/v1/connections/example/connect", {})).json()).data;
+  return { app, database, call, start };
+}
+
+describe("shared personal connection API", () => {
+  it("returns an independent request ID and persists the exact connected app after callback consumption", async () => {
+    const { call, start, database } = await setup();
+    const request = await start();
+    expect(request).toMatchObject({
+      status: "initiated",
+      authorizationUrl: expect.any(String),
+      expiresAt: expect.any(String),
+    });
+    expect(request.connectionRequestId).not.toBe(request.stateHandle);
+    const poll = `/v1/connection-requests/${request.connectionRequestId}`;
+    expect((await (await call(poll)).json()).data.status).toBe("initiated");
+    expect((await call(`/oauth/callback?state=${request.stateHandle}&code=code`)).status).toBe(200);
+    const response = await call(poll);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    const result = (await response.json()).data;
+    expect(result).toMatchObject({ status: "connected", errorCode: null, appId: expect.any(String) });
+    expect((await database.connectionStore.list())[0].id).toBe(result.appId);
+    const detail = (await (await call(`/v1/connections/by-id/${result.appId}`)).json()).data;
+    expect(detail).toMatchObject({ id: result.appId, status: "active", authType: "oauth2" });
+    expect(JSON.stringify(detail)).not.toContain("access-secret");
+    expect((await call(`/oauth/callback?state=${request.stateHandle}&code=again`)).status).toBe(400);
+    expect((await (await call(poll)).json()).data).toEqual(result);
+  });
+
+  it("supersedes unclaimed requests and records denied authorization without upstream secrets", async () => {
+    const { call, start } = await setup();
+    const first = await start();
+    const second = await start();
+    expect((await (await call(`/v1/connection-requests/${first.connectionRequestId}`)).json()).data).toMatchObject({
+      status: "failed",
+      errorCode: "request_superseded",
+    });
+    expect((await call(`/oauth/callback?state=${first.stateHandle}&code=old`)).status).toBe(400);
+    await call(`/oauth/callback?state=${second.stateHandle}&error=access_denied&error_description=secret-value`);
+    const result = (await (await call(`/v1/connection-requests/${second.connectionRequestId}`)).json()).data;
+    expect(result).toMatchObject({ status: "failed", errorCode: "invalid_input", appId: null });
+    expect(JSON.stringify(result)).not.toContain("secret-value");
+  });
+
+  it("expires pending requests and keeps terminal results for the retention window", async () => {
+    vi.useFakeTimers();
+    const { call, start } = await setup();
+    const request = await start();
+    vi.setSystemTime(Date.parse(request.expiresAt));
+    expect((await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data.status).toBe(
+      "expired",
+    );
+    expect((await call(`/oauth/callback?state=${request.stateHandle}&code=late`)).status).toBe(400);
+    vi.setSystemTime(Date.parse(request.expiresAt) + 86_400_000);
+    const expired = await call(`/v1/connection-requests/${request.connectionRequestId}`);
+    expect(expired.status).toBe(404);
+    expect((await expired.json()).errorCode).toBe("connection_request_not_found");
+  });
+
+  it("creates distinct API-key connections and replaces credentials without changing the ID", async () => {
+    const { call, database } = await setup();
+    const create = async (apiKey: string) =>
+      (await (await call("/v1/connections/example/connect/api-key", { apiKey, comment: "My key" })).json()).data;
+    const first = await create("first");
+    const second = await create("second");
+    expect(first.id).not.toBe(second.id);
+    const replaced = (
+      await (
+        await call(`/v1/connections/by-id/${first.id}/connect/api-key`, { apiKey: "replacement", comment: null })
+      ).json()
+    ).data;
+    expect(replaced).toMatchObject({ id: first.id, comment: null });
+    expect((await database.connectionStore.list()).find((item) => item.id === first.id)?.credential).toMatchObject({
+      apiKey: "replacement",
+    });
+    expect((await call("/v1/connections/by-id/missing/connect/api-key", { apiKey: "x" })).status).toBe(404);
+    expect((await call("/v1/connections/example/connect/api-key", { apiKey: 123 })).status).toBe(400);
+    expect(
+      (await call("/v1/connections/example/connect/custom-credential", { values: { password: "secret" } })).status,
+    ).toBe(200);
+  });
+
+  it("keeps the original app ID when OAuth is reconnected", async () => {
+    const { call, start } = await setup();
+    const first = await start();
+    await call(`/oauth/callback?state=${first.stateHandle}&code=first`);
+    const appId = (await (await call(`/v1/connection-requests/${first.connectionRequestId}`)).json()).data.appId;
+    const reconnect = (await (await call(`/v1/connections/by-id/${appId}/connect`, {})).json()).data;
+    await call(`/oauth/callback?state=${reconnect.stateHandle}&code=second`);
+    expect((await (await call(`/v1/connection-requests/${reconnect.connectionRequestId}`)).json()).data).toMatchObject({
+      status: "connected",
+      appId,
+    });
+  });
+
+  it("does not recreate a connection deleted while its reconnect request was pending", async () => {
+    const { call, start, database } = await setup();
+    const first = await start();
+    await call(`/oauth/callback?state=${first.stateHandle}&code=first`);
+    const original = (await database.connectionStore.list())[0];
+    const reconnect = (await (await call(`/v1/connections/by-id/${original.id}/connect`, {})).json()).data;
+    await database.connectionStore.delete(original.service, original.connectionName);
+    expect((await call(`/oauth/callback?state=${reconnect.stateHandle}&code=second`)).status).toBe(400);
+    expect(await database.connectionStore.list()).toEqual([]);
+    expect((await (await call(`/v1/connection-requests/${reconnect.connectionRequestId}`)).json()).data.status).toBe(
+      "failed",
+    );
+  });
+
+  it("requires management credentials even when an execution token is valid", async () => {
+    const { call } = await setup(undefined, { adminToken: "admin", runtimeToken: "runtime" });
+    expect((await call("/v1/connections", undefined, "runtime")).status).toBe(401);
+    expect((await call("/v1/connections")).status).toBe(200);
+    const restricted = await setup(undefined, { runtimeToken: "runtime" });
+    expect((await restricted.call("/v1/connections", undefined, "runtime")).status).toBe(403);
+  });
+
+  it("records a safe failure when token exchange fails", async () => {
+    const { call, start } = await setup(async () => {
+      throw new Error("secret-token");
+    });
+    const request = await start();
+    await call(`/oauth/callback?state=${request.stateHandle}&code=code`);
+    const result = (await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data;
+    expect(result).toMatchObject({ status: "failed", errorCode: "provider_error" });
+    expect(JSON.stringify(result)).not.toContain("secret-token");
+  });
+});
+
+it("applies declared authorization options and always includes required scopes", async () => {
+  const { call } = await setup(undefined, {}, { ...githubProvider, service: "example", actions: [] });
+  const response = await call("/v1/connections/example/connect", { authorizationOptionIds: ["repo"] });
+  expect(response.status).toBe(200);
+  const url = new URL((await response.json()).data.authorizationUrl);
+  expect(url.searchParams.get("scope")).toBe("read:user repo");
+  const invalid = await call("/v1/connections/example/connect", { authorizationOptionIds: ["unknown"] });
+  expect(invalid.status).toBe(400);
+  expect((await invalid.json()).errorCode).toBe("invalid_input");
+});
+
+it("fails a request when the provider does not grant its required authorization scope", async () => {
+  const { call } = await setup(undefined, {}, { ...githubProvider, service: "example", actions: [] });
+  const request = (await (await call("/v1/connections/example/connect", { authorizationOptionIds: [] })).json()).data;
+  await call(`/oauth/callback?state=${request.stateHandle}&code=code`);
+  expect((await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data).toMatchObject({
+    status: "failed",
+    errorCode: "scope_missing",
+  });
+});
+
+it("returns to the caller with success and safe failure parameters", async () => {
+  const { call } = await setup();
+  const create = async () =>
+    (await (await call("/v1/connections/example/connect", { returnUri: "https://client.example/done?keep=1" })).json())
+      .data;
+  const success = await create();
+  const response = await call(`/oauth/callback?state=${success.stateHandle}&code=code`);
+  expect(response.status).toBe(302);
+  const successUrl = new URL(response.headers.get("location")!);
+  expect(Object.fromEntries(successUrl.searchParams)).toEqual({ keep: "1", status: "success", service: "example" });
+  const denied = await create();
+  const failure = await call(
+    `/oauth/callback?state=${denied.stateHandle}&error=access_denied&error_description=secret`,
+  );
+  expect(failure.status).toBe(302);
+  const failureUrl = new URL(failure.headers.get("location")!);
+  expect(failureUrl.searchParams.get("status")).toBe("error");
+  expect(failureUrl.searchParams.get("code")).toBe("invalid_input");
+  expect(failureUrl.toString()).not.toContain("secret");
+  expect((await call("/v1/connections/example/connect", { returnUri: "javascript:alert(1)" })).status).toBe(400);
+});
+
+it("lets a claimed callback finish after expiry and a newer request", async () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const { call, start } = await setup(async () => {
+    started.resolve();
+    await release.promise;
+    return { accessToken: "secret", tokenType: "Bearer", metadata: {} };
+  });
+  const first = await start();
+  const callback = call(`/oauth/callback?state=${first.stateHandle}&code=code`);
+  await started.promise;
+  const second = await start();
+  expect((await (await call(`/v1/connection-requests/${first.connectionRequestId}`)).json()).data.status).toBe(
+    "initiated",
+  );
+  vi.setSystemTime(Date.parse(first.expiresAt) + 1);
+  expect((await (await call(`/v1/connection-requests/${first.connectionRequestId}`)).json()).data.status).toBe(
+    "expired",
+  );
+  release.resolve();
+  expect((await callback).status).toBe(200);
+  expect((await (await call(`/v1/connection-requests/${first.connectionRequestId}`)).json()).data.status).toBe(
+    "connected",
+  );
+  expect((await (await call(`/v1/connection-requests/${second.connectionRequestId}`)).json()).data.status).toBe(
+    "expired",
+  );
+});
+
+it("does not save credentials when a callback is cancelled during token exchange", async () => {
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const { app, start, database, call } = await setup(async () => {
+    started.resolve();
+    await release.promise;
+    return { accessToken: "secret", tokenType: "Bearer", metadata: {} };
+  });
+  const request = await start();
+  const abort = new AbortController();
+  const callback = app.request(`/oauth/callback?state=${request.stateHandle}&code=code`, { signal: abort.signal });
+  await started.promise;
+  abort.abort();
+  release.resolve();
+  await callback;
+  expect(await database.connectionStore.list()).toEqual([]);
+  expect((await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data.status).toBe(
+    "failed",
+  );
+});
+
+it("reports current reauthorization needs separately from a successful request", async () => {
+  const { call, start } = await setup(async () => ({
+    accessToken: "secret",
+    tokenType: "Bearer",
+    expiresAt: new Date(Date.now() - 1000).toISOString(),
+    metadata: {},
+  }));
+  const request = await start();
+  await call(`/oauth/callback?state=${request.stateHandle}&code=code`);
+  const result = (await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data;
+  expect(result.status).toBe("connected");
+  expect((await (await call(`/v1/connections/by-id/${result.appId}`)).json()).data.status).toBe("reauth_required");
+  expect((await (await call("/v1/connections?status=active")).json()).data).toEqual([]);
+  expect((await (await call("/v1/connections?status=reauth_required")).json()).data).toHaveLength(1);
+});
+
+it("preserves existing credentials when provider validation rejects a replacement", async () => {
+  const { call, database } = await setup(undefined, {}, provider, {
+    apiKey: async ({ apiKey }) => {
+      if (apiKey === "bad") throw new Error("Rejected credentials");
+    },
+    oauth2: async () => {
+      throw new Error("Rejected OAuth token");
+    },
+  });
+  const original = (await (await call("/v1/connections/example/connect/api-key", { apiKey: "valid" })).json()).data;
+  expect((await call(`/v1/connections/by-id/${original.id}/connect/api-key`, { apiKey: "bad" })).status).toBe(400);
+  expect((await database.connectionStore.list())[0].credential).toMatchObject({ apiKey: "valid" });
+  const request = (await (await call("/v1/connections/example/connect", {})).json()).data;
+  await call(`/oauth/callback?state=${request.stateHandle}&code=code`);
+  expect((await (await call(`/v1/connection-requests/${request.connectionRequestId}`)).json()).data.status).toBe(
+    "failed",
+  );
+  expect(await database.connectionStore.list()).toHaveLength(1);
+});
+
+it("does not overwrite credentials when a synchronous replacement loses a validation race", async () => {
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const { call, database } = await setup(undefined, {}, provider, {
+    apiKey: async ({ apiKey }) => {
+      if (apiKey === "slow") {
+        started.resolve();
+        await release.promise;
+      }
+    },
+  });
+  const original = (await (await call("/v1/connections/example/connect/api-key", { apiKey: "original" })).json()).data;
+  const pending = call(`/v1/connections/by-id/${original.id}/connect/api-key`, { apiKey: "slow" });
+  await started.promise;
+  expect((await call(`/v1/connections/by-id/${original.id}/connect/api-key`, { apiKey: "winner" })).status).toBe(200);
+  release.resolve();
+  const conflict = await pending;
+  expect(conflict.status).toBe(409);
+  expect((await conflict.json()).errorCode).toBe("request_key_conflict");
+  expect((await database.connectionStore.list())[0].credential).toMatchObject({ apiKey: "winner" });
+});

--- a/src/server/api/connection-routes.ts
+++ b/src/server/api/connection-routes.ts
@@ -1,0 +1,123 @@
+import type { ConnectionService } from "../../connection-service.ts";
+import type { OAuthFlowService } from "../../oauth/oauth-flow-service.ts";
+import type { z } from "zod";
+
+import { Hono } from "hono";
+import { ConnectionError } from "../../connection-service.ts";
+import { OAuthClientConfigError } from "../../oauth/oauth-client-config-service.ts";
+import { OAuthFlowError } from "../../oauth/oauth-flow-service.ts";
+import { readJsonBody, HttpRequestError } from "./http-utils.ts";
+import {
+  connectionManagementFailure,
+  serializeManagedConnection,
+  writeRuntimeSuccess,
+  writeRuntimeFailure,
+} from "./runtime-api.ts";
+
+interface ConnectionRoutesOptions {
+  connections: ConnectionService;
+  oauthFlow: OAuthFlowService;
+}
+
+/** Personal connection management. Authentication runs in the parent app. */
+export function createConnectionRoutes({ connections, oauthFlow }: ConnectionRoutesOptions): Hono {
+  const app = new Hono();
+  // The local runtime has one administrator principal, including its bearer and browser sessions.
+  const owner = "local-admin";
+  app.onError((error, context) => {
+    if (
+      error instanceof ConnectionError ||
+      error instanceof OAuthFlowError ||
+      error instanceof OAuthClientConfigError
+    ) {
+      return writeRuntimeFailure(context, connectionManagementFailure(error));
+    }
+    throw error;
+  });
+  app.get("/connections", async (context) => {
+    const { connectionStatusInput } = await import("./connection-input.ts");
+    const status = parseBody(connectionStatusInput, context.req.query("status"));
+    const apps = (await connections.listManagedConnections()).map(serializeManagedConnection);
+    return writeRuntimeSuccess(context, status ? apps.filter((app) => app.status === status) : apps);
+  });
+  app.get("/connections/by-id/:appId", async (context) => {
+    return writeRuntimeSuccess(
+      context,
+      serializeManagedConnection(await connections.getManagedConnection(context.req.param("appId"))),
+    );
+  });
+  app.get("/connection-requests/:connectionRequestId", async (context) => {
+    const request = await oauthFlow.getConnectionRequest(context.req.param("connectionRequestId"), owner);
+    if (!request)
+      return writeRuntimeFailure(context, {
+        status: 404,
+        errorCode: "connection_request_not_found",
+        message: "Connection request not found.",
+      });
+    return writeRuntimeSuccess(context, request);
+  });
+  for (const reconnect of [false, true]) {
+    const path = reconnect ? "/connections/by-id/:appId/connect" : "/connections/:service/connect";
+    app.post(path, async (context) => {
+      const { oauthConnectionInput } = await import("./connection-input.ts");
+      const input = parseBody(oauthConnectionInput, await readJsonBody(context));
+      const target = reconnect ? await connections.getStoredConnection(context.req.param("appId")!) : undefined;
+      return writeRuntimeSuccess(
+        context,
+        await oauthFlow.startConnectionRequest({
+          ...input,
+          service: target?.service ?? context.req.param("service")!,
+          owner,
+          target,
+        }),
+      );
+    });
+    for (const authType of ["api-key", "custom-credential"]) {
+      app.post(`${path}/${authType}`, async (context) => {
+        const { apiKeyConnectionInput, customConnectionInput } = await import("./connection-input.ts");
+        const body = await readJsonBody(context);
+        const target = reconnect ? await connections.getStoredConnection(context.req.param("appId")!) : undefined;
+        if (target && target.credential.authType !== (authType === "api-key" ? "api_key" : "custom_credential")) {
+          throw new ConnectionError("unsupported_auth_type", "The connection uses a different credential type.");
+        }
+        const service = target?.service ?? context.req.param("service")!;
+        const options = {
+          connectionName: target?.connectionName ?? crypto.randomUUID(),
+          expectedConnection: target,
+          signal: context.req.raw.signal,
+        };
+        let summary;
+        if (authType === "api-key") {
+          const input = parseBody(apiKeyConnectionInput, body);
+          summary = await connections.connectWithApiKey(service, {
+            ...options,
+            values: { ...input.extra, apiKey: input.apiKey },
+            comment: input.comment,
+          });
+        } else {
+          const input = parseBody(customConnectionInput, body);
+          summary = await connections.connectWithCustomCredential(service, {
+            ...options,
+            values: input.values,
+            comment: input.comment,
+          });
+        }
+        return writeRuntimeSuccess(
+          context,
+          serializeManagedConnection(await connections.getManagedConnection(summary.id)),
+        );
+      });
+    }
+  }
+  return app;
+}
+
+function parseBody<T>(schema: z.ZodType<T>, body: unknown): T {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success)
+    throw new HttpRequestError(
+      "invalid_input",
+      parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("; "),
+    );
+  return parsed.data;
+}

--- a/src/server/api/openapi.ts
+++ b/src/server/api/openapi.ts
@@ -1,11 +1,13 @@
 import type { ActionDefinition, JsonSchema, ProviderDefinition } from "../../core/types.ts";
 
+import { z } from "zod";
 import { jsonSchema } from "../../core/json-schema.ts";
 import {
   actionInputMaxDepth,
   idempotencyKeyMaxBytes,
   idempotencyRetentionHours,
 } from "../actions/action-idempotency.ts";
+import { oauthConnectionInput, apiKeyConnectionInput, customConnectionInput } from "./connection-input.ts";
 import { policyRequestMaxBytes, policyRuleListMaxItems, policyRuleMaxBytes } from "./policy-input.ts";
 
 /**
@@ -162,6 +164,24 @@ const idempotencyKeyParameter = {
 const idempotencyConflictDescription =
   "For idempotency, idempotency_request_in_progress means the original request is still running or its outcome is uncertain, while idempotency_key_conflict means the key was reused for a different action, input, effective connection, or stored runtime token. Other runtime conflicts may return their own error code with the same status.";
 
+const runtimeConnectionProperties: Record<string, JsonSchema> = {
+  id: jsonSchema.string({ description: "Stable local connection identifier." }),
+  service: jsonSchema.string({ description: "Provider service identifier." }),
+  status: { type: "string", enum: ["active", "disconnected"] },
+  alias: jsonSchema.string({ description: namedConnectionDescription }),
+  authType: jsonSchema.string({ description: "Connection authentication type." }),
+  displayName: jsonSchema.string({ description: "Human-readable account label." }),
+  accountLabel: jsonSchema.string({
+    description: "Same value as displayName. Kept for existing /v1 clients.",
+  }),
+  isDefault: jsonSchema.boolean({
+    description: "Whether this is the default connection. Same fact as MCP default.",
+  }),
+  scopes: jsonSchema.array(jsonSchema.string(), {
+    description: "Granted scopes. Same fact as MCP profile.grantedScopes.",
+  }),
+};
+
 /**
  * Build OpenAPI docs from the generated catalog.
  *
@@ -265,6 +285,7 @@ export function createOpenApiDocument(
       data: jsonSchema.array({ $ref: "#/components/schemas/ActionSearchResult" }),
       errorStatuses: [400],
     }),
+    ...connectionManagementPaths(),
     "/v1/apps": runtimeGetOperation("Connections", "List connected accounts.", {
       description:
         "RuntimeConnectedApp rows, not the provider catalog. Use GET /v1/providers or MCP list_apps for providers.",
@@ -472,39 +493,20 @@ export function createOpenApiDocument(
             description: "Public runtime action metadata.",
           },
         ),
-        RuntimeConnectedApp: jsonSchema.object(
-          {
-            id: jsonSchema.string({ description: "Stable local connection identifier." }),
-            service: jsonSchema.string({ description: "Provider service identifier." }),
-            status: { type: "string", enum: ["active", "disconnected"] },
-            alias: jsonSchema.string({ description: namedConnectionDescription }),
-            authType: jsonSchema.string({ description: "Connection authentication type." }),
-            displayName: jsonSchema.string({ description: "Human-readable account label." }),
-            accountLabel: jsonSchema.string({
-              description: "Same value as displayName. Kept for existing /v1 clients.",
-            }),
-            isDefault: jsonSchema.boolean({
-              description: "Whether this is the default connection. Same fact as MCP default.",
-            }),
-            scopes: jsonSchema.array(jsonSchema.string(), {
-              description: "Granted scopes. Same fact as MCP profile.grantedScopes.",
-            }),
-          },
-          {
-            required: [
-              "id",
-              "service",
-              "status",
-              "alias",
-              "authType",
-              "displayName",
-              "accountLabel",
-              "isDefault",
-              "scopes",
-            ],
-            description: "Connected account from GET /v1/apps.",
-          },
-        ),
+        RuntimeConnectedApp: jsonSchema.object(runtimeConnectionProperties, {
+          required: [
+            "id",
+            "service",
+            "status",
+            "alias",
+            "authType",
+            "displayName",
+            "accountLabel",
+            "isDefault",
+            "scopes",
+          ],
+          description: "Connected account from GET /v1/apps.",
+        }),
         ConnectionSummary: jsonSchema.object(
           {
             id: jsonSchema.string({ description: "Stable local connection identifier." }),
@@ -1383,7 +1385,7 @@ interface RuntimeGetOperationOptions {
   data: JsonSchema;
   description?: string;
   parameters?: unknown[];
-  errorStatuses?: Array<400 | 404>;
+  errorStatuses?: Array<400 | 401 | 403 | 404>;
 }
 
 function runtimeGetOperation(
@@ -1529,4 +1531,95 @@ function jsonResponse(schema: JsonSchema, description = "JSON response."): Recor
       },
     },
   };
+}
+
+function connectionManagementPaths(): Record<string, unknown> {
+  const app = jsonSchema.object("A stored connection visible to the administrator.", {
+    ...runtimeConnectionProperties,
+    status: jsonSchema.stringEnum("Current connection state.", ["active", "reauth_required", "error", "disconnected"]),
+    providerAccountId: jsonSchema.string("The provider account identifier."),
+    comment: jsonSchema.nullableString("An optional administrator note."),
+  });
+  const start = jsonSchema.object("An OAuth authorization attempt. Poll connectionRequestId to obtain its result.", {
+    authorizationUrl: jsonSchema.string(),
+    stateHandle: jsonSchema.string(),
+    connectionRequestId: jsonSchema.string(),
+    status: jsonSchema.literal("initiated"),
+    expiresAt: jsonSchema.string(),
+  });
+  const request = jsonSchema.object(
+    "One authorization attempt; results remain available until expiresAt plus 24 hours.",
+    {
+      connectionRequestId: jsonSchema.string(),
+      service: jsonSchema.string(),
+      status: jsonSchema.stringEnum("Authorization request status.", ["initiated", "connected", "failed", "expired"]),
+      appId: jsonSchema.nullableString("The exact connection created or reconnected."),
+      errorCode: jsonSchema.nullableString("Safe failure code, including request_superseded."),
+      errorMessage: jsonSchema.nullableString("Safe failure message."),
+      expiresAt: jsonSchema.string(),
+      createdAt: jsonSchema.number(),
+      updatedAt: jsonSchema.number(),
+    },
+  );
+  const parameter = (name: string): unknown => ({ name, in: "path", required: true, schema: { type: "string" } });
+  const paths: Record<string, unknown> = {
+    "/v1/connections": runtimeGetOperation("Connections", "List manageable connections.", {
+      parameters: [
+        queryParameter(
+          "status",
+          "Filter by current connection state.",
+          jsonSchema.stringEnum("Connection state.", ["active", "reauth_required", "error", "disconnected"]),
+        ),
+      ],
+      data: jsonSchema.array(app),
+      errorStatuses: [401, 403],
+    }),
+    "/v1/connections/by-id/{appId}": runtimeGetOperation("Connections", "Get the current connection state.", {
+      data: app,
+      parameters: [parameter("appId")],
+      errorStatuses: [401, 403, 404],
+    }),
+    "/v1/connection-requests/{connectionRequestId}": runtimeGetOperation(
+      "Connections",
+      "Get an OAuth authorization result.",
+      {
+        data: request,
+        parameters: [parameter("connectionRequestId")],
+        errorStatuses: [401, 403, 404],
+        description:
+          "Requires the initiating management principal. A consumed callback does not remove the result. Responses use Cache-Control: private, no-store.",
+      },
+    ),
+  };
+  for (const reconnect of [false, true]) {
+    const base = reconnect ? "/v1/connections/by-id/{appId}/connect" : "/v1/connections/{service}/connect";
+    for (const [suffix, input, output] of [
+      ["", oauthConnectionInput, start],
+      ["/api-key", apiKeyConnectionInput, app],
+      ["/custom-credential", customConnectionInput, app],
+    ] as const) {
+      paths[`${base}${suffix}`] = {
+        post: {
+          tags: ["Connections"],
+          summary: `${reconnect ? "Reconnect" : "Create"} ${suffix || "OAuth"} connection.`,
+          description:
+            "Requires administrator credentials. OAuth returns an authorization request; API key and custom credentials return the saved connection synchronously.",
+          parameters: [parameter(reconnect ? "appId" : "service")],
+          requestBody: {
+            required: Boolean(suffix),
+            content: { "application/json": { schema: z.toJSONSchema(input) } },
+          },
+          responses: {
+            200: jsonResponse(runtimeSuccessSchema(output)),
+            400: jsonResponse(runtimeFailureSchema()),
+            401: jsonResponse(runtimeFailureSchema()),
+            403: jsonResponse(runtimeFailureSchema()),
+            404: jsonResponse(runtimeFailureSchema()),
+            409: jsonResponse(runtimeFailureSchema()),
+          },
+        },
+      };
+    }
+  }
+  return paths;
 }

--- a/src/server/api/runtime-api.ts
+++ b/src/server/api/runtime-api.ts
@@ -1,5 +1,5 @@
 import type { RuntimeActionDefinition, RuntimeProviderDefinition } from "../../catalog-store.ts";
-import type { ConnectionError, ConnectionSummary } from "../../connection-service.ts";
+import type { ConnectionError, ConnectionSummary, ManagedConnectionSummary } from "../../connection-service.ts";
 import type { ExecutionResult, ProviderScenario } from "../../core/types.ts";
 import type { Context } from "hono";
 
@@ -300,4 +300,37 @@ function isRuntimeStatus(value: unknown): value is RuntimeStatus {
     value === 500 ||
     value === 501
   );
+}
+
+/** Management view adds stored account metadata without exposing credentials. */
+export function serializeManagedConnection(connection: ManagedConnectionSummary): Omit<
+  RuntimeConnectedApp,
+  "status"
+> & {
+  status: ManagedConnectionSummary["status"];
+  providerAccountId: string;
+  comment: string | null;
+} {
+  return {
+    ...serializeRuntimeConnectedApp(connection),
+    status: connection.status,
+    providerAccountId: connection.profile.accountId,
+    comment: connection.comment,
+  };
+}
+
+export function connectionManagementFailure(error: { code: string; message: string }): RuntimeFailureInput {
+  const errorCode =
+    error.code === "connection_not_found"
+      ? "app_not_found"
+      : error.code === "unknown_service" || error.code === "unsupported_auth_type"
+        ? "invalid_input"
+        : error.code === "connection_changed"
+          ? "request_key_conflict"
+          : error.code;
+  return {
+    status: errorCode === "app_not_found" ? 404 : errorCode === "request_key_conflict" ? 409 : 400,
+    errorCode,
+    message: error.message,
+  };
 }

--- a/src/server/cloudflare.test.ts
+++ b/src/server/cloudflare.test.ts
@@ -231,6 +231,9 @@ function memoryAssets(files: Record<string, unknown>): AssetsBinding {
 }
 
 class EmptyMarketplaceD1Database implements D1DatabaseBinding {
+  async batch(): Promise<{ results: Record<string, unknown>[] }[]> {
+    throw new Error("Unexpected D1 batch");
+  }
   prepare(query: string): D1PreparedStatementBinding {
     if (query === "select value from marketplace_config where id = 1") {
       return new EmptyMarketplaceConfigStatement();

--- a/src/server/cloudflare/cloudflare-bindings.ts
+++ b/src/server/cloudflare/cloudflare-bindings.ts
@@ -1,5 +1,5 @@
 export interface D1DatabaseBinding {
-  batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] }[]>;
+  batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] | null }[]>;
   prepare(query: string): D1PreparedStatementBinding;
 }
 

--- a/src/server/cloudflare/cloudflare-bindings.ts
+++ b/src/server/cloudflare/cloudflare-bindings.ts
@@ -1,4 +1,5 @@
 export interface D1DatabaseBinding {
+  batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] }[]>;
   prepare(query: string): D1PreparedStatementBinding;
 }
 

--- a/src/server/connect-app.ts
+++ b/src/server/connect-app.ts
@@ -90,6 +90,7 @@ export async function createConnectApp(options: ConnectAppOptions): Promise<Conn
         connections,
         providerLoader: options.providerLoader,
         states: options.runtimeDatabase.oauthStateStore,
+        requests: options.runtimeDatabase.connectionRequestStore,
         secretCodec: options.secretCodec,
         isCustomClientConfigAllowed,
       }),

--- a/src/server/connect-server.test.ts
+++ b/src/server/connect-server.test.ts
@@ -46,6 +46,7 @@ import { TransitFileService } from "./files/transit-files.ts";
 import { AesGcmSecretCodec } from "./secrets/secret-codec.ts";
 import { decodeRunLogCursor, encodeRunLogCursor } from "./storage/runtime-store.ts";
 import { RuntimeTokenService } from "./storage/runtime-token-service.ts";
+import { SqliteRuntimeDatabase } from "./storage/sqlite-runtime-store.ts";
 
 const apiKeyProvider: ProviderDefinition = {
   service: "example",
@@ -55,6 +56,11 @@ const apiKeyProvider: ProviderDefinition = {
   auth: [{ type: "api_key" }],
   actions: [],
 };
+
+const requestDatabases: SqliteRuntimeDatabase[] = [];
+afterEach(() => {
+  for (const database of requestDatabases.splice(0)) database.close();
+});
 
 const oauthProvider: ProviderDefinition = {
   service: "oauth_example",
@@ -3683,6 +3689,8 @@ interface CreateTestServerOptions {
 }
 
 function createTestServer(providers: ProviderDefinition[], options: CreateTestServerOptions = {}): ConnectServer {
+  const requestDatabase = new SqliteRuntimeDatabase(":memory:");
+  requestDatabases.push(requestDatabase);
   const catalog = createCatalogStore(providers, {
     executableActionIds: ["example.echo"],
   });
@@ -3735,6 +3743,7 @@ function createTestServer(providers: ProviderDefinition[], options: CreateTestSe
       connections,
       providerLoader,
       states: new MemoryOAuthStateStore(),
+      requests: requestDatabase.connectionRequestStore,
       secretCodec: options.secretCodec,
       isCustomClientConfigAllowed,
     }),

--- a/src/server/connect-server.ts
+++ b/src/server/connect-server.ts
@@ -25,7 +25,7 @@ import { optionalRecord, optionalString, requiredString, requiredStringArray } f
 import { PromiseCache } from "../core/promise-cache.ts";
 import { MarketplaceError } from "../marketplace/marketplace-service.ts";
 import { OAuthClientConfigError, OAuthClientConfigService } from "../oauth/oauth-client-config-service.ts";
-import { OAuthFlowError, OAuthFlowService } from "../oauth/oauth-flow-service.ts";
+import { OAuthCallbackError, OAuthFlowError, OAuthFlowService } from "../oauth/oauth-flow-service.ts";
 import {
   ActionInputDepthError,
   createIdempotencyExpiry,
@@ -37,9 +37,9 @@ import { ActionRunner } from "./actions/action-runner.ts";
 import { renderActionMarkdown } from "./api/action-markdown.ts";
 import { clearLocalAuthCookie, createLocalAuthMiddleware, readLocalAuthSession, readRuntimeGrant } from "./api/auth.ts";
 import { getResponseCachePolicy } from "./api/cache-policy.ts";
+import { createConnectionRoutes } from "./api/connection-routes.ts";
 import { HttpRequestError, internalError, jsonError, notFound, readJsonBody } from "./api/http-utils.ts";
 import { renderOAuthCompletionPage } from "./api/oauth-completion-page.ts";
-import { createOpenApiDocument } from "./api/openapi.ts";
 import { policyRequestMaxBytes, readRuntimePolicyRules, readTokenPolicy } from "./api/policy-input.ts";
 import {
   mapConnectionErrorStatus,
@@ -196,6 +196,7 @@ export class ConnectServer {
     app.get("/v1/actions/search", (context) => this.searchRuntimeActions(context));
     app.get("/v1/actions/:actionId", (context) => this.getRuntimeAction(context, context.req.param("actionId")));
     app.post("/v1/actions/:actionId", (context) => this.createRuntimeActionRun(context, context.req.param("actionId")));
+    app.route("/v1", createConnectionRoutes(this.options));
     app.get("/v1/apps", (context) => this.listRuntimeApps(context));
     app.get("/v1/apps/authenticated", (context) => this.listAuthenticatedRuntimeApps(context));
     app.get("/v1/apps/services/:service", (context) =>
@@ -203,13 +204,14 @@ export class ConnectServer {
     );
     app.post("/v1/proxy/:service", (context) => this.createRuntimeProxyRequest(context, context.req.param("service")));
 
-    app.get("/openapi.json", (context) =>
-      context.json(
+    app.get("/openapi.json", async (context) => {
+      const { createOpenApiDocument } = await import("./api/openapi.ts");
+      return context.json(
         createOpenApiDocument(this.options.catalog.providers, {
           actionId: optionalString(context.req.query("actionId")),
         }),
-      ),
-    );
+      );
+    });
     app.get("/docs", async (context, next) => (await loadDocsHandler())(context, next));
 
     // Schema-free listing. The action detail view loads full schemas on demand
@@ -278,6 +280,13 @@ export class ConnectServer {
         },
         "request failed",
       );
+      if (context.req.path.startsWith("/v1/connections") || context.req.path.startsWith("/v1/connection-requests")) {
+        return writeRuntimeFailure(context, {
+          status: 500,
+          errorCode: "internal_error",
+          message: "Internal server error.",
+        });
+      }
       return internalError(context, error);
     });
 
@@ -1074,6 +1083,10 @@ export class ConnectServer {
     this.options.logger?.info(logContext, "oauth callback received");
     const providerError = context.req.query("error");
     if (providerError) {
+      const returnUri = state
+        ? await this.options.oauthFlow.rejectAuthorization(state, providerError === "access_denied")
+        : undefined;
+      if (returnUri) return context.redirect(returnUri);
       const providerErrorDescription = context.req.query("error_description");
       this.options.logger?.warn(
         {
@@ -1092,6 +1105,7 @@ export class ConnectServer {
       );
     }
     if (!state || !code) {
+      if (state) await this.options.oauthFlow.rejectAuthorization(state, false);
       this.options.logger?.warn(
         {
           ...logContext,
@@ -1104,14 +1118,14 @@ export class ConnectServer {
 
     let service: string;
     try {
-      service = (
-        await this.options.oauthFlow.completeAuthorization({
-          state,
-          code,
-          callbackParameters: Object.fromEntries(new URL(context.req.url).searchParams),
-          signal: context.req.raw.signal,
-        })
-      ).service;
+      const completed = await this.options.oauthFlow.completeAuthorization({
+        state,
+        code,
+        callbackParameters: Object.fromEntries(new URL(context.req.url).searchParams),
+        signal: context.req.raw.signal,
+      });
+      service = completed.service;
+      if (completed.returnUri) return context.redirect(completed.returnUri);
       this.options.logger?.info(
         {
           ...logContext,
@@ -1120,6 +1134,7 @@ export class ConnectServer {
         "oauth callback completed",
       );
     } catch (error) {
+      if (error instanceof OAuthCallbackError && error.returnUri) return context.redirect(error.returnUri);
       if (error instanceof OAuthFlowError || error instanceof ConnectionError) {
         const cancelled = error instanceof ConnectionError && error.code === "connection_cancelled";
         this.options.logger?.[cancelled ? "info" : "warn"](

--- a/src/server/storage/connection-request-store.cases.ts
+++ b/src/server/storage/connection-request-store.cases.ts
@@ -1,0 +1,108 @@
+import type { ResolvedCredential } from "../../core/types.ts";
+import type { PendingConnectionRequest } from "./connection-request-store.ts";
+import type { RuntimeDatabase } from "./runtime-database.ts";
+
+import { describe, expect, it } from "vitest";
+
+const credential: Extract<ResolvedCredential, { authType: "api_key" }> = {
+  authType: "api_key",
+  apiKey: "secret",
+  values: { apiKey: "secret" },
+  profile: { accountId: "user", displayName: "User", grantedScopes: [] },
+  metadata: {},
+};
+
+function pending(owner = "admin"): PendingConnectionRequest {
+  return {
+    connectionRequestId: crypto.randomUUID(),
+    state: crypto.randomUUID(),
+    owner,
+    service: "example",
+    connectionName: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+}
+
+/** The same transaction and lifecycle contracts must hold on every persistent backend. */
+export function connectionRequestStoreTests(getDatabase: () => RuntimeDatabase): void {
+  describe("connection request lifecycle", () => {
+    it("isolates owners and claims each callback exactly once", async () => {
+      const { connectionRequestStore: requests } = getDatabase();
+      const request = pending();
+      await requests.create(request);
+      expect(await requests.get(request.connectionRequestId, "other")).toBeUndefined();
+      const claims = await Promise.all([requests.claim(request.state), requests.claim(request.state)]);
+      expect(claims.filter(Boolean)).toHaveLength(1);
+      expect(claims.find(Boolean)).toEqual(request);
+    });
+
+    it("rolls back supersession when the new request cannot be saved", async () => {
+      const { connectionRequestStore: requests } = getDatabase();
+      const request = pending();
+      await requests.create(request);
+      await expect(
+        requests.create({ ...pending(), connectionRequestId: request.connectionRequestId }),
+      ).rejects.toThrow();
+      expect(await requests.get(request.connectionRequestId, request.owner)).toMatchObject({
+        status: "initiated",
+        errorCode: null,
+      });
+      expect(await requests.claim(request.state)).toEqual(request);
+    });
+
+    it("does not supersede a claimed callback and never overwrites its terminal result", async () => {
+      const database = getDatabase();
+      const requests = database.connectionRequestStore;
+      const request = pending();
+      await requests.create(request);
+      await requests.claim(request.state);
+      await requests.create(pending());
+      const id = await requests.complete(request, credential);
+      expect(id).toEqual(expect.any(String));
+      expect(await requests.get(request.connectionRequestId, request.owner)).toMatchObject({
+        status: "connected",
+        appId: id,
+      });
+      await requests.fail(request.connectionRequestId, "late", "Late error");
+      expect(await requests.complete(request, credential)).toBeUndefined();
+      expect(await requests.get(request.connectionRequestId, request.owner)).toMatchObject({
+        status: "connected",
+        appId: id,
+      });
+      expect((await database.connectionStore.list()).filter((connection) => connection.id === id)).toHaveLength(1);
+    });
+
+    it("retains the original credential when reconnect races with a replacement", async () => {
+      const database = getDatabase();
+      const original = await database.connectionStore.set("example", crypto.randomUUID(), credential);
+      const request = {
+        ...pending(),
+        connectionName: original.connectionName,
+        target: { id: original.id, revision: original.revision },
+      };
+      await database.connectionRequestStore.create(request);
+      await database.connectionRequestStore.claim(request.state);
+      const replacement: ResolvedCredential = { ...credential, apiKey: "replacement" };
+      await database.connectionStore.updateCredential({ ...original, credential: replacement });
+      expect(await database.connectionRequestStore.complete(request, credential)).toBeUndefined();
+      expect((await database.connectionStore.get(original.service, original.connectionName))?.credential).toEqual(
+        replacement,
+      );
+      expect(await database.connectionRequestStore.get(request.connectionRequestId, request.owner)).toMatchObject({
+        status: "initiated",
+        appId: null,
+      });
+    });
+
+    it("never writes credentials after the request has failed", async () => {
+      const database = getDatabase();
+      const request = pending();
+      await database.connectionRequestStore.create(request);
+      await database.connectionRequestStore.claim(request.state);
+      await database.connectionRequestStore.fail(request.connectionRequestId, "provider_error", "Failed");
+      expect(await database.connectionRequestStore.complete(request, credential)).toBeUndefined();
+      expect(await database.connectionStore.get(request.service, request.connectionName!)).toBeUndefined();
+    });
+  });
+}

--- a/src/server/storage/connection-request-store.ts
+++ b/src/server/storage/connection-request-store.ts
@@ -1,0 +1,163 @@
+import type { StoredConnection } from "../../connection-service.ts";
+import type { ResolvedCredential } from "../../core/types.ts";
+import type { OAuthAuthorizationState } from "../../oauth/oauth-flow-service.ts";
+import type { ISecretCodec } from "../secrets/secret-codec-core.ts";
+import type { RuntimeRow } from "./runtime-sql.ts";
+
+export interface ConnectionRequest {
+  connectionRequestId: string;
+  service: string;
+  status: "initiated" | "connected" | "failed" | "expired";
+  appId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  expiresAt: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PendingConnectionRequest extends OAuthAuthorizationState {
+  connectionName: string;
+  connectionRequestId: string;
+  owner: string;
+  expiresAt: string;
+  returnUri?: string;
+  target?: Pick<StoredConnection, "id" | "revision">;
+}
+
+export interface RequestStatement {
+  sql: string;
+  values: (string | number | null)[];
+}
+
+/** Executes all statements atomically; each result contains its RETURNING/SELECT rows. */
+export type RequestTransaction = (statements: RequestStatement[]) => Promise<RuntimeRow[][]>;
+
+/** Shared SQL lifecycle for SQLite, PostgreSQL and D1. Secrets use the runtime's codec. */
+export class ConnectionRequestStore {
+  private readonly transaction: RequestTransaction;
+  private readonly secretCodec: ISecretCodec;
+
+  constructor(transaction: RequestTransaction, secretCodec: ISecretCodec) {
+    this.transaction = transaction;
+    this.secretCodec = secretCodec;
+  }
+
+  async create(pending: PendingConnectionRequest): Promise<void> {
+    const now = Date.parse(pending.createdAt);
+    const value = await this.secretCodec.encode(JSON.stringify(pending));
+    await this.transaction([
+      {
+        sql: "delete from connection_requests where expires_at <= ?",
+        values: [new Date(now - 86_400_000).toISOString()],
+      },
+      {
+        sql: `update connection_requests set phase = 'completed', status = 'failed', error_code = 'request_superseded',
+          error_message = 'A newer authorization request replaced this request.', value = null, updated_at = ?
+          where owner = ? and service = ? and phase = 'pending' and expires_at > ?`,
+        values: [now, pending.owner, pending.service, pending.createdAt],
+      },
+      {
+        sql: `insert into connection_requests (id, owner, service, state, phase, status, value, expires_at, created_at, updated_at)
+          values (?, ?, ?, ?, 'pending', 'initiated', ?, ?, ?, ?)`,
+        values: [
+          pending.connectionRequestId,
+          pending.owner,
+          pending.service,
+          pending.state,
+          value,
+          pending.expiresAt,
+          now,
+          now,
+        ],
+      },
+    ]);
+  }
+
+  async get(id: string, owner: string): Promise<ConnectionRequest | undefined> {
+    const now = Date.now();
+    const [[row]] = await this.transaction([
+      {
+        sql: "select id, service, status, app_id, error_code, error_message, expires_at, created_at, updated_at from connection_requests where id = ? and owner = ? and expires_at > ?",
+        values: [id, owner, new Date(now - 86_400_000).toISOString()],
+      },
+    ]);
+    if (!row) return undefined;
+    return {
+      connectionRequestId: row.id as string,
+      service: row.service as string,
+      status:
+        row.status === "initiated" && Date.parse(row.expires_at as string) <= now
+          ? "expired"
+          : (row.status as ConnectionRequest["status"]),
+      appId: row.app_id as string | null,
+      errorCode: row.error_code as string | null,
+      errorMessage: row.error_message as string | null,
+      expiresAt: row.expires_at as string,
+      createdAt: Number(row.created_at),
+      updatedAt: Number(row.updated_at),
+    };
+  }
+
+  async claim(state: string): Promise<PendingConnectionRequest | undefined> {
+    const [[row]] = await this.transaction([
+      {
+        sql: "update connection_requests set phase = 'processing', updated_at = ? where state = ? and phase = 'pending' and expires_at > ? returning value",
+        values: [Date.now(), state, new Date().toISOString()],
+      },
+    ]);
+    return row
+      ? (JSON.parse(await this.secretCodec.decode(row.value as string)) as PendingConnectionRequest)
+      : undefined;
+  }
+
+  async fail(id: string, errorCode: string, errorMessage: string): Promise<void> {
+    await this.transaction([
+      {
+        sql: `update connection_requests set phase = 'completed', status = 'failed', error_code = ?, error_message = ?, value = null, updated_at = ?
+        where id = ? and phase = 'processing'`,
+        values: [errorCode, errorMessage, Date.now(), id],
+      },
+    ]);
+  }
+
+  async complete(
+    pending: PendingConnectionRequest,
+    credential: ResolvedCredential,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    const id = pending.target?.id ?? crypto.randomUUID();
+    const revision = crypto.randomUUID();
+    const value = await this.secretCodec.encode(JSON.stringify(credential));
+    signal?.throwIfAborted();
+    const now = new Date();
+    const active = "exists (select 1 from connection_requests where id = ? and phase = 'processing')";
+    const write: RequestStatement = pending.target
+      ? {
+          sql: `update connections set value = ?, revision = ?, updated_at = ? where id = ? and revision = ? and ${active} returning id`,
+          values: [value, revision, now.toISOString(), id, pending.target.revision, pending.connectionRequestId],
+        }
+      : {
+          sql: `insert into connections (id, revision, service, connection_name, value, updated_at)
+        select ?, ?, ?, ?, ?, ? where ${active} returning id`,
+          values: [
+            id,
+            revision,
+            pending.service,
+            pending.connectionName,
+            value,
+            now.toISOString(),
+            pending.connectionRequestId,
+          ],
+        };
+    const [written] = await this.transaction([
+      write,
+      {
+        sql: `update connection_requests set phase = 'completed', status = 'connected', app_id = ?, value = null, updated_at = ?
+          where id = ? and phase = 'processing' and exists (select 1 from connections where id = ? and revision = ?)`,
+        values: [id, now.getTime(), pending.connectionRequestId, id, revision],
+      },
+    ]);
+    return written.length ? id : undefined;
+  }
+}

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -611,10 +611,13 @@ class SqliteD1Database implements D1DatabaseBinding {
     }
   }
 
-  async batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] }[]> {
+  async batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] | null }[]> {
     this.database.exec("begin immediate");
     try {
-      const results = statements.map((statement) => ({ results: (statement as SqliteD1PreparedStatement).readRows() }));
+      const results = statements.map((statement) => {
+        const rows = (statement as SqliteD1PreparedStatement).readRows();
+        return { results: rows.length ? rows : null };
+      });
       this.database.exec("commit");
       return results;
     } catch (error) {

--- a/src/server/storage/d1-runtime-store.test.ts
+++ b/src/server/storage/d1-runtime-store.test.ts
@@ -2,8 +2,9 @@ import type { RuntimeActionHttpResult } from "../api/runtime-api.ts";
 import type { D1DatabaseBinding, D1PreparedStatementBinding } from "../cloudflare/cloudflare-bindings.ts";
 
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { AesGcmSecretCodec } from "../secrets/secret-codec.ts";
+import { connectionRequestStoreTests } from "./connection-request-store.cases.ts";
 import { D1RuntimeDatabase } from "./d1-runtime-store.ts";
 import { defaultMigrationSource } from "./migration-source.ts";
 import { RuntimeTokenService } from "./runtime-token-service.ts";
@@ -610,6 +611,18 @@ class SqliteD1Database implements D1DatabaseBinding {
     }
   }
 
+  async batch(statements: D1PreparedStatementBinding[]): Promise<{ results: Record<string, unknown>[] }[]> {
+    this.database.exec("begin immediate");
+    try {
+      const results = statements.map((statement) => ({ results: (statement as SqliteD1PreparedStatement).readRows() }));
+      this.database.exec("commit");
+      return results;
+    } catch (error) {
+      this.database.exec("rollback");
+      throw error;
+    }
+  }
+
   prepare(query: string): D1PreparedStatementBinding {
     return new SqliteD1PreparedStatement(this.database, query);
   }
@@ -650,8 +663,12 @@ class SqliteD1PreparedStatement implements D1PreparedStatementBinding {
     return (this.database.prepare(this.query).get(...toSqlValues(this.values)) as T | undefined) ?? null;
   }
 
+  readRows(): Record<string, unknown>[] {
+    return this.database.prepare(this.query).all(...toSqlValues(this.values));
+  }
+
   async all<T = Record<string, unknown>>(): Promise<{ results: T[] }> {
-    return { results: this.database.prepare(this.query).all(...toSqlValues(this.values)) as T[] };
+    return { results: this.readRows() as T[] };
   }
 
   async run(): Promise<{ success: boolean; meta: { changes?: number } }> {
@@ -663,3 +680,11 @@ class SqliteD1PreparedStatement implements D1PreparedStatementBinding {
 function toSqlValues(values: unknown[]): Array<string | number | bigint | null | Uint8Array> {
   return values.map((value) => (value === undefined ? null : (value as string | number | bigint | null | Uint8Array)));
 }
+
+describe("D1 connection requests", () => {
+  let database: D1RuntimeDatabase;
+  beforeEach(() => {
+    database = new D1RuntimeDatabase(new SqliteD1Database());
+  });
+  connectionRequestStoreTests(() => database);
+});

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -24,6 +24,7 @@ import type { IRuntimeTokenStore, RuntimeTokenRecord } from "./runtime-token-ser
 
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
+import { ConnectionRequestStore } from "./connection-request-store.ts";
 import {
   listRunLogs,
   parseJson,
@@ -43,6 +44,7 @@ export interface D1RuntimeDatabaseOptions {
 }
 
 export class D1RuntimeDatabase implements RuntimeDatabase {
+  readonly connectionRequestStore: ConnectionRequestStore;
   readonly connectionStore: D1ConnectionStore;
   readonly oauthClientConfigStore: D1OAuthClientConfigStore;
   readonly oauthStateStore: D1OAuthStateStore;
@@ -54,6 +56,10 @@ export class D1RuntimeDatabase implements RuntimeDatabase {
 
   constructor(database: D1DatabaseBinding, options: D1RuntimeDatabaseOptions = {}) {
     const secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
+    this.connectionRequestStore = new ConnectionRequestStore(async (statements) => {
+      const results = await database.batch(statements.map(({ sql, values }) => database.prepare(sql).bind(...values)));
+      return results.map((result) => result.results);
+    }, secretCodec);
     this.connectionStore = new D1ConnectionStore(database, secretCodec);
     this.oauthClientConfigStore = new D1OAuthClientConfigStore(database, secretCodec);
     this.oauthStateStore = new D1OAuthStateStore(database, secretCodec);

--- a/src/server/storage/d1-runtime-store.ts
+++ b/src/server/storage/d1-runtime-store.ts
@@ -58,7 +58,7 @@ export class D1RuntimeDatabase implements RuntimeDatabase {
     const secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
     this.connectionRequestStore = new ConnectionRequestStore(async (statements) => {
       const results = await database.batch(statements.map(({ sql, values }) => database.prepare(sql).bind(...values)));
-      return results.map((result) => result.results);
+      return results.map((result) => result.results ?? []);
     }, secretCodec);
     this.connectionStore = new D1ConnectionStore(database, secretCodec);
     this.oauthClientConfigStore = new D1OAuthClientConfigStore(database, secretCodec);

--- a/src/server/storage/postgres-runtime-store.test.ts
+++ b/src/server/storage/postgres-runtime-store.test.ts
@@ -6,6 +6,7 @@ import { PGLiteSocketServer } from "@electric-sql/pglite-socket";
 import { Pool } from "pg";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { AesGcmSecretCodec } from "../secrets/secret-codec.ts";
+import { connectionRequestStoreTests } from "./connection-request-store.cases.ts";
 import { defaultMigrationSource } from "./migration-source.ts";
 import { createNodeRuntimeDatabase, migratePostgresRuntimeDatabase } from "./node-runtime-database.ts";
 import { assertPostgresSchemaReady, migratePostgresDatabase } from "./postgres-migrations.ts";
@@ -51,6 +52,7 @@ describe("PostgreSQL migrations with PGlite", () => {
           { name: "0010_runtime.sql" },
           { name: "0011_runtime_token_connection_scope.sql" },
           { name: "0012_marketplace.sql" },
+          { name: "0013_connection_requests.sql" },
         ],
       });
 
@@ -109,6 +111,7 @@ describe("PostgreSQL migrations with a custom migration source", () => {
           { name: "0010_runtime.sql" },
           { name: "0011_runtime_token_connection_scope.sql" },
           { name: "0012_marketplace.sql" },
+          { name: "0013_connection_requests.sql" },
           { name: "9998_custom.sql" },
         ],
       });
@@ -193,6 +196,8 @@ describe("PostgresRuntimeDatabase with PGlite", () => {
     await testServer.server.stop();
     await testServer.database.close();
   });
+
+  connectionRequestStoreTests(() => database);
 
   it("persists connections and OAuth data across database instances", async () => {
     const connection = await database.connectionStore.set("github", "default", githubCredential("github-token"));

--- a/src/server/storage/postgres-runtime-store.ts
+++ b/src/server/storage/postgres-runtime-store.ts
@@ -26,6 +26,7 @@ import type { PoolClient } from "pg";
 import { Pool } from "pg";
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
+import { ConnectionRequestStore } from "./connection-request-store.ts";
 import { assertPostgresSchemaReady } from "./postgres-migrations.ts";
 import {
   listRunLogs,
@@ -48,6 +49,7 @@ export interface PostgresRuntimeDatabaseOptions {
 }
 
 export class PostgresRuntimeDatabase implements RuntimeDatabase {
+  readonly connectionRequestStore: ConnectionRequestStore;
   readonly connectionStore: IConnectionStore;
   readonly oauthClientConfigStore: IOAuthClientConfigStore;
   readonly oauthStateStore: IOAuthStateStore;
@@ -63,6 +65,27 @@ export class PostgresRuntimeDatabase implements RuntimeDatabase {
   private constructor(pool: Pool, options: PostgresRuntimeDatabaseOptions) {
     this.pool = pool;
     this.secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
+    this.connectionRequestStore = new ConnectionRequestStore(
+      (statements) =>
+        runInTransaction(pool, async (client) => {
+          // Serialize request transitions across processes, including first requests with no row to lock.
+          await client.query("select pg_advisory_xact_lock(1326382671, 2)");
+          const results: Record<string, unknown>[][] = [];
+          for (const { sql, values } of statements) {
+            let index = 0;
+            results.push(
+              (
+                await client.query(
+                  sql.replaceAll("?", () => `$${++index}`),
+                  values,
+                )
+              ).rows,
+            );
+          }
+          return results;
+        }),
+      this.secretCodec,
+    );
     this.connectionStore = new PostgresConnectionStore(pool, this.secretCodec);
     this.oauthClientConfigStore = new PostgresOAuthClientConfigStore(pool, this.secretCodec);
     this.oauthStateStore = new PostgresOAuthStateStore(pool, this.secretCodec);
@@ -106,6 +129,7 @@ export class PostgresRuntimeDatabase implements RuntimeDatabase {
         delete from connections;
         delete from oauth_client_configs;
         delete from oauth_states;
+        delete from connection_requests;
         delete from runtime_tokens;
         delete from runtime_policy;
         delete from runs;
@@ -119,7 +143,7 @@ export class PostgresRuntimeDatabase implements RuntimeDatabase {
   async rotateSecretCodec(nextSecretCodec: ISecretCodec): Promise<void> {
     await runInTransaction(this.pool, async (client) => {
       await client.query(
-        "lock table connections, oauth_client_configs, oauth_states, idempotency_records in access exclusive mode",
+        "lock table connections, oauth_client_configs, oauth_states, connection_requests, idempotency_records in access exclusive mode",
       );
 
       const connectionRows = await client.query<RuntimeRow>("select service, connection_name, value from connections");
@@ -152,6 +176,13 @@ export class PostgresRuntimeDatabase implements RuntimeDatabase {
         ]);
       }
 
+      const requestRows = await client.query<RuntimeRow>(
+        "select id, value from connection_requests where value is not null",
+      );
+      for (const row of requestRows.rows) {
+        const value = await nextSecretCodec.encode(await this.secretCodec.decode(readString(row, "value")));
+        await client.query("update connection_requests set value = $1 where id = $2", [value, readString(row, "id")]);
+      }
       const stateRows = await client.query<RuntimeRow>("select state, value from oauth_states");
       const states = await Promise.all(
         stateRows.rows.map(async (row) => ({

--- a/src/server/storage/runtime-database.ts
+++ b/src/server/storage/runtime-database.ts
@@ -2,12 +2,14 @@ import type { IConnectionStore } from "../../connection-service.ts";
 import type { IMarketplaceStore } from "../../marketplace/marketplace-service.ts";
 import type { IOAuthClientConfigStore } from "../../oauth/oauth-client-config-service.ts";
 import type { IOAuthStateStore } from "../../oauth/oauth-flow-service.ts";
+import type { ConnectionRequestStore } from "./connection-request-store.ts";
 import type { IIdempotencyStore } from "./idempotency-store.ts";
 import type { IRuntimePolicyStore } from "./runtime-policy-store.ts";
 import type { IRunLogStore } from "./runtime-store.ts";
 import type { IRuntimeTokenStore } from "./runtime-token-service.ts";
 
 export interface RuntimeDatabase {
+  connectionRequestStore: ConnectionRequestStore;
   connectionStore: IConnectionStore;
   oauthClientConfigStore: IOAuthClientConfigStore;
   oauthStateStore: IOAuthStateStore;

--- a/src/server/storage/sqlite-runtime-store.test.ts
+++ b/src/server/storage/sqlite-runtime-store.test.ts
@@ -5,8 +5,9 @@ import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AesGcmSecretCodec } from "../secrets/secret-codec.ts";
+import { connectionRequestStoreTests } from "./connection-request-store.cases.ts";
 import { createDirectoryMigrationSource } from "./migration-source.ts";
 import { RuntimeTokenService } from "./runtime-token-service.ts";
 import { SqliteRunLogStore, SqliteRuntimeDatabase } from "./sqlite-runtime-store.ts";
@@ -52,6 +53,7 @@ describe("SqliteRuntimeDatabase", () => {
       "0010_connection_revision.sql",
       "0011_runtime_token_connection_scope.sql",
       "0012_marketplace.sql",
+      "0013_connection_requests.sql",
     ];
     expect(entries.filter((entry) => entry.message === "sqlite migration started")).toEqual(
       migrations.map((migration) => ({ fields: { migration }, message: "sqlite migration started" })),
@@ -985,3 +987,91 @@ async function expectDatabaseDirectoryNotToContain(databasePath: string, needle:
     expect(bytes).not.toContain(needle);
   }
 }
+
+describe("SQLite connection requests", () => {
+  let database: SqliteRuntimeDatabase;
+  beforeEach(() => {
+    database = new SqliteRuntimeDatabase(":memory:");
+  });
+  afterEach(() => {
+    database.close();
+  });
+  connectionRequestStoreTests(() => database);
+});
+
+it("rolls back credential writes when the request success update fails and recovers after restart", async () => {
+  const databasePath = await createDatabasePath();
+  const codec = new AesGcmSecretCodec("request-secret-key");
+  let database = new SqliteRuntimeDatabase(databasePath, { secretCodec: codec });
+  const inspect = new DatabaseSync(databasePath);
+  const request = {
+    connectionRequestId: "request",
+    state: "state",
+    owner: "admin",
+    service: "github",
+    connectionName: "new",
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    clientConfig: { service: "github", clientId: "id", clientSecret: "client-secret", extra: {}, secretExtra: {} },
+  };
+  try {
+    await database.connectionRequestStore.create(request);
+    expect(inspect.prepare("select value from connection_requests").get()?.value).not.toContain("client-secret");
+    database.close();
+    database = new SqliteRuntimeDatabase(databasePath, { secretCodec: codec });
+    expect(await database.connectionRequestStore.claim("state")).toEqual(request);
+    inspect.exec(
+      "create trigger fail_request_success before update of status on connection_requests when new.status = 'connected' begin select raise(abort, 'injected failure'); end",
+    );
+    const credential = {
+      authType: "api_key" as const,
+      apiKey: "key",
+      values: { apiKey: "key" },
+      profile: githubProfile,
+      metadata: {},
+    };
+    await expect(database.connectionRequestStore.complete(request, credential)).rejects.toThrow("injected failure");
+    expect(await database.connectionStore.list()).toEqual([]);
+    expect(await database.connectionRequestStore.get("request", "admin")).toMatchObject({
+      status: "initiated",
+      appId: null,
+    });
+    inspect.exec("drop trigger fail_request_success");
+    await database.connectionRequestStore.complete(request, credential);
+    const result = await database.connectionRequestStore.get("request", "admin");
+    database.close();
+    database = new SqliteRuntimeDatabase(databasePath, { secretCodec: codec });
+    expect(await database.connectionRequestStore.get("request", "admin")).toEqual(result);
+    expect(result?.status).toBe("connected");
+    expect(inspect.prepare("select value from connection_requests").get()?.value).toBeNull();
+  } finally {
+    inspect.close();
+    database.close();
+  }
+});
+
+it("rotates pending connection-request secrets together with the runtime credentials", async () => {
+  const path = await createDatabasePath();
+  const oldCodec = new AesGcmSecretCodec("old-request-key");
+  const newCodec = new AesGcmSecretCodec("new-request-key");
+  const database = new SqliteRuntimeDatabase(path, { secretCodec: oldCodec });
+  const request = {
+    connectionRequestId: "rotate",
+    state: "rotate-state",
+    owner: "admin",
+    service: "github",
+    connectionName: "new",
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    clientConfig: { service: "github", clientId: "client", clientSecret: "secret", extra: {}, secretExtra: {} },
+  };
+  await database.connectionRequestStore.create(request);
+  await database.rotateSecretCodec(newCodec);
+  database.close();
+  const reopened = new SqliteRuntimeDatabase(path, { secretCodec: newCodec });
+  try {
+    expect(await reopened.connectionRequestStore.claim(request.state)).toEqual(request);
+  } finally {
+    reopened.close();
+  }
+});

--- a/src/server/storage/sqlite-runtime-store.ts
+++ b/src/server/storage/sqlite-runtime-store.ts
@@ -24,6 +24,7 @@ import type { IRuntimeTokenStore, RuntimeTokenRecord } from "./runtime-token-ser
 import { DatabaseSync } from "node:sqlite";
 import { parseRuntimeActionHttpResult } from "../api/runtime-api.ts";
 import { PlainTextSecretCodec } from "../secrets/secret-codec-core.ts";
+import { ConnectionRequestStore } from "./connection-request-store.ts";
 import { defaultMigrationSource } from "./migration-source.ts";
 import {
   listRunLogs,
@@ -81,6 +82,7 @@ interface RotatedStateSecret {
  * Shared SQLite connection for local runtime state.
  */
 export class SqliteRuntimeDatabase implements RuntimeDatabase {
+  readonly connectionRequestStore: ConnectionRequestStore;
   readonly connectionStore: SqliteConnectionStore;
   readonly oauthClientConfigStore: SqliteOAuthClientConfigStore;
   readonly oauthStateStore: SqliteOAuthStateStore;
@@ -97,6 +99,13 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
     this.database = new DatabaseSync(filename);
     this.secretCodec = options.secretCodec ?? new PlainTextSecretCodec();
     this.initialize(options.migrations ?? defaultMigrationSource, options.logger);
+    this.connectionRequestStore = new ConnectionRequestStore(
+      async (statements) =>
+        runInTransaction(this.database, () =>
+          statements.map(({ sql, values }) => this.database.prepare(sql).all(...values)),
+        ),
+      this.secretCodec,
+    );
     this.connectionStore = new SqliteConnectionStore(this.database, this.secretCodec);
     this.oauthClientConfigStore = new SqliteOAuthClientConfigStore(this.database, this.secretCodec);
     this.oauthStateStore = new SqliteOAuthStateStore(this.database, this.secretCodec);
@@ -119,6 +128,15 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
       nextSecretCodec,
       "oauth_client_configs",
     );
+    const requestSecrets = await Promise.all(
+      this.database
+        .prepare("select id, value from connection_requests where value is not null")
+        .all()
+        .map(async (row) => ({
+          id: readString(row, "id"),
+          value: await nextSecretCodec.encode(await this.secretCodec.decode(readString(row, "value"))),
+        })),
+    );
     const oauthStates = await readRotatedStateSecrets(this.database, this.secretCodec, nextSecretCodec);
     const idempotencyResponses = await readRotatedIdempotencySecrets(this.database, this.secretCodec, nextSecretCodec);
     const marketplaceConfig = await this.marketplaceStore.getConfig();
@@ -134,6 +152,10 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
       writeRotatedConnectionSecrets(this.database, connections);
       writeRotatedServiceSecrets(this.database, "oauth_client_configs", oauthConfigs);
       writeRotatedStateSecrets(this.database, oauthStates);
+      for (const request of requestSecrets)
+        this.database
+          .prepare("update connection_requests set value = ? where id = ? and value is not null")
+          .run(request.value, request.id);
       writeRotatedIdempotencySecrets(this.database, idempotencyResponses);
       if (rotatedMarketplaceConfig) {
         this.database
@@ -148,6 +170,7 @@ export class SqliteRuntimeDatabase implements RuntimeDatabase {
       delete from connections;
       delete from oauth_client_configs;
       delete from oauth_states;
+      delete from connection_requests;
       delete from runtime_tokens;
       delete from runtime_policy;
       delete from runs;


### PR DESCRIPTION
Open Connector lacks the public personal connection-management endpoints used by clients of the hosted connector. Add the `/v1/connections` and `/v1/connection-requests` APIs so clients can list and inspect connections, create or replace API-key/custom credentials, start OAuth authorization, and poll its result using the same public paths and response behavior.

- Persist OAuth request lifecycle in SQLite, PostgreSQL, and D1, with a 10-minute authorization window, expiry, supersession, and terminal result tracking. Save credentials and successful results atomically; protect reconnects against concurrent replacement or deletion.
- Restrict management to administrator authentication, validate credentials and authorization options, preserve runtime response/error envelopes, and support callback return URIs.
- Add GitHub authorization metadata and reuse main's Slack options. Preserve console OAuth behavior and keep request validation and OpenAPI dependencies lazy.
- Document the public APIs and update OpenAPI. This change is limited to Open Connector.

Deployment requires migration `0013_connection_requests.sql`. SQLite applies migrations at startup; PostgreSQL and D1 deployments should run their existing migration commands before upgrading.

Validation on the current `origin/main` base:

- `npm run generate:catalog`
- `npm run fix-check`
- `npx vitest run src/server src/oauth src/connection-service.test.ts src/providers/provider-source-guards.clone-baseline.test.ts src/providers/provider-source-guards.basic-auth.test.ts scripts/runtime-data.test.ts` — 43 test files passed, 541 tests passed, 4 skipped. PostgreSQL tests requiring external configuration were skipped; local database and D1 simulation coverage passed.
- `git diff --check`

Live provider OAuth and deployment validation were not run.
