### PR TITLE
fix(sf_express): align sandbox response contracts

### DIFF
--- a/src/providers/sf_express/actions-order.ts
+++ b/src/providers/sf_express/actions-order.ts
@@ -732,7 +732,14 @@ export const sfExpressOrderActions: ActionDefinition[] = [
             customerAcctCode: s.string("The monthly settlement account."),
           },
           {
-            optional: ["paymentTypeCode", "settlementTypeCode", "serviceProdCode", "insuredValue", "customerAcctCode"],
+            optional: [
+              "name",
+              "paymentTypeCode",
+              "settlementTypeCode",
+              "serviceProdCode",
+              "insuredValue",
+              "customerAcctCode",
+            ],
           },
         ),
       ),

--- a/src/providers/sf_express/definition.ts
+++ b/src/providers/sf_express/definition.ts
@@ -44,6 +44,16 @@ export const provider: ProviderDefinition = {
             "The msgDigest algorithm chosen when the partnerID was created, which cannot be changed afterwards: standard_md5 (标准MD5, the default) URL-encodes before hashing, simple_md5 (简易MD5) hashes the raw string, and sm3 (SM3) returns the 国密 SM3 hex digest. Check it under 数字签名方式 on the application's page.",
         },
         {
+          key: "cityClientCode",
+          label: "City Delivery Client Code (同城客户编码)",
+          inputType: "text",
+          required: false,
+          secret: false,
+          placeholder: "SF_EXPRESS_CITY_CLIENT_CODE",
+          description:
+            "The clientCode assigned separately for SF city-delivery APIs. Required only when using the freight_city_* actions; it is not the Open Platform partnerID.",
+        },
+        {
           key: "sandbox",
           label: "Sandbox Mode (沙箱联调)",
           inputType: "text",

--- a/src/providers/sf_express/runtime-freight-tl-city.test.ts
+++ b/src/providers/sf_express/runtime-freight-tl-city.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { sfExpressFreightTlCityHandlers } from "./runtime-freight-tl-city.ts";
 
-const context = (fetcher: typeof fetch) => ({ partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD", fetcher });
+const context = (fetcher: typeof fetch) => ({
+  partnerId: "TEST_PARTNER",
+  checkWord: "TEST_CHECKWORD",
+  cityClientCode: "TEST_CITY_CLIENT",
+  fetcher,
+});
 
 const readForm = (init?: RequestInit): URLSearchParams => new URLSearchParams(String(init?.body));
 
@@ -159,11 +164,11 @@ describe("SF Express freight truckload handlers", () => {
 });
 
 describe("SF Express freight city-delivery handlers", () => {
-  it("auto-fills clientCode from the credential and maps city order fields", async () => {
+  it("reads clientCode from the city-delivery credential and maps city order fields", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
       expect(readForm(init).get("serviceCode")).toBe("FOP_RECE_UFTL_OF_CONFIRM_ORDER");
       expect(readMsgData(init)).toEqual({
-        clientCode: "TEST_PARTNER",
+        clientCode: "TEST_CITY_CLIENT",
         vehicle: "中面",
         carNum: 1,
         sendStartTime: "2026-09-06 10:00:00",
@@ -228,6 +233,29 @@ describe("SF Express freight city-delivery handlers", () => {
     ).rejects.toMatchObject({ status: 400, message: "车型不能为空" });
   });
 
+  it("maps UFTL envelopes that explicitly carry success false", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ status: 400, msg: "clientCode 不合法", success: false }),
+    );
+
+    await expect(sfExpressFreightTlCityHandlers.freight_city_list_cities!({}, context(fetcher))).rejects.toMatchObject({
+      status: 400,
+      message: "clientCode 不合法",
+    });
+  });
+
+  it("requires the separately assigned city-delivery client code", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      sfExpressFreightTlCityHandlers.freight_city_list_cities!(
+        {},
+        { partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD", fetcher },
+      ),
+    ).rejects.toMatchObject({ status: 400, message: "cityClientCode is required." });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("maps a UFTL gateway status to the matching execution error", async () => {
     const cases = [
       [500, 502],
@@ -249,7 +277,7 @@ describe("SF Express freight city-delivery handlers", () => {
   it("normalizes the fee breakdown", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
       const msgData = readMsgData(init) as Record<string, unknown>;
-      expect(msgData.clientCode).toBe("TEST_PARTNER");
+      expect(msgData.clientCode).toBe("TEST_CITY_CLIENT");
       expect(msgData.orderAddressVOList).toEqual([
         {
           contact: "张三",
@@ -305,7 +333,12 @@ describe("SF Express freight city-delivery handlers", () => {
 
   it("normalizes the order list", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
-      expect(readMsgData(init)).toEqual({ clientCode: "TEST_PARTNER", phone: "13112345678", index: 1, size: 10 });
+      expect(readMsgData(init)).toEqual({
+        clientCode: "TEST_CITY_CLIENT",
+        phone: "13112345678",
+        index: 1,
+        size: 10,
+      });
       return uftlEnvelope(200, [
         {
           orderNo: "U20200227000026",
@@ -384,7 +417,7 @@ describe("SF Express freight city-delivery handlers", () => {
   it("cancels a city order with an empty data payload", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
       expect(readMsgData(init)).toEqual({
-        clientCode: "TEST_PARTNER",
+        clientCode: "TEST_CITY_CLIENT",
         customerOrderNo: "MALL-1",
         cancelMessage: "订单地址填写错误",
       });
@@ -429,7 +462,7 @@ describe("SF Express freight city-delivery handlers", () => {
 
   it("normalizes the vehicle models", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
-      expect(readMsgData(init)).toEqual({ clientCode: "TEST_PARTNER", city: "深圳市", orderCategory: 2 });
+      expect(readMsgData(init)).toEqual({ clientCode: "TEST_CITY_CLIENT", city: "深圳市", orderCategory: 2 });
       return uftlEnvelope(200, {
         carModels: [
           {

--- a/src/providers/sf_express/runtime-freight-tl-city.test.ts
+++ b/src/providers/sf_express/runtime-freight-tl-city.test.ts
@@ -252,7 +252,10 @@ describe("SF Express freight city-delivery handlers", () => {
         {},
         { partnerId: "TEST_PARTNER", checkWord: "TEST_CHECKWORD", fetcher },
       ),
-    ).rejects.toMatchObject({ status: 400, message: "cityClientCode is required." });
+    ).rejects.toMatchObject({
+      status: 400,
+      message: /^cityClientCode is required for the SF Express city-delivery actions\./,
+    });
     expect(fetcher).not.toHaveBeenCalled();
   });
 

--- a/src/providers/sf_express/runtime-freight-tl-city.ts
+++ b/src/providers/sf_express/runtime-freight-tl-city.ts
@@ -1,5 +1,5 @@
 import type { ProviderActionHandlerSubset } from "../provider-runtime.ts";
-import type { SfExpressActionHandler } from "./runtime.ts";
+import type { SfExpressActionContext, SfExpressActionHandler } from "./runtime.ts";
 
 import {
   compactObject,
@@ -130,7 +130,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CONFIRM_ORDER",
       compactObject({
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
         carNum: integer(input.car_num, "car_num", providerInputError),
         sendStartTime: requiredInputString(input.send_start_time, "send_start_time"),
@@ -155,7 +155,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CALC_FEE",
       compactObject({
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
         carNum: integer(input.car_num, "car_num", providerInputError),
         sendStartTime: requiredInputString(input.send_start_time, "send_start_time"),
@@ -189,7 +189,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_ORDER_LIST",
       compactObject({
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         phone: requiredInputString(input.phone, "phone"),
         createTimeStart: optionalString(input.create_time_start),
         createTimeEnd: optionalString(input.create_time_end),
@@ -222,7 +222,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_ORDER_DETAIL",
       compactObject({
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         orderNo,
         customerOrderNo,
       }),
@@ -273,7 +273,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     await requestSfExpress(
       "FOP_RECE_UFTL_OF_CANCEL_ORDER",
       compactObject({
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         orderNo,
         customerOrderNo,
         cancelMessage: requiredInputString(input.cancel_message, "cancel_message"),
@@ -287,7 +287,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_AVAILABLE_VAS_LIST",
       {
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         place: requiredInputString(input.place, "place"),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
       },
@@ -309,7 +309,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_VEHICLES",
       {
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         city: requiredInputString(input.city, "city"),
         orderCategory: integer(input.order_category, "order_category", providerInputError),
       },
@@ -349,7 +349,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
   async freight_city_list_cities(_input, context) {
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_LIST",
-      { clientCode: requiredInputString(context.cityClientCode, "cityClientCode") },
+      { clientCode: readCityClientCode(context) },
       context,
       "execute",
     );
@@ -359,7 +359,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_SEND_START_TIME_LIST",
       {
-        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        clientCode: readCityClientCode(context),
         city: requiredInputString(input.city, "city"),
       },
       context,
@@ -434,7 +434,22 @@ function readTlExtraInfos(value: unknown): Array<Record<string, unknown>> | unde
   );
 }
 
-/** The two city-delivery actions spell the address array differently, so the error text follows the caller's field. */
+/**
+ * Read the clientCode the city-delivery endpoints authorize against. SF assigns
+ * it per city-delivery contract, so it is neither the Open Platform partnerID
+ * nor something the caller can pass per request, and every UFTL service rejects
+ * a request without it.
+ */
+function readCityClientCode(context: SfExpressActionContext): string {
+  const clientCode = optionalString(context.cityClientCode);
+  if (clientCode === undefined) {
+    throw providerInputError(
+      "cityClientCode is required for the SF Express city-delivery actions. Add the 同城客户编码 SF assigned you to the connection.",
+    );
+  }
+  return clientCode;
+}
+
 /**
  * The order's addressList carries a detailed address line the fee quote's
  * OrderAddressVO does not define, so only the order path emits it.

--- a/src/providers/sf_express/runtime-freight-tl-city.ts
+++ b/src/providers/sf_express/runtime-freight-tl-city.ts
@@ -130,7 +130,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CONFIRM_ORDER",
       compactObject({
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
         carNum: integer(input.car_num, "car_num", providerInputError),
         sendStartTime: requiredInputString(input.send_start_time, "send_start_time"),
@@ -155,7 +155,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CALC_FEE",
       compactObject({
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
         carNum: integer(input.car_num, "car_num", providerInputError),
         sendStartTime: requiredInputString(input.send_start_time, "send_start_time"),
@@ -189,7 +189,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_ORDER_LIST",
       compactObject({
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         phone: requiredInputString(input.phone, "phone"),
         createTimeStart: optionalString(input.create_time_start),
         createTimeEnd: optionalString(input.create_time_end),
@@ -221,7 +221,11 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     }
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_ORDER_DETAIL",
-      compactObject({ clientCode: context.partnerId, orderNo, customerOrderNo }),
+      compactObject({
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        orderNo,
+        customerOrderNo,
+      }),
       context,
       "execute",
     );
@@ -269,7 +273,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     await requestSfExpress(
       "FOP_RECE_UFTL_OF_CANCEL_ORDER",
       compactObject({
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         orderNo,
         customerOrderNo,
         cancelMessage: requiredInputString(input.cancel_message, "cancel_message"),
@@ -283,7 +287,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_AVAILABLE_VAS_LIST",
       {
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         place: requiredInputString(input.place, "place"),
         vehicle: requiredInputString(input.vehicle, "vehicle"),
       },
@@ -305,7 +309,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_VEHICLES",
       {
-        clientCode: context.partnerId,
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
         city: requiredInputString(input.city, "city"),
         orderCategory: integer(input.order_category, "order_category", providerInputError),
       },
@@ -345,7 +349,7 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
   async freight_city_list_cities(_input, context) {
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_CITY_LIST",
-      { clientCode: context.partnerId },
+      { clientCode: requiredInputString(context.cityClientCode, "cityClientCode") },
       context,
       "execute",
     );
@@ -354,7 +358,10 @@ export const sfExpressFreightTlCityHandlers: ProviderActionHandlerSubset<"sf_exp
   async freight_city_list_appointment_times(input, context) {
     const payload = await requestSfExpress(
       "FOP_RECE_UFTL_OF_SEND_START_TIME_LIST",
-      { clientCode: context.partnerId, city: requiredInputString(input.city, "city") },
+      {
+        clientCode: requiredInputString(context.cityClientCode, "cityClientCode"),
+        city: requiredInputString(input.city, "city"),
+      },
       context,
       "execute",
     );

--- a/src/providers/sf_express/runtime-order.test.ts
+++ b/src/providers/sf_express/runtime-order.test.ts
@@ -389,7 +389,7 @@ describe("SF Express general-shipping handlers", () => {
         },
         waybillFeeList: [
           { type: "1", name: "运费", value: 15.0 },
-          { type: "3", name: "基础保", value: 6.0 },
+          { type: "3", value: 6.0 },
         ],
       });
     });
@@ -403,7 +403,7 @@ describe("SF Express general-shipping handlers", () => {
       waybillInfo: { waybillNo: "SF1040460455098", meterageWeightQty: 1.0, expressTypeName: "顺丰标快" },
       waybillFeeList: [
         { type: "1", name: "运费", value: 15.0 },
-        { type: "3", name: "基础保", value: 6.0 },
+        { type: "3", value: 6.0 },
       ],
     });
   });

--- a/src/providers/sf_express/runtime-order.ts
+++ b/src/providers/sf_express/runtime-order.ts
@@ -571,7 +571,7 @@ function normalizeWaybillFee(payload: unknown): Record<string, unknown> {
       (fee, index) =>
         compactObject({
           type: requiredString(fee.type, `waybillFeeList[${index}].type`, providerResponseError),
-          name: requiredString(fee.name, `waybillFeeList[${index}].name`, providerResponseError),
+          name: optionalString(fee.name),
           value: optionalNumberLike(fee.value) ?? null,
           paymentTypeCode: optionalString(fee.paymentTypeCode),
           settlementTypeCode: optionalString(fee.settlementTypeCode),

--- a/src/providers/sf_express/runtime-query.test.ts
+++ b/src/providers/sf_express/runtime-query.test.ts
@@ -265,6 +265,29 @@ describe("SF Express service-query handlers", () => {
     });
   });
 
+  it("normalizes the live filter_order array response", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      okEnvelope([{ orderId: "TE201407020016", filterResult: 3, originCode: "755", destCode: "020" }]),
+    );
+
+    const output = await sfExpressQueryHandlers.filter_order!(
+      {
+        orders: [
+          {
+            order_id: "TE201407020016",
+            sender: { province: "四川省", city: "成都市", address: "测试地址A" },
+            recipient: { province: "天津市", city: "天津市", address: "测试地址B" },
+          },
+        ],
+      },
+      context(fetcher),
+    );
+
+    expect(output).toEqual({
+      results: [{ orderId: "TE201407020016", filterResult: 3, originCode: "755", destCode: "020", remark: undefined }],
+    });
+  });
+
   it("parses the stringified msgData of the service points response", async () => {
     const fetcher = vi.fn<typeof fetch>(async (_url, init) => {
       const msgData = JSON.parse(readForm(init).get("msgData")!);

--- a/src/providers/sf_express/runtime-query.ts
+++ b/src/providers/sf_express/runtime-query.ts
@@ -111,13 +111,16 @@ export const sfExpressQueryHandlers: ProviderActionHandlerSubset<"sf_express", S
       }),
     );
     const payload = await requestSfExpress("EXP_RECE_FILTER_ORDER_BSP", orders, context, "execute");
-    const results = Array.isArray(payload)
-      ? payload
-      : requiredResponseRecord(payload, "SF Express filter response").resDtos;
+    // The response-parameter table lists the verdict fields directly under
+    // msgData, which is the bare array the gateway returns; the doc's own
+    // example wraps them in resDtos instead, so both shapes are read.
+    const bare = Array.isArray(payload);
+    const results = bare ? payload : requiredResponseRecord(payload, "SF Express filter response").resDtos;
+    const field = bare ? "msgData" : "resDtos";
     return {
-      results: objectArray(results, "resDtos", providerResponseError).map((result, index) => ({
+      results: objectArray(results, field, providerResponseError).map((result, index) => ({
         orderId: optionalString(result.orderId),
-        filterResult: integer(result.filterResult, `resDtos[${index}].filterResult`, providerResponseError),
+        filterResult: integer(result.filterResult, `${field}[${index}].filterResult`, providerResponseError),
         originCode: optionalString(result.originCode),
         destCode: optionalString(result.destCode),
         remark: optionalString(result.remark),

--- a/src/providers/sf_express/runtime-query.ts
+++ b/src/providers/sf_express/runtime-query.ts
@@ -111,9 +111,11 @@ export const sfExpressQueryHandlers: ProviderActionHandlerSubset<"sf_express", S
       }),
     );
     const payload = await requestSfExpress("EXP_RECE_FILTER_ORDER_BSP", orders, context, "execute");
-    const record = requiredResponseRecord(payload, "SF Express filter response");
+    const results = Array.isArray(payload)
+      ? payload
+      : requiredResponseRecord(payload, "SF Express filter response").resDtos;
     return {
-      results: objectArray(record.resDtos, "resDtos", providerResponseError).map((result, index) => ({
+      results: objectArray(results, "resDtos", providerResponseError).map((result, index) => ({
         orderId: optionalString(result.orderId),
         filterResult: integer(result.filterResult, `resDtos[${index}].filterResult`, providerResponseError),
         originCode: optionalString(result.originCode),

--- a/src/providers/sf_express/runtime.test.ts
+++ b/src/providers/sf_express/runtime.test.ts
@@ -184,6 +184,22 @@ describe("SF Express provider core runtime", () => {
     expect(output).toEqual({ waybillNo: "SF1040275268927", valid: true });
   });
 
+  it("does not read a non-city service's status field as a UFTL envelope", async () => {
+    // Only the FOP_RECE_UFTL_ services speak the { status, msg, data } dialect,
+    // so a business envelope that happens to carry status and msg stays a
+    // business envelope rather than turning into a UFTL gateway failure.
+    const fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({ success: true, status: 1, msg: "ok", msgData: true }),
+    );
+
+    const output = await sfExpressQueryHandlers.validate_waybill_no!(
+      { waybill_no: "SF1040275268927" },
+      context(fetcher),
+    );
+
+    expect(output).toEqual({ waybillNo: "SF1040275268927", valid: true });
+  });
+
   it("reads errorMessage on bare business envelope failures", async () => {
     const fetcher = vi.fn<typeof fetch>(async () =>
       Response.json({ success: false, errorCode: "S0003", errorMessage: "模板不存在" }),

--- a/src/providers/sf_express/runtime.ts
+++ b/src/providers/sf_express/runtime.ts
@@ -76,6 +76,9 @@ const sfExpressBusinessSuccessCode = "S0000";
 /** Inner error codes that mean the failure is ours or the platform's, never the caller's input. */
 const sfExpressSystemErrorCodes = new Set(["S0001", "S0003"]);
 
+/** The city-delivery services, and only they, answer with the UFTL { status, msg, data } envelope. */
+const sfExpressUftlServicePrefix = "FOP_RECE_UFTL_";
+
 type SfExpressPhase = "validate" | "execute";
 
 /**
@@ -286,7 +289,7 @@ export async function requestSfExpress(
       await readProviderJson<unknown>(response, "SF Express"),
       "SF Express response",
     );
-    return unwrapSfExpressEnvelope(outer, phase);
+    return unwrapSfExpressEnvelope(outer, serviceCode, phase);
   });
 }
 
@@ -299,7 +302,7 @@ export async function requestSfExpress(
  * text in errorMsg, errorMessage, or message, the error code in errorCode or
  * code, and the payload in msgData, obj, or (SCS cold-chain) data.
  */
-function unwrapSfExpressEnvelope(outer: Record<string, unknown>, phase: SfExpressPhase): unknown {
+function unwrapSfExpressEnvelope(outer: Record<string, unknown>, serviceCode: string, phase: SfExpressPhase): unknown {
   const code = optionalString(outer.apiResultCode);
   if (code !== undefined && code !== sfExpressPlatformSuccessCode) {
     throw createSfExpressPlatformError(code, optionalString(outer.apiErrorMsg), phase);
@@ -319,10 +322,13 @@ function unwrapSfExpressEnvelope(outer: Record<string, unknown>, phase: SfExpres
 
   const record = requiredResponseRecord(inner, "SF Express apiResultData");
 
-  // UFTL (city-delivery) envelope: { status, msg, data, success? } — 200 marks success.
-  const uftlStatus = optionalNumberLike(record.status);
-  if (uftlStatus !== undefined && ("msg" in record || "data" in record)) {
-    if (uftlStatus !== 200) {
+  // UFTL (city-delivery) envelope: { status, msg, data }, where 200 marks success
+  // and the live gateway adds an undocumented success flag on failures. Keyed on
+  // the service code, because a numeric status field also occurs inside ordinary
+  // business payloads and cannot tell the two envelopes apart on its own.
+  const uftlStatus = serviceCode.startsWith(sfExpressUftlServicePrefix) ? optionalNumberLike(record.status) : undefined;
+  if (uftlStatus !== undefined) {
+    if (uftlStatus !== 200 || record.success === false || record.success === "false") {
       throw createSfExpressUftlError(uftlStatus, optionalString(record.msg), phase);
     }
     return record.data;

--- a/src/providers/sf_express/runtime.ts
+++ b/src/providers/sf_express/runtime.ts
@@ -90,6 +90,8 @@ export interface SfExpressActionContext {
   checkWord: string;
   /** Defaults to 标准MD5, the algorithm every application predating the choice signs with. */
   signatureAlgorithm?: SfExpressSignatureAlgorithm;
+  /** Business client code assigned separately for the UFTL city-delivery APIs. */
+  cityClientCode?: string;
   /** When true, all calls go to the SF sandbox gateway regardless of the service's production host. */
   sandbox?: boolean;
   fetcher: ProviderFetch;
@@ -107,6 +109,7 @@ export function createSfExpressContext(
     partnerId: requiredInputString(values.partnerId, "partnerId"),
     checkWord: requiredInputString(values.checkWord, "checkWord"),
     signatureAlgorithm: readSignatureAlgorithm(values.signatureAlgorithm),
+    cityClientCode: optionalString(values.cityClientCode),
     sandbox: readSandboxFlag(values.sandbox),
     fetcher,
     signal,
@@ -316,9 +319,9 @@ function unwrapSfExpressEnvelope(outer: Record<string, unknown>, phase: SfExpres
 
   const record = requiredResponseRecord(inner, "SF Express apiResultData");
 
-  // UFTL (city-delivery) envelope: { status, msg, data } — 200 marks success.
+  // UFTL (city-delivery) envelope: { status, msg, data, success? } — 200 marks success.
   const uftlStatus = optionalNumberLike(record.status);
-  if (record.success === undefined && uftlStatus !== undefined) {
+  if (uftlStatus !== undefined && ("msg" in record || "data" in record)) {
     if (uftlStatus !== 200) {
       throw createSfExpressUftlError(uftlStatus, optionalString(record.msg), phase);
     }
@@ -344,7 +347,10 @@ function unwrapSfExpressEnvelope(outer: Record<string, unknown>, phase: SfExpres
   if (record.success !== true && record.success !== "true") {
     throw createSfExpressBusinessError(
       optionalString(record.errorCode) ?? optionalString(record.code),
-      optionalString(record.errorMsg) ?? optionalString(record.errorMessage) ?? optionalString(record.message),
+      optionalString(record.errorMsg) ??
+        optionalString(record.errorMessage) ??
+        optionalString(record.message) ??
+        optionalString(record.msg),
     );
   }
   return readEnvelopePayload(record);


### PR DESCRIPTION
## Summary

- accept the live array response returned by `filter_order`
- allow waybill fee items without `name`
- add the separate `cityClientCode` credential required by city-delivery APIs
- preserve UFTL error messages when the response also contains `success: false`

## Validation

- `npm run generate:catalog`
- `npm run fix-check`
- targeted SF Express tests: 60 passed
- full test suite: 2,041 passed, 4 skipped

## Sandbox E2E

Tested with a Standard MD5 sandbox application after rebasing onto `upstream/main` with the three-signature-algorithm support from #514.

- fix probes: `filter_order`, waybill fee normalization, vehicle list, appointment times, and available VAS all succeeded
- negative UFTL probe preserved the upstream `clientCode 不合法` message as expected
- lifecycle: create order, register route push, query order/routes/fees for 18 polls, and cancel order all succeeded
- query totals: 18/18 order, 18/18 route, and 18/18 fee calls succeeded; zero polling errors; up to 15 routes parsed

No sandbox credentials or order identifiers are included in this PR.