### PR TITLE
feat(sf_express): support all three documented signature algorithms

### DIFF
--- a/src/core/sm3.test.ts
+++ b/src/core/sm3.test.ts
@@ -1,0 +1,30 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { sm3Hex } from "./sm3.ts";
+
+describe("SM3 digest", () => {
+  it("matches the two GB/T 32905-2016 sample vectors", () => {
+    expect(sm3Hex("abc")).toBe("66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0");
+    expect(sm3Hex("abcd".repeat(16))).toBe("debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732");
+  });
+
+  it("hashes a string as its UTF-8 bytes", () => {
+    const text = "顺丰速运";
+    expect(sm3Hex(text)).toBe(sm3Hex(new TextEncoder().encode(text)));
+  });
+
+  it("agrees with OpenSSL across the padding boundaries", () => {
+    // 55 and 56 bytes straddle the point where the length no longer fits the
+    // final block, and 64 is a whole block, so each takes a different path.
+    const lengths = [0, 1, 55, 56, 63, 64, 65, 119, 120, 1000];
+    for (const length of lengths) {
+      const message = Buffer.alloc(length, "a");
+      expect(sm3Hex(message)).toBe(createHash("sm3").update(message).digest("hex"));
+    }
+  });
+
+  it("keeps a message with high code points byte-identical to OpenSSL", () => {
+    const message = "运单 SF1040275268927 备注：加急 🚚";
+    expect(sm3Hex(message)).toBe(createHash("sm3").update(message, "utf8").digest("hex"));
+  });
+});

--- a/src/core/sm3.ts
+++ b/src/core/sm3.ts
@@ -1,0 +1,110 @@
+/**
+ * SM3 (GB/T 32905-2016), the Chinese national cryptographic hash standard.
+ *
+ * Node's OpenSSL exposes SM3 through `createHash("sm3")`, but the Cloudflare
+ * Workers runtime is built on BoringSSL and has no SM3 digest, so a provider
+ * signing with SM3 would only work on some of the deployment targets this
+ * project supports. The algorithm is therefore written out in full here, so the
+ * same bytes come out on Node, Docker, Fly, and Workers alike.
+ *
+ * The construction mirrors SHA-256: the same length padding, a 256-bit chaining
+ * value, and a 64-round compression function. It differs in the message
+ * expansion, the round constants, and the permutations P0/P1.
+ */
+
+/** The eight-word chaining value, held as u32 so every operation wraps for free. */
+type Sm3State = Uint32Array;
+
+const sm3InitialVector: readonly number[] = [
+  0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600, 0xa96f30bc, 0x163138aa, 0xe38dee4d, 0xb0fb0e4e,
+];
+
+/** The round constant Tj, which takes its second value from round 16 on. */
+const sm3EarlyRoundConstant = 0x79cc4519;
+const sm3LateRoundConstant = 0x7a879d8a;
+
+const sm3BlockBytes = 64;
+
+function rotateLeft(value: number, bits: number): number {
+  return ((value << bits) | (value >>> (32 - bits))) >>> 0;
+}
+
+/** The P0 permutation, applied to the second round output. */
+function permute0(value: number): number {
+  return (value ^ rotateLeft(value, 9) ^ rotateLeft(value, 17)) >>> 0;
+}
+
+/** The P1 permutation, applied during message expansion. */
+function permute1(value: number): number {
+  return (value ^ rotateLeft(value, 15) ^ rotateLeft(value, 23)) >>> 0;
+}
+
+/**
+ * Append the 0x80 terminator, zero padding, and the 64-bit big-endian bit
+ * length, the way SHA-256 and SM3 both define it.
+ */
+function padMessage(message: Uint8Array): Uint8Array {
+  const paddedLength = (Math.floor((message.length + 8) / sm3BlockBytes) + 1) * sm3BlockBytes;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(message);
+  padded[message.length] = 0x80;
+  // The trailer is a bit count, so it outgrows 32 bits past a 512 MB message.
+  new DataView(padded.buffer).setBigUint64(paddedLength - 8, BigInt(message.length) * 8n, false);
+  return padded;
+}
+
+/** Compress one 64-byte block into the chaining value, in place. */
+function compressBlock(state: Sm3State, view: DataView, offset: number): void {
+  const expanded = new Uint32Array(68);
+  for (let index = 0; index < 16; index += 1) {
+    expanded[index] = view.getUint32(offset + index * 4, false);
+  }
+  for (let index = 16; index < 68; index += 1) {
+    const mixed = expanded[index - 16]! ^ expanded[index - 9]! ^ rotateLeft(expanded[index - 3]!, 15);
+    expanded[index] = permute1(mixed) ^ rotateLeft(expanded[index - 13]!, 7) ^ expanded[index - 6]!;
+  }
+
+  let [a, b, c, d, e, f, g, h] = state;
+  for (let round = 0; round < 64; round += 1) {
+    const early = round < 16;
+    const constant = rotateLeft(early ? sm3EarlyRoundConstant : sm3LateRoundConstant, round % 32);
+    const rotatedA = rotateLeft(a!, 12);
+    const ss1 = rotateLeft((rotatedA + e! + constant) >>> 0, 7);
+    const ss2 = (ss1 ^ rotatedA) >>> 0;
+    const ff = early ? a! ^ b! ^ c! : (a! & b!) | (a! & c!) | (b! & c!);
+    const gg = early ? e! ^ f! ^ g! : (e! & f!) | (~e! & g!);
+    // The first round output consumes W'j = Wj XOR Wj+4, the second consumes Wj.
+    const tt1 = ((ff >>> 0) + d! + ss2 + (expanded[round]! ^ expanded[round + 4]!)) >>> 0;
+    const tt2 = ((gg >>> 0) + h! + ss1 + expanded[round]!) >>> 0;
+    d = c;
+    c = rotateLeft(b!, 9);
+    b = a;
+    a = tt1;
+    h = g;
+    g = rotateLeft(f!, 19);
+    f = e;
+    e = permute0(tt2);
+  }
+
+  const next = [a, b, c, d, e, f, g, h];
+  for (let index = 0; index < 8; index += 1) {
+    state[index] = state[index]! ^ next[index]!;
+  }
+}
+
+/**
+ * Hash a message with SM3 and return the 64-character lowercase hex digest.
+ *
+ * A string is hashed as its UTF-8 bytes, which is what every SM3 reference
+ * sample and the SF Express signing documentation assume.
+ */
+export function sm3Hex(message: string | Uint8Array): string {
+  const bytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
+  const padded = padMessage(bytes);
+  const view = new DataView(padded.buffer, padded.byteOffset, padded.byteLength);
+  const state: Sm3State = Uint32Array.from(sm3InitialVector);
+  for (let offset = 0; offset < padded.length; offset += sm3BlockBytes) {
+    compressBlock(state, view, offset);
+  }
+  return Array.from(state, (word) => word.toString(16).padStart(8, "0")).join("");
+}

