### PR TITLE
docs: add a read-only Browser Use V4 local HTTP example

### DIFF
--- a/examples/local-http/README.md
+++ b/examples/local-http/README.md
@@ -55,3 +55,40 @@ http://localhost:3000/oauth/callback
 
 Open the printed authorization URL in a browser, finish consent, then execute Gmail actions through
 the local API.
+
+## List Browser Use V4 Browsers
+
+List the first page of existing browser sessions through an already configured Browser Use
+connection. This example does not create, stop, or extend a browser, dispatch an agent task, or
+change stored credentials. An empty `items` array is a valid result.
+
+1. Configure a `browser_use` API-key connection in your local Web Console. Keep the Browser Use
+   key in OpenConnector; the script needs only an OpenConnector runtime token. See
+   [connection setup](../../docs/credentials.md#api-key-connections).
+2. Create a persistent runtime token in the Access tab with `allowedProxies: ["browser_use"]`.
+   If you restrict `allowedConnections`, grant the selected connection's stable ID, not its name.
+   The deployment and runtime proxy policies must also allow `browser_use`. See
+   [proxy access](../../docs/runtime-api.md#public-runtime-endpoints).
+3. Set `BROWSER_USE_CONNECTION_NAME` to that connection's name, or `default` to select the default
+   connection explicitly. Supply your runtime token in `OOMOL_CONNECT_RUNTIME_TOKEN`, then run:
+
+```bash
+BROWSER_USE_CONNECTION_NAME=work node examples/local-http/browser_use.ts
+```
+
+The script skips without both environment variables. It sends `POST /v1/proxy/browser_use` to the
+local runtime with an inner `GET /api/v4/browsers` request and `pageSize=10`, `pageNumber=1`.
+The explicit `/api/v4` prefix selects the V4 contract; the existing `browser_use.run_task` action
+still uses V3 and is not called. The response is inside OpenConnector's `data.data` envelope. Output
+shows pagination and each browser's ID/status, without connection or recording URLs.
+
+The script is read-only, but the token's provider proxy grant is not a read-only permission. It also
+allows other Browser Use proxy methods, including operations that can create paid resources.
+Action allowlists do not restrict proxy access. Keep the token private and grant it only to trusted
+clients. Configuring a new Browser Use connection validates the key with a read-only V3 billing
+request; that setup step is separate from this V4 example.
+
+Missing proxy grants return `403 proxy_not_allowed`; a denied connection returns
+`403 connection_not_allowed`. A nonexistent named connection does not fall back to the default.
+The script reports non-success responses and exits nonzero. See the
+[Browser Use V4 schema](https://docs.browser-use.com/openapi/v4.json) for the list response and filters.

--- a/examples/local-http/browser_use.ts
+++ b/examples/local-http/browser_use.ts
@@ -1,0 +1,46 @@
+// Browser Use V4 API: https://docs.browser-use.com/openapi/v4.json
+// Read-only: list existing browsers through a previously configured connection.
+
+import { fetchJson, runtimeHeaders } from "./client.ts";
+
+interface BrowserListEnvelope {
+  data: {
+    data: {
+      items: { id: string; status: string }[];
+      totalItems: number;
+      pageNumber: number;
+      pageSize: number;
+    };
+  };
+}
+
+const connectionName = process.env.BROWSER_USE_CONNECTION_NAME;
+if (!process.env.OOMOL_CONNECT_RUNTIME_TOKEN || !connectionName) {
+  console.log("Set OOMOL_CONNECT_RUNTIME_TOKEN and BROWSER_USE_CONNECTION_NAME (or default) to run this example.");
+  process.exit(0);
+}
+
+const result = await fetchJson<BrowserListEnvelope>("http://localhost:3000/v1/proxy/browser_use", {
+  method: "POST",
+  headers: runtimeHeaders({ "content-type": "application/json", "x-oo-connector-alias": connectionName }),
+  body: JSON.stringify({
+    endpoint: "/api/v4/browsers",
+    method: "GET",
+    query: { pageSize: 10, pageNumber: 1 },
+  }),
+});
+
+// OpenConnector's envelope wraps the provider response in data.data.
+const page = result.data.data;
+console.log(
+  JSON.stringify(
+    {
+      items: page.items.map(({ id, status }) => ({ id, status })),
+      totalItems: page.totalItems,
+      pageNumber: page.pageNumber,
+      pageSize: page.pageSize,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
Add a runnable local HTTP example that lists the first page of existing Browser Use browsers through a previously configured connection. It sends an explicit GET /api/v4/browsers inside OpenConnector's provider-proxy request, then prints only browser IDs, statuses, and pagination.

The script requires an OpenConnector runtime token and an explicit connection name, skips when either is missing, and reuses the existing HTTP client. It does not configure credentials, create or stop browsers, dispatch agent tasks, or change the provider. The V4 routing from PR #434 and existing V3 curated actions remain unchanged.

The README explains setup, proxy and connection grants, the nested response envelope, empty results, and errors. Security note: This script is read-only, but allowedProxies grants access to the whole Browser Use provider proxy, including write methods that can create paid resources. Action allowlists do not restrict proxies. The example uses only a runtime token; the Browser Use key stays in OpenConnector.

Locally verified the exact script through createConnectApp, Hono routing, in-memory SQLite, real connection validation, stored-token verification, and the actual Browser Use provider, with all upstream responses supplied in memory. Named/default connection selection, denied grants, missing connections, empty results, and provider errors passed. npm run fix-check and npm test also pass. No deployed server, real credential, Cloud browser, or model task was used.

Disclosure: I work on Browser Use. Public API schema: https://docs.browser-use.com/openapi/v4.json and source: https://github.com/browser-use/browser-use