### PR TITLE
feat(cursor): add cloud agent session actions

### DIFF
--- a/src/providers/cursor/actions.ts
+++ b/src/providers/cursor/actions.ts
@@ -6,12 +6,9 @@ import { defineProviderAction } from "../../core/provider-definition.ts";
 const service = "cursor";
 
 const rawObjectSchema = s.looseObject("A JSON object returned by Cursor.");
-const nonEmptyString = (description: string) => s.nonEmptyString(description);
-const positiveInteger = (description: string, maximum?: number) =>
-  s.positiveInteger(description, maximum === undefined ? {} : { maximum });
 
-const pageSchema = positiveInteger("The 1-indexed page number to request.");
-const pageSizeSchema = positiveInteger("The number of records to return per page.", 500);
+const pageSchema = s.positiveInteger("The 1-indexed page number to request.");
+const pageSizeSchema = s.positiveInteger("The number of records to return per page.", { maximum: 500 });
 
 const teamMemberSchema = s.object(
   {
@@ -84,10 +81,236 @@ const spendRowSchema = s.looseObject("A Cursor team member spending row.", {
   monthlyLimitDollars: s.nullableNumber("The monthly spending limit in dollars, or null when none is set."),
 });
 
+const agentId = s.nonEmptyString("Cloud agent ID returned by create_agent or list_agents (bc-...).");
+const runId = s.nonEmptyString("Run ID returned by create_agent, create_run, or list_runs (run-...).");
+const agentInput = s.requiredObject("Identify a cloud session.", { agentId });
+const runInput = s.requiredObject("Identify a run within a cloud session.", { agentId, runId });
+const limit = s.optional(s.positiveInteger("Page size; Cursor defaults to 20.", { maximum: 100 }));
+const cursor = s.optional(s.nonEmptyString("Use nextCursor from the previous page; omit for the first page."));
+const prompt = s.requiredObject("Instructions for one run.", {
+  text: s.nonWhitespaceString("Task or follow-up instructions."),
+});
+const mode = s.optional(
+  s.stringEnum("Choose plan to explore and propose changes, or agent to implement them.", ["agent", "plan"]),
+);
+const params = s.array(
+  s.requiredObject("A model parameter supported by list_models.", {
+    id: s.nonEmptyString("Parameter ID."),
+    value: s.string("Parameter value."),
+  }),
+);
+const model = s.requiredObject("Omit to use Cursor's configured model.", {
+  id: s.nonEmptyString("Model ID from list_models."),
+  params: s.optional(params),
+});
+const repo = s.requiredObject("Repository available to the Cursor GitHub App.", {
+  url: s.url("GitHub repository URL, including https://."),
+  startingRef: s.optional(s.nonEmptyString("Starting branch or commit; ignored when prUrl is supplied.")),
+  prUrl: s.optional(s.url("Existing pull request to work on; url is still required.")),
+});
+const mcpServers = s.optional(
+  s.array(
+    s.oneOf([
+      s.requiredObject("Remote MCP tools used by the cloud agent.", {
+        name: s.nonEmptyString("Unique server name."),
+        type: s.optional(s.stringEnum(["http", "sse"])),
+        url: s.url("HTTP(S) MCP endpoint that Cursor can reach, without embedded credentials."),
+        headers: s.optional(s.record(s.string(), { description: "Headers sent by Cursor to this MCP server." })),
+      }),
+      s.requiredObject("MCP server started inside the Cursor cloud VM.", {
+        name: s.nonEmptyString("Unique server name."),
+        type: s.optional(s.literal("stdio")),
+        command: s.nonEmptyString("Command to run inside the cloud VM."),
+        args: s.optional(s.array(s.string())),
+        env: s.optional(s.record(s.string(), { description: "Environment variables for the MCP process." })),
+      }),
+    ]),
+    {
+      maxItems: 50,
+      description:
+        "Inline MCP servers. On a follow-up, replaces the current inline servers for that run; omit to retain them.",
+    },
+  ),
+);
+const git = s.looseObject("Current pushed branches across the agent, shared by all of its runs.", {
+  branches: s.array(
+    s.looseRequiredObject("A pushed branch.", {
+      repoUrl: s.string("Repository host and path, without a URL scheme."),
+      branch: s.optional(s.string("Pushed branch name.")),
+      prUrl: s.optional(s.url("Pull request URL.")),
+    }),
+  ),
+});
+const agent = s.looseRequiredObject("Durable cloud session. Read latestRunId with get_run for execution progress.", {
+  id: agentId,
+  name: s.string("Agent name."),
+  status: s.stringEnum(["ACTIVE", "IDLE", "ARCHIVED"]),
+  createdAt: s.dateTime("Creation time."),
+  updatedAt: s.dateTime("Last update time."),
+  url: s.optional(s.url("Open this session in Cursor.")),
+  latestRunId: s.optional(runId),
+  env: s.optional(s.looseObject("Execution environment.", { type: s.string(), name: s.string() })),
+  repos: s.optional(s.array(repo)),
+  workOnCurrentBranch: s.optional(s.boolean("Whether commits are pushed to the starting branch.")),
+  autoCreatePR: s.optional(s.boolean("Whether Cursor opens a pull request.")),
+});
+const run = s.looseRequiredObject("One prompt execution. Poll get_run until a terminal status to read result.", {
+  id: runId,
+  agentId,
+  status: s.stringEnum(["CREATING", "RUNNING", "FINISHED", "ERROR", "CANCELLED", "EXPIRED"]),
+  createdAt: s.dateTime("Creation time."),
+  updatedAt: s.dateTime("Last update time."),
+  durationMs: s.optional(s.nonNegativeInteger("Elapsed milliseconds for a terminal run.")),
+  result: s.optional(s.string("Final assistant reply when available.")),
+  git: s.optional(git),
+});
+const agentResult = s.requiredObject("Agent and initial run accepted by Cursor.", { agent, run });
+const idResult = s.requiredObject("Identifier acknowledged by Cursor.", {
+  id: s.nonEmptyString("Affected agent or run ID."),
+});
+
 export const cursorActions: ActionDefinition[] = [
   defineProviderAction(service, {
+    name: "create_agent",
+    description:
+      "Create a durable Cursor cloud session and enqueue its first run. Returns immediately; poll get_run for the result. MCP servers can give the session access to external tools.",
+    inputSchema: s.requiredObject("Start a cloud session.", {
+      prompt,
+      name: s.optional(s.nonEmptyString("Session name; generated from the prompt when omitted.", { maxLength: 100 })),
+      repos: s.optional(
+        s.array(repo, {
+          maxItems: 20,
+          description: "Repositories to clone. Omit for a no-repo VM, if enabled for your account.",
+        }),
+      ),
+      model: s.optional(model),
+      mode,
+      mcpServers,
+      autoCreatePR: s.optional(s.boolean("Open a pull request after the run finishes.")),
+      workOnCurrentBranch: s.optional(
+        s.boolean("Push to the starting branch or existing PR head; false creates a new branch."),
+      ),
+      skipReviewerRequest: s.optional(s.boolean("Skip requesting the user as reviewer when autoCreatePR is true.")),
+    }),
+    outputSchema: agentResult,
+    followUpActions: ["cursor.get_run", "cursor.create_run"],
+    asyncLifecycle: {
+      startActionId: "cursor.create_agent",
+      statusActionId: "cursor.get_run",
+      cancelActionId: "cursor.cancel_run",
+    },
+  }),
+  defineProviderAction(service, {
+    name: "list_agents",
+    description: "List cloud sessions, newest first. Use nextCursor to request another page.",
+    inputSchema: s.requiredObject("Filter cloud sessions.", {
+      limit,
+      cursor,
+      prUrl: s.optional(s.url("Filter by pull request URL.")),
+      includeArchived: s.optional(s.boolean("Include archived sessions; Cursor defaults to true.")),
+    }),
+    outputSchema: s.requiredObject("One page of cloud sessions.", { items: s.array(agent), nextCursor: cursor }),
+  }),
+  defineProviderAction(service, {
+    name: "get_agent",
+    description: "Read a cloud session's configuration and latestRunId. Use get_run for execution status and results.",
+    inputSchema: agentInput,
+    outputSchema: agent,
+  }),
+  defineProviderAction(service, {
+    name: "create_run",
+    description:
+      "Send a follow-up using the session's conversation and workspace. Wait for or cancel an active run before starting another. Unarchive archived sessions first.",
+    inputSchema: s.requiredObject("Continue a cloud session.", { agentId, prompt, mode, mcpServers }),
+    outputSchema: s.requiredObject("Accepted follow-up run.", { run }),
+    followUpActions: ["cursor.get_run"],
+    asyncLifecycle: {
+      startActionId: "cursor.create_run",
+      statusActionId: "cursor.get_run",
+      cancelActionId: "cursor.cancel_run",
+    },
+  }),
+  defineProviderAction(service, {
+    name: "list_runs",
+    description: "List a cloud session's runs, newest first, with cursor pagination.",
+    inputSchema: s.requiredObject("List session runs.", { agentId, limit, cursor }),
+    outputSchema: s.requiredObject("One page of runs.", { items: s.array(run), nextCursor: cursor }),
+  }),
+  defineProviderAction(service, {
+    name: "get_run",
+    description:
+      "Read a run's progress, final assistant reply, and pushed branches. FINISHED, ERROR, CANCELLED, and EXPIRED are terminal statuses.",
+    inputSchema: runInput,
+    outputSchema: run,
+  }),
+  defineProviderAction(service, {
+    name: "cancel_run",
+    description: "Cancel an active run. To continue afterward, create a new run on the same session.",
+    inputSchema: runInput,
+    outputSchema: idResult,
+  }),
+  defineProviderAction(service, {
+    name: "archive_agent",
+    description:
+      "Archive a session while retaining readable history. Call unarchive_agent before sending another prompt.",
+    inputSchema: agentInput,
+    outputSchema: idResult,
+  }),
+  defineProviderAction(service, {
+    name: "unarchive_agent",
+    description: "Restore an archived session so it can accept new runs.",
+    inputSchema: agentInput,
+    outputSchema: idResult,
+  }),
+  defineProviderAction(service, {
+    name: "delete_agent",
+    description: "Permanently delete a cloud session. This is irreversible; archive_agent provides reversible removal.",
+    inputSchema: agentInput,
+    outputSchema: idResult,
+  }),
+  defineProviderAction(service, {
+    name: "list_models",
+    description: "List available cloud agent models and their supported parameters and variants.",
+    inputSchema: s.object({}),
+    outputSchema: s.requiredObject("Available models.", {
+      items: s.array(
+        s.looseRequiredObject("A model available to this key.", {
+          id: s.nonEmptyString("Model ID for create_agent."),
+          displayName: s.string("Model name."),
+          description: s.optional(s.string()),
+          aliases: s.optional(s.stringArray("Alternative model IDs.")),
+          parameters: s.optional(
+            s.array(
+              s.looseRequiredObject("Supported parameter values.", {
+                id: s.string(),
+                displayName: s.optional(s.string()),
+                values: s.array(
+                  s.looseRequiredObject("An allowed value.", {
+                    value: s.string(),
+                    displayName: s.optional(s.string()),
+                  }),
+                ),
+              }),
+            ),
+          ),
+          variants: s.optional(
+            s.array(
+              s.looseRequiredObject("A supported model configuration.", {
+                params,
+                displayName: s.string(),
+                description: s.optional(s.string()),
+                isDefault: s.optional(s.boolean()),
+              }),
+            ),
+          ),
+        }),
+      ),
+    }),
+  }),
+  defineProviderAction(service, {
     name: "list_team_members",
-    description: "List Cursor team members visible to the team API key.",
+    requiredScopes: ["admin:*"],
+    description: "List team members. Requires Enterprise Admin API access.",
     inputSchema: s.object({}, { description: "The input for listing Cursor team members." }),
     outputSchema: s.object(
       {
@@ -99,13 +322,17 @@ export const cursorActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "list_audit_logs",
-    description: "List Cursor team audit log events with optional time, event type, user, search, and page filters.",
+    requiredScopes: ["admin:*"],
+    description:
+      "List team audit events with time, user, event type, and page filters. Requires Enterprise Admin API access.",
     inputSchema: s.object(
       {
-        startTime: nonEmptyString("The start time as a Cursor date shortcut, ISO timestamp, date, or Unix timestamp."),
-        endTime: nonEmptyString("The end time as a Cursor date shortcut, ISO timestamp, date, or Unix timestamp."),
+        startTime: s.nonEmptyString(
+          "The start time as a Cursor date shortcut, ISO timestamp, date, or Unix timestamp.",
+        ),
+        endTime: s.nonEmptyString("The end time as a Cursor date shortcut, ISO timestamp, date, or Unix timestamp."),
         eventTypes: s.stringArray("Cursor audit event types to include.", { minItems: 1 }),
-        search: nonEmptyString("A search term used to filter audit events."),
+        search: s.nonEmptyString("A search term used to filter audit events."),
         page: pageSchema,
         pageSize: pageSizeSchema,
         users: s.stringArray("User emails or encoded Cursor user IDs to filter by.", { minItems: 1 }),
@@ -131,13 +358,14 @@ export const cursorActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "get_daily_usage_data",
-    description: "Retrieve Cursor daily usage metrics for a team over a date range of up to 30 days.",
+    requiredScopes: ["admin:*"],
+    description: "Retrieve up to 30 days of team usage metrics. Requires Enterprise Admin API access.",
     inputSchema: s.object(
       {
         startDate: s.integer("The inclusive start date in epoch milliseconds."),
         endDate: s.integer("The inclusive end date in epoch milliseconds."),
         page: pageSchema,
-        pageSize: positiveInteger("The number of users to return per page.", 1000),
+        pageSize: s.positiveInteger("The number of users to return per page.", { maximum: 1000 }),
       },
       {
         required: ["startDate", "endDate"],
@@ -161,15 +389,16 @@ export const cursorActions: ActionDefinition[] = [
   }),
   defineProviderAction(service, {
     name: "get_team_spend",
+    requiredScopes: ["admin:*"],
     description:
-      "Retrieve Cursor team spending for the current billing cycle with optional search, sort, and pagination.",
+      "Retrieve team spending for the current billing cycle with search, sorting, and pagination. Requires Enterprise Admin API access.",
     inputSchema: s.object(
       {
-        searchTerm: nonEmptyString("Search text matched against user names and emails."),
+        searchTerm: s.nonEmptyString("Search text matched against user names and emails."),
         sortBy: s.stringEnum("The field used to sort spending rows.", ["amount", "date", "user"]),
         sortDirection: s.stringEnum("The sort direction for spending rows.", ["asc", "desc"]),
         page: pageSchema,
-        pageSize: positiveInteger("The number of spending rows to return per page."),
+        pageSize: s.positiveInteger("The number of spending rows to return per page."),
       },
       {
         optional: ["searchTerm", "sortBy", "sortDirection", "page", "pageSize"],

--- a/src/providers/cursor/definition.ts
+++ b/src/providers/cursor/definition.ts
@@ -7,6 +7,7 @@ const service = "cursor";
 export const provider: ProviderDefinition = {
   service,
   displayName: "Cursor",
+  description: "Run coding agents, continue conversations, and track team usage and spending.",
   categories: ["Developer Tools", "AI"],
   authTypes: ["api_key"],
   auth: [
@@ -15,7 +16,7 @@ export const provider: ProviderDefinition = {
       label: "API Key",
       placeholder: "crsr_...",
       description:
-        "Cursor API key sent with Basic authentication. Create or copy a key from Cursor Dashboard > API Keys: https://cursor.com/dashboard/api",
+        "Create a user API key at https://cursor.com/dashboard/api, or use a service account or admin API key from your team settings.",
     },
   ],
   homepageUrl: "https://cursor.com",

--- a/src/providers/cursor/runtime.test.ts
+++ b/src/providers/cursor/runtime.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import { credentialValidators } from "./executors.ts";
+import { cursorActionHandlers as handlers, validateCursorCredential } from "./runtime.ts";
+
+describe("Cursor requests", () => {
+  it("preserves the existing admin response envelope", async () => {
+    const payload = { teamMembers: [{ id: "user_1", email: "dev@example.com" }] };
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json(payload));
+    await expect(handlers.list_team_members({}, { apiKey: "key", fetcher })).resolves.toEqual({
+      teamMembers: payload.teamMembers,
+      raw: payload,
+    });
+    expect(String(fetcher.mock.calls[0]![0])).toBe("https://api.cursor.com/teams/members");
+  });
+
+  it("preserves admin request bodies and spending fields", async () => {
+    const input = { searchTerm: "dev", sortBy: "amount", page: 2 };
+    const payload = { teamMemberSpend: [], subscriptionCycleStart: 123, totalMembers: 0, totalPages: 0 };
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json(payload));
+    await expect(handlers.get_team_spend(input, { apiKey: "key", fetcher })).resolves.toEqual({
+      ...payload,
+      raw: payload,
+    });
+    expect(JSON.parse(String(fetcher.mock.calls[0]![1]?.body))).toEqual(input);
+    expect(fetcher.mock.calls[0]![1]?.method).toBe("POST");
+  });
+
+  it("retains flat admin error messages through the shared transport", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ message: "Admin access required" }, { status: 403 }));
+    await expect(handlers.list_team_members({}, { apiKey: "key", fetcher })).rejects.toMatchObject({
+      status: 403,
+      message: "Admin access required",
+    });
+  });
+
+  it("submits a follow-up without leaking routing fields into the body", async () => {
+    const payload = { run: { id: "run-next", status: "CREATING" } };
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json(payload));
+    const mcpServers = [
+      { name: "tools", url: "https://example.com/mcp", headers: { Authorization: "Bearer tool-key" } },
+    ];
+    const result = await handlers.create_run(
+      { agentId: "bc-session", prompt: { text: "  Keep whitespace.\n" }, mode: "plan", mcpServers },
+      { apiKey: "clé", fetcher },
+    );
+    expect(result).toEqual(payload);
+    const [url, init] = fetcher.mock.calls[0]!;
+    expect(String(url)).toBe("https://api.cursor.com/v1/agents/bc-session/runs");
+    expect(init?.method).toBe("POST");
+    expect(new Headers(init?.headers).get("authorization")).toBe("Basic Y2zDqTo=");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      prompt: { text: "  Keep whitespace.\n" },
+      mode: "plan",
+      mcpServers,
+    });
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("preserves false filters and opaque pagination cursors", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ items: [], nextCursor: "next" }));
+    await expect(
+      handlers.list_agents({ limit: 5, cursor: "a+/=?", includeArchived: false }, { apiKey: "key", fetcher }),
+    ).resolves.toEqual({ items: [], nextCursor: "next" });
+    const url = new URL(String(fetcher.mock.calls[0]![0]));
+    expect(url.searchParams.get("cursor")).toBe("a+/=?");
+    expect(url.searchParams.get("includeArchived")).toBe("false");
+    expect(url.searchParams.get("limit")).toBe("5");
+  });
+
+  it("rejects URL dot segments before making a request", () => {
+    const fetcher = vi.fn<typeof fetch>();
+    for (const agentId of [".", ".."])
+      expect(() => handlers.get_agent({ agentId }, { apiKey: "key", fetcher })).toThrow("dot segment");
+    expect(() => handlers.get_run({ agentId: "bc-session", runId: ".." }, { apiKey: "key", fetcher })).toThrow("runId");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("encodes IDs as single path segments", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ id: "run-1" }));
+    await handlers.cancel_run({ agentId: "bc-a/b?c", runId: "run-a/b#c" }, { apiKey: "key", fetcher });
+    expect(String(fetcher.mock.calls[0]![0])).toBe(
+      "https://api.cursor.com/v1/agents/bc-a%2Fb%3Fc/runs/run-a%2Fb%23c/cancel",
+    );
+  });
+
+  it.each([401, 403, 404, 409, 429, 503])(
+    "preserves execute-phase HTTP %s and upstream error details",
+    async (status) => {
+      const payload = { error: { code: "upstream_code", message: "Upstream message" } };
+      const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json(payload, { status }));
+      await expect(handlers.list_agents({}, { apiKey: "key", fetcher })).rejects.toMatchObject({
+        status,
+        message: "Upstream message",
+        details: payload,
+      });
+    },
+  );
+
+  it("preserves authorization failure for non-JSON error responses", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(new Response("Unauthorized", { status: 401 }));
+    await expect(handlers.list_models({}, { apiKey: "key", fetcher })).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects malformed success responses", async () => {
+    for (const response of [new Response("not json"), Response.json([]), new Response(null)]) {
+      const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response);
+      await expect(handlers.list_models({}, { apiKey: "key", fetcher })).rejects.toMatchObject({ status: 502 });
+    }
+  });
+});
+
+describe("Cursor credentials", () => {
+  it("validates a user key without requesting team data", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ userId: 42, apiKeyName: "Development" }));
+    await expect(credentialValidators.apiKey!({ apiKey: "key", values: {} }, { fetcher })).resolves.toMatchObject({
+      profile: { accountId: "42" },
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(String(fetcher.mock.calls[0]![0])).toBe("https://api.cursor.com/v1/me");
+  });
+
+  it("accepts an admin-only key without attributing it to a team member", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ error: "Forbidden" }, { status: 403 }))
+      .mockResolvedValueOnce(Response.json({ teamMembers: [{ id: "user_1", email: "someone@example.com" }] }));
+    await expect(credentialValidators.apiKey!({ apiKey: "key", values: {} }, { fetcher })).resolves.toEqual({
+      profile: { accountId: "cursor:team", grantedScopes: ["admin:*"] },
+    });
+    expect(fetcher.mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(["/v1/me", "/teams/members"]);
+  });
+
+  it.each([400, 404, 429, 503])("does not probe another API after validation HTTP %s", async (status) => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ error: "Unavailable" }, { status }));
+    await expect(credentialValidators.apiKey!({ apiKey: "key", values: {} }, { fetcher })).rejects.toMatchObject({
+      status,
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it.each([401, 403])("maps validation HTTP %s to a credential field error", async (status) => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => Response.json({ error: "Invalid key" }, { status }));
+    await expect(validateCursorCredential("key", fetcher)).rejects.toMatchObject({
+      status: 400,
+      message: "Invalid key",
+    });
+    expect(String(fetcher.mock.calls[0]![0])).toBe("https://api.cursor.com/v1/me");
+  });
+
+  it("uses the authenticated user ID rather than a team member's identity", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ userId: 42, userEmail: "dev@example.com", apiKeyName: "Development" }));
+    await expect(validateCursorCredential("key", fetcher)).resolves.toEqual({
+      profile: { accountId: "42", displayName: "dev@example.com" },
+    });
+  });
+
+  it("accepts service account keys without inventing a user identity", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ apiKeyName: "Automation", createdAt: "2026-09-01T00:00:00Z" }));
+    await expect(validateCursorCredential("key", fetcher)).resolves.toEqual({
+      profile: { accountId: undefined, displayName: "Automation" },
+    });
+  });
+});

