### PR TITLE
feat(googledrive): declare the read-only scopes its own read actions require

### DIFF
--- a/src/providers/googledrive/definition.test.ts
+++ b/src/providers/googledrive/definition.test.ts
@@ -1,12 +1,52 @@
 import { describe, expect, it } from "vitest";
+import { googledriveActions } from "./actions.ts";
 import { provider } from "./definition.ts";
+import {
+  googleDriveFullScope,
+  googleDriveMetadataReadonlyScope,
+  googleDriveReadonlyScope,
+  googledriveReadScopes,
+  googledriveWriteScopes,
+} from "./scopes.ts";
 
-const googleDriveFullScope = "https://www.googleapis.com/auth/drive";
+function declaredScopes(): string[] {
+  return provider.auth.find((auth) => auth.type === "oauth2")?.scopes ?? [];
+}
 
 describe("Google Drive provider definition", () => {
-  it("requests only the full Drive scope required by the write action catalog", () => {
-    const oauth = provider.auth.find((auth) => auth.type === "oauth2");
+  it("declares the write scope the write action catalog requires", () => {
+    expect(declaredScopes()).toContain(googleDriveFullScope);
+  });
 
-    expect(oauth?.scopes).toEqual([googleDriveFullScope]);
+  it("declares the read-only scopes its own read actions require", () => {
+    // `requestedScopes` may narrow the declared defaults but cannot add to
+    // them, so a scope a caller can never request is a scope no action can be
+    // authorized by. Twenty of this provider's actions declare exactly this
+    // pair and nothing else -- without it here, a read-only integration has to
+    // ask the user for full read-write-delete over their entire Drive.
+    expect(declaredScopes()).toEqual(expect.arrayContaining(googledriveReadScopes));
+  });
+
+  it("lets a read-only caller narrow to exactly what the read actions declare", () => {
+    const declared = new Set(declaredScopes());
+
+    expect(googledriveReadScopes.every((scope) => declared.has(scope))).toBe(true);
+  });
+
+  it("declares no scope that no action asks for", () => {
+    const asked = new Set(googledriveActions.flatMap((action) => action.requiredScopes ?? []));
+
+    for (const scope of declaredScopes()) {
+      expect(asked).toContain(scope);
+    }
+  });
+
+  it("keeps the read and write scope sets disjoint", () => {
+    // The two sets name the two halves of the catalog; an overlap would make
+    // `googledriveReadScopes` a way to request write access by another name.
+    const write = new Set(googledriveWriteScopes);
+
+    expect(googledriveReadScopes.some((scope) => write.has(scope))).toBe(false);
+    expect(googledriveReadScopes).toEqual([googleDriveReadonlyScope, googleDriveMetadataReadonlyScope]);
   });
 });

--- a/src/providers/googledrive/scopes.ts
+++ b/src/providers/googledrive/scopes.ts
@@ -2,4 +2,11 @@ export const googleDriveReadonlyScope = "https://www.googleapis.com/auth/drive.r
 export const googleDriveMetadataReadonlyScope = "https://www.googleapis.com/auth/drive.metadata.readonly";
 export const googleDriveFullScope = "https://www.googleapis.com/auth/drive";
 
-export const googledriveOAuthScopes: string[] = [googleDriveFullScope];
+export const googledriveReadScopes: string[] = [googleDriveReadonlyScope, googleDriveMetadataReadonlyScope];
+export const googledriveWriteScopes: string[] = [googleDriveFullScope];
+
+export const googledriveOAuthScopes: string[] = [
+  googleDriveReadonlyScope,
+  googleDriveMetadataReadonlyScope,
+  googleDriveFullScope,
+];


### PR DESCRIPTION
## The problem

`googledriveOAuthScopes` declares `[drive]` and nothing else, while **20 of this provider's 43 actions** declare `[drive.readonly, drive.metadata.readonly]` as their `requiredScopes`.

Since `requestedScopes` "may narrow the provider-declared defaults but cannot add scopes" (the OpenAPI description of that field), those two read-only scopes are unreachable: defined in `scopes.ts`, named by half the action catalog, and impossible for any caller to actually request.

The practical effect is that **a read-only Drive integration cannot be read-only**. `files.list`, `drives.list`, `permissions.list` and `files.export` all declare read-only, yet authorizing any of them makes the end user grant read, write and delete over every file in their Drive. That is what the Google consent screen shows, and it is a hard blocker for indexing/search use cases.

## The change

Adopt the shape the sibling Google providers already use. `googlesheets` declares:

```ts
export const googlesheetsOAuthScopes: string[] = [
  googleSheetsReadonlyScope, googleSheetsFullScope,
  googleDriveReadonlyScope, googleDriveFullScope,   // ← both, for these same Drive scopes
];
```

and splits them into named `ReadScopes` / `WriteScopes` sets; `googleslides` does the same. This applies that pattern to `googledrive`, which is currently the outlier among them.

**Nothing is removed.** `drive` stays declared, so the 23 write actions are unaffected. A caller that sends no `requestedScopes` now receives a superset of what it received before — and since `drive` already implies `drive.readonly`, the grant is not widened, only spelled out.

## Verification

Unit tests assert both directions: every declared scope is asked for by some action, the read pair is requestable, the read and write sets stay disjoint.

```
npx vitest run src/providers/ src/server/api    →  142 files, 1314 tests passed
```

`npm run fix-check` reports no new errors (the 12 `scripts/build-binary.ts` TS errors about missing `Bun` types are pre-existing and identical on an unmodified tree).

### End to end, against live Google

Run on a local gateway with a real Google OAuth client, `requestedScopes` set to the read-only pair:

```
PUT /api/oauth/configs/googledrive
  → requestedScopes:  [drive.readonly, drive.metadata.readonly]     accepted
  → effectiveScopes:  [drive.readonly, drive.metadata.readonly]     no full scope
```

That same call is rejected on `main`, which is the bug this fixes.

With a connection authorized under only those two scopes:

| action | result |
| --- | --- |
| `googledrive.files.list` | 200, rows |
| `googledrive.files.export` (`text/plain`) | 200, transit file created |
| transit `downloadUrl` fetched | 200, **22174 bytes**, `text/plain` |

The exported byte count is identical to what Google's own `files.export` returns for the same document when called directly with the same two scopes — so the read-only pair really does serve the read action catalog end to end.

Separately measured against Drive API v3 with the same two scopes: `files.export` returned real text for 5 of 5 Google Docs (none owned by the caller), `files.get?alt=media` returned complete bytes for 3 of 3 binary files, and the only failures anywhere were `403 insufficientFilePermissions` on `permissions.list` — per-file authorization, unrelated to scope, and identical under the full scope.

### The consent screen, as Google renders it

Confirmed by hand on the Google Account connections page after authorizing with this branch. The grant reads:

> **See and download all your Google Drive files** — see your files, download your files, see the names and email addresses of people you share files with
>
> **See info about your Google Drive files** — file titles and descriptions, names and email addresses of people files are shared with, how folders and files are organised

No "edit", "create", "delete" or "manage" anywhere, which is the whole point of the change. Under the current `[drive]` declaration the same screen reads "See, edit, create and delete all of your Google Drive files".

Note the third line of the first block: the ACL read (`permissions.list`) is authorized by `drive.readonly` alone — the `403 insufficientFilePermissions` responses really are per-file authorization, not a missing scope.

## Note for reviewers

With no `requestedScopes`, the default consent now lists three scopes instead of one. It is not a wider grant (`drive` ⊇ `drive.readonly`), but it is visibly different, and `googlesheets`/`googleslides` already accept that same trade-off.

The existing test asserted `toEqual([googleDriveFullScope])` with the rationale "requests only the full Drive scope required by the write action catalog". That rationale treats the array as the write actions' requirement, but the array is the menu of *requestable* scopes — which is why the narrowing feature is currently unusable for this provider. The test is replaced rather than deleted, and now asserts the property that actually matters.

