### PR TITLE
feat(weixin-bot): add iLink messaging provider

### DIFF
--- a/examples/weixin-bot-login.ts
+++ b/examples/weixin-bot-login.ts
@@ -88,6 +88,7 @@ async function getQrCode(): Promise<QrCodeResponse> {
     method: "POST",
     headers: qrPostHeaders(),
     body: JSON.stringify({ local_token_list: [] }),
+    signal: AbortSignal.timeout(35_000),
   });
   return readJsonResponse<QrCodeResponse>(response, "get bot QR code");
 }

--- a/examples/weixin-bot-login.ts
+++ b/examples/weixin-bot-login.ts
@@ -1,0 +1,142 @@
+import { Buffer } from "node:buffer";
+import { createInterface } from "node:readline/promises";
+
+interface QrCodeResponse {
+  qrcode: string;
+  qrcode_img_content: string;
+}
+
+interface QrStatusResponse {
+  status: string;
+  bot_token?: string;
+  ilink_bot_id?: string;
+  baseurl?: string;
+  ilink_user_id?: string;
+  redirect_host?: string;
+}
+
+const apiBaseUrl = "https://ilinkai.weixin.qq.com";
+const appClientVersion = "65536";
+const input = createInterface({ input: process.stdin, output: process.stdout });
+
+try {
+  process.stdout.write(
+    "This script starts Tencent's official Weixin iLink QR pairing flow. Review the terms shown in Weixin before confirming.\n\n",
+  );
+
+  let qr = await getQrCode();
+  let pollingBaseUrl = apiBaseUrl;
+  let verifyCode: string | undefined;
+  showQrCode(qr.qrcode_img_content);
+
+  while (true) {
+    const result = await getQrStatus(pollingBaseUrl, qr.qrcode, verifyCode);
+    switch (result.status) {
+      case "wait":
+        process.stdout.write(".");
+        break;
+      case "scaned":
+        verifyCode = undefined;
+        process.stdout.write("\nQR code scanned. Confirm the connection in Weixin.\n");
+        break;
+      case "need_verifycode":
+        verifyCode = (await input.question("Enter the verification code shown in Weixin: ")).trim();
+        continue;
+      case "scaned_but_redirect":
+        pollingBaseUrl = readRedirectBaseUrl(result.redirect_host);
+        break;
+      case "expired":
+        process.stdout.write("\nThe QR code expired. Requesting a new one.\n");
+        qr = await getQrCode();
+        pollingBaseUrl = apiBaseUrl;
+        verifyCode = undefined;
+        showQrCode(qr.qrcode_img_content);
+        break;
+      case "verify_code_blocked":
+        throw new Error("Verification was blocked after too many failed attempts. Run the script again later.");
+      case "binded_redirect":
+        throw new Error("This bot is already paired with an existing client instance.");
+      case "confirmed": {
+        if (!result.bot_token || !result.ilink_bot_id) {
+          throw new Error("Weixin confirmed the login without returning a bot token and account ID.");
+        }
+        process.stdout.write("\n\nPairing succeeded. Store botToken as a secret custom credential.\n");
+        process.stdout.write(
+          `${JSON.stringify({ botToken: result.bot_token, accountId: result.ilink_bot_id }, null, 2)}\n`,
+        );
+        process.stdout.write(
+          "The token may expire or be revoked; rerun this script when the provider asks you to reconnect.\n",
+        );
+        process.exitCode = 0;
+        break;
+      }
+      default:
+        throw new Error(`Unknown Weixin QR status: ${result.status}`);
+    }
+
+    if (result.status === "confirmed") break;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+} finally {
+  input.close();
+}
+
+async function getQrCode(): Promise<QrCodeResponse> {
+  const url = new URL("/ilink/bot/get_bot_qrcode", apiBaseUrl);
+  url.searchParams.set("bot_type", "3");
+  const response = await fetch(url, {
+    method: "POST",
+    headers: qrPostHeaders(),
+    body: JSON.stringify({ local_token_list: [] }),
+  });
+  return readJsonResponse<QrCodeResponse>(response, "get bot QR code");
+}
+
+async function getQrStatus(baseUrl: string, qrcode: string, verifyCode?: string): Promise<QrStatusResponse> {
+  const url = new URL("/ilink/bot/get_qrcode_status", baseUrl);
+  url.searchParams.set("qrcode", qrcode);
+  if (verifyCode) url.searchParams.set("verify_code", verifyCode);
+  try {
+    const response = await fetch(url, { headers: appHeaders(), signal: AbortSignal.timeout(35_000) });
+    return readJsonResponse<QrStatusResponse>(response, "poll QR code status");
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") return { status: "wait" };
+    throw error;
+  }
+}
+
+function showQrCode(qrcodeUrl: string): void {
+  process.stdout.write("Open this URL and scan the displayed QR code with Weixin:\n");
+  process.stdout.write(`${qrcodeUrl}\n\n`);
+}
+
+function appHeaders(): Headers {
+  return new Headers({
+    "iLink-App-Id": "bot",
+    "iLink-App-ClientVersion": appClientVersion,
+  });
+}
+
+function qrPostHeaders(): Headers {
+  const headers = appHeaders();
+  headers.set("content-type", "application/json");
+  headers.set("AuthorizationType", "ilink_bot_token");
+  const randomValue = crypto.getRandomValues(new Uint32Array(1))[0]!;
+  headers.set("X-WECHAT-UIN", Buffer.from(String(randomValue), "utf8").toString("base64"));
+  return headers;
+}
+
+function readRedirectBaseUrl(host: string | undefined): string {
+  if (!host) throw new Error("Weixin requested a polling redirect without a host.");
+  const url = new URL(`https://${host}`);
+  if (url.hostname !== "weixin.qq.com" && !url.hostname.endsWith(".weixin.qq.com")) {
+    throw new Error(`Refusing an unexpected Weixin redirect host: ${url.hostname}`);
+  }
+  return url.origin;
+}
+
+async function readJsonResponse<T>(response: Response, operation: string): Promise<T> {
+  const text = await response.text();
+  if (!response.ok) throw new Error(`Failed to ${operation}: HTTP ${response.status} ${text}`);
+  return JSON.parse(text) as T;
+}

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -12,7 +12,7 @@ const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 runChecked(process.execPath, ["scripts/ensure-generated.ts"]);
 
 const processes: DevProcess[] = [
-  startProcess("api", process.execPath, ["src/server/index.ts"]),
+  startProcess("api", process.execPath, ["--watch", "--watch-preserve-output", "src/server/index.ts"]),
   startProcess("web", npmCommand, ["run", "dev", "--workspace", "web", "--", "--clearScreen", "false"]),
 ];
 

--- a/src/providers/weixin_bot/actions.ts
+++ b/src/providers/weixin_bot/actions.ts
@@ -1,0 +1,109 @@
+import type { ProviderActionDefinition } from "../../core/provider-definition.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "weixin_bot";
+
+const messageSchema = s.looseObject("A Weixin iLink message, including its sender, content items, and reply context.", {
+  message_id: s.string("The message identifier returned by Weixin."),
+  from_user_id: s.string("The Weixin user that sent the message."),
+  to_user_id: s.string("The message recipient."),
+  create_time_ms: s.number("The message creation time in milliseconds."),
+  message_type: s.integer("The message sender type reported by Weixin."),
+  message_state: s.integer("The message lifecycle state reported by Weixin."),
+  context_token: s.string("The conversation token to pass back when replying."),
+  item_list: s.array("The text or media items carried by the message.", s.looseObject("A Weixin message item.")),
+});
+
+const transitFileInput = s.requiredObject("A file already uploaded to local transit storage.", {
+  fileId: s.nonEmptyString("The transit file identifier."),
+});
+
+const transitFileOutput = s.requiredObject("Decrypted media stored in local transit storage.", {
+  fileId: s.nonEmptyString("The new transit file identifier."),
+  downloadUrl: s.url("The local download URL."),
+  sizeBytes: s.nonNegativeInteger("The decrypted file size in bytes."),
+  name: s.nonEmptyString("The stored file name."),
+  mimeType: s.nonEmptyString("The media MIME type."),
+});
+
+export const weixinBotActions: ProviderActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_updates",
+    description:
+      "Long-poll for inbound Weixin bot messages. Pass the returned cursor to the next call to avoid receiving the same updates again.",
+    inputSchema: s.object(
+      {
+        cursor: s.nonEmptyString("The cursor returned by the previous get_updates call."),
+      },
+      { optional: ["cursor"] },
+    ),
+    outputSchema: s.requiredObject("Inbound messages and the state needed for the next long-poll.", {
+      messages: s.array("Messages received during this poll.", messageSchema),
+      nextCursor: s.nullableString("The cursor to pass to the next get_updates call."),
+      longPollingTimeoutMs: s.nullableInteger("The next long-poll duration suggested by Weixin."),
+    }),
+    providerPermissions: ["Receive messages sent to the connected Weixin bot"],
+  }),
+  defineProviderAction(service, {
+    name: "send_message",
+    description: "Send a text reply from the connected Weixin bot to a user or conversation.",
+    inputSchema: s.requiredObject("A text message and its Weixin reply context.", {
+      toUserId: s.nonEmptyString("The target user ID from an inbound Weixin message."),
+      text: s.nonEmptyString("The text to send."),
+      contextToken: s.nonEmptyString("The context_token from the inbound message being answered."),
+    }),
+    outputSchema: s.requiredObject("The accepted Weixin message.", {
+      messageId: s.nullableString("The server-assigned message identifier when returned."),
+    }),
+    providerPermissions: ["Send messages as the connected Weixin bot"],
+    followUpActions: ["weixin_bot.get_updates"],
+  }),
+  defineProviderAction(service, {
+    name: "send_media",
+    description: "Encrypt, upload, and send an image, video, or file from local transit storage.",
+    inputSchema: s.object(
+      "A transit file and its Weixin reply context.",
+      {
+        toUserId: s.nonEmptyString("The target user ID from an inbound Weixin message."),
+        contextToken: s.nonEmptyString("The context_token from the inbound message being answered."),
+        mediaType: s.stringEnum("How Weixin should present the file.", ["image", "video", "file"]),
+        file: transitFileInput,
+        caption: s.nonEmptyString("Optional text sent as a separate message before the media."),
+      },
+      { optional: ["caption"] },
+    ),
+    outputSchema: s.requiredObject("The accepted Weixin media message.", {
+      messageId: s.nullableString("The server-assigned message identifier when returned."),
+    }),
+    providerPermissions: ["Upload and send media as the connected Weixin bot"],
+  }),
+  defineProviderAction(service, {
+    name: "download_media",
+    description: "Download and decrypt one image, voice, video, or file item returned by get_updates.",
+    inputSchema: s.object(
+      "A media item returned inside a Weixin message item_list.",
+      {
+        item: s.looseObject("The complete Weixin media item."),
+        name: s.nonEmptyString("Optional output file name."),
+      },
+      { optional: ["name"] },
+    ),
+    outputSchema: s.requiredObject("The locally stored decrypted media.", { file: transitFileOutput }),
+    providerPermissions: ["Download media received by the connected Weixin bot"],
+  }),
+  defineProviderAction(service, {
+    name: "send_typing",
+    description: "Start or stop the typing indicator for a Weixin conversation.",
+    inputSchema: s.requiredObject("A conversation and typing state.", {
+      userId: s.nonEmptyString("The Weixin user ID from an inbound message."),
+      contextToken: s.nonEmptyString("The context_token from the inbound message."),
+      status: s.stringEnum("Whether to start or stop the typing indicator.", ["typing", "cancel"]),
+    }),
+    outputSchema: s.requiredObject("The typing state accepted by Weixin.", {
+      status: s.stringEnum("The typing state sent to Weixin.", ["typing", "cancel"]),
+    }),
+    providerPermissions: ["Update typing status as the connected Weixin bot"],
+  }),
+];