--- a/src/providers/sf_express/definition.ts
+++ b/src/providers/sf_express/definition.ts
@@ -34,6 +34,16 @@ export const provider: ProviderDefinition = {
             "The checkWord (校验码) of the same SF Express Open Platform application, used to sign requests. New applications must pass the sandbox tests on https://open.sf-express.com before production calls succeed.",
         },
         {
+          key: "signatureAlgorithm",
+          label: "Signature Algorithm (数字签名方式)",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "standard_md5",
+          description:
+            "The msgDigest algorithm chosen when the partnerID was created, which cannot be changed afterwards: standard_md5 (标准MD5, the default) URL-encodes before hashing, simple_md5 (简易MD5) hashes the raw string, and sm3 (SM3) returns the 国密 SM3 hex digest. Check it under 数字签名方式 on the application's page.",
+        },
+        {
           key: "sandbox",
           label: "Sandbox Mode (沙箱联调)",
           inputType: "text",

--- a/src/providers/sf_express/runtime.test.ts
+++ b/src/providers/sf_express/runtime.test.ts
@@ -2,7 +2,12 @@ import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import { sfExpressQueryHandlers } from "./runtime-query.ts";
 import { sfExpressStationHandlers } from "./runtime-stations.ts";
-import { sfExpressApiBaseUrl, validateSfExpressCredential } from "./runtime.ts";
+import {
+  createSfExpressContext,
+  sfExpressApiBaseUrl,
+  signSfExpressPayload,
+  validateSfExpressCredential,
+} from "./runtime.ts";
 
 const context = (fetcher: typeof fetch) => ({ partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD", fetcher });
 
@@ -62,6 +67,71 @@ describe("SF Express provider core runtime", () => {
 
     expect(fetcher).toHaveBeenCalledOnce();
     expect(output).toEqual({ waybillNo: "SF1040275268927", valid: true });
+  });
+
+  describe("digital signature algorithms", () => {
+    // The worked example the 数字签名认证说明 page repeats on all three tabs.
+    const msgData = '{"language":"zh-CN","orderId":"QIAO-20200618-004"}';
+    const timestamp = "12312334453453";
+    const checkWord = "fjcg5PGKaNpPSHFAZ4QsCOkV71R3zVci";
+
+    it("reproduces the documented 标准MD5 and SM3 digests", () => {
+      expect(signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5")).toBe("IIKJtuLVzoFTu4kHI8M8vA==");
+      expect(signSfExpressPayload(msgData, timestamp, checkWord, "sm3")).toBe(
+        "b05d21124eb6aedb3c6c99b1a37f9fc9a23a9898cb6a4b5df00d4402bda9081f",
+      );
+    });
+
+    it("hashes the raw string for 简易MD5", () => {
+      // The 简易MD5 page reprints the 标准MD5 digest for this sample, which cannot
+      // be right: the payload is JSON, so URL-encoding rewrites most of it. The
+      // expectation is therefore restated from the algorithm the same page describes.
+      const expected = createHash("md5")
+        .update(msgData + timestamp + checkWord, "utf8")
+        .digest("base64");
+      expect(signSfExpressPayload(msgData, timestamp, checkWord, "simple_md5")).toBe(expected);
+      expect(expected).not.toBe(signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5"));
+    });
+
+    it("defaults to 标准MD5 when the connection names no algorithm", () => {
+      expect(signSfExpressPayload(msgData, timestamp, checkWord)).toBe(
+        signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5"),
+      );
+      expect(
+        createSfExpressContext({ partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD" }, fetch).signatureAlgorithm,
+      ).toBeUndefined();
+    });
+
+    it("signs live requests with the algorithm the credential selects", async () => {
+      for (const algorithm of ["standard_md5", "simple_md5", "sm3"] as const) {
+        const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
+          const form = readForm(init);
+          expect(form.get("msgDigest")).toBe(
+            signSfExpressPayload(form.get("msgData")!, form.get("timestamp")!, "TEST_CHECKWORD", algorithm),
+          );
+          return okEnvelope(true);
+        });
+
+        await sfExpressQueryHandlers.validate_waybill_no!(
+          { waybill_no: "SF1040275268927" },
+          {
+            ...context(fetcher),
+            signatureAlgorithm: algorithm,
+          },
+        );
+
+        expect(fetcher).toHaveBeenCalledOnce();
+      }
+    });
+
+    it("rejects an unrecognized signatureAlgorithm instead of signing with the wrong one", () => {
+      expect(() =>
+        createSfExpressContext(
+          { partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD", signatureAlgorithm: "md5" },
+          fetch,
+        ),
+      ).toThrow(/signatureAlgorithm must be standard_md5, simple_md5 or sm3/);
+    });
   });
 
   it("signs payloads carrying spaces, Chinese, and characters encodeURIComponent leaves alone", async () => {

--- a/src/providers/sf_express/runtime.test.ts
+++ b/src/providers/sf_express/runtime.test.ts
@@ -70,22 +70,22 @@ describe("SF Express provider core runtime", () => {
   });
 
   describe("digital signature algorithms", () => {
-    // The worked example the 数字签名认证说明 page repeats on all three tabs.
+    // The worked example SF repeats on all three tabs of its signing guide.
     const msgData = '{"language":"zh-CN","orderId":"QIAO-20200618-004"}';
     const timestamp = "12312334453453";
     const checkWord = "fjcg5PGKaNpPSHFAZ4QsCOkV71R3zVci";
 
-    it("reproduces the documented 标准MD5 and SM3 digests", () => {
+    it("reproduces the documented standard_md5 and sm3 digests", () => {
       expect(signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5")).toBe("IIKJtuLVzoFTu4kHI8M8vA==");
       expect(signSfExpressPayload(msgData, timestamp, checkWord, "sm3")).toBe(
         "b05d21124eb6aedb3c6c99b1a37f9fc9a23a9898cb6a4b5df00d4402bda9081f",
       );
     });
 
-    it("hashes the raw string for 简易MD5", () => {
-      // The 简易MD5 page reprints the 标准MD5 digest for this sample, which cannot
-      // be right: the payload is JSON, so URL-encoding rewrites most of it. The
-      // expectation is therefore restated from the algorithm the same page describes.
+    it("hashes the raw string for simple_md5", () => {
+      // SF's simple_md5 page reprints the standard_md5 digest for this sample,
+      // which cannot be right: the payload is JSON, so URL-encoding rewrites most
+      // of it. The expectation is restated from the algorithm that page describes.
       const expected = createHash("md5")
         .update(msgData + timestamp + checkWord, "utf8")
         .digest("base64");
@@ -93,7 +93,7 @@ describe("SF Express provider core runtime", () => {
       expect(expected).not.toBe(signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5"));
     });
 
-    it("defaults to 标准MD5 when the connection names no algorithm", () => {
+    it("defaults to standard_md5 when the connection names no algorithm", () => {
       expect(signSfExpressPayload(msgData, timestamp, checkWord)).toBe(
         signSfExpressPayload(msgData, timestamp, checkWord, "standard_md5"),
       );

--- a/src/providers/sf_express/runtime.ts
+++ b/src/providers/sf_express/runtime.ts
@@ -10,6 +10,7 @@ import {
   optionalRecord,
   optionalString,
 } from "../../core/cast.ts";
+import { sm3Hex } from "../../core/sm3.ts";
 import {
   parseProviderJsonBodyText,
   ProviderRequestError,
@@ -77,9 +78,18 @@ const sfExpressSystemErrorCodes = new Set(["S0001", "S0003"]);
 
 type SfExpressPhase = "validate" | "execute";
 
+/**
+ * The msgDigest algorithm a partnerID is bound to. SF fixes the choice when the
+ * application is created and cannot change it afterwards, so it belongs to the
+ * credential rather than to a request.
+ */
+export type SfExpressSignatureAlgorithm = "standard_md5" | "simple_md5" | "sm3";
+
 export interface SfExpressActionContext {
   partnerId: string;
   checkWord: string;
+  /** Defaults to 标准MD5, the algorithm every application predating the choice signs with. */
+  signatureAlgorithm?: SfExpressSignatureAlgorithm;
   /** When true, all calls go to the SF sandbox gateway regardless of the service's production host. */
   sandbox?: boolean;
   fetcher: ProviderFetch;
@@ -96,6 +106,7 @@ export function createSfExpressContext(
   return {
     partnerId: requiredInputString(values.partnerId, "partnerId"),
     checkWord: requiredInputString(values.checkWord, "checkWord"),
+    signatureAlgorithm: readSignatureAlgorithm(values.signatureAlgorithm),
     sandbox: readSandboxFlag(values.sandbox),
     fetcher,
     signal,
@@ -116,6 +127,23 @@ function readSandboxFlag(value: unknown): boolean {
     return true;
   }
   throw providerInputError("sandbox must be true or false.");
+}
+
+/**
+ * Read the optional signature-algorithm credential field, leaving it unset when
+ * the connection does not name one so {@link signSfExpressPayload} owns the
+ * default. An unrecognized value is rejected rather than falling back, because
+ * the wrong algorithm fails every call with A1006 数字签名无效.
+ */
+function readSignatureAlgorithm(value: unknown): SfExpressSignatureAlgorithm | undefined {
+  const algorithm = optionalString(value)?.toLowerCase();
+  if (algorithm === undefined) {
+    return undefined;
+  }
+  if (algorithm === "standard_md5" || algorithm === "simple_md5" || algorithm === "sm3") {
+    return algorithm;
+  }
+  throw providerInputError("signatureAlgorithm must be standard_md5, simple_md5 or sm3.");
 }
 
 /** Map an optional boolean action input to the 1/0 flags SF Express expects on the wire. */
@@ -159,6 +187,9 @@ export async function validateSfExpressCredential(
       environment: context.sandbox ? "sandbox" : "production",
       // The default gateway for that environment; a few services document their own host.
       apiBaseUrl: context.sandbox ? sfExpressSandboxBaseUrl : sfExpressApiBaseUrl,
+      // The algorithm this validation signed with, so an A1006 on a later call
+      // can be told apart from a wrong check word.
+      signatureAlgorithm: context.signatureAlgorithm ?? "standard_md5",
       validationEndpoint: "EXP_RECE_VALIDATE_WAYBILLNO",
     },
   };
@@ -177,14 +208,31 @@ function javaFormUrlEncode(value: string): string {
 }
 
 /**
- * Sign one request the way the SF Express Open Platform documents it:
- * Base64(MD5(URLEncoder.encode(msgData + timestamp + checkWord))). Skipping the
- * URL-encoding step fails signature verification for every payload, because JSON
- * always carries characters the encoder rewrites.
+ * Sign one request with the algorithm the application was created against. All
+ * three sign the same `msgData + timestamp + checkWord` string and differ only
+ * in how they turn it into msgDigest:
+ *
+ * - `standard_md5` (标准MD5) runs it through `URLEncoder.encode(text, "UTF-8")`
+ *   first, then Base64(MD5(...)). Skipping that step fails verification for
+ *   every payload, because JSON always carries characters the encoder rewrites.
+ * - `simple_md5` (简易MD5) is the same Base64(MD5(...)) over the raw string.
+ * - `sm3` (SM3) is the lowercase-hex 国密 SM3 digest of the raw string.
+ *
+ * 标准MD5 is the default, because it is what SF signed with before it offered
+ * the choice and what every application created back then still uses.
  */
-function signSfExpressPayload(msgData: string, timestamp: string, checkWord: string): string {
+export function signSfExpressPayload(
+  msgData: string,
+  timestamp: string,
+  checkWord: string,
+  algorithm: SfExpressSignatureAlgorithm = "standard_md5",
+): string {
+  const text = msgData + timestamp + checkWord;
+  if (algorithm === "sm3") {
+    return sm3Hex(text);
+  }
   return createHash("md5")
-    .update(javaFormUrlEncode(msgData + timestamp + checkWord))
+    .update(algorithm === "standard_md5" ? javaFormUrlEncode(text) : text)
     .digest("base64");
 }
 
@@ -211,7 +259,7 @@ export async function requestSfExpress(
       requestID: randomUUID(),
       serviceCode,
       timestamp,
-      msgDigest: signSfExpressPayload(body, timestamp, context.checkWord),
+      msgDigest: signSfExpressPayload(body, timestamp, context.checkWord, context.signatureAlgorithm),
       msgData: body,
     });
     // A few forwarding services document a field beside msgData rather than inside it.


### PR DESCRIPTION
SF Express binds a partnerID to one of three msgDigest algorithms when the application is created, and the choice cannot be changed afterwards. Only 标准MD5 was implemented, so an application created with 简易MD5 or SM3 failed every call with A1006 数字签名无效 and had no setting that could fix it.

An optional `signatureAlgorithm` credential field now takes `standard_md5`, `simple_md5` or `sm3`. All three sign the same `msgData + timestamp + checkWord` string and differ only in how they finish: 标准MD5 URL-encodes it the way `java.net.URLEncoder` does before Base64(MD5(...)), 简易MD5 runs the same Base64(MD5(...)) over the raw string, and SM3 returns the lowercase-hex 国密 digest. An unset field still means 标准MD5, which is what SF signed with before it offered the choice. An unrecognized value is rejected rather than falling back, since the wrong algorithm fails every call on the signature.

https://github.com/oomol-lab/open-connector/blob/2dff31b15613abf2e5762b6d654e7daabd46c36b/src/providers/sf_express/runtime.ts#L224-L237

SM3 is written out in _src/core/sm3.ts_ rather than taken from `node:crypto`. Node's OpenSSL has the digest but the Cloudflare Workers runtime is built on BoringSSL and does not, and sf_express ships in the Workers registry, so `createHash("sm3")` would leave this algorithm working on only some deployment targets. The implementation is checked against both GB/T 32905-2016 sample vectors, against OpenSSL across the padding boundaries, and against the digest SF publishes for its own worked example.

One documentation quirk worth flagging: the 简易MD5 page reprints the 标准MD5 digest for that shared example, which cannot be right, because the payload is JSON and URL-encoding rewrites most of it. The test restates the expectation from the algorithm that page itself describes, and says so in a comment.