--- a/src/providers/cursor/runtime.test.ts
+++ b/src/providers/cursor/runtime.test.ts
@@ -127,7 +127,8 @@ describe("Cursor credentials", () => {
       .mockResolvedValueOnce(Response.json({ error: "Forbidden" }, { status: 403 }))
       .mockResolvedValueOnce(Response.json({ teamMembers: [{ id: "user_1", email: "someone@example.com" }] }));
     await expect(credentialValidators.apiKey!({ apiKey: "key", values: {} }, { fetcher })).resolves.toEqual({
-      profile: { accountId: "cursor:team", grantedScopes: ["admin:*"] },
+      profile: { accountId: "cursor:team" },
+      grantedScopes: ["admin:*"],
     });
     expect(fetcher.mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(["/v1/me", "/teams/members"]);
   });

--- a/src/providers/cursor/runtime.ts
+++ b/src/providers/cursor/runtime.ts
@@ -1,230 +1,220 @@
-import type { ProviderActionHandlers } from "../provider-runtime.ts";
-import type { ApiKeyProviderContext } from "../provider-runtime.ts";
+import type { CredentialValidationResult } from "../../core/types.ts";
+import type {
+  ApiKeyProviderContext,
+  ProviderActionHandlers,
+  ProviderFetch,
+  ProviderRuntimeHandler,
+} from "../provider-runtime.ts";
 
-import { Buffer } from "node:buffer";
-import { compactObject, optionalNumber, optionalRecord, optionalString } from "../../core/cast.ts";
-import { queryParams } from "../../core/request.ts";
-import { providerFetch, ProviderRequestError, providerUserAgent } from "../provider-runtime.ts";
-
-type CursorActionHandler = (input: Record<string, unknown>, context: ApiKeyProviderContext) => Promise<unknown>;
+import {
+  optionalBoolean,
+  optionalNumber,
+  optionalRecord,
+  optionalScalarString,
+  optionalString,
+  requiredNumber,
+} from "../../core/cast.ts";
+import { encodePathSegment, queryParams } from "../../core/request.ts";
+import { arrayPayload } from "../http-json-runtime.ts";
+import {
+  basicAuthorizationHeader,
+  providerInputError,
+  providerResponseError,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+  requiredInputString,
+  requiredResponseRecord,
+  runProviderRequest,
+  setSearchParams,
+} from "../provider-runtime.ts";
 
 export const cursorApiBaseUrl = "https://api.cursor.com";
 
-export const cursorActionHandlers: ProviderActionHandlers<"cursor", CursorActionHandler> = {
+export const cursorActionHandlers: ProviderActionHandlers<"cursor", ProviderRuntimeHandler<ApiKeyProviderContext>> = {
+  create_agent(input, context) {
+    return requestCursor("/v1/agents", context, { method: "POST", body: input });
+  },
+  list_agents(input, context) {
+    return requestCursor("/v1/agents", context, {
+      query: queryParams({
+        limit: optionalNumber(input.limit),
+        cursor: optionalString(input.cursor),
+        prUrl: optionalString(input.prUrl),
+        includeArchived: optionalBoolean(input.includeArchived),
+      }),
+    });
+  },
+  get_agent(input, context) {
+    return requestCursor(agentPath(input), context);
+  },
+  create_run(input, context) {
+    return requestCursor(`${agentPath(input)}/runs`, context, {
+      method: "POST",
+      body: { prompt: input.prompt, mode: input.mode, mcpServers: input.mcpServers },
+    });
+  },
+  list_runs(input, context) {
+    return requestCursor(`${agentPath(input)}/runs`, context, {
+      query: queryParams({ limit: optionalNumber(input.limit), cursor: optionalString(input.cursor) }),
+    });
+  },
+  get_run(input, context) {
+    return requestCursor(runPath(input), context);
+  },
+  cancel_run(input, context) {
+    return requestCursor(`${runPath(input)}/cancel`, context, { method: "POST" });
+  },
+  archive_agent(input, context) {
+    return requestCursor(`${agentPath(input)}/archive`, context, { method: "POST" });
+  },
+  unarchive_agent(input, context) {
+    return requestCursor(`${agentPath(input)}/unarchive`, context, { method: "POST" });
+  },
+  delete_agent(input, context) {
+    return requestCursor(agentPath(input), context, { method: "DELETE" });
+  },
+  list_models(_input, context) {
+    return requestCursor("/v1/models", context);
+  },
   async list_team_members(_input, context) {
-    const payload = await requestCursor({ method: "GET", path: "/teams/members" }, context, "execute");
-    return {
-      teamMembers: readArray(payload.teamMembers, "teamMembers"),
-      raw: payload,
-    };
+    const payload = await requestCursor("/teams/members", context);
+    return { teamMembers: arrayPayload(payload.teamMembers, "Cursor teamMembers"), raw: payload };
   },
   async list_audit_logs(input, context) {
-    const payload = await requestCursor(
-      {
-        method: "GET",
-        path: "/teams/audit-logs",
-        query: queryParams({
-          startTime: optionalString(input.startTime),
-          endTime: optionalString(input.endTime),
-          eventTypes: joinOptionalStrings(input.eventTypes),
-          search: optionalString(input.search),
-          page: optionalNumber(input.page),
-          pageSize: optionalNumber(input.pageSize),
-          users: joinOptionalStrings(input.users),
-        }),
-      },
-      context,
-      "execute",
-    );
+    const payload = await requestCursor("/teams/audit-logs", context, {
+      query: queryParams({
+        startTime: optionalString(input.startTime),
+        endTime: optionalString(input.endTime),
+        eventTypes: joinOptionalStrings(input.eventTypes),
+        search: optionalString(input.search),
+        page: optionalNumber(input.page),
+        pageSize: optionalNumber(input.pageSize),
+        users: joinOptionalStrings(input.users),
+      }),
+    });
     return {
-      events: readArray(payload.events, "events"),
-      pagination: readObject(payload.pagination, "pagination"),
+      events: arrayPayload(payload.events, "Cursor events"),
+      pagination: requiredResponseRecord(payload.pagination, "Cursor pagination"),
       params: optionalRecord(payload.params),
       raw: payload,
     };
   },
   async get_daily_usage_data(input, context) {
-    const payload = await requestCursor(
-      {
-        method: "POST",
-        path: "/teams/daily-usage-data",
-        body: compactObject({
-          startDate: input.startDate,
-          endDate: input.endDate,
-          page: input.page,
-          pageSize: input.pageSize,
-        }),
-      },
-      context,
-      "execute",
-    );
+    const payload = await requestCursor("/teams/daily-usage-data", context, { method: "POST", body: input });
     return {
-      data: readArray(payload.data, "data"),
-      period: readObject(payload.period, "period"),
+      data: arrayPayload(payload.data, "Cursor daily usage"),
+      period: requiredResponseRecord(payload.period, "Cursor period"),
       pagination: optionalRecord(payload.pagination),
       raw: payload,
     };
   },
   async get_team_spend(input, context) {
-    const payload = await requestCursor(
-      {
-        method: "POST",
-        path: "/teams/spend",
-        body: compactObject({
-          searchTerm: optionalString(input.searchTerm),
-          sortBy: optionalString(input.sortBy),
-          sortDirection: optionalString(input.sortDirection),
-          page: input.page,
-          pageSize: input.pageSize,
-        }),
-      },
-      context,
-      "execute",
-    );
+    const payload = await requestCursor("/teams/spend", context, { method: "POST", body: input });
     return {
-      teamMemberSpend: readArray(payload.teamMemberSpend, "teamMemberSpend"),
-      subscriptionCycleStart: readNumber(payload.subscriptionCycleStart, "subscriptionCycleStart"),
-      totalMembers: readNumber(payload.totalMembers, "totalMembers"),
-      totalPages: readNumber(payload.totalPages, "totalPages"),
+      teamMemberSpend: arrayPayload(payload.teamMemberSpend, "Cursor teamMemberSpend"),
+      subscriptionCycleStart: requiredNumber(
+        payload.subscriptionCycleStart,
+        "subscriptionCycleStart",
+        providerResponseError,
+      ),
+      totalMembers: requiredNumber(payload.totalMembers, "totalMembers", providerResponseError),
+      totalPages: requiredNumber(payload.totalPages, "totalPages", providerResponseError),
       raw: payload,
     };
   },
 };
 
+/** Validate user and service account keys first, with compatibility for admin-only keys. */
 export async function validateCursorCredential(
   apiKey: string,
-  fetcher: typeof fetch = providerFetch,
+  fetcher: ProviderFetch,
   signal?: AbortSignal,
-): Promise<{
-  profile: { accountId: string; displayName: string };
-  grantedScopes: string[];
-  metadata: Record<string, unknown>;
-}> {
-  const payload = await requestCursor(
-    { method: "GET", path: "/teams/members" },
-    { apiKey, fetcher, signal },
-    "validate",
-  );
-  const members = readArray(payload.teamMembers, "teamMembers");
-  const firstMember = optionalRecord(members[0]);
-  const firstMemberEmail = optionalString(firstMember?.email);
-  return {
-    profile: {
-      accountId: "cursor:team",
-      displayName: firstMemberEmail ? `Cursor Team (${firstMemberEmail})` : "Cursor Team",
-    },
-    grantedScopes: [],
-    metadata: compactObject({
-      apiBaseUrl: cursorApiBaseUrl,
-      validationEndpoint: "/teams/members",
-      teamMemberCount: members.length,
-      firstMemberEmail,
-    }),
-  };
-}
-
-interface CursorRequest {
-  method: "GET" | "POST";
-  path: string;
-  query?: Record<string, string>;
-  body?: Record<string, unknown>;
-}
-
-async function requestCursor(
-  request: CursorRequest,
-  context: Pick<ApiKeyProviderContext, "apiKey" | "fetcher" | "signal">,
-  phase: "validate" | "execute",
-): Promise<Record<string, unknown>> {
-  const url = new URL(request.path, cursorApiBaseUrl);
-  for (const [key, value] of Object.entries(request.query ?? {})) {
-    url.searchParams.set(key, value);
-  }
-  const headers: Record<string, string> = {
-    accept: "application/json",
-    authorization: `Basic ${Buffer.from(`${context.apiKey}:`).toString("base64")}`,
-    "user-agent": providerUserAgent,
-  };
-  if (request.body !== undefined) {
-    headers["content-type"] = "application/json";
-  }
-
-  let response: Response;
+): Promise<CredentialValidationResult> {
+  const context: ApiKeyProviderContext = { apiKey, fetcher, signal };
   try {
-    response = await context.fetcher(url, {
-      method: request.method,
-      headers,
-      body: request.body === undefined ? undefined : JSON.stringify(request.body),
-      signal: context.signal,
-    });
+    const payload = await requestCursor("/v1/me", context);
+    return {
+      profile: {
+        accountId: optionalScalarString(payload.userId),
+        displayName: optionalString(payload.userEmail) ?? optionalString(payload.apiKeyName),
+      },
+    };
   } catch (error) {
-    throw new ProviderRequestError(
-      502,
-      error instanceof Error ? `Cursor request failed: ${error.message}` : "Cursor request failed",
-    );
+    if (!(error instanceof ProviderRequestError) || (error.status !== 401 && error.status !== 403)) throw error;
   }
 
-  const text = await response.text();
-  let payload: Record<string, unknown> = {};
+  // Older admin keys may only have access to the Admin API.
   try {
-    payload = parseJsonObject(text, response.status);
+    const payload = await requestCursor("/teams/members", context);
+    arrayPayload(payload.teamMembers, "Cursor teamMembers");
+    return { profile: { accountId: "cursor:team", grantedScopes: ["admin:*"] } };
   } catch (error) {
-    if (response.ok) {
-      throw error;
+    if (error instanceof ProviderRequestError && (error.status === 401 || error.status === 403)) {
+      throw providerInputError(error.message);
     }
-  }
-
-  if (!response.ok) {
-    throw new ProviderRequestError(
-      response.status === 401 || response.status === 403 ? (phase === "validate" ? 400 : 401) : response.status || 502,
-      readCursorErrorMessage(payload, response.status),
-      payload,
-    );
-  }
-
-  return payload;
-}
-
-function parseJsonObject(text: string, status: number): Record<string, unknown> {
-  if (!text) {
-    return {};
-  }
-  try {
-    const value = JSON.parse(text) as unknown;
-    return readObject(value, `response (${status})`);
-  } catch {
-    throw new ProviderRequestError(502, `Cursor returned non-JSON response (${status})`);
+    throw error;
   }
 }
 
-function readCursorErrorMessage(payload: Record<string, unknown>, status: number): string {
-  return (
-    optionalString(payload.message) ??
-    optionalString(payload.error) ??
-    optionalString(payload.code) ??
-    `Cursor API request failed with status ${status}`
-  );
+interface CursorRequestOptions {
+  method?: "GET" | "POST" | "DELETE";
+  body?: Record<string, unknown>;
+  query?: Record<string, string>;
 }
 
-function readArray(value: unknown, fieldName: string): unknown[] {
-  if (!Array.isArray(value)) {
-    throw new ProviderRequestError(502, `Cursor response field ${fieldName} is not an array`);
-  }
-  return value;
+function requestCursor(
+  path: string,
+  context: ApiKeyProviderContext,
+  options: CursorRequestOptions = {},
+): Promise<Record<string, unknown>> {
+  const url = new URL(path, cursorApiBaseUrl);
+  setSearchParams(url, options.query ?? {});
+  return runProviderRequest({ signal: context.signal, label: "Cursor" }, async (signal) => {
+    const headers = new Headers({
+      accept: "application/json",
+      authorization: basicAuthorizationHeader(`${context.apiKey}:`),
+      "user-agent": providerUserAgent,
+    });
+    if (options.body !== undefined) headers.set("content-type", "application/json");
+    const response = await context.fetcher(url, {
+      method: options.method ?? "GET",
+      headers,
+      signal,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+    const payload = await readProviderJsonBody(response, {
+      emptyBody: null,
+      invalidJsonMessage: "Cursor returned invalid JSON",
+      invalidJsonFallback: response.ok ? undefined : () => null,
+    });
+    if (!response.ok) {
+      const record = optionalRecord(payload);
+      const error = optionalRecord(record?.error);
+      throw new ProviderRequestError(
+        response.status,
+        optionalString(error?.message) ??
+          optionalString(record?.message) ??
+          optionalString(record?.error) ??
+          optionalString(record?.code) ??
+          `Cursor request failed with HTTP ${response.status}`,
+        payload,
+      );
+    }
+    return requiredResponseRecord(payload, "Cursor");
+  });
 }
 
-function readNumber(value: unknown, fieldName: string): number {
-  if (typeof value !== "number") {
-    throw new ProviderRequestError(502, `Cursor response field ${fieldName} is not a number`);
-  }
-  return value;
+function agentPath(input: Record<string, unknown>): string {
+  const id = requiredInputString(input.agentId, "agentId");
+  if (id === "." || id === "..") throw providerInputError("agentId cannot be a URL dot segment.");
+  return `/v1/agents/${encodePathSegment(id)}`;
 }
 
-function readObject(value: unknown, fieldName: string): Record<string, unknown> {
-  const record = optionalRecord(value);
-  if (!record) {
-    throw new ProviderRequestError(502, `Cursor response field ${fieldName} is not an object`);
-  }
-  return record;
+function runPath(input: Record<string, unknown>): string {
+  const id = requiredInputString(input.runId, "runId");
+  if (id === "." || id === "..") throw providerInputError("runId cannot be a URL dot segment.");
+  return `${agentPath(input)}/runs/${encodePathSegment(id)}`;
 }
 
 function joinOptionalStrings(value: unknown): string | undefined {

--- a/src/providers/cursor/runtime.ts
+++ b/src/providers/cursor/runtime.ts
@@ -148,7 +148,7 @@ export async function validateCursorCredential(
   try {
     const payload = await requestCursor("/teams/members", context);
     arrayPayload(payload.teamMembers, "Cursor teamMembers");
-    return { profile: { accountId: "cursor:team", grantedScopes: ["admin:*"] } };
+    return { profile: { accountId: "cursor:team" }, grantedScopes: ["admin:*"] };
   } catch (error) {
     if (error instanceof ProviderRequestError && (error.status === 401 || error.status === 403)) {
       throw providerInputError(error.message);


### PR DESCRIPTION
The Cursor provider previously exposed only team administration actions and rejected user keys during connection setup. Add 11 executable Cloud Agents v1 actions to create and inspect sessions, send follow-ups, poll and cancel runs, archive/unarchive or delete agents, and discover models. Create and follow-up actions accept inline MCP servers.

Use one request implementation for agent and administration endpoints, with shared Basic authentication, guarded fetch, timeouts, bounded JSON reads, and error handling. Validate user and service account keys through `/v1/me` first, falling back to the team endpoint only after authorization rejection. Preserve existing admin action envelopes and label their Enterprise API and `admin:*` requirements.

Validation:
- `npm run generate:catalog`
- `npm run fix-check`
- `npm test`: 2136 passed, 4 skipped
- No live credential testing performed.

Closes #516