--- a/src/providers/weixin_bot/definition.ts
+++ b/src/providers/weixin_bot/definition.ts
@@ -1,0 +1,42 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { weixinBotActions } from "./actions.ts";
+
+export const nodeOnly = true;
+
+export const provider: ProviderDefinition = {
+  service: "weixin_bot",
+  displayName: "Weixin Bot",
+  description:
+    "Receive and reply to Weixin messages through Tencent's iLink Bot API. Media encryption requires the Node.js runtime.",
+  categories: ["Communication"],
+  authTypes: ["custom_credential"],
+  auth: [
+    {
+      type: "custom_credential",
+      fields: [
+        {
+          key: "botToken",
+          label: "Bot Token",
+          inputType: "password",
+          required: true,
+          secret: true,
+          placeholder: "Paste the botToken from the QR login example",
+          description:
+            "The secret bot token returned after QR pairing. Run `node examples/weixin-bot-login.ts` locally to obtain it, and do not share it.",
+        },
+        {
+          key: "accountId",
+          label: "Bot Account ID",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "Paste the accountId from the QR login example",
+          description: "The ilink_bot_id returned together with the bot token after QR pairing.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://github.com/Tencent/openclaw-weixin",
+  actions: weixinBotActions,
+};

--- a/src/providers/weixin_bot/executors.ts
+++ b/src/providers/weixin_bot/executors.ts
@@ -1,0 +1,22 @@
+import type { ExecutionContext, ProviderExecutors } from "../../core/types.ts";
+import type { WeixinBotContext } from "./runtime.ts";
+
+import { ProviderRequestError, defineProviderExecutors, requireCustomCredential } from "../provider-runtime.ts";
+import { weixinBotActionHandlers } from "./runtime.ts";
+
+const service = "weixin_bot";
+
+export const executors: ProviderExecutors = defineProviderExecutors<WeixinBotContext>({
+  service,
+  handlers: weixinBotActionHandlers,
+  skipDnsValidation: true,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<WeixinBotContext> {
+    const credential = await requireCustomCredential(context, service);
+    const botToken = credential.values.botToken?.trim();
+    const accountId = credential.values.accountId?.trim();
+    if (!botToken || !accountId) {
+      throw new ProviderRequestError(401, "Configure the Weixin bot token and bot account ID first.");
+    }
+    return { botToken, accountId, fetcher, signal: context.signal, transitFiles: context.transitFiles };
+  },
+});

--- a/src/providers/weixin_bot/runtime-media.ts
+++ b/src/providers/weixin_bot/runtime-media.ts
@@ -11,6 +11,7 @@ import {
   readTransitFileInput,
   requiredInputString,
   requiredResponseRecord,
+  runProviderRequest,
 } from "../provider-runtime.ts";
 
 type WeixinRequest = (options: WeixinRequestOptions) => Promise<Record<string, unknown>>;
@@ -48,12 +49,14 @@ export async function sendWeixinMedia(
     },
   });
   const uploadUrl = resolveCdnUrl(upload.upload_full_url, upload.upload_param, "upload", filekey);
-  const uploadResponse = await providerFetch(uploadUrl, {
-    method: "POST",
-    headers: { "content-type": "application/octet-stream" },
-    body: Uint8Array.from(ciphertext),
-    signal: context.signal,
-  });
+  const uploadResponse = await runProviderRequest({ signal: context.signal, label: "Weixin CDN upload" }, (signal) =>
+    providerFetch(uploadUrl, {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: Uint8Array.from(ciphertext),
+      signal,
+    }),
+  );
   const encryptedParam = uploadResponse.headers.get("x-encrypted-param");
   if (uploadResponse.status !== 200 || !encryptedParam) {
     throw new ProviderRequestError(502, `Weixin CDN upload failed with HTTP ${uploadResponse.status}`);
@@ -80,23 +83,28 @@ export async function downloadWeixinMedia(
   input: Record<string, unknown>,
   context: WeixinBotContext,
 ): Promise<Record<string, unknown>> {
-  if (!context.transitFiles) throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+  const transitFiles = context.transitFiles;
+  if (!transitFiles) throw new ProviderRequestError(400, "Transit file storage is not enabled.");
   const item = requiredResponseRecord(input.item, "Weixin media item");
   const details = readMediaDetails(item);
   const url = resolveCdnUrl(details.fullUrl, details.encryptedParam, "download");
-  const response = await providerFetch(url, { signal: context.signal });
-  if (!response.ok) throw new ProviderRequestError(502, `Weixin CDN download failed with HTTP ${response.status}`);
-  const encrypted = await readBoundedResponseBytes(response, {
-    maxBytes: context.transitFiles.maxBytes + 16,
-    fieldName: "Weixin media",
-    createError: (message) => new ProviderRequestError(413, message),
-  });
+  const encrypted = await runProviderRequest(
+    { signal: context.signal, label: "Weixin CDN download" },
+    async (signal) => {
+      const response = await providerFetch(url, { signal });
+      if (!response.ok) throw new ProviderRequestError(502, `Weixin CDN download failed with HTTP ${response.status}`);
+      return readBoundedResponseBytes(response, {
+        maxBytes: transitFiles.maxBytes + 16,
+        fieldName: "Weixin media",
+        createError: (message) => new ProviderRequestError(413, message),
+      });
+    },
+  );
   const bytes = details.key ? decrypt(Buffer.from(encrypted), details.key) : Buffer.from(encrypted);
-  if (bytes.byteLength > context.transitFiles.maxBytes)
-    throw new ProviderRequestError(413, "Weixin media is too large");
+  if (bytes.byteLength > transitFiles.maxBytes) throw new ProviderRequestError(413, "Weixin media is too large");
   const mimeType = detectImageMimeType(bytes) ?? details.mimeType;
   const name = optionalString(input.name) ?? mediaNameForMimeType(details.name, mimeType);
-  const stored = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  const stored = await transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
   return { file: { ...stored, name, mimeType } };
 }
 

--- a/src/providers/weixin_bot/runtime-media.ts
+++ b/src/providers/weixin_bot/runtime-media.ts
@@ -1,0 +1,235 @@
+import type { WeixinBotContext, WeixinRequestOptions } from "./runtime.ts";
+
+import { Buffer } from "node:buffer";
+import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
+import { optionalString } from "../../core/cast.ts";
+import { readBoundedResponseBytes } from "../../core/request.ts";
+import {
+  ProviderRequestError,
+  providerFetch,
+  providerResponseError,
+  readTransitFileInput,
+  requiredInputString,
+  requiredResponseRecord,
+} from "../provider-runtime.ts";
+
+type WeixinRequest = (options: WeixinRequestOptions) => Promise<Record<string, unknown>>;
+type MediaKind = "image" | "video" | "file";
+
+const cdnBaseUrl = "https://novac2c.cdn.weixin.qq.com/c2c";
+
+export async function sendWeixinMedia(
+  input: Record<string, unknown>,
+  context: WeixinBotContext,
+  request: WeixinRequest,
+): Promise<Record<string, unknown>> {
+  const toUserId = requiredInputString(input.toUserId, "toUserId");
+  const contextToken = requiredInputString(input.contextToken, "contextToken");
+  const kind = readMediaKind(input.mediaType);
+  const source = await readTransitFileInput(input.file, context);
+  const plaintext = Buffer.from(await source.file.arrayBuffer());
+  const key = randomBytes(16);
+  const ciphertext = encrypt(plaintext, key);
+  const filekey = randomBytes(16).toString("hex");
+  const upload = await request({
+    context,
+    path: "/ilink/bot/getuploadurl",
+    label: "Weixin get upload URL",
+    body: {
+      filekey,
+      media_type: kind === "image" ? 1 : kind === "video" ? 2 : 3,
+      to_user_id: toUserId,
+      rawsize: plaintext.byteLength,
+      rawfilemd5: createHash("md5").update(plaintext).digest("hex"),
+      filesize: ciphertext.byteLength,
+      no_need_thumb: true,
+      aeskey: key.toString("hex"),
+      base_info: { channel_version: "1.0.0", bot_agent: "OpenConnector/1.0.0" },
+    },
+  });
+  const uploadUrl = resolveCdnUrl(upload.upload_full_url, upload.upload_param, "upload", filekey);
+  const uploadResponse = await providerFetch(uploadUrl, {
+    method: "POST",
+    headers: { "content-type": "application/octet-stream" },
+    body: Uint8Array.from(ciphertext),
+    signal: context.signal,
+  });
+  const encryptedParam = uploadResponse.headers.get("x-encrypted-param");
+  if (uploadResponse.status !== 200 || !encryptedParam) {
+    throw new ProviderRequestError(502, `Weixin CDN upload failed with HTTP ${uploadResponse.status}`);
+  }
+
+  const caption = optionalString(input.caption);
+  if (caption) await sendItem(request, context, toUserId, contextToken, { type: 1, text_item: { text: caption } });
+  const media = {
+    encrypt_query_param: encryptedParam,
+    aes_key: Buffer.from(key.toString("hex")).toString("base64"),
+    encrypt_type: 1,
+  };
+  const item =
+    kind === "image"
+      ? { type: 2, image_item: { media, mid_size: ciphertext.byteLength } }
+      : kind === "video"
+        ? { type: 5, video_item: { media, video_size: ciphertext.byteLength } }
+        : { type: 4, file_item: { media, file_name: source.name, len: String(plaintext.byteLength) } };
+  const result = await sendItem(request, context, toUserId, contextToken, item);
+  return { messageId: optionalString(result.message_id) ?? null };
+}
+
+export async function downloadWeixinMedia(
+  input: Record<string, unknown>,
+  context: WeixinBotContext,
+): Promise<Record<string, unknown>> {
+  if (!context.transitFiles) throw new ProviderRequestError(400, "Transit file storage is not enabled.");
+  const item = requiredResponseRecord(input.item, "Weixin media item");
+  const details = readMediaDetails(item);
+  const url = resolveCdnUrl(details.fullUrl, details.encryptedParam, "download");
+  const response = await providerFetch(url, { signal: context.signal });
+  if (!response.ok) throw new ProviderRequestError(502, `Weixin CDN download failed with HTTP ${response.status}`);
+  const encrypted = await readBoundedResponseBytes(response, {
+    maxBytes: context.transitFiles.maxBytes + 16,
+    fieldName: "Weixin media",
+    createError: (message) => new ProviderRequestError(413, message),
+  });
+  const bytes = details.key ? decrypt(Buffer.from(encrypted), details.key) : Buffer.from(encrypted);
+  if (bytes.byteLength > context.transitFiles.maxBytes)
+    throw new ProviderRequestError(413, "Weixin media is too large");
+  const mimeType = detectImageMimeType(bytes) ?? details.mimeType;
+  const name = optionalString(input.name) ?? mediaNameForMimeType(details.name, mimeType);
+  const stored = await context.transitFiles.create(new File([Uint8Array.from(bytes)], name, { type: mimeType }));
+  return { file: { ...stored, name, mimeType } };
+}
+
+async function sendItem(
+  request: WeixinRequest,
+  context: WeixinBotContext,
+  toUserId: string,
+  contextToken: string,
+  item: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return request({
+    context,
+    path: "/ilink/bot/sendmessage",
+    label: "Weixin send media",
+    body: {
+      msg: {
+        from_user_id: "",
+        to_user_id: toUserId,
+        client_id: randomUUID(),
+        message_type: 2,
+        message_state: 2,
+        context_token: contextToken,
+        item_list: [item],
+      },
+      base_info: { channel_version: "1.0.0", bot_agent: "OpenConnector/1.0.0" },
+    },
+  });
+}
+
+function readMediaKind(value: unknown): MediaKind {
+  const kind = requiredInputString(value, "mediaType");
+  if (kind === "image" || kind === "video" || kind === "file") return kind;
+  throw new ProviderRequestError(400, "mediaType must be image, video, or file");
+}
+
+function resolveCdnUrl(
+  fullUrl: unknown,
+  encryptedParam: unknown,
+  operation: "upload" | "download",
+  filekey?: string,
+): string {
+  const direct = optionalString(fullUrl);
+  if (direct) return direct;
+  const param = optionalString(encryptedParam);
+  if (!param) throw providerResponseError(`Weixin CDN ${operation} parameters are missing`);
+  const url = new URL(`${cdnBaseUrl}/${operation}`);
+  url.searchParams.set("encrypted_query_param", param);
+  if (filekey) url.searchParams.set("filekey", filekey);
+  return url.toString();
+}
+
+function readMediaDetails(item: Record<string, unknown>): {
+  encryptedParam: string;
+  fullUrl?: string;
+  key?: Buffer;
+  name: string;
+  mimeType: string;
+} {
+  const type = item.type;
+  const field =
+    type === 2
+      ? "image_item"
+      : type === 3
+        ? "voice_item"
+        : type === 4
+          ? "file_item"
+          : type === 5
+            ? "video_item"
+            : undefined;
+  if (!field) throw new ProviderRequestError(400, "item must contain image, voice, file, or video media");
+  const content = requiredResponseRecord(item[field], field);
+  const media = requiredResponseRecord(content.media, `${field}.media`);
+  const fileName = optionalString(content.file_name) ?? "weixin-file.bin";
+  const keyText = type === 2 ? optionalString(content.aeskey) : undefined;
+  const key = keyText ? Buffer.from(keyText, "hex") : parseKey(optionalString(media.aes_key));
+  if (type !== 2 && !key) throw providerResponseError(`Weixin ${field} AES key is missing`);
+  return {
+    encryptedParam: optionalString(media.encrypt_query_param) ?? "",
+    fullUrl: optionalString(media.full_url),
+    key,
+    name:
+      type === 4 ? fileName : type === 2 ? "weixin-image.jpg" : type === 3 ? "weixin-voice.silk" : "weixin-video.mp4",
+    mimeType: type === 2 ? "image/jpeg" : type === 3 ? "audio/silk" : type === 5 ? "video/mp4" : fileMimeType(fileName),
+  };
+}
+
+function parseKey(value: string | undefined): Buffer | undefined {
+  if (!value) return undefined;
+  const decoded = Buffer.from(value, "base64");
+  return decoded.length === 32 ? Buffer.from(decoded.toString("ascii"), "hex") : decoded;
+}
+
+function encrypt(value: Buffer, key: Buffer): Buffer {
+  const cipher = createCipheriv("aes-128-ecb", key, null);
+  return Buffer.concat([cipher.update(value), cipher.final()]);
+}
+
+function decrypt(value: Buffer, key: Buffer): Buffer {
+  if (key.length !== 16) throw new ProviderRequestError(502, "Weixin media AES key is invalid");
+  const decipher = createDecipheriv("aes-128-ecb", key, null);
+  return Buffer.concat([decipher.update(value), decipher.final()]);
+}
+
+function detectImageMimeType(bytes: Buffer): string | undefined {
+  if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return "image/png";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  const prefix = bytes.subarray(0, 12).toString("ascii");
+  if (prefix.startsWith("GIF87a") || prefix.startsWith("GIF89a")) return "image/gif";
+  if (prefix.startsWith("RIFF") && prefix.endsWith("WEBP")) return "image/webp";
+  return undefined;
+}
+
+function mediaNameForMimeType(name: string, mimeType: string): string {
+  const extension =
+    mimeType === "image/png"
+      ? ".png"
+      : mimeType === "image/gif"
+        ? ".gif"
+        : mimeType === "image/webp"
+          ? ".webp"
+          : undefined;
+  return extension ? name.replace(/\.[^.]+$/, extension) : name;
+}
+
+function fileMimeType(name: string): string {
+  const extension = name.toLowerCase().match(/\.[^.]+$/)?.[0];
+  const types: Record<string, string> = {
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".md": "text/markdown",
+    ".pdf": "application/pdf",
+    ".txt": "text/plain",
+    ".zip": "application/zip",
+  };
+  return (extension && types[extension]) ?? "application/octet-stream";
+}

--- a/src/providers/weixin_bot/runtime.test.ts
+++ b/src/providers/weixin_bot/runtime.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { parseWeixinJson } from "./runtime.ts";
+
+describe("parseWeixinJson", () => {
+  it("preserves uint64 message identifiers without changing text content", () => {
+    expect(
+      parseWeixinJson('{"message_id":18446744073709551615,"item_list":[{"text_item":{"text":"\\\"msg_id\\\":123"}}]}'),
+    ).toEqual({
+      message_id: "18446744073709551615",
+      item_list: [{ text_item: { text: '"msg_id":123' } }],
+    });
+  });
+});

--- a/src/providers/weixin_bot/runtime.ts
+++ b/src/providers/weixin_bot/runtime.ts
@@ -1,0 +1,238 @@
+import type { TransitFileWriter } from "../../core/types.ts";
+import type { ProviderActionHandlers } from "../provider-runtime.ts";
+
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import { looseArray, optionalInteger, optionalString } from "../../core/cast.ts";
+import {
+  ProviderRequestError,
+  providerResponseError,
+  requiredInputString,
+  requiredResponseRecord,
+  runProviderRequest,
+} from "../provider-runtime.ts";
+
+export interface WeixinBotContext {
+  botToken: string;
+  accountId: string;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+  transitFiles?: TransitFileWriter;
+}
+
+export interface WeixinRequestOptions {
+  context: WeixinBotContext;
+  path: string;
+  label: string;
+  body: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+type WeixinBotActionHandler = (
+  input: Record<string, unknown>,
+  context: WeixinBotContext,
+) => Promise<Record<string, unknown>>;
+
+const apiBaseUrl = "https://ilinkai.weixin.qq.com";
+const channelVersion = "1.0.0";
+const botAgent = "oomol-connect/0.1";
+const appClientVersion = "65536";
+
+export const weixinBotActionHandlers: ProviderActionHandlers<"weixin_bot", WeixinBotActionHandler> = {
+  async get_updates(input, context) {
+    const payload = await requestWeixin({
+      context,
+      path: "/ilink/bot/getupdates",
+      label: "Weixin get updates",
+      timeoutMs: 40_000,
+      body: {
+        get_updates_buf: optionalString(input.cursor) ?? "",
+        base_info: baseInfo(),
+      },
+    });
+
+    return {
+      messages: looseArray(payload.msgs).map((message) => requiredResponseRecord(message, "Weixin message")),
+      nextCursor: optionalString(payload.get_updates_buf) ?? null,
+      longPollingTimeoutMs: optionalInteger(payload.longpolling_timeout_ms) ?? null,
+    };
+  },
+
+  async send_message(input, context) {
+    const payload = await requestWeixin({
+      context,
+      path: "/ilink/bot/sendmessage",
+      label: "Weixin send message",
+      body: {
+        msg: {
+          from_user_id: "",
+          to_user_id: requiredInputString(input.toUserId, "toUserId"),
+          client_id: randomUUID(),
+          message_type: 2,
+          message_state: 2,
+          context_token: requiredInputString(input.contextToken, "contextToken"),
+          item_list: [{ type: 1, text_item: { text: requiredInputString(input.text, "text") } }],
+        },
+        base_info: baseInfo(),
+      },
+    });
+
+    return { messageId: optionalString(payload.message_id) ?? null };
+  },
+
+  async send_media(input, context) {
+    const { sendWeixinMedia } = await import("./runtime-media.ts");
+    return sendWeixinMedia(input, context, requestWeixin);
+  },
+
+  async download_media(input, context) {
+    const { downloadWeixinMedia } = await import("./runtime-media.ts");
+    return downloadWeixinMedia(input, context);
+  },
+
+  async send_typing(input, context) {
+    const userId = requiredInputString(input.userId, "userId");
+    const contextToken = requiredInputString(input.contextToken, "contextToken");
+    const status = readTypingStatus(input.status);
+    const config = await requestWeixin({
+      context,
+      path: "/ilink/bot/getconfig",
+      label: "Weixin get config",
+      body: {
+        ilink_user_id: userId,
+        context_token: contextToken,
+        base_info: baseInfo(),
+      },
+    });
+    const typingTicket = optionalString(config.typing_ticket);
+    if (!typingTicket) {
+      throw providerResponseError("Weixin get config response is missing typing_ticket");
+    }
+
+    await requestWeixin({
+      context,
+      path: "/ilink/bot/sendtyping",
+      label: "Weixin send typing",
+      body: {
+        ilink_user_id: userId,
+        typing_ticket: typingTicket,
+        status: status === "typing" ? 1 : 2,
+        base_info: baseInfo(),
+      },
+    });
+
+    return { status };
+  },
+};
+
+function baseInfo(): Record<string, string> {
+  return {
+    channel_version: channelVersion,
+    bot_agent: botAgent,
+  };
+}
+
+export async function requestWeixin(options: WeixinRequestOptions): Promise<Record<string, unknown>> {
+  return runProviderRequest(
+    { signal: options.context.signal, label: options.label, timeoutMs: options.timeoutMs },
+    async (signal) => {
+      const response = await options.context.fetcher(new URL(options.path, apiBaseUrl), {
+        method: "POST",
+        headers: authenticatedHeaders(options.context.botToken),
+        body: JSON.stringify(options.body),
+        signal,
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new ProviderRequestError(response.status, text || `${options.label} failed`);
+      }
+      const payload = requiredResponseRecord(parseWeixinJson(text), `${options.label} response`);
+      assertWeixinSuccess(payload, options.label);
+      return payload;
+    },
+  );
+}
+
+function authenticatedHeaders(botToken: string): Headers {
+  const headers = new Headers({
+    "content-type": "application/json",
+    AuthorizationType: "ilink_bot_token",
+    Authorization: `Bearer ${botToken}`,
+    "iLink-App-Id": "bot",
+    "iLink-App-ClientVersion": appClientVersion,
+  });
+  const randomValue = crypto.getRandomValues(new Uint32Array(1))[0]!;
+  headers.set("X-WECHAT-UIN", Buffer.from(String(randomValue), "utf8").toString("base64"));
+  return headers;
+}
+
+function assertWeixinSuccess(payload: Record<string, unknown>, label: string): void {
+  const ret = optionalInteger(payload.ret);
+  const errorCode = optionalInteger(payload.errcode);
+  const failureCode = ret && ret !== 0 ? ret : errorCode && errorCode !== 0 ? errorCode : undefined;
+  if (failureCode === undefined) return;
+
+  const message = optionalString(payload.errmsg) ?? `${label} failed with code ${failureCode}`;
+  if (failureCode === -14) {
+    throw new ProviderRequestError(401, `${message}. Run the QR login example again to reconnect.`);
+  }
+  throw new ProviderRequestError(502, message, payload);
+}
+
+function readTypingStatus(value: unknown): "typing" | "cancel" {
+  const status = requiredInputString(value, "status");
+  if (status === "typing" || status === "cancel") return status;
+  throw new ProviderRequestError(400, "status must be typing or cancel");
+}
+
+export function parseWeixinJson(text: string): unknown {
+  const losslessIds = new Set(["message_id", "msg_id", "svr_id"]);
+  let output = "";
+  let position = 0;
+
+  while (position < text.length) {
+    if (text[position] !== '"') {
+      output += text[position++];
+      continue;
+    }
+
+    const start = position++;
+    let escaped = false;
+    while (position < text.length) {
+      const character = text[position++];
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') break;
+    }
+    const token = text.slice(start, position);
+    output += token;
+
+    let cursor = position;
+    while (/\s/.test(text[cursor] ?? "")) cursor++;
+    if (text[cursor] !== ":") continue;
+
+    let key: unknown;
+    try {
+      key = JSON.parse(token);
+    } catch {
+      continue;
+    }
+    if (typeof key !== "string" || !losslessIds.has(key)) continue;
+
+    output += text.slice(position, cursor + 1);
+    cursor++;
+    while (/\s/.test(text[cursor] ?? "")) output += text[cursor++];
+    const numberStart = cursor;
+    if (text[cursor] === "-") cursor++;
+    while (/\d/.test(text[cursor] ?? "")) cursor++;
+    if (cursor === numberStart || (cursor === numberStart + 1 && text[numberStart] === "-")) {
+      position = numberStart;
+      continue;
+    }
+
+    output += `"${text.slice(numberStart, cursor)}"`;
+    position = cursor;
+  }
+
+  return JSON.parse(output);
+}


### PR DESCRIPTION
## Summary

- add the `weixin_bot` custom-credential provider for Tencent iLink Bot
- support text polling/replies, typing state, and encrypted image, video, voice, and file media
- add a local QR login example for obtaining `botToken` and `accountId`
- reload the local API process during development when source files change

## Validation

- `npm run fix-check`
- `npm test` (208 passed, 1 skipped; 2138 tests passed, 4 skipped)
- live end-to-end verification with a connected Weixin bot: text, typing/cancel, image, voice, video, and file send/receive paths

Closes #519