### PR TITLE
fix(minimax): support the H3 AIGC watermark option

### DIFF
--- a/src/providers/minimax/actions.ts
+++ b/src/providers/minimax/actions.ts
@@ -351,8 +351,9 @@ const videoGenerationV2InputSchema = s.object(
       default: "adaptive",
     }),
     callback_url: videoCallbackUrlSchema,
+    aigc_watermark: s.boolean("Whether to add an AIGC watermark to the generated video."),
   },
-  { optional: ["ratio", "callback_url"] },
+  { optional: ["ratio", "callback_url", "aigc_watermark"] },
 );
 
 const textToVideoInputSchema = s.object(

--- a/src/providers/minimax/executors.test.ts
+++ b/src/providers/minimax/executors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { minimaxActionHandlers } from "./executors.ts";
+
+describe("MiniMax H3 watermark forwarding", () => {
+  for (const watermark of [true, false, undefined]) {
+    it(`preserves the watermark option ${watermark}`, async () => {
+      const input = {
+        model: "MiniMax-H3",
+        content: [{ type: "text", text: "Ocean at sunrise" }],
+        resolution: "768P",
+        duration: 4,
+        ratio: "16:9",
+        aigc_watermark: watermark,
+      };
+      const fetcher = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.aigc_watermark).toBe(watermark);
+        expect(Object.hasOwn(body, "aigc_watermark")).toBe(watermark !== undefined);
+        return Response.json({ task_id: "task-1" });
+      });
+      const result = await minimaxActionHandlers.create_video_generation_v2(input, {
+        apiKey: "test-key",
+        apiBaseUrl: "https://api.minimax.io",
+        fetcher: fetcher as typeof fetch,
+      });
+      expect(result).toEqual({ task_id: "task-1" });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+  }
+});


### PR DESCRIPTION
Allows callers to set `aigc_watermark` on `minimax.create_video_generation_v2`, matching the official MiniMax H3 request contract. The option remains optional and the existing executor preserves true, false and omission.

Validation on current main in an isolated worktree: `npm run generate:catalog`, `npm run fix-check`, and watermark forwarding plus Marketplace tests (6 passed).
