### PR TITLE
feat(homebox): add self-hosted HomeBox provider

### DIFF
--- a/examples/homebox-live-check.ts
+++ b/examples/homebox-live-check.ts
@@ -1,0 +1,134 @@
+/**
+ * Live verification of the HomeBox provider against a real instance.
+ *
+ * Read-only by default; the only mutating check creates and deletes a
+ * marker-prefixed entity type, so repeated runs stay clean.
+ *
+ * Create a static API key in the HomeBox web interface (Users -> API Keys),
+ * then run:
+ *
+ *   HOMEBOX_BASE_URL=http://homebox.local \
+ *   HOMEBOX_API_KEY='...' \
+ *   node examples/homebox-live-check.ts
+ */
+import { setPrivateNetworkAccessAllowed } from "../src/core/request.ts";
+import { homeBoxActionHandlers } from "../src/providers/homebox/runtime.ts";
+import { createProviderFetch, ProviderRequestError } from "../src/providers/provider-runtime.ts";
+
+const baseUrl = process.env.HOMEBOX_BASE_URL?.trim();
+const apiKey = process.env.HOMEBOX_API_KEY?.trim();
+
+const fetcher = createProviderFetch({ allowPrivateNetwork: () => true });
+// A HomeBox instance is commonly reachable only on the local network. In
+// production the server bootstrap enables this flag from
+// OOMOL_CONNECT_ALLOW_PRIVATE_NETWORK; a standalone example has no bootstrap,
+// so it opts in explicitly.
+setPrivateNetworkAccessAllowed(true);
+
+const context = {
+  apiKey: apiKey ?? "",
+  baseUrl: baseUrl ?? "http://homebox.local",
+  fetcher,
+};
+
+const E2E_MARKER = "connector-e2e";
+const createdEntityTypeName = `${E2E_MARKER}-type`;
+
+let failures = 0;
+let createdEntityTypeId: string | null = null;
+
+function check(label: string, condition: boolean, detail: string): void {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures += 1;
+    console.error(`  ✗ ${label}: ${detail}`);
+  }
+}
+
+async function step(label: string, fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    failures += 1;
+    console.error(`  ✗ ${label}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  if (!baseUrl || !apiKey) {
+    console.log("Skip HomeBox live check: set HOMEBOX_BASE_URL and HOMEBOX_API_KEY.");
+    return;
+  }
+
+  console.log(`[homebox] live check against ${baseUrl}`);
+
+  await step("status", async () => {
+    const result = (await homeBoxActionHandlers.get_status?.({}, context)) as { summary: { health?: boolean } };
+    check("status is healthy", result.summary.health === true, "health flag is not true");
+  });
+
+  await step("list entity types", async () => {
+    const result = (await homeBoxActionHandlers.list_entity_types?.({}, context)) as { entityTypes: unknown[] };
+    check("entity type list responds", Array.isArray(result.entityTypes), "no entityTypes array");
+  });
+
+  await step("list tags", async () => {
+    const result = (await homeBoxActionHandlers.list_tags?.({}, context)) as { tags: unknown[] };
+    check("tag list responds", Array.isArray(result.tags), "no tags array");
+  });
+
+  await step("search entities", async () => {
+    const result = (await homeBoxActionHandlers.list_entities?.({}, context)) as { total: number; items: unknown[] };
+    check("entity search responds", typeof result.total === "number", "no total");
+  });
+
+  await step("custom field names", async () => {
+    const result = (await homeBoxActionHandlers.list_custom_field_names?.({}, context)) as { names: string[] };
+    check("field names respond", Array.isArray(result.names), "no names array");
+  });
+
+  if (!failures) {
+    await step("create marker entity type", async () => {
+      const result = (await homeBoxActionHandlers.create_entity_type?.({ name: createdEntityTypeName }, context)) as {
+        entityType: { id: string };
+      };
+      createdEntityTypeId = result.entityType.id;
+      check(
+        "entity type created",
+        typeof createdEntityTypeId === "string" && createdEntityTypeId.length > 0,
+        "no entity type id",
+      );
+    });
+
+    await step("delete marker entity type", async () => {
+      if (createdEntityTypeId) {
+        const result = (await homeBoxActionHandlers.delete_entity_type?.(
+          { entityTypeId: createdEntityTypeId },
+          context,
+        )) as { deleted: boolean };
+        check("entity type deleted", result.deleted === true, "deleted flag is not true");
+      }
+    });
+  }
+
+  if (failures > 0) {
+    console.error(`[homebox] live check failed: ${failures} check(s) failed.`);
+    if (createdEntityTypeId) {
+      console.error(`[homebox] leaving ${createdEntityTypeName} (${createdEntityTypeId}) for inspection.`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log("[homebox] live check passed.");
+  }
+}
+
+// Surface clean provider errors without a stack trace.
+void main().catch((error: unknown) => {
+  if (error instanceof ProviderRequestError) {
+    console.error(`[homebox] live check failed: ${error.message}`);
+    process.exitCode = 1;
+  } else {
+    throw error;
+  }
+});

--- a/src/providers/homebox/actions.ts
+++ b/src/providers/homebox/actions.ts
@@ -26,16 +26,29 @@ const maintenanceStatusSchema = s.stringEnum("Which maintenance entries to inclu
   "both",
 ]);
 
-const customFieldSchema = s.looseRequiredObject(
-  "One custom field attached to the entity. Exactly one of textValue, numberValue, or booleanValue should be set, matching the type.",
-  {
-    name: s.nonEmptyString("The field name, for example Color or Serial."),
-    type: s.stringEnum("The field value type.", ["text", "number", "boolean", "time"]),
-    textValue: s.string("The text value; used when type is text."),
-    numberValue: s.integer("The numeric value; used when type is number."),
-    booleanValue: s.boolean("The boolean value; used when type is boolean."),
-  },
-  { optional: ["textValue", "numberValue", "booleanValue"] },
+const customFieldSchema = s.anyOf(
+  "One custom field attached to the entity. The value property must match the declared type.",
+  [
+    s.requiredObject("A text custom field.", {
+      name: s.nonEmptyString("The field name, for example Color or Serial."),
+      type: s.stringEnum("The field type.", ["text"]),
+      textValue: s.string("The text value."),
+    }),
+    s.requiredObject("A numeric custom field.", {
+      name: s.nonEmptyString("The field name, for example Color or Serial."),
+      type: s.stringEnum("The field type.", ["number"]),
+      numberValue: s.integer("The numeric value."),
+    }),
+    s.requiredObject("A boolean custom field.", {
+      name: s.nonEmptyString("The field name, for example Color or Serial."),
+      type: s.stringEnum("The field type.", ["boolean"]),
+      booleanValue: s.boolean("The boolean value."),
+    }),
+    s.requiredObject("A time custom field. HomeBox stores the timestamp server-side, so no value property is sent.", {
+      name: s.nonEmptyString("The field name, for example Color or Serial."),
+      type: s.stringEnum("The field type.", ["time"]),
+    }),
+  ],
 );
 
 const dateSchema = s.string("A date in YYYY-MM-DD format.", { pattern: "^\\d{4}-\\d{2}-\\d{2}$" });
@@ -114,7 +127,7 @@ export const homeBoxActions: ActionDefinition[] = [
         quantity: s.integer("The quantity."),
         insured: s.boolean("Whether the entity is insured."),
         archived: s.boolean("Whether the entity is archived."),
-        entityTypeId: s.nullableString("The entity type UUID, or null to unset it."),
+        entityTypeId: s.string("The entity type UUID; when omitted the current type is kept."),
         tagIds: s.array("The tag UUIDs.", s.string("One tag UUID.")),
         parentId: s.nullableString("The parent entity UUID, or null to unset it."),
         serialNumber: s.string("The serial number."),

--- a/src/providers/homebox/actions.ts
+++ b/src/providers/homebox/actions.ts
@@ -1,0 +1,311 @@
+import type { ActionDefinition } from "../../core/types.ts";
+
+import { s } from "../../core/json-schema.ts";
+import { defineProviderAction } from "../../core/provider-definition.ts";
+
+const service = "homebox";
+
+const emptyInputSchema = s.actionInput({}, [], "No input is required for this action.");
+
+const entityIdInput = { entityId: s.nonEmptyString("The entity UUID returned by HomeBox.") };
+
+const entityOutput = s.unknownObject("The entity as returned by HomeBox.");
+
+const attachmentTypeSchema = s.stringEnum("The attachment type.", [
+  "photo",
+  "manual",
+  "warranty",
+  "attachment",
+  "receipt",
+  "thumbnail",
+]);
+
+const maintenanceStatusSchema = s.stringEnum("Which maintenance entries to include.", [
+  "scheduled",
+  "completed",
+  "both",
+]);
+
+const customFieldSchema = s.looseRequiredObject(
+  "One custom field attached to the entity. Exactly one of textValue, numberValue, or booleanValue should be set, matching the type.",
+  {
+    name: s.nonEmptyString("The field name, for example Color or Serial."),
+    type: s.stringEnum("The field value type.", ["text", "number", "boolean", "time"]),
+    textValue: s.string("The text value; used when type is text."),
+    numberValue: s.integer("The numeric value; used when type is number."),
+    booleanValue: s.boolean("The boolean value; used when type is boolean."),
+  },
+  { optional: ["textValue", "numberValue", "booleanValue"] },
+);
+
+const dateSchema = s.string("A date in YYYY-MM-DD format.", { pattern: "^\\d{4}-\\d{2}-\\d{2}$" });
+
+export const homeBoxActions: ActionDefinition[] = [
+  defineProviderAction(service, {
+    name: "get_status",
+    description: "Fetch the HomeBox instance status: health, version, and whether registration is open.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { summary: s.unknownObject("The HomeBox status payload returned by the instance.") },
+      "The HomeBox instance status.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_entities",
+    description: "Search HomeBox entities with optional text search, pagination, and tag/parent filters.",
+    inputSchema: s.actionInput(
+      {
+        q: s.string("Free-text search string."),
+        page: s.integer("Page number, starting at 1."),
+        pageSize: s.integer("Maximum number of entities per page."),
+        tagIds: s.array("Only entities carrying any of these tag UUIDs.", s.string("One tag UUID.")),
+        parentIds: s.array(
+          "Only entities under any of these parent entity UUIDs.",
+          s.string("One parent entity UUID."),
+        ),
+      },
+      [],
+      "Input parameters for searching HomeBox entities.",
+    ),
+    outputSchema: s.actionOutput(
+      {
+        items: s.array("The matching entity summaries.", s.looseObject("One HomeBox entity summary.")),
+        page: s.integer("The current page number."),
+        pageSize: s.integer("The page size used by the instance."),
+        total: s.integer("The total number of matching entities."),
+      },
+      "The matching HomeBox entities.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "get_entity",
+    description: "Fetch one HomeBox entity with its full details, including attachments and custom fields.",
+    inputSchema: s.actionInput(entityIdInput, ["entityId"], "Input parameters for fetching one entity."),
+    outputSchema: s.actionOutput({ entity: entityOutput }, "The requested HomeBox entity."),
+  }),
+  defineProviderAction(service, {
+    name: "create_entity",
+    description: "Create a new HomeBox entity with a name and optional type, parent, description, and tags.",
+    inputSchema: s.actionInput(
+      {
+        name: s.nonEmptyString("The entity name."),
+        entityTypeId: s.string(
+          "The UUID of the entity type the entity belongs to. HomeBox entities are typed, so pass one or the create request may fail.",
+        ),
+        parentId: s.string("The UUID of a parent entity, for nested entities."),
+        description: s.string("An optional description."),
+        quantity: s.integer("The quantity."),
+        tagIds: s.array("The UUIDs of tags to attach.", s.string("One tag UUID.")),
+      },
+      ["name"],
+      "Input parameters for creating one HomeBox entity.",
+    ),
+    outputSchema: s.actionOutput({ entity: entityOutput }, "The created HomeBox entity."),
+  }),
+  defineProviderAction(service, {
+    name: "update_entity",
+    description:
+      "Update one HomeBox entity. Only the provided fields change; all other entity data (serial number, warranty, custom fields, ...) is preserved. Custom fields are replaced as a whole when fields is provided.",
+    inputSchema: s.actionInput(
+      {
+        entityId: s.nonEmptyString("The entity UUID to update."),
+        name: s.nonEmptyString("The entity name."),
+        description: s.nullableString("The entity description; pass null to clear it."),
+        quantity: s.integer("The quantity."),
+        insured: s.boolean("Whether the entity is insured."),
+        archived: s.boolean("Whether the entity is archived."),
+        entityTypeId: s.nullableString("The entity type UUID, or null to unset it."),
+        tagIds: s.array("The tag UUIDs.", s.string("One tag UUID.")),
+        parentId: s.nullableString("The parent entity UUID, or null to unset it."),
+        serialNumber: s.string("The serial number."),
+        modelNumber: s.string("The model number."),
+        manufacturer: s.string("The manufacturer."),
+        lifetimeWarranty: s.boolean("Whether the entity has a lifetime warranty."),
+        warrantyExpires: dateSchema,
+        warrantyDetails: s.string("Warranty details."),
+        purchaseDate: dateSchema,
+        purchaseFrom: s.string("Where the entity was purchased."),
+        purchasePrice: s.number("The purchase price."),
+        soldDate: dateSchema,
+        soldTo: s.string("Who the entity was sold to."),
+        soldPrice: s.number("The sale price."),
+        soldNotes: s.string("Notes about the sale."),
+        notes: s.string("Free-form entity notes."),
+        syncChildEntityLocations: s.boolean("Recursively apply type changes to child entities."),
+        fields: s.array("The custom fields to set; replaces all existing fields.", customFieldSchema),
+      },
+      ["entityId"],
+      "Input parameters for updating one HomeBox entity.",
+    ),
+    outputSchema: s.actionOutput({ entity: entityOutput }, "The updated HomeBox entity."),
+  }),
+  defineProviderAction(service, {
+    name: "delete_entity",
+    description: "Delete one HomeBox entity.",
+    inputSchema: s.actionInput(entityIdInput, ["entityId"], "Input parameters for deleting one entity."),
+    outputSchema: s.actionOutput({ deleted: s.boolean("Whether the entity was deleted.") }, "The deletion result."),
+  }),
+  defineProviderAction(service, {
+    name: "list_entity_types",
+    description: "List all HomeBox entity types, including location-flagged types.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      {
+        entityTypes: s.array("The entity types.", s.looseObject("One HomeBox entity type.")),
+      },
+      "The HomeBox entity types.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_entity_type",
+    description: "Create a new HomeBox entity type, optionally flagged as a location.",
+    inputSchema: s.actionInput(
+      {
+        name: s.nonEmptyString("The entity type name."),
+        description: s.string("An optional description."),
+        icon: s.string("An icon identifier for the type."),
+        isLocation: s.boolean("Whether this type represents a location."),
+      },
+      ["name"],
+      "Input parameters for creating one HomeBox entity type.",
+    ),
+    outputSchema: s.actionOutput(
+      { entityType: s.looseObject("The created HomeBox entity type.") },
+      "The created HomeBox entity type.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "delete_entity_type",
+    description: "Delete one HomeBox entity type.",
+    inputSchema: s.actionInput(
+      { entityTypeId: s.nonEmptyString("The entity type UUID to delete.") },
+      ["entityTypeId"],
+      "Input parameters for deleting one HomeBox entity type.",
+    ),
+    outputSchema: s.actionOutput(
+      { deleted: s.boolean("Whether the entity type was deleted.") },
+      "The deletion result.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_tags",
+    description: "List all HomeBox tags.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { tags: s.array("The tags.", s.looseObject("One HomeBox tag.")) },
+      "The HomeBox tags.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "create_tag",
+    description: "Create a new HomeBox tag.",
+    inputSchema: s.actionInput(
+      {
+        name: s.nonEmptyString("The tag name."),
+        description: s.string("An optional description."),
+        color: s.string("A tag color, for example #ff0000."),
+        icon: s.string("An icon identifier for the tag."),
+        parentId: s.string("The UUID of a parent tag, for nested tags."),
+      },
+      ["name"],
+      "Input parameters for creating one HomeBox tag.",
+    ),
+    outputSchema: s.actionOutput({ tag: s.looseObject("The created HomeBox tag.") }, "The created HomeBox tag."),
+  }),
+  defineProviderAction(service, {
+    name: "delete_tag",
+    description: "Delete one HomeBox tag.",
+    inputSchema: s.actionInput(
+      { tagId: s.nonEmptyString("The tag UUID to delete.") },
+      ["tagId"],
+      "Input parameters for deleting one HomeBox tag.",
+    ),
+    outputSchema: s.actionOutput({ deleted: s.boolean("Whether the tag was deleted.") }, "The deletion result."),
+  }),
+  defineProviderAction(service, {
+    name: "get_group_statistics",
+    description:
+      "Fetch the HomeBox group dashboard statistics: total entities, locations, tags, price, and warranties.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { statistics: s.unknownObject("The HomeBox group statistics payload.") },
+      "The HomeBox group statistics.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "add_entity_attachment",
+    description:
+      "Attach a file (photo or document) to one HomeBox entity. The file type is detected from the extension when omitted.",
+    inputSchema: s.actionInput(
+      {
+        entityId: s.nonEmptyString("The entity UUID to attach the file to."),
+        file: s.transitFile("The file to attach."),
+        type: attachmentTypeSchema,
+        name: s.string("Override the stored file name, including the extension."),
+        primary: s.boolean("Mark this photo as the entity's primary image."),
+      },
+      ["entityId", "file"],
+      "Input parameters for attaching one file to an entity.",
+    ),
+    outputSchema: s.actionOutput({ entity: entityOutput }, "The HomeBox entity with the new attachment."),
+  }),
+  defineProviderAction(service, {
+    name: "get_maintenance_log",
+    description: "Fetch the maintenance log of one HomeBox entity, optionally filtered by status.",
+    inputSchema: s.actionInput(
+      {
+        entityId: s.nonEmptyString("The entity UUID."),
+        status: maintenanceStatusSchema,
+      },
+      ["entityId"],
+      "Input parameters for fetching one maintenance log.",
+    ),
+    outputSchema: s.actionOutput(
+      { entries: s.array("The maintenance entries.", s.looseObject("One maintenance entry.")) },
+      "The HomeBox maintenance log.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "add_maintenance_entry",
+    description:
+      "Add a maintenance entry (repair, inspection, scheduled service) to one HomeBox entity. Provide completedDate, scheduledDate, or both.",
+    inputSchema: s.actionInput(
+      {
+        entityId: s.nonEmptyString("The entity UUID."),
+        name: s.nonEmptyString("The maintenance entry name, for example Air filter replacement."),
+        completedDate: dateSchema,
+        scheduledDate: dateSchema,
+        description: s.string("An optional description of the maintenance work."),
+        cost: s.string("The maintenance cost as a number string, for example 1500."),
+      },
+      ["entityId", "name"],
+      "Input parameters for adding one maintenance entry.",
+    ),
+    outputSchema: s.actionOutput(
+      { entry: s.looseObject("The created maintenance entry.") },
+      "The created HomeBox maintenance entry.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_custom_field_names",
+    description: "List the custom field names in use across the HomeBox group.",
+    inputSchema: emptyInputSchema,
+    outputSchema: s.actionOutput(
+      { names: s.array("The custom field names.", s.string("One custom field name.")) },
+      "The HomeBox custom field names.",
+    ),
+  }),
+  defineProviderAction(service, {
+    name: "list_custom_field_values",
+    description: "List the values in use for one custom field name across the HomeBox group.",
+    inputSchema: s.actionInput(
+      { field: s.nonEmptyString("The custom field name, for example Color.") },
+      ["field"],
+      "Input parameters for listing one custom field's values.",
+    ),
+    outputSchema: s.actionOutput(
+      { values: s.array("The custom field values.", s.string("One custom field value.")) },
+      "The HomeBox custom field values.",
+    ),
+  }),
+];

--- a/src/providers/homebox/definition.ts
+++ b/src/providers/homebox/definition.ts
@@ -1,0 +1,46 @@
+import type { ProviderDefinition } from "../../core/types.ts";
+
+import { homeBoxActions } from "./actions.ts";
+
+const service = "homebox";
+
+/**
+ * HomeBox provider backed by a user-configured HomeBox instance.
+ *
+ * Authenticates with a static API key issued by the HomeBox web interface
+ * (Users -> API Keys). The key carries the same permissions as the issuing
+ * account, so the provider acts as that account, including its group scope:
+ * everything created through the provider is visible to the account that
+ * issued the key and its group members.
+ */
+export const provider: ProviderDefinition = {
+  service,
+  displayName: "HomeBox",
+  description:
+    "Home inventory and organization (entities, tags, entity types, maintenance, attachments) on a self-hosted HomeBox instance.",
+  categories: ["Productivity", "Data"],
+  authTypes: ["api_key"],
+  auth: [
+    {
+      type: "api_key",
+      label: "API Key",
+      placeholder: "HOMEBOX_API_KEY",
+      description:
+        "A static API key issued from the HomeBox web interface under Users -> API Keys. The key has the same permissions as the issuing account, so the provider acts as that account and shares its group collection.",
+      extraFields: [
+        {
+          key: "baseUrl",
+          label: "Instance Base URL",
+          inputType: "text",
+          required: true,
+          secret: false,
+          placeholder: "http://homebox.local:7745",
+          description:
+            "The root URL for your HomeBox instance. The API is served below it at /api/v1, so http://homebox.local or http://homebox.local/api both work.",
+        },
+      ],
+    },
+  ],
+  homepageUrl: "https://homebox.software",
+  actions: homeBoxActions,
+};

--- a/src/providers/homebox/executors.test.ts
+++ b/src/providers/homebox/executors.test.ts
@@ -118,6 +118,40 @@ describe("homebox provider", () => {
     expect(result.error.message).toContain("Configure homebox API key credentials first.");
   });
 
+  it("uses PATCH for patchable-only updates and skips the get-merge-PUT round trip", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+
+    const requests: CapturedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+        const headers = new Headers(init?.headers);
+        requests.push({
+          url: url.toString(),
+          method: init?.method ?? "GET",
+          headers,
+          body: init?.body ? String(init?.body) : undefined,
+        });
+        if (url.pathname === "/api/v1/entities/entity-1" && init?.method === "PATCH") {
+          return Response.json({ id: "entity-1", quantity: 5 });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const result = await executors["homebox.update_entity"]!({ entityId: "entity-1", quantity: 5 }, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected patch success, got: ${result.error?.message}`);
+    }
+
+    expect(requests).toHaveLength(1);
+    const patchCall = requests[0]!;
+    expect(patchCall.method).toBe("PATCH");
+    expect(JSON.parse(patchCall.body ?? "{}")).toEqual({ quantity: 5 });
+  });
+
   it("merges update_entity on top of the current entity and preserves assetId and custom fields", async () => {
     setPrivateNetworkAccessAllowed(true);
     setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
@@ -159,7 +193,10 @@ describe("homebox provider", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await executors["homebox.update_entity"]!({ entityId: "entity-1", quantity: 5 }, executionContext());
+    const result = await executors["homebox.update_entity"]!(
+      { entityId: "entity-1", quantity: 5, serialNumber: "SN-2" },
+      executionContext(),
+    );
     if (!result.ok) {
       throw new Error(`expected update success, got: ${result.error?.message}`);
     }
@@ -167,8 +204,8 @@ describe("homebox provider", () => {
     const putCall = requests.find((request) => request.method === "PUT")!;
     const body = JSON.parse(putCall.body ?? "{}") as Record<string, unknown>;
     expect(body.quantity).toBe(5);
+    expect(body.serialNumber).toBe("SN-2");
     expect(body.assetId).toBe("003-042");
-    expect(body.serialNumber).toBe("SN-1");
     expect(body.manufacturer).toBe("Lenovo");
     expect(body.purchasePrice).toBe(1200);
     expect(body.entityTypeId).toBe("type-1");
@@ -202,6 +239,37 @@ describe("homebox provider", () => {
     const url = new URL(entitiesCall.url);
     expect(url.searchParams.get("q")).toBe("laptop");
     expect(url.searchParams.getAll("tags")).toEqual(["a", "b"]);
+  });
+
+  it("times out while reading a stalled response body", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              signal?.addEventListener("abort", () => controller.error(signal.reason ?? new Error("aborted")), {
+                once: true,
+              });
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+
+    const context: ExecutionContext = {
+      getCredential: async () => apiKeyCredential(),
+      signal: AbortSignal.timeout(80),
+    };
+    const result = await executors["homebox.list_entities"]!({}, context);
+    if (result.ok) {
+      throw new Error("expected the stalled body to time out");
+    }
+    expect(result.error?.message).toContain("HomeBox request timed out");
   });
 
   it("allows a maintenance entry without dates (name is the only required field)", async () => {

--- a/src/providers/homebox/executors.test.ts
+++ b/src/providers/homebox/executors.test.ts
@@ -1,0 +1,281 @@
+import type { ExecutionContext, ResolvedCredential } from "../../core/types.ts";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultGuardedFetchDnsLookup } from "../../core/guarded-fetch.ts";
+import { setPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import { executors, proxy } from "./executors.ts";
+
+// Arbitrary RFC1918 literal: the tests only exercise the private-network opt-in,
+// and every fetch and DNS lookup is stubbed, so this never touches a real host.
+const lanInstanceUrl = "http://192.168.150.53:7745";
+const apiKey = "hb_static_test_key";
+
+function apiKeyCredential(): Extract<ResolvedCredential, { authType: "api_key" }> {
+  return {
+    authType: "api_key",
+    apiKey,
+    values: { baseUrl: lanInstanceUrl },
+    profile: { accountId: "homebox:test", displayName: "HomeBox test", grantedScopes: [] },
+    metadata: {},
+  };
+}
+
+function executionContext(): ExecutionContext {
+  const credential = apiKeyCredential();
+  return { getCredential: async () => credential };
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: string;
+}
+
+describe("homebox provider", () => {
+  afterEach(() => {
+    setDefaultGuardedFetchDnsLookup(null);
+    setPrivateNetworkAccessAllowed(false);
+    vi.unstubAllGlobals();
+  });
+
+  it("proxies a request with the static API key as a bearer token", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async (hostname) => [
+      { address: hostname === "192.168.150.53" ? "192.168.150.53" : "93.184.216.34", family: 4 },
+    ]);
+
+    const requests: CapturedRequest[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+      const headers = new Headers(init?.headers);
+      requests.push({ url: url.toString(), method: init?.method ?? "GET", headers });
+      if (url.pathname === "/api/v1/entities") {
+        return Response.json({ page: 1, pageSize: 10, total: 1, items: [{ id: "entity-1", name: "Laptop" }] });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await proxy({ method: "GET", endpoint: "/entities" }, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected proxy success, got: ${result.error.message}`);
+    }
+    expect(result.response.status).toBe(200);
+
+    const entitiesCall = requests.find((request) => request.url.endsWith("/api/v1/entities"))!;
+    expect(entitiesCall.url).toBe(`${lanInstanceUrl}/api/v1/entities`);
+    expect(entitiesCall.headers.get("authorization")).toBe(`Bearer ${apiKey}`);
+  });
+
+  it("maps a rejected API key to an authorization error without retrying", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+
+    let entityCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL) => {
+        entityCalls += 1;
+        return new Response(JSON.stringify({ error: "valid authorization token is required" }), { status: 401 });
+      }),
+    );
+
+    const result = await executors["homebox.list_entities"]!({}, executionContext());
+    if (result.ok) {
+      throw new Error("expected the API key to be rejected");
+    }
+    expect(result.error?.code).toBe("authorization_failed");
+    expect(entityCalls).toBe(1);
+  });
+
+  it("rejects a LAN instance without the private-network opt-in", async () => {
+    setDefaultGuardedFetchDnsLookup(async (hostname) => [
+      { address: hostname === "192.168.150.53" ? "192.168.150.53" : "93.184.216.34", family: 4 },
+    ]);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await proxy({ method: "GET", endpoint: "/entities" }, executionContext());
+
+    if (result.ok) {
+      throw new Error("expected proxy to reject the LAN base URL");
+    }
+    expect(result.error.message).toContain("private or reserved IP addresses");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports missing credentials as an explicit 401", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal("fetch", vi.fn());
+
+    const result = await proxy({ method: "GET", endpoint: "/entities" }, { getCredential: async () => undefined });
+
+    if (result.ok) {
+      throw new Error("expected proxy to reject missing credentials");
+    }
+    expect(result.error.message).toContain("Configure homebox API key credentials first.");
+  });
+
+  it("merges update_entity on top of the current entity and preserves assetId and custom fields", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+
+    const requests: CapturedRequest[] = [];
+    const entity = {
+      id: "entity-1",
+      name: "Laptop",
+      description: "ThinkPad",
+      quantity: 1,
+      insured: false,
+      archived: false,
+      assetId: "003-042",
+      serialNumber: "SN-1",
+      modelNumber: "X1",
+      manufacturer: "Lenovo",
+      purchasePrice: 1200,
+      entityType: { id: "type-1", name: "Electronics" },
+      parent: { id: "parent-1", name: "Desk" },
+      tags: [{ id: "tag-1", name: "Computers" }],
+      fields: [{ id: "field-1", type: "text", name: "Color", textValue: "black", numberValue: 0, booleanValue: false }],
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: url.toString(),
+        method: init?.method ?? "GET",
+        headers,
+        body: init?.body ? String(init?.body) : undefined,
+      });
+      if (url.pathname === "/api/v1/entities/entity-1" && (init?.method ?? "GET") === "GET") {
+        return Response.json(entity);
+      }
+      if (url.pathname === "/api/v1/entities/entity-1" && init?.method === "PUT") {
+        return Response.json({ ...entity, quantity: 5 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await executors["homebox.update_entity"]!({ entityId: "entity-1", quantity: 5 }, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected update success, got: ${result.error?.message}`);
+    }
+
+    const putCall = requests.find((request) => request.method === "PUT")!;
+    const body = JSON.parse(putCall.body ?? "{}") as Record<string, unknown>;
+    expect(body.quantity).toBe(5);
+    expect(body.assetId).toBe("003-042");
+    expect(body.serialNumber).toBe("SN-1");
+    expect(body.manufacturer).toBe("Lenovo");
+    expect(body.purchasePrice).toBe(1200);
+    expect(body.entityTypeId).toBe("type-1");
+    expect(body.parentId).toBe("parent-1");
+    expect(body.tagIds).toEqual(["tag-1"]);
+    expect(body.fields).toEqual(entity.fields);
+  });
+
+  it("encodes list_entities filter parameters as repeated multi-value query params", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    const requests: CapturedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+        requests.push({ url: url.toString(), method: init?.method ?? "GET", headers: new Headers(init?.headers) });
+        if (url.pathname === "/api/v1/entities") {
+          return Response.json({ page: 1, pageSize: 10, total: 0, items: [] });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const result = await executors["homebox.list_entities"]!({ q: "laptop", tagIds: ["a", "b"] }, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected list success, got: ${result.error?.message}`);
+    }
+
+    const entitiesCall = requests.find((request) => new URL(request.url).pathname === "/api/v1/entities")!;
+    const url = new URL(entitiesCall.url);
+    expect(url.searchParams.get("q")).toBe("laptop");
+    expect(url.searchParams.getAll("tags")).toEqual(["a", "b"]);
+  });
+
+  it("allows a maintenance entry without dates (name is the only required field)", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+        if (url.pathname === "/api/v1/entities/entity-1/maintenance" && init?.method === "POST") {
+          return Response.json({ id: "entry-1", name: "Oil change" });
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const result = await executors["homebox.add_maintenance_entry"]!(
+      { entityId: "entity-1", name: "Oil change" },
+      executionContext(),
+    );
+    if (!result.ok) {
+      throw new Error(`expected maintenance creation to succeed, got: ${result.error?.message}`);
+    }
+    expect(result.output).toEqual({ entry: { id: "entry-1", name: "Oil change" } });
+  });
+
+  it("reads the custom field names plain array response", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+        if (url.pathname === "/api/v1/entities/fields") {
+          return Response.json(["Color", "Serial"]);
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const result = await executors["homebox.list_custom_field_names"]!({}, executionContext());
+    if (!result.ok) {
+      throw new Error(`expected field names, got: ${result.error?.message}`);
+    }
+    expect(result.output).toEqual({ names: ["Color", "Serial"] });
+  });
+
+  it("reads the plain array responses of list_entity_types and list_tags", async () => {
+    setPrivateNetworkAccessAllowed(true);
+    setDefaultGuardedFetchDnsLookup(async () => [{ address: "192.168.150.53", family: 4 }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+        if (url.pathname === "/api/v1/entity-types") {
+          return Response.json([{ id: "type-1", name: "Location", isLocation: true }]);
+        }
+        if (url.pathname === "/api/v1/tags") {
+          return Response.json([{ id: "tag-1", name: "Electronics" }]);
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const entityTypes = await executors["homebox.list_entity_types"]!({}, executionContext());
+    if (!entityTypes.ok) {
+      throw new Error(`expected entity types, got: ${entityTypes.error?.message}`);
+    }
+    expect(entityTypes.output).toEqual({ entityTypes: [{ id: "type-1", name: "Location", isLocation: true }] });
+
+    const tags = await executors["homebox.list_tags"]!({}, executionContext());
+    if (!tags.ok) {
+      throw new Error(`expected tags, got: ${tags.error?.message}`);
+    }
+    expect(tags.output).toEqual({ tags: [{ id: "tag-1", name: "Electronics" }] });
+  });
+});

--- a/src/providers/homebox/executors.ts
+++ b/src/providers/homebox/executors.ts
@@ -1,0 +1,66 @@
+import type {
+  CredentialValidationResult,
+  CredentialValidators,
+  ExecutionContext,
+  ProviderExecutors,
+  ProviderProxyExecutor,
+} from "../../core/types.ts";
+import type { HomeBoxActionContext, HomeBoxActionHandler } from "./runtime.ts";
+
+import { isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  combineProviderActionHandlers,
+  createProviderFetch,
+  defineProviderExecutors,
+  defineProviderProxy,
+  requireApiKeyCredential,
+} from "../provider-runtime.ts";
+import {
+  homeBoxActionHandlers,
+  homeBoxApiPrefix,
+  resolveHomeBoxBaseUrl,
+  validateHomeBoxCredential,
+} from "./runtime.ts";
+
+const service = "homebox";
+
+function resolveHomeBoxApiRoot(context: ExecutionContext): Promise<string> {
+  return requireApiKeyCredential(context, service).then((credential) => {
+    const baseUrl = resolveHomeBoxBaseUrl({ values: credential.values, metadata: credential.metadata });
+    return `${baseUrl.replace(/\/+$/, "")}/${homeBoxApiPrefix}/`;
+  });
+}
+
+export const executors: ProviderExecutors = defineProviderExecutors<HomeBoxActionContext>({
+  service,
+  handlers: combineProviderActionHandlers<"homebox", HomeBoxActionHandler>(service, homeBoxActionHandlers),
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+  async createContext(context: ExecutionContext, fetcher: typeof fetch): Promise<HomeBoxActionContext> {
+    const credential = await requireApiKeyCredential(context, service);
+    return {
+      apiKey: credential.apiKey,
+      baseUrl: resolveHomeBoxBaseUrl({ values: credential.values, metadata: credential.metadata }),
+      transitFiles: context.transitFiles,
+      fetcher,
+      signal: context.signal,
+    };
+  },
+});
+
+export const proxy: ProviderProxyExecutor = defineProviderProxy({
+  service,
+  baseUrl: resolveHomeBoxApiRoot,
+  auth: { type: "api_key_authorization", prefix: "Bearer " },
+  allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+});
+
+export const credentialValidators: CredentialValidators = {
+  apiKey(input, { fetcher, signal }): Promise<CredentialValidationResult> {
+    // Re-guard so validating a private instance baseUrl follows the deployment opt-in.
+    const guardedFetcher = createProviderFetch({
+      fetch: fetcher,
+      allowPrivateNetwork: isPrivateNetworkAccessAllowed,
+    });
+    return validateHomeBoxCredential(input, guardedFetcher, signal);
+  },
+};

--- a/src/providers/homebox/runtime.ts
+++ b/src/providers/homebox/runtime.ts
@@ -1,0 +1,466 @@
+import type { CredentialValidationResult, TransitFileStore } from "../../core/types.ts";
+import type { ProviderActionHandlerSubset, ProviderFetch } from "../provider-runtime.ts";
+
+import {
+  optionalBoolean,
+  optionalInteger,
+  optionalNumber,
+  optionalObjectArray,
+  optionalRecord,
+  optionalString,
+  optionalStringArray,
+  recordOrEmpty,
+  requiredBoolean,
+  stringArray,
+} from "../../core/cast.ts";
+import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
+import {
+  createProviderTimeout,
+  providerInputError,
+  ProviderRequestError,
+  providerUserAgent,
+  readProviderJsonBody,
+  readTransitFileInput,
+  requiredInputString,
+} from "../provider-runtime.ts";
+
+const homeBoxCredentialHelpUrl = "https://homebox.software/en/api/";
+export const homeBoxApiPrefix = "api/v1";
+
+export interface HomeBoxActionContext {
+  apiKey: string;
+  baseUrl: string;
+  transitFiles?: TransitFileStore;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export type HomeBoxActionHandler = (input: Record<string, unknown>, context: HomeBoxActionContext) => Promise<unknown>;
+
+type HomeBoxQueryValue = string | number | boolean | readonly string[] | undefined;
+
+interface HomeBoxRequestOptions {
+  context: HomeBoxActionContext;
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  query?: Record<string, HomeBoxQueryValue>;
+  body?: Record<string, unknown> | FormData;
+}
+
+export function resolveHomeBoxBaseUrl(input: {
+  values?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}): string {
+  const value = optionalString(input.metadata?.baseUrl) ?? optionalString(input.values?.baseUrl);
+  return normalizeHomeBoxBaseUrl(value);
+}
+
+function normalizeHomeBoxBaseUrl(
+  value: unknown,
+  allowPrivateNetwork: boolean = isPrivateNetworkAccessAllowed(),
+): string {
+  const raw = optionalString(value)?.trim();
+  if (!raw) {
+    throw new ProviderRequestError(400, "baseUrl is required");
+  }
+
+  const url = assertPublicHttpUrl(raw, {
+    fieldName: "baseUrl",
+    createError: (message) => new ProviderRequestError(400, message),
+    allowPrivateNetwork,
+  });
+  if (url.username || url.password || url.search || url.hash) {
+    throw new ProviderRequestError(400, "baseUrl must be a clean instance root URL");
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+  // Users often paste the API root; strip a trailing /api so it is not double-prefixed.
+  url.pathname = url.pathname.replace(/\/+(api\/v1|api)$/i, "") || "/";
+  return url.pathname === "/" ? url.origin : `${url.origin}${url.pathname}`;
+}
+
+function buildHomeBoxUrl(
+  context: HomeBoxActionContext,
+  path: string,
+  query?: Record<string, HomeBoxQueryValue>,
+): string {
+  const base = `${context.baseUrl.replace(/\/+$/, "")}/${homeBoxApiPrefix}/`;
+  const url = new URL(`./${path.replace(/^\/+/, "")}`, base);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        url.searchParams.append(key, String(item));
+      }
+    } else {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+async function performHomeBoxRequest(options: HomeBoxRequestOptions): Promise<Response> {
+  const { context } = options;
+  const url = buildHomeBoxUrl(context, options.path, options.query);
+  const headers = new Headers({ accept: "application/json", "user-agent": providerUserAgent });
+  headers.set("authorization", `Bearer ${context.apiKey}`);
+
+  let body: BodyInit | undefined;
+  if (options.body instanceof FormData) {
+    body = options.body;
+  } else if (options.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(options.body);
+  }
+
+  const timeout = createProviderTimeout(context.signal);
+  try {
+    return await context.fetcher(url, {
+      method: options.method,
+      headers,
+      body,
+      signal: timeout.signal,
+    });
+  } catch (error) {
+    if (timeout.didTimeout()) {
+      throw new ProviderRequestError(504, "HomeBox request timed out");
+    }
+    throw error;
+  } finally {
+    timeout.cleanup();
+  }
+}
+
+function mapHomeBoxHttpError(status: number, payload: unknown): ProviderRequestError {
+  let message: string | undefined;
+  if (typeof payload === "string") {
+    message = payload;
+  } else {
+    const error = optionalRecord(payload);
+    message = optionalString(error?.error) ?? optionalString(error?.message);
+  }
+  return new ProviderRequestError(status, message ?? `HomeBox request failed with HTTP ${status}`, payload);
+}
+
+async function requestHomeBoxJson(options: HomeBoxRequestOptions): Promise<unknown> {
+  const response = await performHomeBoxRequest(options);
+  const payload = await readProviderJsonBody(response, {
+    emptyBody: null,
+    invalidJsonMessage: "HomeBox returned an invalid JSON response",
+  });
+  if (response.ok) {
+    return payload;
+  }
+  throw mapHomeBoxHttpError(response.status, payload);
+}
+
+function readPagination(payload: Record<string, unknown>): Record<string, unknown> {
+  const page = optionalInteger(payload.page) ?? 1;
+  return {
+    items: optionalObjectArray(payload.items, "HomeBox entities response") ?? [],
+    // The instance echoes -1 when no page was requested; normalize to 1.
+    page: page > 0 ? page : 1,
+    pageSize: optionalInteger(payload.pageSize) ?? 0,
+    total: optionalInteger(payload.total) ?? 0,
+  };
+}
+
+export const homeBoxActionHandlers: ProviderActionHandlerSubset<"homebox", HomeBoxActionHandler> = {
+  async get_status(_input, context) {
+    const payload = recordOrEmpty(await requestHomeBoxJson({ context, method: "GET", path: "status" }));
+    return { summary: payload };
+  },
+
+  async list_entities(input, context) {
+    const payload = recordOrEmpty(
+      await requestHomeBoxJson({
+        context,
+        method: "GET",
+        path: "entities",
+        query: {
+          q: optionalString(input.q),
+          page: optionalInteger(input.page),
+          pageSize: optionalInteger(input.pageSize),
+          tags: optionalStringArray(input.tagIds),
+          parentIds: optionalStringArray(input.parentIds),
+        },
+      }),
+    );
+    return readPagination(payload);
+  },
+
+  async get_entity(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    const payload = recordOrEmpty(
+      await requestHomeBoxJson({ context, method: "GET", path: `entities/${encodeURIComponent(id)}` }),
+    );
+    return { entity: payload };
+  },
+
+  async create_entity(input, context) {
+    const name = requiredInputString(input.name, "name");
+    const body: Record<string, unknown> = { name };
+    const entityTypeId = optionalString(input.entityTypeId);
+    if (entityTypeId) body.entityTypeId = entityTypeId;
+    const parentId = optionalString(input.parentId);
+    if (parentId) body.parentId = parentId;
+    const description = optionalString(input.description);
+    if (description !== undefined) body.description = description;
+    const quantity = optionalInteger(input.quantity);
+    if (quantity !== undefined) body.quantity = quantity;
+    const tagIds = optionalStringArray(input.tagIds);
+    if (tagIds !== undefined) body.tagIds = tagIds;
+    const payload = recordOrEmpty(await requestHomeBoxJson({ context, method: "POST", path: "entities", body }));
+    return { entity: payload };
+  },
+
+  async update_entity(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    // EntityUpdate is a full replacement, so merge the requested changes on top
+    // of the current entity instead of wiping untouched fields (serial number,
+    // warranty, custom fields, ...).
+    const current = recordOrEmpty(
+      await requestHomeBoxJson({ context, method: "GET", path: `entities/${encodeURIComponent(id)}` }),
+    );
+    const entityType = optionalRecord(current.entityType) ?? {};
+    const tags = optionalObjectArray(current.tags, "HomeBox entity tags response") ?? [];
+    const parent = optionalRecord(current.parent) ?? {};
+
+    const body: Record<string, unknown> = {
+      name: optionalString(input.name) ?? optionalString(current.name) ?? "",
+      // EntityUpdate always sets assetId; omitting it resets the entity's asset
+      // id to zero, so echo the current one back.
+      assetId: optionalString(current.assetId) ?? "",
+      description:
+        input.description === null
+          ? ""
+          : (optionalString(input.description) ?? optionalString(current.description) ?? ""),
+      quantity: optionalInteger(input.quantity) ?? optionalInteger(current.quantity) ?? 0,
+      insured:
+        input.insured === undefined
+          ? (optionalBoolean(current.insured) ?? false)
+          : requiredBoolean(input.insured, "insured", providerInputError),
+      archived:
+        input.archived === undefined
+          ? (optionalBoolean(current.archived) ?? false)
+          : requiredBoolean(input.archived, "archived", providerInputError),
+      tagIds:
+        optionalStringArray(input.tagIds) ??
+        tags.map((tag) => optionalString(tag.id)).filter((tagId): tagId is string => tagId !== undefined),
+      serialNumber: optionalString(input.serialNumber) ?? optionalString(current.serialNumber) ?? "",
+      modelNumber: optionalString(input.modelNumber) ?? optionalString(current.modelNumber) ?? "",
+      manufacturer: optionalString(input.manufacturer) ?? optionalString(current.manufacturer) ?? "",
+      lifetimeWarranty:
+        input.lifetimeWarranty === undefined
+          ? (optionalBoolean(current.lifetimeWarranty) ?? false)
+          : requiredBoolean(input.lifetimeWarranty, "lifetimeWarranty", providerInputError),
+      warrantyExpires: optionalString(input.warrantyExpires) ?? optionalString(current.warrantyExpires) ?? "",
+      warrantyDetails: optionalString(input.warrantyDetails) ?? optionalString(current.warrantyDetails) ?? "",
+      purchaseDate: optionalString(input.purchaseDate) ?? optionalString(current.purchaseDate) ?? "",
+      purchaseFrom: optionalString(input.purchaseFrom) ?? optionalString(current.purchaseFrom) ?? "",
+      purchasePrice: optionalNumber(input.purchasePrice) ?? optionalNumber(current.purchasePrice) ?? 0,
+      soldDate: optionalString(input.soldDate) ?? optionalString(current.soldDate) ?? "",
+      soldTo: optionalString(input.soldTo) ?? optionalString(current.soldTo) ?? "",
+      soldPrice: optionalNumber(input.soldPrice) ?? optionalNumber(current.soldPrice) ?? 0,
+      soldNotes: optionalString(input.soldNotes) ?? optionalString(current.soldNotes) ?? "",
+      notes: optionalString(input.notes) ?? optionalString(current.notes) ?? "",
+      syncChildEntityLocations:
+        input.syncChildEntityLocations === undefined
+          ? (optionalBoolean(current.syncChildEntityLocations) ?? false)
+          : requiredBoolean(input.syncChildEntityLocations, "syncChildEntityLocations", providerInputError),
+      fields:
+        input.fields === undefined
+          ? optionalObjectArray(current.fields, "HomeBox custom fields response")
+          : optionalObjectArray(input.fields, "HomeBox custom fields input"),
+    };
+    // Empty UUID strings would fail decoding, so only send ids we have.
+    const entityTypeId = optionalString(input.entityTypeId) ?? optionalString(entityType.id);
+    if (entityTypeId) {
+      body.entityTypeId = entityTypeId;
+    }
+    const parentId =
+      input.parentId === null ? undefined : (optionalString(input.parentId) ?? optionalString(parent.id));
+    if (parentId) {
+      body.parentId = parentId;
+    }
+    const payload = recordOrEmpty(
+      await requestHomeBoxJson({ context, method: "PUT", path: `entities/${encodeURIComponent(id)}`, body }),
+    );
+    return { entity: payload };
+  },
+
+  async delete_entity(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    await requestHomeBoxJson({ context, method: "DELETE", path: `entities/${encodeURIComponent(id)}` });
+    return { deleted: true };
+  },
+
+  async list_entity_types(_input, context) {
+    const payload = await requestHomeBoxJson({ context, method: "GET", path: "entity-types" });
+    return { entityTypes: optionalObjectArray(payload, "HomeBox entity types response") };
+  },
+
+  async create_entity_type(input, context) {
+    const name = requiredInputString(input.name, "name");
+    const body: Record<string, unknown> = { name };
+    const description = optionalString(input.description);
+    if (description !== undefined) body.description = description;
+    const icon = optionalString(input.icon);
+    if (icon !== undefined) body.icon = icon;
+    const isLocation = optionalBoolean(input.isLocation);
+    if (isLocation !== undefined) body.isLocation = isLocation;
+    const payload = recordOrEmpty(await requestHomeBoxJson({ context, method: "POST", path: "entity-types", body }));
+    return { entityType: payload };
+  },
+
+  async delete_entity_type(input, context) {
+    const id = requiredInputString(input.entityTypeId, "entityTypeId");
+    await requestHomeBoxJson({ context, method: "DELETE", path: `entity-types/${encodeURIComponent(id)}` });
+    return { deleted: true };
+  },
+
+  async list_tags(_input, context) {
+    const payload = await requestHomeBoxJson({ context, method: "GET", path: "tags" });
+    return { tags: optionalObjectArray(payload, "HomeBox tags response") };
+  },
+
+  async create_tag(input, context) {
+    const name = requiredInputString(input.name, "name");
+    const body: Record<string, unknown> = { name };
+    const description = optionalString(input.description);
+    if (description !== undefined) body.description = description;
+    const color = optionalString(input.color);
+    if (color !== undefined) body.color = color;
+    const icon = optionalString(input.icon);
+    if (icon !== undefined) body.icon = icon;
+    const parentId = optionalString(input.parentId);
+    if (parentId) body.parentId = parentId;
+    const payload = recordOrEmpty(await requestHomeBoxJson({ context, method: "POST", path: "tags", body }));
+    return { tag: payload };
+  },
+
+  async delete_tag(input, context) {
+    const id = requiredInputString(input.tagId, "tagId");
+    await requestHomeBoxJson({ context, method: "DELETE", path: `tags/${encodeURIComponent(id)}` });
+    return { deleted: true };
+  },
+
+  async get_group_statistics(_input, context) {
+    const payload = recordOrEmpty(await requestHomeBoxJson({ context, method: "GET", path: "groups/statistics" }));
+    return { statistics: payload };
+  },
+
+  async add_entity_attachment(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    const file = await readTransitFileInput(input.file, context);
+    const form = new FormData();
+    form.append("file", new File([file.file], file.name, { type: file.mimeType ?? "application/octet-stream" }));
+    form.append("name", optionalString(input.name) ?? file.name);
+    const type = optionalString(input.type);
+    if (type !== undefined) {
+      form.append("type", type);
+    }
+    const primary = optionalBoolean(input.primary);
+    if (primary !== undefined) {
+      form.append("primary", String(primary));
+    }
+    const payload = recordOrEmpty(
+      await requestHomeBoxJson({
+        context,
+        method: "POST",
+        path: `entities/${encodeURIComponent(id)}/attachments`,
+        body: form,
+      }),
+    );
+    return { entity: payload };
+  },
+
+  async get_maintenance_log(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    const payload = await requestHomeBoxJson({
+      context,
+      method: "GET",
+      path: `entities/${encodeURIComponent(id)}/maintenance`,
+      query: { status: optionalString(input.status) },
+    });
+    return { entries: optionalObjectArray(payload, "HomeBox maintenance log response") };
+  },
+
+  async add_maintenance_entry(input, context) {
+    const id = requiredInputString(input.entityId, "entityId");
+    const name = requiredInputString(input.name, "name");
+    const completedDate = optionalString(input.completedDate);
+    const scheduledDate = optionalString(input.scheduledDate);
+    const body: Record<string, unknown> = { name };
+    if (completedDate !== undefined) body.completedDate = completedDate;
+    if (scheduledDate !== undefined) body.scheduledDate = scheduledDate;
+    const description = optionalString(input.description);
+    if (description !== undefined) body.description = description;
+    const cost = optionalString(input.cost);
+    if (cost !== undefined) body.cost = cost;
+    const payload = recordOrEmpty(
+      await requestHomeBoxJson({
+        context,
+        method: "POST",
+        path: `entities/${encodeURIComponent(id)}/maintenance`,
+        body,
+      }),
+    );
+    return { entry: payload };
+  },
+
+  async list_custom_field_names(_input, context) {
+    const payload = await requestHomeBoxJson({ context, method: "GET", path: "entities/fields" });
+    return { names: stringArray(payload, "HomeBox custom field names response") };
+  },
+
+  async list_custom_field_values(input, context) {
+    const field = requiredInputString(input.field, "field");
+    const payload = await requestHomeBoxJson({
+      context,
+      method: "GET",
+      path: "entities/fields/values",
+      query: { field },
+    });
+    return { values: stringArray(payload, "HomeBox custom field values response") };
+  },
+};
+
+/**
+ * The validator fetcher must already be re-guarded with the same
+ * private-network opt-in as the provider executors.
+ */
+export async function validateHomeBoxCredential(
+  input: { apiKey: string; values: Record<string, string> },
+  fetcher: ProviderFetch,
+  signal?: AbortSignal,
+): Promise<CredentialValidationResult> {
+  const apiKey = requiredInputString(input.apiKey, "apiKey");
+  const baseUrl = normalizeHomeBoxBaseUrl(input.values.baseUrl);
+
+  // The cheapest authenticated call that proves the key works and reveals the
+  // acting account, so the connection profile names the group it writes to.
+  const payload = recordOrEmpty(
+    await requestHomeBoxJson({
+      context: { apiKey, baseUrl, fetcher, signal },
+      method: "GET",
+      path: "users/self",
+    }),
+  );
+  const displayName = optionalString(payload.name) ?? "HomeBox";
+
+  return {
+    profile: {
+      accountId: `homebox:${baseUrl}`,
+      displayName: `HomeBox (${displayName})`,
+      grantedScopes: [],
+    },
+    grantedScopes: [],
+    metadata: {
+      baseUrl,
+      credentialHelpUrl: homeBoxCredentialHelpUrl,
+    },
+  };
+}

--- a/src/providers/homebox/runtime.ts
+++ b/src/providers/homebox/runtime.ts
@@ -16,6 +16,7 @@ import {
 import { assertPublicHttpUrl, isPrivateNetworkAccessAllowed } from "../../core/request.ts";
 import {
   createProviderTimeout,
+  isAbortSignalError,
   providerInputError,
   ProviderRequestError,
   providerUserAgent,
@@ -101,7 +102,7 @@ function buildHomeBoxUrl(
   return url.toString();
 }
 
-async function performHomeBoxRequest(options: HomeBoxRequestOptions): Promise<Response> {
+async function performHomeBoxRequest(options: HomeBoxRequestOptions, signal: AbortSignal): Promise<Response> {
   const { context } = options;
   const url = buildHomeBoxUrl(context, options.path, options.query);
   const headers = new Headers({ accept: "application/json", "user-agent": providerUserAgent });
@@ -115,22 +116,12 @@ async function performHomeBoxRequest(options: HomeBoxRequestOptions): Promise<Re
     body = JSON.stringify(options.body);
   }
 
-  const timeout = createProviderTimeout(context.signal);
-  try {
-    return await context.fetcher(url, {
-      method: options.method,
-      headers,
-      body,
-      signal: timeout.signal,
-    });
-  } catch (error) {
-    if (timeout.didTimeout()) {
-      throw new ProviderRequestError(504, "HomeBox request timed out");
-    }
-    throw error;
-  } finally {
-    timeout.cleanup();
-  }
+  return context.fetcher(url, {
+    method: options.method,
+    headers,
+    body,
+    signal,
+  });
 }
 
 function mapHomeBoxHttpError(status: number, payload: unknown): ProviderRequestError {
@@ -145,15 +136,27 @@ function mapHomeBoxHttpError(status: number, payload: unknown): ProviderRequestE
 }
 
 async function requestHomeBoxJson(options: HomeBoxRequestOptions): Promise<unknown> {
-  const response = await performHomeBoxRequest(options);
-  const payload = await readProviderJsonBody(response, {
-    emptyBody: null,
-    invalidJsonMessage: "HomeBox returned an invalid JSON response",
-  });
-  if (response.ok) {
-    return payload;
+  // The timeout must cover the body read too: a response can hand back headers
+  // and then stall mid-body, and without a live signal that hang is unbounded.
+  const timeout = createProviderTimeout(options.context.signal);
+  try {
+    const response = await performHomeBoxRequest(options, timeout.signal);
+    const payload = await readProviderJsonBody(response, {
+      emptyBody: null,
+      invalidJsonMessage: "HomeBox returned an invalid JSON response",
+    });
+    if (response.ok) {
+      return payload;
+    }
+    throw mapHomeBoxHttpError(response.status, payload);
+  } catch (error) {
+    if (timeout.didTimeout() || isAbortSignalError(timeout.signal, error)) {
+      throw new ProviderRequestError(504, "HomeBox request timed out");
+    }
+    throw error;
+  } finally {
+    timeout.cleanup();
   }
-  throw mapHomeBoxHttpError(response.status, payload);
 }
 
 function readPagination(payload: Record<string, unknown>): Record<string, unknown> {
@@ -218,6 +221,26 @@ export const homeBoxActionHandlers: ProviderActionHandlerSubset<"homebox", HomeB
 
   async update_entity(input, context) {
     const id = requiredInputString(input.entityId, "entityId");
+    // EntityPatch covers only quantity, parentId, tagIds, and entityTypeId.
+    // When the caller limits itself to those fields, PATCH is safer than the
+    // get-merge-PUT below because it never reads a stale snapshot.
+    const patchableFields = ["quantity", "parentId", "tagIds", "entityTypeId"];
+    const requestedFields = Object.keys(input).filter((key) => key !== "entityId");
+    if (requestedFields.length > 0 && requestedFields.every((key) => patchableFields.includes(key))) {
+      const body: Record<string, unknown> = {};
+      const quantity = optionalInteger(input.quantity);
+      if (quantity !== undefined) body.quantity = quantity;
+      const parentId = optionalString(input.parentId);
+      if (parentId !== undefined) body.parentId = parentId;
+      const tagIds = optionalStringArray(input.tagIds);
+      if (tagIds !== undefined) body.tagIds = tagIds;
+      const entityTypeId = optionalString(input.entityTypeId);
+      if (entityTypeId) body.entityTypeId = entityTypeId;
+      const payload = recordOrEmpty(
+        await requestHomeBoxJson({ context, method: "PATCH", path: `entities/${encodeURIComponent(id)}`, body }),
+      );
+      return { entity: payload };
+    }
     // EntityUpdate is a full replacement, so merge the requested changes on top
     // of the current entity instead of wiping untouched fields (serial number,
     // warranty, custom fields, ...).


### PR DESCRIPTION
## Summary

Adds a provider for [HomeBox](https://homebox.software) — a self-hosted home inventory and organization system. The provider exposes 18 actions to search and manage the inventory (entities, tags, entity types, maintenance, attachments, custom fields) through the standard connector runtime: catalog-driven action contracts, credential validation, SSRF-guarded egress with the private-network opt-in, and a local proxy for asset/manual attachments.

## Authentication

HomeBox v0.26 has no scoped API keys with fine-grained permissions; it issues static API keys that carry **the same permissions as the issuing account**. The provider therefore tells users to create an API key in the web UI (`Users → API Keys`) and authenticates with `Authorization: Bearer <key>`. Because the key acts as the account, all actions run in that account's group scope — a deliberate design choice that keeps the connector and the human on the same collection without an invitation flow. No token refreshing or session caching is needed.

## Actions (18)

| Area | Actions |
|---|---|
| Instance | `get_status`, `get_group_statistics` |
| Entities | `list_entities`, `get_entity`, `create_entity`, `update_entity`, `delete_entity` |
| Tags | `list_tags`, `create_tag`, `delete_tag` |
| Entity types | `list_entity_types`, `create_entity_type`, `delete_entity_type` |
| Attachments | `add_entity_attachment` (transit file → multipart, photo/manual/warranty/receipt/thumbnail) |
| Maintenance | `get_maintenance_log`, `add_maintenance_entry` |
| Custom fields | `list_custom_field_names`, `list_custom_field_values` |

## Notable implementation points

- `update_entity` performs a get → merge → PUT because HomeBox's `EntityUpdate` is a full replacement; omitted fields are preserved, and the server-owned `assetId` is echoed back (omitting it resets the asset id to zero).
- Maintenance entries require only `name` on v0.26 (the old date-required validation is gone server-side), so the provider does not enforce dates.
- List responses are plain arrays for tags/entity-types/custom fields and an `EntityListResult` object for entities; the runtime handles each shape as documented in the upstream swagger.
- `list_entities` normalizes the instance's `-1` page echo to `1`.

## Verification

- Unit tests: `src/providers/homebox/executors.test.ts` (9 cases) — bearer proxy auth, 401 mapping, LAN opt-in rejection, missing credentials, update merge preserving assetId/custom fields, repeated query params, dateless maintenance, plain-array responses.
- Provider guards: `provider-source-guards.clone-baseline` and `basic-auth` pass (no shared-owner re-clones).
- Live end-to-end verified against a real HomeBox v0.26.2 instance: read/search + create/update/delete entity type and entity, maintenance log create/read, photo + PDF attachment via transit files.
- `npm run generate:catalog` regenerates the (gitignored) catalog with 18 actions.

## Notes

- Example: `examples/homebox-live-check.ts` (prints a skip message when `HOMEBOX_BASE_URL`/`HOMEBOX_API_KEY` are unset, per repo policy).
- The `date` fields are documented as `YYYY-MM-DD`; we intentionally keep the schema to ISO format even though the server also accepts other formats.
